### PR TITLE
Review: getattribute speedups

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -222,6 +222,7 @@ struct ShaderGlobals {
                                           details like userdata) */
     void* tracedata;                 /**< Opaque pointer to renderer state
                                           resuling from a trace() call. */
+    void* objdata;                   /**< Opaque pointer to object data */
     pvt::ShadingContext* context;    /**< ShadingContext (this will be set by
                                           OSL itself) */
     TransformationPtr object2common; /**< Object->common xform */

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -509,8 +509,9 @@ RuntimeOptimizer::llvm_type_sg ()
     sg_types.push_back (llvm_type_triple());  // dPdtime
     sg_types.push_back (triple_deriv);        // Ps
 
-    sg_types.push_back(llvm_type_void_ptr()); // opaque render state*
-    sg_types.push_back(llvm_type_void_ptr()); // opaque trace data*
+    sg_types.push_back(llvm_type_void_ptr()); // opaque renderstate*
+    sg_types.push_back(llvm_type_void_ptr()); // opaque tracedata*
+    sg_types.push_back(llvm_type_void_ptr()); // opaque objdata*
     sg_types.push_back(llvm_type_void_ptr()); // ShadingContext*
     sg_types.push_back(llvm_type_void_ptr()); // object2common
     sg_types.push_back(llvm_type_void_ptr()); // shader2common
@@ -675,7 +676,7 @@ ShaderGlobalNameToIndex (ustring name)
         Strings::P, Strings::I, Strings::N, Strings::Ng,
         Strings::u, Strings::v, Strings::dPdu, Strings::dPdv,
         Strings::time, Strings::dtime, Strings::dPdtime, Strings::Ps,
-        ustring("renderstate"), ustring("tracedata"),
+        ustring("renderstate"), ustring("tracedata"), ustring("objdata"),
         ustring("shadingcontext"),
         ustring("object2common"), ustring("shader2common"),
         Strings::Ci,

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1721,6 +1721,7 @@ osl_trace (void *sg_, void *opt_, void *Pos_, void *dPosdx_, void *dPosdy_,
 
 
 
+#if 1
 OSL_SHADEOP int osl_get_attribute(void *sg_,
                              int   dest_derivs,
                              void *obj_name_,
@@ -1734,8 +1735,16 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
     const ustring &obj_name  = USTR(obj_name_);
     const ustring &attr_name = USTR(attr_name_);
 
+#if 1
+    return sg->context->osl_get_attribute (sg->renderstate, sg->objdata,
+                                           dest_derivs, obj_name, attr_name,
+                                           array_lookup, index,
+                                           *(const TypeDesc *)attr_type,
+                                           attr_dest);
+#else
     if (array_lookup)
         return sg->context->renderer()->get_array_attribute(sg->renderstate,  
+                                                  sg->objdata,
                                                   dest_derivs,
                                                   obj_name,
                                                   *(TypeDesc *)attr_type,
@@ -1744,12 +1753,16 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
                                                   attr_dest);
     else
         return sg->context->renderer()->get_attribute(sg->renderstate,  
+                                                  sg->objdata,
                                                   dest_derivs,
                                                   obj_name,
                                                   *(TypeDesc *)attr_type,
                                                   attr_name,
                                                   attr_dest);
+#endif
 }
+#endif
+
 
 inline Vec3 calculatenormal(void *P_, bool flipHandedness)
 {

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -169,3 +169,39 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
         messages.add(name, NULL, type, layeridx, sourcefile, sourceline);
     return 0;
 }
+
+
+
+#if 0
+OSL_SHADEOP int
+osl_get_attribute (ShaderGlobals *sg,
+                   int   dest_derivs,
+                   const char *obj_name_,
+                   const char *attr_name_,
+                   int   array_lookup,
+                   int   index,
+                   const void *attr_type,
+                   void *attr_dest)
+{
+    const ustring &obj_name  = USTR(obj_name_);
+    const ustring &attr_name = USTR(attr_name_);
+    bool ok;
+    if (array_lookup)
+        ok = sg->context->renderer()->get_array_attribute (sg->renderstate,
+                                                           dest_derivs,
+                                                           obj_name,
+                                                           *(TypeDesc *)attr_type,
+                                                           attr_name,
+                                                           index,
+                                                           attr_dest);
+    else
+        ok = sg->context->renderer()->get_attribute (sg->renderstate,
+                                                     dest_derivs,
+                                                     obj_name,
+                                                     *(TypeDesc *)attr_type,
+                                                     attr_name,
+                                                     attr_dest);
+    return ok;
+}
+#endif
+

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -171,6 +171,9 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_total_syms = 0;
     m_stat_syms_with_derivs = 0;
     m_stat_optimization_time = 0;
+    m_stat_getattribute_time = 0;
+    m_stat_getattribute_fail_time = 0;
+    m_stat_getattribute_calls = 0;
 
     init_global_heap_offsets ();
 
@@ -543,7 +546,12 @@ ShadingSystemImpl::getstats (int level) const
     }
 
     out << "  Regex's compiled: " << m_stat_regexes << "\n";
-
+    if (m_stat_getattribute_calls) {
+        out << "  getattribute calls: " << m_stat_getattribute_calls << " ("
+            << Strutil::timeintervalformat (m_stat_getattribute_time, 2) << ")\n";
+        out << "     (fail time "
+            << Strutil::timeintervalformat (m_stat_getattribute_fail_time, 2) << ")\n";
+    }
     out << "  Memory total: " << m_stat_memory.memstat() << '\n';
     out << "    Master memory: " << m_stat_mem_master.memstat() << '\n';
     out << "        Master ops:            " << m_stat_mem_master_ops.memstat() << '\n';


### PR DESCRIPTION
getattribute refactor: measure how much time we spend making getattribute calls, and have the ShadingContext maintain a small cache of failed getattribute queries so that subsequent identical queries can fail very quickly without searching many places for the data that are known not to exist.  Along the way, we add an opaque object pointer to the ShaderGlobals (needed for the cache, but also anticipated to be useful for other things down the road).  

On some production test scenes, this appears to reduce by 75% the amount of time it searches for getattribute calls that are destined to fail (a couple percent of runtime, for our getattribute-happy shader library).  I still don't recommend littering your shaders with tons of getattribute calls, but this patch addresses much of the easy-to-avoid waste.
