### PR TITLE
Support derivatives in pointcloud()

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -363,8 +363,8 @@ public:
     ///
     ///   For more insight look at llvm_gen_pointcloud in llvm_instance.cpp
     ///
-    virtual void *get_pointcloud_attr_query (ustring *attr_names,
-                                             TypeDesc *attr_types, int nattrs) = 0;
+    virtual void *get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
+                                             bool derivatives, int nattrs) = 0;
 
     /// Lookup nearest points in a point cloud. It will search for points
     /// around the given center within the specified radius. attr_outdata

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -98,8 +98,8 @@ SimpleRenderer::has_userdata (ustring name, TypeDesc type, void *renderstate)
 }
 
 void *
-SimpleRenderer::get_pointcloud_attr_query (ustring *attr_names,
-                                           TypeDesc *attr_types, int nattrs)
+SimpleRenderer::get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
+                                           bool derivatives, int nattrs)
 {
 #if 0
     // Example code of how to cache some useful query info to

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -67,8 +67,8 @@ public:
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type, 
                                void *renderstate, void *val);
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate);
-    virtual void *get_pointcloud_attr_query (ustring *attr_names,
-                                             TypeDesc *attr_types, int nattrs);
+    virtual void *get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
+                                             bool derivatives, int nattrs);
     virtual int  pointcloud (ustring filename, const OSL::Vec3 &center, float radius,
                              int max_points, void *attr_query, void **attr_outdata);
 


### PR DESCRIPTION
They only get computed for distances. We zero any other output params. This was requested so bump mapping on values filtered from the pointcloud's lookup distance works. Just delegates distance derivs on the renderer.
