### PR TITLE
Review: fix getmessage deriv handling

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -402,7 +402,9 @@ public:
     /// write it into 'val'.  Otherwise, return false.  This is only
     /// called for "sourced" messages, not ordinary intra-group messages.
     virtual bool getmessage (ShaderGlobals *sg, ustring source, ustring name, 
-                             TypeDesc type, void *val) { return false; }
+                             TypeDesc type, void *val, bool derivatives) {
+        return false;
+    }
 
 private:
     TextureSystem *m_texturesys;   // For default texture implementation

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -279,7 +279,7 @@ static const char *llvm_helper_function_table[] = {
     "osl_spline_dvdfv", "xXXXXi",
     "osl_spline_dvfdv", "xXXXXi",
     "osl_setmessage", "xXsLX",
-    "osl_getmessage", "iXssLX",
+    "osl_getmessage", "iXssLXi",
     "osl_pointcloud", "iXsvfiXi*",
 
 #ifdef OSL_LLVM_NO_BITCODE
@@ -3461,7 +3461,7 @@ LLVMGEN (llvm_gen_getmessage)
     DASSERT (Result.typespec().is_int() && Name.typespec().is_string());
     DASSERT (has_source == 0 || Source.typespec().is_string());
 
-    llvm::Value *args[5];
+    llvm::Value *args[6];
     args[0] = rop.sg_void_ptr();
     args[1] = has_source ? rop.llvm_load_value(Source) 
                          : rop.llvm_constant(ustring());
@@ -3472,8 +3472,9 @@ LLVMGEN (llvm_gen_getmessage)
         args[4] = rop.llvm_ptr_cast(rop.llvm_get_pointer(Data), rop.llvm_type_void_ptr());
     else
         args[4] = rop.llvm_void_ptr (Data);
+    args[5] = rop.llvm_constant ((int)Data.has_derivs());
 
-    llvm::Value *r = rop.llvm_call_function ("osl_getmessage", args, 5);
+    llvm::Value *r = rop.llvm_call_function ("osl_getmessage", args, 6);
     rop.llvm_store_value (r, Result);
     return true;
 }

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -82,7 +82,7 @@ osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val
 
 OSL_SHADEOP int
 osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
-                long long type_, void *val)
+                long long type_, void *val, int derivs)
 {
     const ustring &source (USTR(source_));
     const ustring &name (USTR(name_));
@@ -96,7 +96,7 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
     if (source == ktrace) {
         // Source types where we need to ask the renderer
         RendererServices *renderer = sg->context->renderer();
-        return renderer->getmessage (sg, source, name, type, val);
+        return renderer->getmessage (sg, source, name, type, val, derivs);
     }
 
     ParamValueList &messages (sg->context->messages());
@@ -107,7 +107,10 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
 
     if (p) {
         // Message found
-        memcpy (val, p->data(), type.size());
+        size_t size = type.size();
+        memcpy (val, p->data(), size);
+        if (derivs)
+            memset (((char *)val)+size, 0, 2*size);
         return 1;
     }
 


### PR DESCRIPTION
setmessage doesn't store derivs, getmessage doesn't retrieve them.  That's fine (at least for now), but if the 'data' param passed to getmessage has a slot for derivs, we need to clear them, and didn't.  Fix that, which also needs to propagate a couple extra params around to osl_getmessage and also to RendererServices::getmessage.
