### PR TITLE
Review: Fix subtle bug in marking the lifetime of variables within loops.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,7 @@ endmacro ()
 # special installed tests.
 #TESTSUITE ( oslc-empty )
 TESTSUITE ( arithmetic array array-derivs
-            blendmath cellnoise closure color comparison
+            blendmath bug-locallifetime cellnoise closure color comparison
             derivs error-dupes exponential
             function-simple function-outputelem
             geomath gettextureinfo hyperb

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -980,23 +980,43 @@ OSLCompilerImpl::track_variable_lifetimes (const OpcodeVec &code,
     }
 
 
-    // Special case: temporaries referenced both inside AND outside a
-    // loop need their lifetimes extended to cover the entire loop so
-    // they aren't accidentally coalesced incorrectly.  The specific
-    // danger is for a function that contains a loop, and the function
-    // is passed an argument that is a temporary calculation.
+    // Special cases: handle variables whose lifetimes cross the boundaries
+    // of a loop.
     opnum = 0;
     BOOST_FOREACH (const Opcode &op, code) {
         if (op.opname() == op_for ||
             op.opname() == op_while ||
             op.opname() == op_dowhile) {
+            int loopcond = op.jump (0);  // after initialization, before test
             int loopend = op.farthest_jump() - 1;
             BOOST_FOREACH (Symbol *s, allsyms) {
-                if (s->symtype() == SymTypeTemp && 
-                    ((s->firstuse() < opnum && s->lastuse() >= opnum) ||
+                // Temporaries referenced both inside AND outside a loop
+                // need their lifetimes extended to cover the entire
+                // loop so they aren't coalesced incorrectly.  The
+                // specific danger is for a function that contains a
+                // loop, and the function is passed an argument that is
+                // a temporary calculation.
+                if (s->symtype() == SymTypeTemp &&
+                    ((s->firstuse() < loopcond && s->lastuse() >= loopcond) ||
                      (s->firstuse() < loopend && s->lastuse() >= loopend))) {
                     s->mark_rw (opnum, true, true);
                     s->mark_rw (loopend, true, true);
+                }
+
+                // Locals that are written within the loop should have
+                // their usage conservatively expanded to the whole
+                // loop.  This is not a worry for temps, because they
+                // CAN'T be read in the next iteration unless they were
+                // set before the loop, handled above.  Ideally, we
+                // could be less conservative if we knew that the
+                // variable in question was declared/scoped internal to
+                // the loop, in which case it can't carry values to the
+                // next iteration (FIXME).
+                if (s->symtype() == SymTypeLocal &&
+                      s->firstuse() < loopend && s->lastwrite() >= loopcond) {
+                    bool read = (s->lastread() >= loopcond);
+                    s->mark_rw (opnum, read, true);
+                    s->mark_rw (loopend, read, true);
                 }
             }
         }

--- a/testsuite/bug-locallifetime/ref/out.txt
+++ b/testsuite/bug-locallifetime/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+Ran 2 iterations
+

--- a/testsuite/bug-locallifetime/run.py
+++ b/testsuite/bug-locallifetime/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade -O2 test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/bug-locallifetime/test.osl
+++ b/testsuite/bug-locallifetime/test.osl
@@ -1,0 +1,28 @@
+// This is a regression test for a bug wherein the lifetime of the
+// 'done' variable was miscomputed, and as a result optimized away --
+// erroneously believing that the 'done=1' could be elided because it
+// was not subsequently read, but of course it survives to the next
+// iteration of the loop.
+//
+// With the bug, this runs 4 iterations.  When fixed, it runs two
+// iterations.
+
+shader test ()
+{
+    int done = 0;
+    int iters = 0;
+                
+    for (int i = 0; i < 4 && done < 1; i++) {
+        int success = (i == 0);
+        if (! success)
+            done = 1;
+        
+//        printf("iter %d %d\n", i, done);
+        
+        iters += 1;
+    }
+
+    printf ("Ran %d iterations\n", iters);
+    
+}
+


### PR DESCRIPTION
When analyzing the lifetimes of variables, a local that is written within the body of a loop needs to make sure its lifetime encompass the whole loop, since it may be read on the next iteration!  This led to an optimizer bug for a simple shader like this:

```
int done = 0;
for (int i = 0; i < 4 && done < 1; i++) {
    if (blah)
        done = 1;      
}
```

This was iterating the wrong number of times because the "done=1" looked like it was the last use of done, so the runtime optimizer was removing it.  The conservative solution is that a local variable written inside a loop needs to remain alive for the whole body of the loop.  That's actually too strict, but it's harder to do it "correctly", which would NOT extend the lifetimes of variables who are declared within the scope of the loop body (but we don't currently track that in such a way that it's available to us at the right time).
