### PR TITLE
Review: Fix struct containing an array of other structs

### DIFF
--- a/testsuite/struct-array-mixture/ref/out.txt
+++ b/testsuite/struct-array-mixture/ref/out.txt
@@ -8,10 +8,10 @@ d.c.bs[4].a.i = 4
 
 passing a ref to a D:
 d.c.bs[0].a.i = 0
-d.c.bs[1].a.i = 2
-d.c.bs[2].a.i = 4
-d.c.bs[3].a.i = 6
-d.c.bs[4].a.i = 8
+d.c.bs[1].a.i = 1
+d.c.bs[2].a.i = 2
+d.c.bs[3].a.i = 3
+d.c.bs[4].a.i = 4
 
 passing a ref to a C:
 c.bs[0].a.i = 0
@@ -29,5 +29,13 @@ bs[4].a.i = 16
 
 passing a ref to a B:
 b.a.i = 4
+
+Testing assignment of the whole nested structure:
+passing a ref to a D:
+d.c.bs[0].a.i = 0
+d.c.bs[1].a.i = 1
+d.c.bs[2].a.i = 2
+d.c.bs[3].a.i = 3
+d.c.bs[4].a.i = 4
 
 

--- a/testsuite/struct-array-mixture/test.osl
+++ b/testsuite/struct-array-mixture/test.osl
@@ -70,11 +70,17 @@ shader test ()
         printf ("d.c.bs[%d].a.i = %d\n", i, d.c.bs[i].a.i);
     printf ("\n");
 
-    Dtest (d, 2);
+    Dtest (d, 1);
     Ctest (d.c, 3);
     Barraytest (d.c.bs, 4);
     Btest (d.c.bs[1], 4);
 
 // FIXME -- needs work!  these still don't work properly
 //    Atest (d.c.bs[2].a, 5);
+
+    // Test assignment of the whole thing
+    printf ("Testing assignment of the whole nested structure:\n");
+    D d2;
+    d2 = d;
+    Dtest (d2, 1);
 }


### PR DESCRIPTION
Fix struct containing an array of other structs, it was not generating proper code for copying all the elements of one nested struct to another.
