### PR TITLE
Fix arrays of structs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,7 +132,8 @@ TESTSUITE ( arithmetic array array-derivs
             ieee_fp if incdec initops intbits layers layers-lazy
             logic loop matrix message miscmath missing-shader noise pnoise
             oslc-err-paramdefault raytype shortcircuit spline string 
-            struct struct-err struct-layers struct-with-array 
+            struct struct-array struct-array-mixture
+            struct-err struct-layers struct-with-array 
             struct-within-struct ternary
             texture-alpha texture-blur texture-field3d
             texture-firstchannel texture-interp texture-simple

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -149,6 +149,11 @@ public:
     /// is not responsible for freeing the characters.
     const char *c_str () const;
 
+    /// Stream output
+    friend std::ostream& operator<< (std::ostream& o, const TypeSpec& t) {
+        return (o << t.string());
+    }
+
     /// Assignment of a simple TypeDesc to a full TypeSpec.
     ///
     const TypeSpec & operator= (const TypeDesc simple) {
@@ -180,6 +185,10 @@ public:
     /// it's an array of structs.  N.B. You can find out which struct
     /// with structure().
     bool is_structure () const { return m_structure > 0 && !is_array(); }
+
+    /// Is this typespec an array of structures?
+    ///
+    bool is_structure_array () const { return m_structure > 0 && is_array(); }
 
     /// Return the structure ID of this typespec, or 0 if it's not a
     /// struct.

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -438,7 +438,7 @@ private:
     // Add individual symbols for each field of a structure, using the
     // given basename.
     void add_struct_fields (StructSpec *structspec, ustring basename,
-                            SymType symtype);
+                            SymType symtype, int arraylen);
 
     ustring m_name;     ///< Name of the symbol (unmangled)
     Symbol *m_sym;      ///< Ptr to the symbol this declares
@@ -504,16 +504,10 @@ public:
 class ASTindex : public ASTNode
 {
 public:
-    ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index)
-        : ASTNode (index_node, comp, 0, expr, index)
-    { }
-    ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index, ASTNode *index2)
-        : ASTNode (index_node, comp, 0, expr, index, index2)
-    { }
+    ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index);
+    ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index, ASTNode *index2);
     ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index,
-              ASTNode *index2, ASTNode *index3)
-        : ASTNode (index_node, comp, 0, expr, index, index2, index3)
-    { }
+              ASTNode *index2, ASTNode *index3);
     const char *nodetypename () const { return "index"; }
     const char *childname (size_t i) const;
     TypeSpec typecheck (TypeSpec expected = TypeSpec());
@@ -547,17 +541,26 @@ public:
     TypeSpec typecheck (TypeSpec expected);
     Symbol *codegen (Symbol *dest = NULL);
 
+    /// Special code generation of assignment of src to this structure
+    /// field.
+    void codegen_assign (Symbol *dest, Symbol *src);
+
     ref lvalue () const { return child (0); }
     ustring field () const { return m_field; }
-    ustring mangledfield () const { return m_mangledfield; }
-    Symbol *mangledsym () const { return m_mangledsym; }
+    ustring fieldname () const { return m_fieldname; }
+    Symbol *fieldsym () const { return m_fieldsym; }
 
 private:
+    Symbol *find_fieldsym (int &structid, int &fieldid);
+    static void find_structsym (ASTNode *structnode, ustring &structname,
+                                 TypeSpec &structtype);
+    Symbol *codegen_index ();
+
     ustring m_field;         ///< Name of the field
     int m_structid;          ///< index of the structure
     int m_fieldid;           ///< index of the field within the structure
-    ustring m_mangledfield;  ///< Mangled name of the field variable
-    Symbol *m_mangledsym;    ///< Symbol of the field variable
+    ustring m_fieldname;     ///< Name of the field variable
+    Symbol *m_fieldsym;      ///< Symbol of the field variable
 };
 
 

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -55,22 +55,14 @@ TypeSpec::string () const
     std::string str;
     if (is_closure())
         str += "closure color";
-    else if (is_structure())
+    else if (structure() > 0) {
         str += Strutil::format ("struct %d", structure());
-    else {
-        // Substitute some special names
-        if (m_simple == TypeDesc::TypeColor)
-            str += "color";
-        else if (m_simple == TypeDesc::TypePoint)
-            str += "point";
-        else if (m_simple == TypeDesc::TypeVector)
-            str += "vector";
-        else if (m_simple == TypeDesc::TypeNormal)
-            str += "normal";
-        else if (m_simple == TypeDesc::TypeMatrix)
-            str += "matrix";
-        else
-            str += simpletype().c_str();
+        if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
+        else if (arraylength() < 0)
+            str += "[]";
+    } else {
+        str += simpletype().c_str();
     }
     return str;
 }

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -318,7 +318,7 @@ TypeSpec
 ASTstructselect::typecheck (TypeSpec expected)
 {
     // The ctr already figured out if this was a valid structure selection
-    if (m_fieldid < 0 || m_mangledsym == NULL) {
+    if (m_fieldid < 0 || m_fieldsym == NULL) {
         return TypeSpec();
     }
 

--- a/testsuite/struct-array-mixture/ref/out.txt
+++ b/testsuite/struct-array-mixture/ref/out.txt
@@ -1,0 +1,23 @@
+Compiled test.osl -> test.oso
+Using a D directly in main:
+d.c.bs[0].a.i = 0
+d.c.bs[1].a.i = 1
+d.c.bs[2].a.i = 2
+d.c.bs[3].a.i = 3
+d.c.bs[4].a.i = 4
+
+passing a ref to a D:
+d.c.bs[0].a.i = 0
+d.c.bs[1].a.i = 2
+d.c.bs[2].a.i = 4
+d.c.bs[3].a.i = 6
+d.c.bs[4].a.i = 8
+
+passing a ref to a C:
+c.bs[0].a.i = 0
+c.bs[1].a.i = 3
+c.bs[2].a.i = 6
+c.bs[3].a.i = 9
+c.bs[4].a.i = 12
+
+

--- a/testsuite/struct-array-mixture/run.py
+++ b/testsuite/struct-array-mixture/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ "test.oso" ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/struct-array-mixture/test.osl
+++ b/testsuite/struct-array-mixture/test.osl
@@ -1,0 +1,73 @@
+struct A { int i; };
+struct B { A a; };
+struct C { B bs[5]; };
+struct D { C c; };
+
+        
+//float foo (structA result) {
+//    printf ("x is %g\n", result.x);
+//    return result.x;
+//}
+
+void Atest (A a, int multiplier)
+{
+    printf ("passing a ref to a A:\n");
+    a.i = multiplier;
+    printf ("a.i = %d\n", a.i);
+    printf ("\n");
+}
+
+
+
+void Btest (B b, int multiplier)
+{
+    printf ("passing a ref to a B:\n");
+    b.a.i = multiplier;
+    printf ("b.a.i = %d\n", b.a.i);
+    printf ("\n");
+}
+
+
+
+void Ctest (C c, int multiplier)
+{
+    printf ("passing a ref to a C:\n");
+    for (int i = 0;  i < 5;  ++i)
+        c.bs[i].a.i = i*multiplier;
+    for (int i = 0;  i < 5;  ++i)
+        printf ("c.bs[%d].a.i = %d\n", i, c.bs[i].a.i);
+    printf ("\n");
+}
+
+
+
+void Dtest (D d, int multiplier)
+{
+    printf ("passing a ref to a D:\n");
+    for (int i = 0;  i < 5;  ++i)
+        d.c.bs[i].a.i = i*multiplier;
+    for (int i = 0;  i < 5;  ++i)
+        printf ("d.c.bs[%d].a.i = %d\n", i, d.c.bs[i].a.i);
+    printf ("\n");
+}
+
+
+
+shader test ()
+{
+    D d;
+
+    printf ("Using a D directly in main:\n");
+    for (int i = 0;  i < 5;  ++i)
+        d.c.bs[i].a.i = i*1;
+    for (int i = 0;  i < 5;  ++i)
+        printf ("d.c.bs[%d].a.i = %d\n", i, d.c.bs[i].a.i);
+    printf ("\n");
+
+    Dtest (d, 2);
+    Ctest (d.c, 3);
+
+// FIXME -- needs work!  these still don't work properly
+//    Btest (d.c.b[1], 4);
+//    Atest (d.c.b[2].a, 5);
+}

--- a/testsuite/struct-array/ref/out.txt
+++ b/testsuite/struct-array/ref/out.txt
@@ -1,0 +1,8 @@
+Compiled test.osl -> test.oso
+test arrays of struct
+
+float f; f = a[2].f;  ==> 15
+float g = a[2].f;  ==> 15
+test struct containing array of struct:
+b.a[1].f == 3.14159
+

--- a/testsuite/struct-array/run.py
+++ b/testsuite/struct-array/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ "test.oso" ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/struct-array/test.osl
+++ b/testsuite/struct-array/test.osl
@@ -1,0 +1,39 @@
+//
+// Test structs containing other structs
+//
+
+
+
+struct Astruct {
+    float f;
+    point p;
+};
+
+
+struct Bstruct {
+    Astruct a[5];
+};
+
+
+shader
+test (
+//    Astruct aparam = { 1.0, point(1,2,3) }
+)
+{
+    printf ("test arrays of struct\n\n");
+
+    Astruct a[5];
+    a[2].f = 15;
+
+    float f;
+    f = a[2].f;
+    printf ("float f; f = a[2].f;  ==> %g\n", f);
+
+    float g = a[2].f;
+    printf ("float g = a[2].f;  ==> %g\n", g);
+
+    printf ("test struct containing array of struct:\n");
+    Bstruct b;
+    b.a[1].f = M_PI;
+    printf ("b.a[1].f == %g\n", b.a[1].f);
+}

--- a/testsuite/struct-within-struct/test.osl
+++ b/testsuite/struct-within-struct/test.osl
@@ -18,6 +18,12 @@ struct Bstruct {
 };
 
 
+struct Cstruct {
+    float x;
+    Astruct aarray[5];   // array of structs within a struct
+};
+
+
 
 void test_output_param (output float fout)
 {
@@ -62,9 +68,6 @@ test (
 {
     printf ("test struct within struct\n\n");
 
-    // Make sure it came in ok as a param
-//    printA ("aparam", aparam);
-
     // Make some structs
     Astruct a;
     Bstruct b;
@@ -91,7 +94,6 @@ test (
     printf ("test passing the inner struct to a function:\n");
     printA (" b.a", b.a);
     
-
     // Structure assignment
     printf ("test sub-structure assignment:\n");
     b.a = aparam;


### PR DESCRIPTION
At long last, I think I've got a stable set of fixes for oslc to properly compile arrays of structs, including structs that contain arrays of other structs.

Apologies, I don't really expect anybody to understand this -- not because it's stupid, but it's merely esoteric beyond belief to anybody not the author of oslc.  But it passes all old tests, plus adds a couple new, very challenging tests.  An example of something that was previously broken, but now works just fine is:

  struct A { int i; };
  struct B { A a; };
  struct C { B bs[5]; };
  struct D { C c; };

  D d;
  d.c.bs[1].a.i = 3;

Caveat: it's still not good at handling a nesting that involves more than one level of arrayness (for example, if the definition of struct B above was "struct B {A a[5];};", in addition to a C also having an array of B's.  But let me tackle that obscure case later.
