### PR TITLE
Review: Range checking of array and component access.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,9 +124,9 @@ endmacro ()
 # List all the individual testsuite tests here, except those that need
 # special installed tests.
 #TESTSUITE ( oslc-empty )
-TESTSUITE ( arithmetic array array-derivs
+TESTSUITE ( arithmetic array array-derivs array-range
             blendmath bug-locallifetime cellnoise closure color comparison
-            const-array-params
+            component-range const-array-params
             derivs derivs-muldiv-clobber error-dupes exponential
             function-simple function-outputelem
             geomath gettextureinfo hyperb

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1541,7 +1541,7 @@ ASTfunction_call::codegen (Symbol *dest)
             const TypeSpec &ftype (f->sym()->typespec());
             // If the formal parameter is a struct, we also need to alias
             // each of the fields
-            if (ftype.is_structure()) {
+            if (ftype.is_structure() || ftype.is_structure_array()) {
                 if (a->nodetype() == variable_ref_node) {
                     // Passed a variable that is a struct ; make the struct
                     // fields of the formal param alias to the struct fields

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1094,10 +1094,9 @@ RuntimeOptimizer::llvm_load_component_value (const Symbol& sym, int deriv,
 
     TypeDesc t = sym.typespec().simpletype();
     ASSERT (t.aggregate != TypeDesc::SCALAR);
-    std::vector<llvm::Value *> indexes;
-    indexes.push_back(llvm_constant(0));
-    indexes.push_back(component);
-    result = builder().CreateGEP (result, indexes.begin(), indexes.end(), "compaccess");  // Find the component
+    // cast the Vec* to a float*
+    result = llvm_ptr_cast (result, llvm_type_float_ptr());
+    result = builder().CreateGEP (result, component);  // get the component
 
     // Now grab the value
     return builder().CreateLoad (result);
@@ -1153,9 +1152,9 @@ RuntimeOptimizer::llvm_store_component_value (llvm::Value* new_val,
 
     TypeDesc t = sym.typespec().simpletype();
     ASSERT (t.aggregate != TypeDesc::SCALAR);
-    // Find the component
-    llvm::Value *indexes[2] = { llvm_constant(0), component };
-    result = builder().CreateGEP (result, indexes, indexes+2, "compaccess");
+    // cast the Vec* to a float*
+    result = llvm_ptr_cast (result, llvm_type_float_ptr());
+    result = builder().CreateGEP (result, component);  // get the component
 
     // Finally, store the value.
     builder().CreateStore (new_val, result);
@@ -2186,13 +2185,23 @@ LLVMGEN (llvm_gen_compref)
     Symbol& Val = *rop.opargsym (op, 1);
     Symbol& Index = *rop.opargsym (op, 2);
 
+    llvm::Value *c = rop.llvm_load_value(Index);
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { c, rop.llvm_constant(3),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        c = rop.llvm_call_function ("osl_range_check", args, 5);
+        ASSERT (c);
+    }
+
     for (int d = 0;  d < 3;  ++d) {  // deriv
-        llvm::Value *val = NULL; 
-        // FIXME -- should we test for out-of-range component?
+        llvm::Value *val = NULL;
         if (Index.is_constant()) {
-            val = rop.llvm_load_value (Val, d, *((int*)Index.data()));
+            int i = *(int*)Index.data();
+            i = Imath::clamp (i, 0, 2);
+            val = rop.llvm_load_value (Val, d, i);
         } else {
-            llvm::Value *c = rop.llvm_load_value(Index, d);
             val = rop.llvm_load_component_value (Val, d, c);
         }
         rop.llvm_store_value (val, Result, d);
@@ -2212,13 +2221,22 @@ LLVMGEN (llvm_gen_compassign)
     Symbol& Index = *rop.opargsym (op, 1);
     Symbol& Val = *rop.opargsym (op, 2);
 
+    llvm::Value *c = rop.llvm_load_value(Index);
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { c, rop.llvm_constant(3),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        c = rop.llvm_call_function ("osl_range_check", args, 5);
+    }
+
     for (int d = 0;  d < 3;  ++d) {  // deriv
         llvm::Value *val = rop.llvm_load_value (Val, d, 0, TypeDesc::TypeFloat);
-        // FIXME -- should we test for out-of-range component?
         if (Index.is_constant()) {
-            rop.llvm_store_value (val, Result, d, *((int*)Index.data()));
+            int i = *(int*)Index.data();
+            i = Imath::clamp (i, 0, 2);
+            rop.llvm_store_value (val, Result, d, i);
         } else {
-            llvm::Value *c = rop.llvm_load_value(Index, d);
             rop.llvm_store_component_value (val, Result, d, c);
         }
         if (! Result.has_derivs())  // skip the derivs if we don't need them
@@ -2238,14 +2256,25 @@ LLVMGEN (llvm_gen_mxcompref)
     Symbol& Row = *rop.opargsym (op, 2);
     Symbol& Col = *rop.opargsym (op, 3);
 
+    llvm::Value *row = rop.llvm_load_value (Row);
+    llvm::Value *col = rop.llvm_load_value (Col);
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { row, rop.llvm_constant(4),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        row = rop.llvm_call_function ("osl_range_check", args, 5);
+        args[0] = col;
+        col = rop.llvm_call_function ("osl_range_check", args, 5);
+    }
+
     llvm::Value *val = NULL; 
-    // FIXME -- should we test for out-of-range component?
     if (Row.is_constant() && Col.is_constant()) {
-        int comp = 4 * ((int*)Row.data())[0] + ((int*)Col.data())[0];
+        int r = Imath::clamp (((int*)Row.data())[0], 0, 3);
+        int c = Imath::clamp (((int*)Col.data())[0], 0, 3);
+        int comp = 4 * r + c;
         val = rop.llvm_load_value (M, 0, comp);
     } else {
-        llvm::Value *row = rop.llvm_load_value (Row);
-        llvm::Value *col = rop.llvm_load_value (Col);
         llvm::Value *comp = rop.builder().CreateMul (row, rop.llvm_constant(4));
         comp = rop.builder().CreateAdd (comp, col);
         val = rop.llvm_load_component_value (M, 0, comp);
@@ -2267,15 +2296,26 @@ LLVMGEN (llvm_gen_mxcompassign)
     Symbol& Col = *rop.opargsym (op, 2);
     Symbol& Val = *rop.opargsym (op, 3);
 
+    llvm::Value *row = rop.llvm_load_value (Row);
+    llvm::Value *col = rop.llvm_load_value (Col);
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { row, rop.llvm_constant(4),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        row = rop.llvm_call_function ("osl_range_check", args, 5);
+        args[0] = col;
+        col = rop.llvm_call_function ("osl_range_check", args, 5);
+    }
+
     llvm::Value *val = rop.llvm_load_value (Val, 0, 0, TypeDesc::TypeFloat);
 
-    // FIXME -- should we test for out-of-range component?
     if (Row.is_constant() && Col.is_constant()) {
-        int comp = 4 * ((int*)Row.data())[0] + ((int*)Col.data())[0];
+        int r = Imath::clamp (((int*)Row.data())[0], 0, 3);
+        int c = Imath::clamp (((int*)Col.data())[0], 0, 3);
+        int comp = 4 * r + c;
         rop.llvm_store_value (val, Result, 0, comp);
     } else {
-        llvm::Value *row = rop.llvm_load_value(Row);
-        llvm::Value *col = rop.llvm_load_value(Col);
         llvm::Value *comp = rop.builder().CreateMul (row, rop.llvm_constant(4));
         comp = rop.builder().CreateAdd (comp, col);
         rop.llvm_store_component_value (val, Result, 0, comp);
@@ -2312,8 +2352,14 @@ LLVMGEN (llvm_gen_aref)
     llvm::Value *index = rop.loadLLVMValue (Index);
     if (! index)
         return false;
-    // FIXME -- do range detection here for constant indices
-    // Or should we always do range detection for safety?
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { index,
+                                 rop.llvm_constant(Src.typespec().arraylength()),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        index = rop.llvm_call_function ("osl_range_check", args, 5);
+    }
 
     int num_components = Src.typespec().simpletype().aggregate;
     for (int d = 0;  d <= 2;  ++d) {
@@ -2342,8 +2388,14 @@ LLVMGEN (llvm_gen_aassign)
     llvm::Value *index = rop.loadLLVMValue (Index);
     if (! index)
         return false;
-    // FIXME -- do range detection here for constant indices
-    // Or should we always do range detection for safety?
+    if (rop.shadingsys().range_checking()) {
+        llvm::Value *args[5] = { index,
+                                 rop.llvm_constant(Result.typespec().arraylength()),
+                                 rop.sg_void_ptr(),
+                                 rop.llvm_constant(op.sourcefile()),
+                                 rop.llvm_constant(op.sourceline()) };
+        index = rop.llvm_call_function ("osl_range_check", args, 5);
+    }
 
     int num_components = Result.typespec().simpletype().aggregate;
     for (int d = 0;  d <= 2;  ++d) {

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1860,3 +1860,22 @@ osl_bind_interpolated_param (void *sg_, const void *name, long long type,
     return renderer->get_userdata (has_derivs, USTR(name), TYPEDESC(type),
                                    sg->renderstate, result);
 }
+
+
+
+OSL_SHADEOP int
+osl_range_check (int indexvalue, int length,
+                 void *sg, const void *sourcefile, int sourceline)
+{
+    if (indexvalue < 0 || indexvalue >= length) {
+        ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
+        ctx->shadingsys().error ("Index [%d] out of range [0..%d]: %s:%d",
+                                 indexvalue, length-1,
+                                 USTR(sourcefile).c_str(), sourceline);
+        if (indexvalue >= length)
+            indexvalue = length-1;
+        else
+            indexvalue = 0;
+    }
+    return indexvalue;
+}

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -669,6 +669,7 @@ public:
     bool debug_nan () const { return m_debugnan; }
     bool lockgeom_default () const { return m_lockgeom_default; }
     bool strict_messages() const { return m_strict_messages; }
+    bool range_checking() const { return m_range_checking; }
     int optimize () const { return m_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
 
@@ -767,6 +768,7 @@ private:
     bool m_debugnan;                      ///< Root out NaN's?
     bool m_lockgeom_default;              ///< Default value of lockgeom
     bool m_strict_messages;               ///< Strict checking of message passing usage?
+    bool m_range_checking;                ///< Range check arrays & components?
     int m_optimize;                       ///< Runtime optimization level
     int m_llvm_debug;                     ///< More LLVM debugging output
     std::string m_searchpath;             ///< Shader search path

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1088,7 +1088,15 @@ DECLFOLDER(constfold_aref)
         TypeSpec elemtype = A.typespec().elementtype();
         ASSERT (equivalent(elemtype, R.typespec()));
         int index = *(int *)Index.data();
-        DASSERT (index < A.typespec().arraylength());
+        if (index < 0 || index >= A.typespec().arraylength()) {
+            // We are indexing a const array out of range.  But this
+            // isn't necessarily a reportable error, because it may be a
+            // code path that will never be taken.  Punt -- don't
+            // optimize this op, leave it to the execute-time range
+            // check to catch, if indeed it is a problem.
+            return 0;
+        }
+        ASSERT (index < A.typespec().arraylength());
         int cind = rop.add_constant (elemtype,
                         (char *)A.data() + index*elemtype.simpletype().size());
         rop.turn_into_assign (op, cind);
@@ -1113,39 +1121,41 @@ DECLFOLDER(constfold_compassign)
     // Component assignment
     Opcode &op (rop.inst()->ops()[opnum]);
     // Symbol *A (rop.inst()->argsymbol(op.firstarg()+0));
-    Symbol *I (rop.inst()->argsymbol(op.firstarg()+1));
-    Symbol *C (rop.inst()->argsymbol(op.firstarg()+2));
+    // We are obviously not assigning to a constant, but it could be
+    // that at this point in our current block, the value of A is known,
+    // and that will show up as a block alias.
     int Aalias = rop.block_alias (rop.inst()->arg(op.firstarg()+0));
     Symbol *AA = rop.inst()->symbol(Aalias);
+    Symbol *I (rop.inst()->argsymbol(op.firstarg()+1));
+    Symbol *C (rop.inst()->argsymbol(op.firstarg()+2));
     // N.B. symbol returns NULL if Aalias is < 0
 
+    // Try to turn A[I]=C into nop if A[I] already is C
+    // The optimization we are making here is that if the current (at
+    // this point in this block) value of A is known (revealed by A's
+    // block alias, AA, being a constant), and we are assigning the same
+    // value it already has, then this is a nop.
     if (I->is_constant() && C->is_constant() && AA && AA->is_constant()) {
-        // Try to turn A[I]=C into nop if A[I] already is C
-        if (AA->typespec().is_int() && C->typespec().is_int()) {
-            int *aa = (int *)AA->data();
-            int i = *(int *)I->data();
-            int c = *(int *)C->data();
-            if (aa[i] == c) {
-                rop.turn_into_nop (op);
-                return 1;
-            }
-        } else if (AA->typespec().is_float() && C->typespec().is_float()) {
-            float *aa = (float *)AA->data();
-            int i = *(int *)I->data();
-            float c = *(float *)C->data();
-            if (aa[i] == c) {
-                rop.turn_into_nop (op);
-                return 1;
-            }
-        } else if (AA->typespec().is_triple() && C->typespec().is_triple()) {
-            Vec3 *aa = (Vec3 *)AA->data();
-            int i = *(int *)I->data();
-            Vec3 c = *(Vec3 *)C->data();
-            if (aa[i] == c) {
-                rop.turn_into_nop (op);
-                return 1;
-            }
+        ASSERT (AA->typespec().is_triple() &&
+                (C->typespec().is_float() || C->typespec().is_int()));
+        int index = *(int *)I->data();
+        if (index < 0 || index >= 3) {
+            // We are indexing a const triple out of range.  But this
+            // isn't necessarily a reportable error, because it may be a
+            // code path that will never be taken.  Punt -- don't
+            // optimize this op, leave it to the execute-time range
+            // check to catch, if indeed it is a problem.
+            return 0;
         }
+        float *aa = (float *)AA->data();
+        float c = C->typespec().is_int() ? *(int *)C->data()
+                                         : *(float *)C->data();
+        if (aa[index] == c) {
+            rop.turn_into_nop (op);
+            return 1;
+        }
+        // FIXME -- we can take this one step further, by giving A a new
+        // alias that is the modified constant.
     }
     return 0;
 }
@@ -1162,6 +1172,14 @@ DECLFOLDER(constfold_compref)
     if (A.is_constant() && Index.is_constant()) {
         ASSERT (A.typespec().is_triple() && Index.typespec().is_int());
         int index = *(int *)Index.data();
+        if (index < 0 || index >= 3) {
+            // We are indexing a const triple out of range.  But this
+            // isn't necessarily a reportable error, because it may be a
+            // code path that will never be taken.  Punt -- don't
+            // optimize this op, leave it to the execute-time range
+            // check to catch, if indeed it is a problem.
+            return 0;
+        }
         int cind = rop.add_constant (TypeDesc::TypeFloat, (float *)A.data() + index);
         rop.turn_into_assign (op, cind);
         return 1;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -139,7 +139,9 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_statslevel (0), m_debug (false), m_lazylayers (true),
       m_lazyglobals (false),
       m_clearmemory (false), m_rebind (false), m_debugnan (false),
-      m_lockgeom_default (false), m_strict_messages(true), m_optimize (1),
+      m_lockgeom_default (false), m_strict_messages(true),
+      m_range_checking(true),
+      m_optimize (1),
       m_llvm_debug(false),
       m_commonspace_synonym("world"),
       m_in_group (false),
@@ -311,6 +313,10 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
         m_strict_messages = *(const int *)val;
         return true;
     }
+    if (name == "range_checking" && type == TypeDesc::INT) {
+        m_range_checking = *(const int *)val;
+        return true;
+    }
     if (name == "commonspace" && type == TypeDesc::STRING) {
         m_commonspace_synonym = ustring (*(const char **)val);
         return true;
@@ -354,6 +360,7 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("optimize", int, m_optimize);
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
+    ATTR_DECODE ("range_checking", int, m_range_checking);
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);
     ATTR_DECODE ("stat:instances", int, m_stat_groupinstances);

--- a/testsuite/array-range/ref/out.txt
+++ b/testsuite/array-range/ref/out.txt
@@ -1,0 +1,20 @@
+Compiled test.osl -> test.oso
+constant index:
+ reading:
+  array[1] = 1
+ERROR: Index [10] out of range [0..4]: test.osl:8
+  array[10] = 4
+ writing:
+ERROR: Index [10] out of range [0..4]: test.osl:10
+variable index:
+ reading:
+  array[0] = 0
+  array[1] = 1
+  array[2] = 2
+  array[3] = 3
+  array[4] = 42
+ERROR: Index [5] out of range [0..4]: test.osl:15
+  array[5] = 42
+ writing:
+ERROR: Index [5] out of range [0..4]: test.osl:19
+

--- a/testsuite/array-range/run.py
+++ b/testsuite/array-range/run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out1.txt"
+command = command + "; " + path + "testshade/testshade test >& out2.txt"
+command = command + "; cat out1.txt out2.txt > out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/array-range/test.osl
+++ b/testsuite/array-range/test.osl
@@ -1,0 +1,21 @@
+shader test ()
+{
+    int array[5] = { 0, 1, 2, 3, 4 };
+
+    printf ("constant index:\n");
+    printf (" reading:\n");
+    printf ("  array[1] = %d\n", array[1]);
+    printf ("  array[10] = %d\n", array[10]);
+    printf (" writing:\n");
+    array[10] = 42;
+
+    printf ("variable index:\n");
+    printf (" reading:\n");
+    for (int i = 0;  i < 6;  ++i) {
+        printf ("  array[%d] = %d\n", i, array[i]);
+    }
+    printf (" writing:\n");
+    for (int i = 0;  i < 6;  ++i) {
+        array[i] = 84;
+    }
+}

--- a/testsuite/component-range/ref/out.txt
+++ b/testsuite/component-range/ref/out.txt
@@ -1,0 +1,18 @@
+Compiled test.osl -> test.oso
+constant index:
+ reading:
+  V[1] = 1
+ERROR: Index [10] out of range [0..2]: test.osl:8
+  V[10] = 2
+ writing:
+ERROR: Index [10] out of range [0..2]: test.osl:10
+variable index:
+ reading:
+  V[0] = 0
+  V[1] = 1
+  V[2] = 42
+ERROR: Index [3] out of range [0..2]: test.osl:15
+  V[3] = 42
+ writing:
+ERROR: Index [3] out of range [0..2]: test.osl:19
+

--- a/testsuite/component-range/run.py
+++ b/testsuite/component-range/run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out1.txt"
+command = command + "; " + path + "testshade/testshade test >& out2.txt"
+command = command + "; cat out1.txt out2.txt > out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/component-range/test.osl
+++ b/testsuite/component-range/test.osl
@@ -1,0 +1,21 @@
+shader test ()
+{
+    vector V = vector(0,1,2);
+
+    printf ("constant index:\n");
+    printf (" reading:\n");
+    printf ("  V[1] = %g\n", V[1]);
+    printf ("  V[10] = %g\n", V[10]);
+    printf (" writing:\n");
+    V[10] = 42;
+
+    printf ("variable index:\n");
+    printf (" reading:\n");
+    for (int i = 0;  i < 4;  ++i) {
+        printf ("  V[%d] = %g\n", i, V[i]);
+    }
+    printf (" writing:\n");
+    for (int i = 0;  i < 4;  ++i) {
+        V[i] = 84;
+    }
+}

--- a/testsuite/struct-array-mixture/test.osl
+++ b/testsuite/struct-array-mixture/test.osl
@@ -4,30 +4,49 @@ struct C { B bs[5]; };
 struct D { C c; };
 
         
-void Atest (A a, int multiplier)
+void Awrite (A a, int multiplier)
 {
     printf ("passing a ref to a A:\n");
     a.i = multiplier;
+}
+
+
+
+void Aprint (A a)
+{
     printf ("a.i = %d\n", a.i);
     printf ("\n");
 }
 
 
 
-void Btest (B b, int multiplier)
+void Bwrite (B b, int multiplier)
 {
     printf ("passing a ref to a B:\n");
     b.a.i = multiplier;
+}
+
+
+
+void Bprint (B b)
+{
     printf ("b.a.i = %d\n", b.a.i);
     printf ("\n");
 }
 
 
-void Barraytest (B bs[], int multiplier)
+
+void Barraywrite (B bs[], int multiplier)
 {
     printf ("passing a ref to a B[]:\n");
     for (int i = 0;  i < 5;  ++i)
         bs[i].a.i = i*multiplier;
+}
+
+
+
+void Barrayprint (B bs[])
+{
     for (int i = 0;  i < 5;  ++i)
         printf ("bs[%d].a.i = %d\n", i, bs[i].a.i);
     printf ("\n");
@@ -35,11 +54,17 @@ void Barraytest (B bs[], int multiplier)
 
 
 
-void Ctest (C c, int multiplier)
+void Cwrite (C c, int multiplier)
 {
     printf ("passing a ref to a C:\n");
     for (int i = 0;  i < 5;  ++i)
         c.bs[i].a.i = i*multiplier;
+}
+
+
+
+void Cprint (C c)
+{
     for (int i = 0;  i < 5;  ++i)
         printf ("c.bs[%d].a.i = %d\n", i, c.bs[i].a.i);
     printf ("\n");
@@ -47,11 +72,17 @@ void Ctest (C c, int multiplier)
 
 
 
-void Dtest (D d, int multiplier)
+void Dwrite (D d, int multiplier)
 {
     printf ("passing a ref to a D:\n");
     for (int i = 0;  i < 5;  ++i)
         d.c.bs[i].a.i = i*multiplier;
+}
+
+
+
+void Dprint (D d)
+{
     for (int i = 0;  i < 5;  ++i)
         printf ("d.c.bs[%d].a.i = %d\n", i, d.c.bs[i].a.i);
     printf ("\n");
@@ -77,19 +108,25 @@ shader test ()
         printf ("d.c.bs[%d].a.i = %d\n", i, d.c.bs[i].a.i);
     printf ("\n");
 
-    Dtest (d, 1);
-    Ctest (d.c, 3);
-    Barraytest (d.c.bs, 4);
-    Btest (d.c.bs[1], 4);
+    Dwrite (d, 1);
+    Dprint (d);
+    Cwrite (d.c, 3);
+    Cprint (d.c);
+    Barraywrite (d.c.bs, 4);
+    Barrayprint (d.c.bs);
+    Bwrite (d.c.bs[1], 4);
+    Bprint (d.c.bs[1]);
 
 // FIXME -- needs work!  these still don't work properly
-//    Atest (d.c.bs[2].a, 5);
+//    Awrite (d.c.bs[2].a, 5);
+//    Aprint (d.c.bs[2].a);
 
     // Test assignment of the whole thing
     printf ("Testing assignment of the whole nested structure:\n");
     D d2;
     d2 = d;
-    Dtest (d2, 1);
+    Dwrite (d2, 1);
+    Dprint (d2);
 
     printf ("Testing writing to the innermost struct through function call:\n");
     d.c.bs[0].a.i = 0;


### PR DESCRIPTION
This patch fully implements array and component access range checking.  We used to have this for the old interpreted OSL, but lost the range checking in the switch to LLVM JIT.  Here we:
1. Add range-checking code while generating IR (it should get optimized away when the index values are known to be in range).  This applies to triple and matrix components as well as arrays.
2. Add a "range_checking" option to the ShadingSystem, defaulting to true, but giving the option to turn off range checking code if they really need the extra performance (I doubt it will be measurable in a typical shader, but somebody let me know if they actually find it helpful to turn off for production runs).
3. Fixed some longstanding bugs in runtimeoptimize.cpp where we had DASSERT's for cases where array or component access appeared out of range when doing constant folding.  But this was wrong!  It could be examining ops in conditional branches which would never be taken, so it's wrong to assert or issue error messages at this stage.  An out of range index is only an error if actually executed.  But you still need to be careful for the optimizer itself not to access an array out of range, which it would do before while constant folding constant_triple[constant_index] if the index was out of range.
4. Once I had range checking working, I immediately got range errors in the old struct-array-mixture test, which it turns out was due to a bug in codegen.cpp where it wasn't recursing properly for struct arrays when making aliases between the formal and actual parameters.  I also restructured the struct-array-mixture test itself to more starkly reveal problems like this, by separating the setting and printing of the struct array members into separate functions, to reveal any issues wherein the values were incorrectly modifying only local copies of the parameters rather than the referred outer scope variables (which is what was indirectly happening).
