### PR TITLE
Review: better dict_find return codes

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -63,7 +63,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
  \bigskip \\
 }
-\date{{\large Date: 14 March, 2011 \\
+\date{{\large Date: 10 May, 2011 \\
 %(with corrections, 7 January, 2011)
 }}
 
@@ -4716,7 +4716,9 @@ int {\ce dict_find} (int nodeID, string query)}
 
     The return value is a \emph{Node ID}, an opaque integer identifier
     that is the handle of a node within the dictionary data.  The value
-    0 is reserved to mean ``not found.''  If more than one node within
+    0 is reserved to mean ``query not found'' and the value -1 indicates
+    that the dictionary was not a valid syntax (or, if a file, could not
+    be read).  If more than one node within
     the dictionary matched the query, the node ID of the first match is
     returned, and {\cf dict_next()} may be used to step to the next
     matching node.

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -186,13 +186,14 @@ Dictionary::get_document_index (ustring dictionaryname)
             m_shadingsys.error ("XML parsed with errors: %s, at offset %d",
                                 parse_result.description(),
                                 parse_result.offset);
-            return 0;
+            m_document_map[dictionaryname] = -1;
+            return -1;
         }
     } else {
         dindex = dm->second;
     }
 
-    DASSERT (dindex >= 0 && dindex < (int)m_documents.size());
+    DASSERT (dindex < (int)m_documents.size());
     return dindex;
 }
 
@@ -202,6 +203,8 @@ int
 Dictionary::dict_find (ustring dictionaryname, ustring query)
 {
     int dindex = get_document_index (dictionaryname);
+    if (dindex < 0)
+        return dindex;
     ASSERT (dindex >= 0 && dindex < (int)m_documents.size());
 
     Query q (dindex, 0, query);

--- a/testsuite/xml/ref/out.txt
+++ b/testsuite/xml/ref/out.txt
@@ -9,15 +9,8 @@ Found camera 'right_cam':
     channel: 'color'
     channel: 'bump'
 
-Found camera 'main_cam':
-    two sides?  1
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 10.000 1.000 ]
-    channel: 'color'
-Found camera 'right_cam':
-    two sides?  0
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
-    channel: 'color'
-    channel: 'bump'
+testing dictionary error: dict_find("noexist.xml","foo") = -1
+
 
 Found camera 'main_cam':
     two sides?  1
@@ -29,6 +22,9 @@ Found camera 'right_cam':
     channel: 'color'
     channel: 'bump'
 
+testing dictionary error: dict_find("noexist.xml","foo") = -1
+
+
 Found camera 'main_cam':
     two sides?  1
     transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 10.000 1.000 ]
@@ -38,5 +34,21 @@ Found camera 'right_cam':
     transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
     channel: 'color'
     channel: 'bump'
+
+testing dictionary error: dict_find("noexist.xml","foo") = -1
+
+
+Found camera 'main_cam':
+    two sides?  1
+    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 10.000 1.000 ]
+    channel: 'color'
+Found camera 'right_cam':
+    two sides?  0
+    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
+    channel: 'color'
+    channel: 'bump'
+
+testing dictionary error: dict_find("noexist.xml","foo") = -1
+
 
 

--- a/testsuite/xml/test.osl
+++ b/testsuite/xml/test.osl
@@ -27,4 +27,8 @@ shader test (string xml = "test.xml")
         }
     }
     printf ("\n");
+
+    printf ("testing dictionary error: dict_find(\"noexist.xml\",\"foo\") = %d\n",
+            dict_find ("noexist.xml", "foo"));
+    printf ("\n\n");
 }


### PR DESCRIPTION
Make dict_find return -1 for invalid dictionary, to distinguish from 0 meaning that the query failed but on a valid dictionary.
