### PR TITLE
Review: dict_value was truncating floats to integers due to incorrect int cast

### DIFF
--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -381,7 +381,7 @@ Dictionary::dict_value (int nodeID, ustring attribname,
     if (type.basetype == TypeDesc::FLOAT) {
         r.valueoffset = (int) m_floatdata.size();
         for (int i = 0;  i < n;  ++i) {
-            float v = (int) strtod (val, (char **)&val);
+            float v = strtof (val, (char **)&val);
             while (isspace(*val) || *val == ',')
                 ++val;
             m_floatdata.push_back (v);

--- a/testsuite/xml/ref/out.txt
+++ b/testsuite/xml/ref/out.txt
@@ -5,7 +5,7 @@ Found camera 'main_cam':
     channel: 'color'
 Found camera 'right_cam':
     two sides?  0
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
+    transform matrix = [ 3.142 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.500 0.000 0.000 1.000 ]
     channel: 'color'
     channel: 'bump'
 
@@ -18,7 +18,7 @@ Found camera 'main_cam':
     channel: 'color'
 Found camera 'right_cam':
     two sides?  0
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
+    transform matrix = [ 3.142 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.500 0.000 0.000 1.000 ]
     channel: 'color'
     channel: 'bump'
 
@@ -31,7 +31,7 @@ Found camera 'main_cam':
     channel: 'color'
 Found camera 'right_cam':
     two sides?  0
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
+    transform matrix = [ 3.142 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.500 0.000 0.000 1.000 ]
     channel: 'color'
     channel: 'bump'
 
@@ -44,7 +44,7 @@ Found camera 'main_cam':
     channel: 'color'
 Found camera 'right_cam':
     two sides?  0
-    transform matrix = [ 1.000 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.000 0.000 0.000 1.000 ]
+    transform matrix = [ 3.142 0.000 0.000 0.000 0.000 1.000 0.000 0.000 0.000 0.000 1.000 0.000 -20.500 0.000 0.000 1.000 ]
     channel: 'color'
     channel: 'bump'
 

--- a/testsuite/xml/test.xml
+++ b/testsuite/xml/test.xml
@@ -10,7 +10,7 @@
 
  <camerapack name="second cam" twoSidesOn="0">
   <camera name="right_cam">
-   <xform matrix="1.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 -20.0 0.0 0.0 1.0"/>
+   <xform matrix="3.14159 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 1.0 0.0 -20.5 0.0 0.0 1.0"/>
    <lens bottom="-1.0" fovHorz="30" left="-1.0" right="1.0" top="1.0"/>
   </camera>
   <image channel="color" path="textures/view2.tif">


### PR DESCRIPTION
Duh, cut and paste error ended up with (int) cast incorrectly used in the decode of float-based dictionary entries.  Fix and modify the testsuite/xml to not have the float values all be whole numbers!
