### PR TITLE
Remove constant constraint for pointcloud attrs

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -343,43 +343,26 @@ public:
                                    ustring dataname, TypeDesc datatype,
                                    void *data);
 
-    /// Get a handle to a query object. A query is a list of attribute names
-    /// given in the attr_names array, and their corresponding types given in
-    /// attr_types. The returned handle will be valid until RendererServices
-    /// is destroyed and can be used to perform queries with the pointcloud
-    /// method below.
-    ///
-    /// Be aware this is a function we never call during the render. It is
-    /// not used from the shader. LLVM gen code calls it once for each specific
-    /// pointcloud call it finds in the code. That provides a handle that is
-    /// used as a constant in the shader throughout the rest of the render. It
-    /// never changes since a pointcloud call has always the same type profile
-    /// for the returned data in that specific line of code.
-    ///
-    /// So the renderer can cache and optimize any possible things associated
-    /// with this call and link it to the handle. From that point, the shader
-    /// will always use it when calling pointcloud. Even if the renderer
-    /// doesn't optimize anything, we already save some arguments.
-    ///
-    ///   For more insight look at llvm_gen_pointcloud in llvm_instance.cpp
-    ///
-    virtual void *get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
-                                             bool derivatives, int nattrs) = 0;
 
     /// Lookup nearest points in a point cloud. It will search for points
-    /// around the given center within the specified radius. attr_outdata
-    /// is an array of pointers to arrays of elements of the appropiate type.
-    /// Its length has to be the same as the number of attributes passed
-    /// when the query object was created with get_pointcloud_attr_query, and
-    /// the type of the referenced data arrays has to match the types of the
-    /// query object too. Those arrays will be filled with the found points
-    /// up to max_points. So they have to be allocated with enough space.
+    /// around the given center within the specified radius. A list of indices
+    /// is returned so the programmer can later retrieve attributes with
+    /// pointcloud_get. The indices array is mandatory, but distances can be NULL.
+    /// If a derivs_offset > 0 is given, derivatives will be computed for
+    /// distances (when provided).
     ///
-    /// attr_query is a special handle created by get_pointcloud_attr_query
-    /// When we find a call to pointcloud in the shader we get one of those
-    /// handlers and then compile this call with it in attr_query as a constant
-    virtual int pointcloud (ustring filename, const OSL::Vec3 &center, float radius,
-                            int max_points, void *attr_query, void **attr_outdata) = 0;
+    /// Return the number of points found, always < max_points
+    virtual int pointcloud_search (ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, size_t *out_indices,
+                                   float *out_distances, int derivs_offset) = 0;
+
+    /// Retrieve an attribute for an index list. The result is another array
+    /// of the requested type stored in out_data.
+    ///
+    /// Return 1 if the attribute is found, 0 otherwise.
+    virtual int pointcloud_get (ustring filename, size_t *indices, int count,
+                                ustring attr_name, TypeDesc attr_type,
+                                void *out_data) = 0;
 
     /// Options for the trace call.
     struct TraceOpt {

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -895,6 +895,8 @@ ASTfunction_call::typecheck_builtin_specialcase ()
                    m_name == "gettextureinfo" || m_name == "dict_value") {
             // these all write to their last argument
             argwriteonly ((int)listlength(args()));
+        } else if (m_name == "pointcloud_get") {
+            argwriteonly (5);
         } else if (m_name == "pointcloud_search") {
             mark_optional_output(5, pointcloud_out_args);
         } else if (func()->texture_args()) {
@@ -1082,6 +1084,7 @@ static const char * builtin_func_args [] = {
     "noise", NOISE_ARGS, NULL,
     "pnoise", PNOISE_ARGS, NULL,
     "pointcloud_search", "ispfi.", "!rw", NULL,
+    "pointcloud_get", "isi[]is?[]", "!rw", NULL,
     "printf", "xs*", "!printf", NULL,
     "psnoise", PNOISE_ARGS, NULL,
     "random", "f", "c", "p", "v", "n", NULL,

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1879,3 +1879,5 @@ osl_range_check (int indexvalue, int length,
     }
     return indexvalue;
 }
+
+

--- a/src/liboslexec/opcloud.cpp
+++ b/src/liboslexec/opcloud.cpp
@@ -29,23 +29,45 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "oslops.h"
 #include "oslexec_pvt.h"
 
-#define USTR(cstr) (*((ustring *)&cstr))
+inline ustring USTR(const char *cstr) { return (*((const ustring *)&cstr)); }
+inline TypeDesc TYPEDESC(long long x) { return (*(const TypeDesc *)&x); }
 
 OSL_SHADEOP int
-osl_pointcloud (ShaderGlobals *sg, const char *_filename, void *_center, float radius,
-                int max_points, void *attr_query, int nattrs, ...)
+osl_pointcloud_search (ShaderGlobals *sg, const char *filename, void *center, float radius,
+                       int max_points, void *out_indices, void *out_distances, int derivs_offset,
+                       int nattrs, ...)
 {
-    const ustring &filename (USTR(_filename));
-    Vec3 *center = (Vec3 *)_center;
+    size_t *indices = (size_t *)alloca (sizeof(size_t) * max_points);
 
-    // Convert the list of arguments to a void * array to call
-    // render services
-    void **attr_outdata = (void **)alloca (sizeof(void *) * nattrs);
+    int count = sg->context->renderer()->pointcloud_search (USTR(filename), *((Vec3 *)center), radius, max_points,
+                                                            indices, (float *)out_distances, derivs_offset);
     va_list args;
     va_start (args, nattrs);
-    for (int i = 0; i < nattrs; ++i)
-        attr_outdata[i] = va_arg (args, void*);
+    for (int i = 0; i < nattrs; i += 3)
+    {
+        ustring  attr_name = USTR (va_arg (args, const char *));
+        TypeDesc attr_type = TYPEDESC (va_arg (args, long long));
+        void     *out_data = va_arg (args, void*);
+        sg->context->renderer()->pointcloud_get (USTR(filename), indices, count, attr_name, attr_type, out_data);
+    }
     va_end (args);
 
-    return sg->context->renderer()->pointcloud (filename, *center, radius, max_points, attr_query, attr_outdata);
+    if (out_indices)
+        for(int i = 0; i < count; ++i)
+            ((int *)out_indices)[i] = indices[i];
+    return count;
 }
+
+OSL_SHADEOP int
+osl_pointcloud_get (ShaderGlobals *sg, const char *filename, void *in_indices, int count,
+                    const char *attr_name, long long attr_type, void *out_data)
+{
+    size_t *indices = (size_t *)alloca (sizeof(size_t) * count);
+
+    for(int i = 0; i < count; ++i)
+        indices[i] = ((int *)in_indices)[i];
+
+    return sg->context->renderer()->pointcloud_get (USTR(filename), (size_t *)indices, count, USTR(attr_name),
+                                                    TYPEDESC(attr_type), out_data);
+}
+

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -97,123 +97,20 @@ SimpleRenderer::has_userdata (ustring name, TypeDesc type, void *renderstate)
     return false;
 }
 
-void *
-SimpleRenderer::get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
-                                           bool derivatives, int nattrs)
+int
+SimpleRenderer::pointcloud_search (ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, size_t *out_indices,
+                                   float *out_distances, int derivs_offset)
 {
-#if 0
-    // Example code of how to cache some useful query info to
-    // save time quering Partio for pointclouds
-
-    m_attr_queries.push_back(AttrQuery());
-    AttrQuery &query = m_attr_queries.back();
-    // Make space for what we need. The only reason to use
-    // std::vector is to skip the delete
-    query.attr_names.resize(nattrs);
-    query.attr_partio_types.resize(nattrs);
-    // capacity will keep the length of the smallest array passed
-    // to the query. Just to prevent buffer overruns
-    query.capacity = -1;
-
-    for (int i = 0; i < nattrs; ++i)
-    {
-        query.attr_names[i] = attr_names[i];
-        TypeDesc element_type = attr_types[i].elementtype ();
-        if (query.capacity < 0)
-           query.capacity = attr_types[i].numelements();
-        else
-           query.capacity = MIN(query.capacity, (int)attr_types[i].numelements());
-
-        // Convert the OSL (OIIO) type to the equivalent Partio type so
-        // we can do a fast check at query time.
-        if (element_type == TypeDesc::TypeFloat)
-           query.attr_partio_types[i] = Partio::FLOAT;
-        else if (element_type == TypeDesc::TypeInt)
-           query.attr_partio_types[i] = Partio::INT;
-        else if (element_type == TypeDesc::TypeColor  || element_type == TypeDesc::TypePoint ||
-                 element_type == TypeDesc::TypeVector || element_type == TypeDesc::TypeNormal)
-           query.attr_partio_types[i] = Partio::VECTOR;
-        else
-        {
-            // Report some error of unknown type
-            return NULL;
-        }
-    }
-    // This is valid until the end of RenderServices
-    return &query;
-#else
-    return NULL;
-#endif
+    return 0;
 }
 
 int
-SimpleRenderer::pointcloud (ustring filename, const OSL::Vec3 &center, float radius,
-                            int max_points, void *_attr_query, void **attr_outdata)
+SimpleRenderer::pointcloud_get (ustring filename, size_t *indices, int count,
+                                ustring attr_name, TypeDesc attr_type,
+                                void *out_data)
 {
-#if 0
-    // Example code of how to query Partio for this pointcloud lookup
-    // using some cached that in attr_query
-
-    if (!_attr_query)
-        return 0;
-    AttrQuery *attr_query = (AttrQuery *)_attr_query;
-    if (attr_query->capacity < max_points)
-        return 0;
-
-    // Get the pointcloud entry for the given filename
-    Partio::ParticleData * cloud = get_pointcloud(filename);
-
-    // Now we have to look up all the attributes in the file. We can't do this
-    // before hand cause we never know what we are going to load.
-    int nattrs = attr_query->attr_names.size();
-    Partio::ParticleAttribute **attr = (Partio::ParticleAttribute **)alloca (sizeof(Partio::ParticleAttribute *) * nattrs );
-    for (int i = 0; i < nattrs; ++i)
-    {
-        // Special case attributes
-        if (attr_query->attr_names[i] == u_distance || attr_query->attr_names[i] == u_index)
-            continue;
-        // lookup the ParticleAttribute pointer, left unimplemented ...
-        attr[i] = partio_attr_by_name(cloud, attr_query->attr_names[i]);
-        if (attr[i]->type != attr_query->attr_partio_types[i])
-        {
-            // Issue an error here and return, types don't match
-        }
-    }
-
-    std::vector<Partio::ParticleIndex *> indices;
-    std::vector<float>                   dist2;
-
-    // Finally, do the lookup
-    entry->cloud->findNPoints((const float *)&center, max_points, radius, indices, dist2);
-    int count = indices.size();
-
-    // Retrieve the attributes directly to user space.
-    for (int j = 0; j < nattrs; ++j)
-    {
-        // special cases
-        if (attr_query->attr_names[j] == u_distance)
-        {
-           for (int i = 0; i < count; ++i)
-              ((float *)attr_outdata[j])[i] = sqrtf(dist2[i]);
-        }
-        else if (attr_query->attr_names[j] == u_index)
-        {
-           for (int i = 0; i < count; ++i)
-              ((int *)attr_outdata[j])[i] = indices[i];
-        }
-        else if (attr[j])
-        {
-           // Note we make a single call per attribute, we don't loop over the
-           // points. Partio does it, so it is there that we have to care about
-           // performance
-
-           entry->cloud->data (*attr[j], count, &indices[0], true /* What is this sorted flag? */, attr_outdata[j]);
-        }
-    }
-    return count;
-#else
     return 0;
-#endif
 }
 
 };  // namespace OSL

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -67,42 +67,19 @@ public:
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type, 
                                void *renderstate, void *val);
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate);
-    virtual void *get_pointcloud_attr_query (ustring *attr_names, TypeDesc *attr_types,
-                                             bool derivatives, int nattrs);
-    virtual int  pointcloud (ustring filename, const OSL::Vec3 &center, float radius,
-                             int max_points, void *attr_query, void **attr_outdata);
+
+    virtual int pointcloud_search (ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, size_t *out_indices,
+                                   float *out_distances, int derivs_offset);
+
+    virtual int pointcloud_get (ustring filename, size_t *indices, int count,
+                                ustring attr_name, TypeDesc attr_type,
+                                void *out_data);
 
 private:
     typedef std::map <ustring, shared_ptr<Transformation> > TransformMap;
     TransformMap m_named_xforms;
 
-#if 0
-    // Example cached data for pointcloud implementation with Partio
-
-    // OSL gets pointers to this but its definition is private.
-    // Right now it only caches the types already converted to
-    // Partio constants. This is what get_pointcloud_attr_query
-    // returns
-    struct AttrQuery
-    {
-        // Names of the attributes to query
-        std::vector<ustring> attr_names;
-        // Types as (enum Partio::ParticleAttributeType) of the
-        // attributes in the query
-        std::vector<int>     attr_partio_types;
-        // For sanity checks, capacity of the output arrays
-        int                  capacity;
-    };
-
-    // We will left this function as an exercise. It is only responsible
-    // for loading the point cloud if it is not already in memory and so
-    // on. You might or might not use Partio cache system
-    Partio::ParticleData *get_pointcloud (ustring filename);
-
-    // Keep a list so adding elements doesn't invalidate pointers.
-    // Careful, don't use a vector here!
-    std::list<AttrQuery> m_attr_queries;
-#endif
 };
 
 


### PR DESCRIPTION
The previous implementation required that the strings
used to name attributes were constant at JIT time. This
patch removes that constraint and also simplifies the code
by splitting the render services call in two:
- pointcloud_search -> just return the indices of the query
- pointcloud_get -> retrieve a single attribute

No need to precompute query objects anymore.
