### PR TITLE
Review: Allow array function parameters of unspecified length.

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4919,6 +4919,7 @@ nothing (empty, no token).
 \alt <variable-declaration>
 
 <arrayspec> ::= "[" <integer> "]"
+\alt "[" "]"
 
 <variable-declaration> ::= <typespec> <def-expressions> ";"
 

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -274,6 +274,10 @@ metadatum
                 {
                     TypeDesc simple = lextype ($1);
                     simple.arraylen = $3;
+                    if (simple.arraylen < 1)
+                        oslcompiler->error (oslcompiler->filename(),
+                                            oslcompiler->lineno(),
+                                            "Invalid array length for %s", $2);
                     TypeSpec t (simple, false);
                     ASTvariable_declaration *var;
                     var = new ASTvariable_declaration (oslcompiler, t, 
@@ -397,6 +401,10 @@ typed_field
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
+                    if (t.arraylength() < 1)
+                        oslcompiler->error (oslcompiler->filename(),
+                                            oslcompiler->lineno(),
+                                            "Invalid array length for %s", $1);
                     oslcompiler->symtab().add_struct_field (t, ustring($1));
                     $$ = 0;
                 }
@@ -428,6 +436,10 @@ def_expression
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
+                    if (t.arraylength() < 1)
+                        oslcompiler->error (oslcompiler->filename(),
+                                            oslcompiler->lineno(),
+                                            "Invalid array length for %s", $1);
                     $$ = new ASTvariable_declaration (oslcompiler, t, 
                                  ustring($1), $3, false, false, false,
                                  true /* initializer list */);
@@ -526,7 +538,15 @@ simple_typename
         ;
 
 arrayspec
-        : '[' INT_LITERAL ']'           { $$ = $2; }
+        : '[' INT_LITERAL ']'
+                {
+                    if ($2 < 1)
+                        oslcompiler->error (oslcompiler->filename(),
+                                            oslcompiler->lineno(),
+                                            "Invalid array length (%d)", $2);
+                    $$ = $2;
+                }
+        | '[' ']'                       { $$ = -1; }
         ;
 
 /* typespec operates by merely setting the current_typespec */

--- a/testsuite/array/ref/out-single.txt
+++ b/testsuite/array/ref/out-single.txt
@@ -21,6 +21,8 @@ marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
 Test varying array assignment and reference:
 After carray[2] = color(u,v,4)...
 carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0 0 4)]
+Verify compile of functions with array parameters of unspecified length:
+	length of s is 3
 Test basic array initialization and referencing:
 iarray = [10 11 12]
 farray = [10.5 11.5 12]
@@ -43,6 +45,8 @@ marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
 Test varying array assignment and reference:
 After carray[2] = color(u,v,4)...
 carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (1 0 4)]
+Verify compile of functions with array parameters of unspecified length:
+	length of s is 3
 Test basic array initialization and referencing:
 iarray = [10 11 12]
 farray = [10.5 11.5 12]
@@ -65,6 +69,8 @@ marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
 Test varying array assignment and reference:
 After carray[2] = color(u,v,4)...
 carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0 1 4)]
+Verify compile of functions with array parameters of unspecified length:
+	length of s is 3
 Test basic array initialization and referencing:
 iarray = [10 11 12]
 farray = [10.5 11.5 12]
@@ -87,4 +93,6 @@ marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
 Test varying array assignment and reference:
 After carray[2] = color(u,v,4)...
 carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (1 1 4)]
+Verify compile of functions with array parameters of unspecified length:
+	length of s is 3
 

--- a/testsuite/array/test.osl
+++ b/testsuite/array/test.osl
@@ -1,3 +1,11 @@
+void test_unspecified_length (string s[])
+{
+    printf ("Verify compile of functions with array parameters of unspecified length:\n");
+    printf ("\tlength of s is %d\n", arraylength(s));
+}
+
+
+
 shader
 test (color cparamarray[2] = { color(0,1,2), color(3,4,5) })
 {
@@ -40,4 +48,6 @@ test (color cparamarray[2] = { color(0,1,2), color(3,4,5) })
     printf ("After carray[2] = color(u,v,4)...\n");
     carray[2] = color (u, v, 4);
     printf ("carray = [(%g) (%g) (%g)]\n", carray[0], carray[1], carray[2]);
+
+    test_unspecified_length (sarray);
 }


### PR DESCRIPTION
This was always intended, and was documented in the spec, but the bison grammar didn't have the clause to allow it.
