### PR TITLE
Review: Fix struct-within-struct, broken in various ways.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,7 +132,8 @@ TESTSUITE ( arithmetic array array-derivs
             ieee_fp if incdec initops intbits layers layers-lazy
             logic loop matrix message miscmath missing-shader noise pnoise
             oslc-err-paramdefault raytype shortcircuit spline string 
-            struct struct-err struct-layers struct-with-array ternary
+            struct struct-err struct-layers struct-with-array 
+            struct-within-struct ternary
             texture-alpha texture-blur texture-field3d
             texture-firstchannel texture-interp texture-simple
             texture-width texture-withderivs texture-wrap

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -203,10 +203,6 @@ public:
     ///
     static int new_struct (StructSpec *n);
 
-    /// Return a pointer to the last structure added to the end of the
-    /// structure list.
-    static StructSpec *last_struct () { return struct_list().back().get(); }
-
     /// Return a reference to the structure list.
     ///
     static std::vector<shared_ptr<StructSpec> > & struct_list ();

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -435,6 +435,11 @@ private:
     bool param_one_default_literal (const Symbol *sym, ASTNode *init,
                                     std::string &out);
 
+    // Add individual symbols for each field of a structure, using the
+    // given basename.
+    void add_struct_fields (StructSpec *structspec, ustring basename,
+                            SymType symtype);
+
     ustring m_name;     ///< Name of the symbol (unmangled)
     Symbol *m_sym;      ///< Ptr to the symbol this declares
     bool m_isparam;     ///< Is this a parameter?
@@ -544,6 +549,9 @@ public:
 
     ref lvalue () const { return child (0); }
     ustring field () const { return m_field; }
+    ustring mangledfield () const { return m_mangledfield; }
+    Symbol *mangledsym () const { return m_mangledsym; }
+
 private:
     ustring m_field;         ///< Name of the field
     int m_structid;          ///< index of the structure
@@ -664,6 +672,9 @@ public:
 
     ref var () const { return child (0); }
     ref expr () const { return child (1); }
+private:
+    void codegen_assign_struct (StructSpec *structspec,
+                                ustring dstsym, ustring srcsym);
 };
 
 
@@ -857,6 +868,18 @@ private:
                 m_argtakesderivs &= ~(1 << arg);
         }
     }
+
+    void codegen_arg (SymbolPtrVec &argdest, SymbolPtrVec &index,
+                      SymbolPtrVec &index1, SymbolPtrVec &index2,
+                      int argnum, ASTNode *arg,
+                      ASTNode *form, const TypeSpec &formaltype,
+                      bool writearg,
+                      bool &indexed_output_params);
+
+    /// Call compiler->struct_field_pair for each field in the struct.
+    ///
+    void struct_pair_all_fields (StructSpec *structspec,
+                                 ustring formal, ustring actual);
 
     ustring m_name;                 ///< Name of the function being called
     Symbol *m_sym;                  ///< Symbol of the function

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -867,6 +867,7 @@ OSLCompilerImpl::type_c_str (const TypeSpec &type) const
 
 
 
+
 void
 OSLCompilerImpl::struct_field_pair (Symbol *sym1, Symbol *sym2, int fieldnum,
                                     Symbol * &field1, Symbol * &field2)
@@ -883,6 +884,25 @@ OSLCompilerImpl::struct_field_pair (Symbol *sym1, Symbol *sym2, int fieldnum,
     ustring name1 = ustring::format ("%s.%s", sym1->mangled().c_str(),
                                      field.name.c_str());
     ustring name2 = ustring::format ("%s.%s", sym2->mangled().c_str(),
+                                     field.name.c_str());
+    // Retrieve the symbols
+    field1 = symtab().find_exact (name1);
+    field2 = symtab().find_exact (name2);
+    ASSERT (field1 && field2);
+}
+
+
+
+void
+OSLCompilerImpl::struct_field_pair (const StructSpec *structspec, int fieldnum,
+                                    ustring sym1, ustring sym2,
+                                    Symbol * &field1, Symbol * &field2)
+{
+    // Find the FieldSpec for the field we are interested in
+    const StructSpec::FieldSpec &field (structspec->field(fieldnum));
+    ustring name1 = ustring::format ("%s.%s", sym1.c_str(),
+                                     field.name.c_str());
+    ustring name2 = ustring::format ("%s.%s", sym2.c_str(),
                                      field.name.c_str());
     // Retrieve the symbols
     field1 = symtab().find_exact (name1);

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -257,6 +257,15 @@ public:
     void struct_field_pair (Symbol *sym1, Symbol *sym2, int fieldnum,
                             Symbol * &field1, Symbol * &field2);
 
+    /// Given symbol names sym1 and sym2, both the same kind of struct
+    /// described by structspec, and the index of the structure field
+    /// we're interested in, find the symbols that represent that field
+    /// in the each sym[12] and place them in field1 and field2,
+    /// respectively.
+    void struct_field_pair (const StructSpec *structspec, int fieldnum,
+                            ustring sym1, ustring sym2,
+                            Symbol * &field1, Symbol * &field2);
+
     static void track_variable_lifetimes (const OpcodeVec &ircode,
                                           const SymbolPtrVec &opargs,
                                           const SymbolPtrVec &allsyms);

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -182,10 +182,20 @@ SymbolTable::new_struct (ustring name)
 
 
 
+StructSpec *
+SymbolTable::current_struct ()
+{
+    return TypeSpec::struct_list().back().get();
+}
+
+
+
 void
 SymbolTable::add_struct_field (const TypeSpec &type, ustring name)
 {
-    TypeSpec::last_struct()->add_field (type, name);
+    StructSpec *s = current_struct();
+    ASSERT (s && "add_struct_field couldn't find a current struct");
+    s->add_field (type, name);
 }
 
 

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -213,6 +213,8 @@ public:
 
     void add_struct_field (const TypeSpec &type, ustring name);
 
+    StructSpec *current_struct ();
+
     /// Return the current scope ID
     ///
     int scopeid () const {

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -318,8 +318,9 @@ TypeSpec
 ASTstructselect::typecheck (TypeSpec expected)
 {
     // The ctr already figured out if this was a valid structure selection
-    if (m_fieldid < 0 || m_mangledsym == NULL)
+    if (m_fieldid < 0 || m_mangledsym == NULL) {
         return TypeSpec();
+    }
 
     typecheck_children ();
     StructSpec *structspec (TypeSpec::structspec (m_structid));

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -3871,7 +3871,7 @@ LLVMGEN (llvm_gen_dict_next)
 {
     // dict_net is very straightforward -- just insert sg ptr as first arg
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 3);
+    DASSERT (op.nargs() == 2);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& NodeID = *rop.opargsym (op, 1);
     DASSERT (Result.typespec().is_int() && NodeID.typespec().is_int());
@@ -3888,7 +3888,7 @@ LLVMGEN (llvm_gen_dict_value)
 {
     // int dict_value (int nodeID, string attribname, output TYPE value)
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 3);
+    DASSERT (op.nargs() == 4);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& NodeID = *rop.opargsym (op, 1);
     Symbol& Name   = *rop.opargsym (op, 2);

--- a/testsuite/struct-within-struct/ref/out.txt
+++ b/testsuite/struct-within-struct/ref/out.txt
@@ -1,0 +1,12 @@
+Compiled test.osl -> test.oso
+test struct within struct
+
+test struct-with-struct field assignment:
+  ok
+test passing the outer struct to a function:
+ b == { 2.71828, { 3.14159, [1 2 3 4 5], [0 1 2] } }
+test passing the inner struct to a function:
+ b.a == { 3.14159, [1 2 3 4 5], [0 1 2] }
+test sub-structure assignment:
+ after b.a=aparam, b.a= == { 1, [10 11 12 13 14], [3 4 5] }
+

--- a/testsuite/struct-within-struct/run.py
+++ b/testsuite/struct-within-struct/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ "test.oso" ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/struct-within-struct/test.osl
+++ b/testsuite/struct-within-struct/test.osl
@@ -1,0 +1,99 @@
+//
+// Test structs containing other structs
+//
+
+
+
+// struct declaration in global scope
+struct Astruct {
+    float f;
+    int i[5];
+    point p;
+};
+
+
+struct Bstruct {
+    float x;
+    Astruct a;
+};
+
+
+
+void test_output_param (output float fout)
+{
+    fout = 310.5;
+}
+
+
+float func_with_struct_param (Astruct ap)
+{
+    return ap.f * 2;
+}
+
+
+
+void func_with_struct_output_param (output Astruct ap)
+{
+    ap.i[1] *= 14;
+}
+
+
+
+void printA (string name, Astruct a)
+{
+    printf ("%s == { %g, [%i], [%g] }\n", name,
+            a.f, a.i, a.p);
+}
+
+
+
+void printB (string name, Bstruct b)
+{
+    printf ("%s == { %g, { %g, [%i], [%g] } }\n", name,
+            b.x, b.a.f, b.a.i, b.a.p);
+}
+
+
+
+shader
+test (
+    Astruct aparam = { 1.0, {10,11,12,13,14}, point(3,4,5) }
+)
+{
+    printf ("test struct within struct\n\n");
+
+    // Make sure it came in ok as a param
+//    printA ("aparam", aparam);
+
+    // Make some structs
+    Astruct a;
+    Bstruct b;
+
+    b.x = M_E;
+
+    // Field assignment and access
+    printf ("test struct-with-struct field assignment:\n");
+    b.a.f = M_PI;
+    if (b.a.f == M_PI)
+        printf ("  ok\n");
+    else
+        printf ("  fail\n");
+    b.a.i[0] = 1;
+    b.a.i[1] = 2;
+    b.a.i[2] = 3;
+    b.a.i[3] = 4;
+    b.a.i[4] = 5;
+    b.a.p = point (0, 1, 2);
+
+    printf ("test passing the outer struct to a function:\n");
+    printB (" b", b); // also tests param passing a struct containing a struct
+
+    printf ("test passing the inner struct to a function:\n");
+    printA (" b.a", b.a);
+    
+
+    // Structure assignment
+    printf ("test sub-structure assignment:\n");
+    b.a = aparam;
+    printA (" after b.a=aparam, b.a=", b.a);
+}


### PR DESCRIPTION
Turns out that lots of things were broken for structs that contain other structs as members.  I had to do a bunch of refactoring to shore this up.  Now we can assign structs to one another (even if they contain other structs), access inner struct components (e.g., a.b.c = foo), and pass both the "outer" (a) and "inner" (a.b) stucts as parameters to functions.

I don't have an easy way to explain the changes, other than to say simply that various places that had to do something to every field in a struct -> now have to recurse if one of those fields is itself a struct.  And the rest was refactoring to allow this to happen, for example, what could be just a loop before now has to be a separate function that optionally recurses.
