### PR TITLE
Review: Make array parameters safe to convert to constants

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ endmacro ()
 #TESTSUITE ( oslc-empty )
 TESTSUITE ( arithmetic array array-derivs
             blendmath bug-locallifetime cellnoise closure color comparison
+            const-array-params
             derivs error-dupes exponential
             function-simple function-outputelem
             geomath gettextureinfo hyperb

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -909,8 +909,8 @@ ASTindex::codegen_copy_struct_array_element (StructSpec *structspec,
             // struct within struct -- recurse!
             const char *fieldname = field.name.c_str();
             codegen_copy_struct_array_element (type.structspec(),
-                     ustring::format ("%s.%s", srcname.c_str(), fieldname),
                      ustring::format ("%s.%s", destname.c_str(), fieldname),
+                     ustring::format ("%s.%s", srcname.c_str(), fieldname),
                      index);
         } else {
             ASSERT (! type.is_array());

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1787,10 +1787,6 @@ RuntimeOptimizer::find_constant_params (ShaderGroup &group)
             s->symtype() == SymTypeParam && s->lockgeom() &&
             // and it's NOT a default val that needs to run init ops
             !(s->valuesource() == Symbol::DefaultVal && s->has_init_ops()) &&
-
-            !s->typespec().is_array() &&
-
-
             // and it not a structure or closure variable...
             !s->typespec().is_structure() && !s->typespec().is_closure_based())
         {

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -290,6 +290,14 @@ public:
                                   llvm::Value *arrayindex, int component,
                                   TypeDesc cast=TypeDesc::UNKNOWN);
 
+    /// Just like llvm_load_value, but when both the symbol and the
+    /// array index are known to be constants.  This can even handle
+    /// pulling constant-indexed elements out of constant arrays.  Use
+    /// arrayindex==-1 to indicate that it's not an array dereference.
+    llvm::Value *llvm_load_constant_value (const Symbol& sym,
+                                           int arrayindex, int component,
+                                           TypeDesc cast=TypeDesc::UNKNOWN);
+
     /// llvm_load_value with non-constant component designation.  Does
     /// not work with arrays or do type casts!
     llvm::Value *llvm_load_component_value (const Symbol& sym, int deriv,

--- a/testsuite/const-array-params/ref/out.txt
+++ b/testsuite/const-array-params/ref/out.txt
@@ -1,0 +1,11 @@
+Compiled test.osl -> test.oso
+static array reference (const index):
+  i[0] = 10, s[0] = foo0
+  i[1] = 11, s[1] = bar1
+  i[2] = 12, s[2] = baz2
+
+dynamic array reference (variable index in a loop):
+  i[0] = 10, s[0] = foo0
+  i[1] = 11, s[1] = bar1
+  i[2] = 12, s[2] = baz2
+

--- a/testsuite/const-array-params/run.py
+++ b/testsuite/const-array-params/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade -O2 test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/const-array-params/test.osl
+++ b/testsuite/const-array-params/test.osl
@@ -1,0 +1,13 @@
+shader test (int i[3] = { 10, 11, 12 },
+             string s[3] = { "foo0", "bar1", "baz2" })
+{
+    printf ("static array reference (const index):\n");
+    printf ("  i[0] = %d, s[0] = %s\n", i[0], s[0]);
+    printf ("  i[1] = %d, s[1] = %s\n", i[1], s[1]);
+    printf ("  i[2] = %d, s[2] = %s\n", i[2], s[2]);
+
+    printf ("\ndynamic array reference (variable index in a loop):\n");
+    for (int j = 0;  j < 3;  ++j) {
+        printf ("  i[%d] = %d, s[%d] = %s\n", j, i[j], j, s[j]);
+    }
+}


### PR DESCRIPTION
I had a report a week ago about a case where we were crashing in our llvm-generating code, specific to certain array parameters where values were known at runtime, things going awry when it attempted to turn it into a true constant.

I inadvertently fixed it (!) in my last commit, by accidentally including the "! s->typespec().is_array()" clause in find_constant_params (circa line 1790 of runtimeoptimize.cpp) -- in fact, if you look at the weird spacing, it's clear that it was just something I was testing and didn't intend to commit.  An accident from my looking at two bugs at once and not fully backing out some tests in progress.

Anyway, the "fix" operated by preventing array parameters from being coerced into constants (in cases where their values were fully known at runtime), thus avoiding some other code that wasn't properly set up to handle arrays.  But by doing so, it also prevented some handy optimizations where we turned the values into true constants.

The attached patch restores the process of turning known-value array parameters into true array constants, and fixes up all the little bits where that went wrong, a cascade of errors.  The new code is now very good at optimizing references to array parameters of known (at runtime) value.  I added a testsuite entry to verify that it works.
