### PR TITLE
Closure crash

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -131,7 +131,7 @@ public:
     /// Construct a TypeSpec representing a closure (pass closure=true)
     /// of a simple type.
     TypeSpec (TypeDesc simple, bool closure)
-        : m_simple(simple), m_structure(0), m_closure(closure)
+        : m_simple(closure ? TypeDesc::PTR : simple), m_structure(0), m_closure(closure)
     { }
 
     /// Construct a TypeSpec describing a struct or array of structs,
@@ -358,7 +358,7 @@ public:
     /// Is it a color closure?
     ///
     bool is_color_closure () const {
-        return is_closure() && (m_simple == TypeDesc::TypeColor);
+        return is_closure();
     }
 
     /// Types are equivalent if they are identical, or if both are

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -158,6 +158,11 @@ OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name)
         } else if (typespec.simpletype().basetype == TypeDesc::STRING) {
             sym.dataoffset ((int) m_master->m_sdefaults.size());
             expand (m_master->m_sdefaults, t.aggregate * t.numelements());
+        } else if (typespec.is_closure()) {
+            // Closures are pointers, so we allocate a string default taking
+            // adventage of their default being NULL as well.
+            sym.dataoffset ((int) m_master->m_sdefaults.size());
+            expand (m_master->m_sdefaults, t.aggregate * t.numelements());
         } else {
             ASSERT (0 && "unexpected type");
         }


### PR DESCRIPTION
We were using color as the basic TypeDesc type for closures. So at every place where we were copying closure objects (pointers) we were using a size of 12. And therefore corrupting everything. I found this affecting getmessage, but there could be other parts fixed by this patch. Bascially I have just switched it to use PTR whenever is_closure is on.
