### PR TITLE
Review: Fixes to constant folding of gettextureinfo

### DIFF
--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -104,8 +104,11 @@ RendererServices::texture (ustring filename, TextureOpt &options,
     if (!status)
     {
         std::string err = texturesys()->geterror();
-        if (err.size())
+        if (err.size()) {
             std::cerr << "[RendererServices::texture] " << err.c_str();
+            if (err[err.size()-1] != '\n')
+                std::cerr << "\n";
+        }
     }
     return status;
 }
@@ -124,8 +127,11 @@ RendererServices::texture3d (ustring filename, TextureOpt &options,
     if (!status)
     {
         std::string err = texturesys()->geterror();
-        if (err.size())
+        if (err.size()) {
             std::cerr << "[RendererServices::texture3d] " << err.c_str();
+            if (err[err.size()-1] != '\n')
+                std::cerr << "\n";
+        }
     }
     return status;
 #else
@@ -144,8 +150,11 @@ RendererServices::environment (ustring filename, TextureOpt &options,
     bool status = texturesys()->environment (filename, options, R, dRdx, dRdy, result);
     if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size())
+        if (err.size()) {
             std::cerr << "[RendererServices::environment] " << err.c_str();
+            if (err[err.size()-1] != '\n')
+                std::cerr << "\n";
+        }
     }
     return status;
 #else
@@ -166,11 +175,13 @@ RendererServices::get_texture_info (ustring filename, int subimage,
 #else
     bool status = texturesys()->get_texture_info (filename, dataname, datatype, data);
 #endif
-    if (!status)
-    {
+    if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size())
+        if (err.size()) {
             std::cerr << "[RendererServices::get_texture_info] " << err.c_str();
+            if (err[err.size()-1] != '\n')
+                std::cerr << "\n";
+        }
     }
     return status;
 }

--- a/testsuite/gettextureinfo/ref/out.txt
+++ b/testsuite/gettextureinfo/ref/out.txt
@@ -1,30 +1,47 @@
-Compiled test.osl -> test.oso
+Executing...
 ../common/textures/grid.tx resolution: 1024 1024 (1)
 ../common/textures/grid.tx channels: 4 (1)
 ../common/textures/grid.tx texturetype: Plain Texture (1)
 ../common/textures/grid.tx textureformat: Plain Texture (1)
 ../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
 ../common/textures/grid.tx foobar: not found (0)
+[RendererServices::get_texture_info] Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
+Invalid image file "badfile"
 badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+Executing...
 ../common/textures/grid.tx resolution: 1024 1024 (1)
 ../common/textures/grid.tx channels: 4 (1)
 ../common/textures/grid.tx texturetype: Plain Texture (1)
 ../common/textures/grid.tx textureformat: Plain Texture (1)
 ../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
 ../common/textures/grid.tx foobar: not found (0)
+[RendererServices::get_texture_info] Invalid image file "badfile"
 badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+Executing...
 ../common/textures/grid.tx resolution: 1024 1024 (1)
 ../common/textures/grid.tx channels: 4 (1)
 ../common/textures/grid.tx texturetype: Plain Texture (1)
 ../common/textures/grid.tx textureformat: Plain Texture (1)
 ../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
 ../common/textures/grid.tx foobar: not found (0)
+[RendererServices::get_texture_info] Invalid image file "badfile"
 badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+Executing...
 ../common/textures/grid.tx resolution: 1024 1024 (1)
 ../common/textures/grid.tx channels: 4 (1)
 ../common/textures/grid.tx texturetype: Plain Texture (1)
 ../common/textures/grid.tx textureformat: Plain Texture (1)
 ../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
 ../common/textures/grid.tx foobar: not found (0)
+[RendererServices::get_texture_info] Invalid image file "badfile"
 badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
 

--- a/testsuite/gettextureinfo/run.py
+++ b/testsuite/gettextureinfo/run.py
@@ -11,7 +11,7 @@ if len(sys.argv) > 2 :
 
 # A command to run
 command = path + "oslc/oslc test.osl > out.txt"
-command = command + "; " + path + "testshade/testshade -g 2 2 test >> out.txt"
+command = command + "; " + path + "testshade/testshade -g 2 2 -O2 test >& out.txt"
 
 # Outputs to check against references
 outputs = [ "out.txt" ]

--- a/testsuite/gettextureinfo/test.osl
+++ b/testsuite/gettextureinfo/test.osl
@@ -3,6 +3,7 @@
 shader
 test (string filename = "../common/textures/grid.tx")
 {
+    printf ("Executing...\n");
     int r;
 
     int resolution[2];
@@ -36,4 +37,30 @@ test (string filename = "../common/textures/grid.tx")
     string badfile = "badfile";
     r = gettextureinfo (badfile, "textureformat", data);
     printf ("%s data: %s (%d)\n", badfile, data, r);
+
+    // Make a query of a bad file inside a conditional -- the idea is that
+    // we should NOT see an error message if the statement is not executed.
+    if (u > 2) {
+        string data = "not found";
+        string badfile = "badfile2";
+        r = gettextureinfo (badfile, "textureformat", data);
+        printf ("%s data: %s (%d)\n", badfile, data, r);
+    }
+
+    // Test existence of a valid file
+    {
+        int e;
+        r = gettextureinfo (filename, "exists", e);
+        printf ("%s exists? %d (return %d)\n", filename, e, r);
+    }
+
+    // Test existence of a monexistant file
+    {
+        int e;
+        string badfile = "badfile3";
+        r = gettextureinfo (badfile, "exists", e);
+        printf ("%s exists? %d (return %d)\n", badfile, e, r);
+    }
+
+
 }


### PR DESCRIPTION
Fixes to constant folding of gettextureinfo: a failed gettextureinfo should NOT fold, because we want its error to happen in shader execution, not during optimization, especially if the instruction was in a branch that will never be executed and therefore will be a confusing spurious error.  Beef up testsuite/gettextureinfo to test this.  Also alter renderservices default (for testshade) to print texture errors more nicely with linefeeds if not already supplied.
