### PR TITLE
Mark pointcloud output arguments

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -867,7 +867,9 @@ private:
         argread (arg, false);
         argwrite (arg, true);
     }
-
+    /// Declare optional arguments as outputs (write only) by this op.
+    ///
+    void mark_optional_output (int firstopt, const char **tags);
     /// Declare that argument number 'arg' takes derivatives.
     ///
     void argtakesderivs (int arg, bool val) {


### PR DESCRIPTION
This also reverts previous fix that was marking "center" as
always needing derivatives. With this other approach derivs
are taken only when needed.
