### PR TITLE
Review: Initialize local string variables

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -298,6 +298,12 @@ public:
         return m_simple == TypeDesc::TypeString && !is_closure();
     }
 
+    /// Is it a string or an array of strings?
+    ///
+    bool is_string_based () const {
+        return m_simple.basetype == TypeDesc::STRING;
+    }
+
     /// Is it a void?
     ///
     bool is_void () const {


### PR DESCRIPTION
Initialize local string variables to NULL when generating LLVM IR, so there aren't any bad pointers.
