### PR TITLE
Review: array of struct inside struct parameter passing buglet

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1705,7 +1705,7 @@ ASTfunction_call::struct_pair_all_fields (StructSpec *structspec,
     for (int fi = 0;  fi < (int)structspec->numfields();  ++fi) {
         const StructSpec::FieldSpec &field (structspec->field(fi));
         const TypeSpec &type (field.type);
-        if (type.is_structure()) {
+        if (type.is_structure() || type.is_structure_array()) {
             // struct within struct -- recurse!
             struct_pair_all_fields (type.structspec(),
                                     ustring::format ("%s.%s", formal.c_str(), field.name.c_str()),

--- a/testsuite/struct-array-mixture/ref/out.txt
+++ b/testsuite/struct-array-mixture/ref/out.txt
@@ -38,4 +38,7 @@ d.c.bs[2].a.i = 2
 d.c.bs[3].a.i = 3
 d.c.bs[4].a.i = 4
 
+Testing writing to the innermost struct through function call:
+  before: d.c.bs[0].a.i = 0
+  after:  d.c.bs[0].a.i = 42
 

--- a/testsuite/struct-array-mixture/test.osl
+++ b/testsuite/struct-array-mixture/test.osl
@@ -59,6 +59,13 @@ void Dtest (D d, int multiplier)
 
 
 
+void test_writing (output D d)
+{
+    d.c.bs[0].a.i = 42;
+}
+
+
+
 shader test ()
 {
     D d;
@@ -83,4 +90,10 @@ shader test ()
     D d2;
     d2 = d;
     Dtest (d2, 1);
+
+    printf ("Testing writing to the innermost struct through function call:\n");
+    d.c.bs[0].a.i = 0;
+    printf ("  before: d.c.bs[0].a.i = %d\n", d.c.bs[0].a.i);
+    test_writing (d);
+    printf ("  after:  d.c.bs[0].a.i = %d\n", d.c.bs[0].a.i);
 }


### PR DESCRIPTION
One more struct vs array of struct issue prevented user functions from properly writing output variables that were array elements inside nested structs.
