### PR TITLE
Review: Fix CreateICmpSGE error in pointcloud IR generation

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -3928,7 +3928,7 @@ LLVMGEN (llvm_gen_pointcloud_search)
     // Compare capacity to the requested number of points. The available
     // space on the arrays is a constant, the requested number of
     // points is not, so runtime check.
-    llvm::Value *sizeok = rop.builder().CreateICmpSGE (rop.llvm_constant(capacity), args[4]); // max_points
+    llvm::Value *sizeok = rop.builder().CreateICmpSGE (rop.llvm_constant((int)capacity), args[4]); // max_points
 
     llvm::BasicBlock* sizeok_block = rop.llvm_new_basic_block ("then");
     llvm::BasicBlock* badsize_block = rop.llvm_new_basic_block ("else");


### PR DESCRIPTION
Fix CreateICmpSGE which was incorrectly comparing 32 and 64 bit quantities and hitting an LLVM assertion
