### PR TITLE
Review: Fix bad IR for mul/div

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,7 +127,7 @@ endmacro ()
 TESTSUITE ( arithmetic array array-derivs
             blendmath bug-locallifetime cellnoise closure color comparison
             const-array-params
-            derivs error-dupes exponential
+            derivs derivs-muldiv-clobber error-dupes exponential
             function-simple function-outputelem
             geomath gettextureinfo hyperb
             ieee_fp if incdec initops intbits layers layers-lazy

--- a/testsuite/derivs-muldiv-clobber/ref/out.txt
+++ b/testsuite/derivs-muldiv-clobber/ref/out.txt
@@ -1,0 +1,8 @@
+Compiled test.osl -> test.oso
+mul:
+  x  = 0.25, dx=1 dy=0
+  gx = 0.25, dx=1 dy=0
+div:
+  y  = 1, dx=0 dy=0
+  gy = 1, dx=0 dy=0
+

--- a/testsuite/derivs-muldiv-clobber/run.py
+++ b/testsuite/derivs-muldiv-clobber/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/derivs-muldiv-clobber/test.osl
+++ b/testsuite/derivs-muldiv-clobber/test.osl
@@ -1,0 +1,23 @@
+// Test for regression of a bug we had were mul and div could clobber
+// derivatives if the result went to the operand itself (like x=x*x).
+//
+// When the bug was present, x and gx would not have matching derivs!
+//
+
+shader test()
+{
+    float x = u;
+
+    float gx = x * x;
+    x = x* x;
+    printf ("mul:\n");
+    printf ("  x  = %g, dx=%g dy=%g\n", x, Dx(x), Dy(x));
+    printf ("  gx = %g, dx=%g dy=%g\n", gx, Dx(gx), Dy(gx));
+
+    float y = u;
+    float gy = y / y;
+    y = y / y;
+    printf ("div:\n");
+    printf ("  y  = %g, dx=%g dy=%g\n", y, Dx(y), Dy(y));
+    printf ("  gy = %g, dx=%g dy=%g\n", gy, Dx(gy), Dy(gy));
+}


### PR DESCRIPTION
Fix bad IR for mul/div -- used a load/store ordering that, for cases where the result was the same as one of the operands, would botch the derivatives.
