### PR TITLE
Review: Fixes necessary for liboslexec to be called by a DSO plugins to other apps

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -216,7 +216,7 @@ typedef bool (*OpLLVMGen) (LLVMGEN_ARGS);
     "osl_" #name "_dfdffff",  "xXXfff",         \
     "osl_" #name "_dffdfff",  "xXfXff",         \
     "osl_" #name "_dfdfdfff", "xXXXff",         \
-    "osl_" #name "_dfdvdv",   "xXvv",           \
+    "osl_" #name "_dfdvv",    "xXXv",           \
     "osl_" #name "_dfdvfvf",  "xXvfvf",         \
     "osl_" #name "_dfvdfvf",  "xXvXvf",         \
     "osl_" #name "_dfdvdfvf", "xXvXvf",         \

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -1,5 +1,25 @@
+# The 'testshade' executable
 SET ( testshade_srcs testshade.cpp simplerend.cpp )
-ADD_EXECUTABLE ( testshade ${testshade_srcs} )
+ADD_EXECUTABLE ( testshade ${testshade_srcs} testshademain.cpp )
 LINK_ILMBASE ( testshade )
 TARGET_LINK_LIBRARIES ( testshade oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 INSTALL ( TARGETS testshade RUNTIME DESTINATION bin )
+
+# The 'libtestshade' dynamic library
+add_library ("libtestshade" SHARED ${testshade_srcs})
+target_link_libraries (libtestshade oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} )
+set_target_properties (libtestshade PROPERTIES PREFIX "")
+install (TARGETS libtestshade
+#         RUNTIME DESTINATION "${BINDIR}" COMPONENT user
+         LIBRARY DESTINATION lib 
+#COMPONENT user
+#         ARCHIVE DESTINATION "${LIBDIR}" COMPONENT developer
+)
+
+# The 'testshade_dso' executable
+ADD_EXECUTABLE ( testshade_dso testshade_dso.cpp )
+LINK_ILMBASE ( testshade_dso )
+TARGET_LINK_LIBRARIES ( testshade_dso ${OPENIMAGEIO_LIBRARY} ${CMAKE_DL_LIBS} )
+#oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+INSTALL ( TARGETS testshade_dso RUNTIME DESTINATION bin )
+

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <cmath>
+#include <dlfcn.h>
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
@@ -195,8 +196,8 @@ getargs (int argc, const char *argv[])
 
 
 
-int
-main (int argc, const char *argv[])
+extern "C" int
+test_shade (int argc, const char *argv[])
 {
     // Create a new shading system.
     Timer timer;

--- a/src/testshade/testshade_dso.cpp
+++ b/src/testshade/testshade_dso.cpp
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2009-2011 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <cstdlib>
+#include <dlfcn.h>
+
+#include <OpenImageIO/plugin.h>
+using namespace OIIO_NAMESPACE;
+
+
+typedef int (*EntryPoint)(int argc, const char *argv[]);
+
+
+
+int
+main (int argc, const char *argv[])
+{
+#ifdef __linux__
+    // On Linux, if an app loads a plugin (DSO/DLL) using dlopen without
+    // passing RTLD_GLOBAL as the mode, and that plugin accesses OSL (by
+    // linking against liboslexec), it turns out that LLVM can fail in
+    // finding symbols when it does its dlsym to resolve functions in
+    // the app called by the IR.  Since we can't control the app
+    // (Houdini and Maya, I'm talking to you!), we compensate by asking
+    // to dlopen it here, the "right" way, and then later on, LLVM will
+    // be able to find the symbols.  I haven't can't seem to reproduce
+    // this issue on OS X, so for now we only do this on Linux.
+    //
+    // This would not be necessary if we didn't specifically disallow
+    // RTLD_GLOBAL in the Plugin::open call below, but we are purposely
+    // disallowing global symbol visibility in order to test this
+    // solution.
+    //
+    // Note also that in the real world, you'd need to be really sure
+    // that the file you dlopen'ed is the name "our" .so file -- beware
+    // renaming.
+    dlopen ("liboslexec.so", RTLD_LAZY | RTLD_GLOBAL);
+#endif
+
+
+    std::string pluginname = std::string("libtestshade.") 
+                             + Plugin::plugin_extension();
+#if OPENIMAGEIO_VERSION >= 1000 /* 0.10.0 */
+    Plugin::Handle handle = Plugin::open (pluginname, 
+                                          false /* NOT RTLD_GLOBAL! */);
+#else
+    Plugin::Handle handle = Plugin::open (pluginname);
+#endif
+    if (! handle) {
+        std::cerr << "Could not open " << pluginname << "\n";
+        exit (1);
+    }
+
+    EntryPoint entry = (EntryPoint) Plugin::getsym (handle, "test_shade");
+    if (! entry) {
+        std::cerr << "Cound not find test_shade symbol\n";
+        exit (1);
+    }
+
+    int r = entry (argc, argv);
+
+    Plugin::close (handle);
+    return r;
+}
+

--- a/src/testshade/testshademain.cpp
+++ b/src/testshade/testshademain.cpp
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2009-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+
+extern "C" int test_shade (int argc, const char *argv[]);
+
+
+int
+main (int argc, const char *argv[])
+{
+    return test_shade (argc, argv);
+}


### PR DESCRIPTION
We have another group at SPI that's trying to use OSL in some interesting ways from within a Houdini plugin, and it turns out that LLVM is failing its function resolution because of the way the osl-using plugin is loaded by the app.  This implements a workaround.  I think I explain it best in the comments, which I reproduce here:

On Linux, if an app loads a plugin (DSO/DLL) using dlopen without passing RTLD_GLOBAL as the mode, and that plugin accesses OSL (by linking against liboslexec), it turns out that LLVM can fail in finding symbols when it does its dlsym to resolve functions in the app called by the IR.  Since we can't control the app (Houdini and Maya, I'm talking to you!), we compensate by asking to dlopen it here, the "right" way, and then later on, LLVM will be able to find the symbols.  I can't seem to reproduce this issue on OS X, so for now we only do this on Linux.

In order to track this down and test it, I needed an app that acted like Houdini, with the app loading a plugin, and the plugin using OSL (i.e. linking against liboslexec and LLVM).  To facilitate this, I did some refactoring of testshade: instead of doing all its magic in 'main' of the testshade binary, I instead make a trivial main() in a separate file, which calls a test_shade() function that, in addition to being part of the testshade binary, also exists in a shared library libtestshade.so.  Then I have another binary, testshade_dso, which is just like testshade except that instead of linking against libtestshade.so and directly calling test_shade(), it does a dlopen to load libtestshade.so (like a runtime plugin) and a dlsym to find the test_shade function.  (Actually, I do this via the OIIO 'plugin.h' utility functions.)  As you'll see, this is actually very minor surgery, but it allows us to use testshade as before as a standalone binary, or the nearly identical testshade_dso program that exercises OSL as would an application that loads it as a plugin.  And of course I rig the dlopen to neglect to use RTLD_GLOBAL, to trigger the bug that required this workaround. 

So, in summary, these fixes seem to be necessary for people to implement Houdini (and I think Maya as well) plugins which in turn use OSL.

Incidentally, in the process I found and fixed a typo bug in the llvm_helper_function_table in llvm_instance.cpp.
