### PR TITLE
Refactor testshade to be self-documenting and instructive

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -61,7 +61,8 @@ static ShadingSystem *shadingsys = NULL;
 static std::vector<std::string> shadernames;
 static std::vector<std::string> outputfiles;
 static std::vector<std::string> outputvars;
-static std::vector<OIIO::ImageBuf*>   outputimgs;
+static std::vector<ustring> outputvarnames;
+static std::vector<OIIO::ImageBuf*> outputimgs;
 static std::string dataformatname = "";
 static bool debug = false;
 static bool verbose = false;
@@ -81,6 +82,9 @@ static int sparamindex = 0;
 static ErrorHandler errhandler;
 static int iters = 1;
 static std::string raytype = "camera";
+static SimpleRenderer rend;  // RendererServices
+static OSL::Matrix44 Mshad;  // "shader" space to "common" space matrix
+static OSL::Matrix44 Mobj;   // "object" space to "common" space matrix
 
 
 
@@ -194,6 +198,210 @@ getargs (int argc, const char *argv[])
         ap.usage ();
         exit (EXIT_SUCCESS);
     }
+
+    if (debug || verbose)
+        errhandler.verbosity (ErrorHandler::VERBOSE);
+}
+
+
+
+// Here we set up transformations.  These are just examples, set up so
+// that our unit tests can transform among spaces in ways that we will
+// recognize as correct.  The "shader" and "object" spaces are required
+// by OSL and the ShaderGlobals will need to have references to them.
+// For good measure, we also set up a "myspace" space, registering it
+// with the RendererServices.
+// 
+static void
+setup_transformations (SimpleRenderer &rend, OSL::Matrix44 &Mshad,
+                       OSL::Matrix44 &Mobj)
+{
+    // Make a "shader" space that is translated one unit in x and rotated
+    // 45deg about the z axis.
+    Mshad.makeIdentity ();
+    Mshad.translate (OSL::Vec3 (1.0, 0.0, 0.0));
+    Mshad.rotate (OSL::Vec3 (0.0, 0.0, M_PI_4));
+    // std::cout << "shader-to-common matrix: " << Mshad << "\n";
+
+    // Make an object space that is translated one unit in y and rotated
+    // 90deg about the z axis.
+    Mobj.makeIdentity ();
+    Mobj.translate (OSL::Vec3 (0.0, 1.0, 0.0));
+    Mobj.rotate (OSL::Vec3 (0.0, 0.0, M_PI_2));
+    // std::cout << "object-to-common matrix: " << Mobj << "\n";
+
+    OSL::Matrix44 Mmyspace;
+    Mmyspace.scale (OSL::Vec3 (1.0, 2.0, 1.0));
+    // std::cout << "myspace-to-common matrix: " << Mmyspace << "\n";
+    rend.name_transform ("myspace", Mmyspace);
+}
+
+
+
+// Set up the ShaderGlobals fields for pixel (x,y).
+static void
+setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
+                     int x, int y)
+{
+    // Just zero the whole thing out to start
+    memset(&sg, 0, sizeof(ShaderGlobals));
+
+    // Set "shader" space to be Mshad.  In a real renderer, this may be
+    // different for each shader group.
+    sg.shader2common = OSL::TransformationPtr (&Mshad);
+
+    // Set "object" space to be Mobj.  In a real renderer, this may be
+    // different for each object.
+    sg.object2common = OSL::TransformationPtr (&Mobj);
+
+    // Just make it look like all shades are the result of 'raytype' rays.
+    sg.raytype = ((ShadingSystemImpl *)shadingsys)->raytype_bit (ustring(raytype));
+
+    // Set up u,v to vary across the "patch", and also their derivatives.
+    // Note that since u & x, and v & y are aligned, we only need to set
+    // values for dudx and dvdy, we can use the memset above to have set
+    // dvdx and dudy to 0.
+    if (pixelcenters) {
+        // Our patch is like an "image" with shading samples at the
+        // centers of each pixel.
+        sg.u = (float)(x+0.5f) / xres;
+        sg.v = (float)(y+0.5f) / yres;
+        sg.dudx = 1.0f / xres;
+        sg.dvdy = 1.0f / yres;
+    } else {
+        // Our patch is like a Reyes grid of points, with the border
+        // samples being exactly on u,v == 0 or 1.
+        sg.u = (xres == 1) ? 0.5f : (float) x / (xres - 1);
+        sg.v = (yres == 1) ? 0.5f : (float) y / (yres - 1);
+        sg.dudx = 1.0f / std::max (1, xres-1);
+        sg.dvdy = 1.0f / std::max (1, yres-1);
+    }
+
+    // Assume that position P is simply (u,v,1), that makes the patch lie
+    // on [0,1] at z=1.
+    sg.P = Vec3 (sg.u, sg.v, 1.0f);
+    // Derivatives with respect to x,y
+    sg.dPdx = Vec3 (sg.dudx, sg.dudy, 0.0f);
+    sg.dPdy = Vec3 (sg.dvdx, sg.dvdy, 0.0f);
+    // Tangents of P with respect to surface u,v
+    sg.dPdu = Vec3 (1.0f, 0.0f, 0.0f);
+    sg.dPdv = Vec3 (0.0f, 1.0f, 0.0f);
+    // That also implies that our normal points to (0,0,1)
+    sg.N    = Vec3 (0, 0, 1);
+    sg.Ng   = Vec3 (0, 0, 1);
+
+    // Set the surface area of the patch to 1 (which it is).  This is
+    // only used for light shaders that call the surfacearea() function.
+    sg.surfacearea = 1;
+}
+
+
+
+static void
+setup_output_images (ShadingSystem *shadingsys,
+                     ShadingAttribStateRef &shaderstate)
+{
+    ShadingSystemImpl *ss = (ShadingSystemImpl *)shadingsys;
+    ShadingContext *ctx = ss->get_context ();  // needed for ctx->symbol()
+    ctx->prepare_execution (ShadUseSurface, *shaderstate);
+
+    // For each output file specified on the command line...
+    for (size_t i = 0;  i < outputfiles.size();  ++i) {
+        // Make a ustring version of the output name, for fast manipulation
+        outputvarnames.push_back (ustring(outputvars[i]));
+        // Start with a NULL ImageBuf pointer
+        outputimgs.push_back (NULL);
+
+        // Retrieve a record of the symbol
+        Symbol *sym = ctx->symbol (ShadUseSurface, outputvarnames[i]);
+        if (! sym) {
+            std::cout << "Output " << outputvars[i] << " not found, skipping.\n";
+            continue;
+        }
+        std::cout << "Output " << outputvars[i] << " to " << outputfiles[i]<< "\n";
+        
+        // Find out the type of the symbol
+        TypeDesc t = sym->typespec().simpletype();
+        // And the "base" type, i.e. the type of each element or channel
+        TypeDesc tbase = TypeDesc ((TypeDesc::BASETYPE)t.basetype);
+
+        // But which type are we going to write?  Use the true data type
+        // from OSL, unless the command line options indicated that
+        // something else was desired.
+        TypeDesc outtypebase = tbase;
+        if (dataformatname == "uint8")
+            outtypebase = TypeDesc::UINT8;
+        else if (dataformatname == "half")
+            outtypebase = TypeDesc::HALF;
+        else if (dataformatname == "float")
+            outtypebase = TypeDesc::FLOAT;
+
+        // Number of channels to write to the image is the number of (array)
+        // elements times the number of channels (e.g. 1 for scalar, 3 for
+        // vector, etc.)
+        int nchans = t.numelements() * t.aggregate;
+
+        // Make an ImageBuf of the right type and size to hold this
+        // symbol's output, and initially clear it to all black pixels.
+        OIIO::ImageSpec spec (xres, yres, nchans, outtypebase);
+        outputimgs[i] = new OIIO::ImageBuf(outputfiles[i], spec);
+#if OPENIMAGEIO_VERSION >= 900 /* 0.9.0 */
+        OIIO::ImageBufAlgo::zero (*outputimgs[i]);
+#else
+        outputimgs[i]->zero ();
+#endif
+    }
+
+    ss->release_context (ctx);  // don't need this anymore for now
+}
+
+
+
+// For pixel (x,y) that was just shaded by the given shading context,
+// save each of the requested outputs to the corresponding output
+// ImageBuf.
+//
+// In a real renderer, this is illustrative of how you would pull shader
+// outputs into "AOV's" (arbitrary output variables, or additional
+// renderer outputs).  You would, of course, also grab the closure Ci
+// and integrate the lights using that BSDF to determine the radiance
+// in the direction of the camera for that pixel.
+static void
+save_outputs (int x, int y, ShadingContext *ctx)
+{
+    // For each output requested on the command line...
+    for (size_t i = 0;  i < outputfiles.size();  ++i) {
+        // Skip if we couldn't open the image or didn't match a known output
+        if (! outputimgs[i])
+            continue;
+
+        // Ask for a Symbol pointer for the named symbol.
+        Symbol *sym = ctx->symbol (ShadUseSurface, outputvarnames[i]);
+        if (! sym)
+            continue;
+
+        // Ask for a raw pointer to the symbol's data, as computed by
+        // this shader.
+        const void * symboldata = ctx->symbol_data (*sym, 0);
+
+        // Find out the type of the symbol
+        TypeDesc t = sym->typespec().simpletype();
+
+        if (t.basetype == TypeDesc::FLOAT) {
+            // If the variable we are outputting is float-based, set it
+            // directly in the output buffer.
+            outputimgs[i]->setpixel (x, y, (const float *)symboldata);
+        } else if (t.basetype == TypeDesc::INT) {
+            // We are outputting an integer variable, so we need to
+            // convert it to floating point.
+            int nchans = outputimgs[i]->nchannels();
+            float *pixel = (float *) alloca (nchans * sizeof(float));
+            OIIO::convert_types (TypeDesc::BASETYPE(t.basetype), symboldata,
+                                 TypeDesc::FLOAT, pixel, nchans);
+            outputimgs[i]->setpixel (x, y, &pixel[0]);
+        }
+        // N.B. Drop any outputs that aren't float- or int-based
+    }
 }
 
 
@@ -201,18 +409,66 @@ getargs (int argc, const char *argv[])
 extern "C" int
 test_shade (int argc, const char *argv[])
 {
-    // Create a new shading system.
     Timer timer;
-    SimpleRenderer rend;
+
+    // Create a new shading system.  We pass it the RendererServices
+    // object that services callbacks from the shading system, NULL for
+    // the TextureSystem (that just makes 'create' make its own TS), and
+    // an error handler.
     shadingsys = ShadingSystem::create (&rend, NULL, &errhandler);
+
+    // Remember that each shader parameter may optionally have a
+    // metadata hint [[int lockgeom=...]], where 0 indicates that the
+    // parameter may be overridden by the geometry itself, for example
+    // with data interpolated from the mesh vertices, and a value of 1
+    // means that it is "locked" with respect to the geometry (i.e. it
+    // will not be overridden with interpolated or
+    // per-geometric-primitive data).
+    // 
+    // In order to most fully optimize shader, we typically want any
+    // shader parameter not explicitly specified to default to being
+    // locked (i.e. no per-geometry override):
     shadingsys->attribute("lockgeom", 1);
 
+    // Now we declare our shader.
+    // 
+    // Each material in the scene is comprised of a "shader group."
+    // Each group is comprised of one or more "layers" (a.k.a. shader
+    // instances) with possible connections from outputs of
+    // upstream/early layers into the inputs of downstream/later layers.
+    // A shader instance is the combination of a reference to a shader
+    // master and its parameter values that may override the defaults in
+    // the shader source and may be particular to this instance (versus
+    // all the other instances of the same shader).
+    // 
+    // A shader group declaration typically looks like this:
+    //
+    //   ss->ShaderGroupBegin ();
+    //   ss->Parameter ("paramname", TypeDesc paramtype, void *value);
+    //      ... and so on for all the other parameters of...
+    //   ss->Shader ("shadertype", "shadername", "layername");
+    //      The Shader() call creates a new instance, which gets
+    //      all the pending Parameter() values made right before it.
+    //   ... and other shader instances in this group, interspersed with...
+    //   ss->ConnectShaders ("layer1", "param1", "layer2", "param2");
+    //   ... and other connections ...
+    //   ss->ShaderGroupEnd ();
+    //   // and now grab an opaque reference to that shader group:
+    //   ShadingAttribStateRef shaderstate = s->state ();
+    // 
+    // It looks so simple, and it really is, except that the way this
+    // testshade program works is that all the Parameter() and Shader()
+    // calls are done inside getargs(), as it walks through the command
+    // line arguments, whereas the connections accumulate and have
+    // to be processed at the end.  Bear with us.
+    
+    // Start the shader group.
     shadingsys->ShaderGroupBegin ();
+    // Get the command line arguments.  That will set up all the shader
+    // instances and their parameters for the group.
     getargs (argc, argv);
 
-    if (debug || verbose)
-        errhandler.verbosity (ErrorHandler::VERBOSE);
-
+    // Now set up the connections
     for (size_t i = 0;  i < connections.size();  i += 4) {
         if (i+3 < connections.size()) {
             std::cout << "Connect " 
@@ -226,146 +482,120 @@ test_shade (int argc, const char *argv[])
         }
     }
 
+    // End the group
     shadingsys->ShaderGroupEnd ();
 
-    // getargs called 'add_shader' for each shader mentioned on the command
-    // line.  So now we should have a valid shading state.
+    // Now we should have a valid shading state, to get a reference to it.
     ShadingAttribStateRef shaderstate = shadingsys->state ();
-
-    // Set up shader globals and a little test grid of points to shade.
-    ShaderGlobals shaderglobals;
-    memset(&shaderglobals, 0, sizeof(ShaderGlobals));
-
-    // Make a shader space that is translated one unit in x and rotated
-    // 45deg about the z axis.
-    OSL::Matrix44 Mshad;
-    Mshad.translate (OSL::Vec3 (1.0, 0.0, 0.0));
-    Mshad.rotate (OSL::Vec3 (0.0, 0.0, M_PI_4));
-    // std::cout << "shader-to-common matrix: " << Mshad << "\n";
-    OSL::TransformationPtr Mshadptr (&Mshad);
-    shaderglobals.shader2common = Mshadptr;
-
-    // Make an object space that is translated one unit in y and rotated
-    // 90deg about the z axis.
-    OSL::Matrix44 Mobj;
-    Mobj.translate (OSL::Vec3 (0.0, 1.0, 0.0));
-    Mobj.rotate (OSL::Vec3 (0.0, 0.0, M_PI_2));
-    // std::cout << "object-to-common matrix: " << Mobj << "\n";
-    OSL::TransformationPtr Mobjptr (&Mobj);
-    shaderglobals.object2common = Mobjptr;
-
-    // Make a 'myspace that is non-uniformly scaled
-    OSL::Matrix44 Mmyspace;
-    Mmyspace.scale (OSL::Vec3 (1.0, 2.0, 1.0));
-    // std::cout << "myspace-to-common matrix: " << Mmyspace << "\n";
-    rend.name_transform ("myspace", Mmyspace);
-
-    if (pixelcenters) {
-        shaderglobals.dudx = 1.0f / xres;
-        shaderglobals.dvdy = 1.0f / yres;
-    } else {
-        shaderglobals.dudx = 1.0f / std::max (1, xres-1);
-        shaderglobals.dvdy = 1.0f / std::max (1, yres-1);
-    }
-
-    shaderglobals.raytype = ((ShadingSystemImpl *)shadingsys)->raytype_bit (ustring(raytype));
-
-    double setuptime = timer ();
-    double runtime = 0;
-
-    std::vector<float> pixel;
 
     if (outputfiles.size() != 0)
         std::cout << "\n";
 
-    // grab this once since we will be shading several points
+    // Set up the image outputs requested on the command line
+    setup_output_images (shadingsys, shaderstate);
+
+    // Set up the named transformations, including shader and object.
+    // For this test application, we just do this statically; in a real
+    // renderer, the global named space (like "myspace") would probably
+    // be static, but shader and object spaces may be different for each
+    // object.
+    setup_transformations (rend, Mshad, Mobj);
+
+    // Set up shader globals and a little test grid of points to shade.
+    ShaderGlobals shaderglobals;
+
+    double setuptime = timer.lap ();
+
+    std::vector<float> pixel;
+
+    // grab this once since we will be shading several points.
+    // FIXME: eventually, there will be no reason to reach into the guts
+    // of the (supposedly private) ShadingSystemImpl.  Sorry, will fix
+    // soon.
     ShadingSystemImpl *ssi = (ShadingSystemImpl *)shadingsys;
+
+    // Optional: high-performance apps may request this thread-specific
+    // pointer in order to save a bit of time on each shade.  Just like
+    // the name implies, a multithreaded renderer would need to do this
+    // separately for each thread, and be careful to always use the same
+    // thread_info each time for that thread.
+    //
+    // There's nothing wrong with a simpler app just passing NULL for
+    // the thread_info; in such a case, the ShadingSystem will do the
+    // necessary calls to find the thread-specific pointer itself, but
+    // this will degrade performance just a bit.
     void* thread_info = ssi->create_thread_info();
+
+    // Allow a settable number of iterations to "render" the whole image,
+    // which is useful for time trials of things that would be too quick
+    // to accurately time for a single iteration
     for (int iter = 0;  iter < iters;  ++iter) {
+
+        // Loop over all pixels in the image (in x and y)...
         for (int y = 0, n = 0;  y < yres;  ++y) {
             for (int x = 0;  x < xres;  ++x, ++n) {
-                if (pixelcenters) {
-                    shaderglobals.u = (float)(x+0.5f) / xres;
-                    shaderglobals.v = (float)(y+0.5f) / yres;
-                } else {
-                    shaderglobals.u = (xres == 1) ? 0.5f : (float) x / (xres - 1);
-                    shaderglobals.v = (yres == 1) ? 0.5f : (float) y / (yres - 1);
-                }
-                shaderglobals.P = Vec3 (shaderglobals.u, shaderglobals.v, 1.0f);
-                shaderglobals.dPdx = Vec3 (shaderglobals.dudx, shaderglobals.dudy, 0.0f);
-                shaderglobals.dPdy = Vec3 (shaderglobals.dvdx, shaderglobals.dvdy, 0.0f);
-                shaderglobals.N    = Vec3 (0, 0, 1);
-                shaderglobals.Ng   = Vec3 (0, 0, 1);
-                shaderglobals.dPdu = Vec3 (1.0f, 0.0f, 0.0f);
-                shaderglobals.dPdv = Vec3 (0.0f, 1.0f, 0.0f);
-                shaderglobals.surfacearea = 1;
 
-                // Request a shading context, bind it, execute the shaders.
+                // In a real renderer, this is where you would figure
+                // out what object point is visible in this pixel (or
+                // this sample, for antialiasing).  Once determined,
+                // you'd set up a ShaderGlobals that contained the vital
+                // information about that point, such as its location,
+                // the normal there, the u and v coordinates on the
+                // surface, the transformation of that object, and so
+                // on.  
+                //
+                // This test app is not a real renderer, so we just
+                // set it up rigged to look like we're rendering a single
+                // quadrilateral that exactly fills the viewport, and that
+                // setup is done in the following function call:
+                setup_shaderglobals (shaderglobals, shadingsys, x, y);
+
+                // Request a shading context so that we can execute
+                // the shader for this point.
+                //
                 // FIXME -- this will eventually be replaced with a public
                 // ShadingSystem call that encapsulates it.
                 ShadingContext *ctx = ssi->get_context (thread_info);
-                timer.reset ();
-                timer.start ();
-                // run shader for this point
-                ctx->execute (ShadUseSurface, *shaderstate, shaderglobals);
-                runtime += timer ();
 
+                // Actually run the shader for this point
+                ctx->execute (ShadUseSurface, *shaderstate, shaderglobals);
+
+                // Save all the designated outputs.  But only do so if we
+                // are on the last iteration requested, so that if we are
+                // doing a bunch of iterations for time trials, we only
+                // including the output pixel copying once in the timing.
                 if (iter == (iters - 1)) {
-                   // extract any output vars into images (on last iteration only)
-                   for (size_t i = 0;  i < outputfiles.size();  ++i) {
-                       Symbol *sym = ctx->symbol (ShadUseSurface, ustring(outputvars[i]));
-                       if (! sym) {
-                           if (n == 0) {
-                              std::cout << "Output " << outputvars[i] << " not found, skipping.\n";
-                              outputimgs.push_back(0); // invalid image
-                           }
-                           continue;
-                       }
-                       if (n == 0)
-                           std::cout << "Output " << outputvars[i] << " to " << outputfiles[i]<< "\n";
-                       TypeDesc t = sym->typespec().simpletype();
-                       TypeDesc tbase = TypeDesc ((TypeDesc::BASETYPE)t.basetype);
-                       TypeDesc outtypebase = tbase;
-                       if (dataformatname == "uint8")
-                           outtypebase = TypeDesc::UINT8;
-                       else if (dataformatname == "half")
-                           outtypebase = TypeDesc::HALF;
-                       else if (dataformatname == "float")
-                           outtypebase = TypeDesc::FLOAT;
-                       int nchans = t.numelements() * t.aggregate;
-                       pixel.resize (nchans);
-                       if (n == 0) {
-                           OIIO::ImageSpec spec (xres, yres, nchans, outtypebase);
-                           OIIO::ImageBuf* img = new OIIO::ImageBuf(outputfiles[i], spec);
-#if OPENIMAGEIO_VERSION >= 900 /* 0.9.0 */
-                           OIIO::ImageBufAlgo::zero (*img);
-#else
-                           img->zero ();
-#endif
-                           outputimgs.push_back(img);
-                       }
-                       OIIO::convert_types (tbase, ctx->symbol_data (*sym, 0),
-                                                   TypeDesc::FLOAT, &pixel[0], nchans);
-                       outputimgs[i]->setpixel (x, y, &pixel[0]);
-                   }
+                    save_outputs (x, y, ctx);
                 }
+
+                // We're done shading this point, so release the
+                // context.
                 ssi->release_context (ctx, thread_info);
             }
         }
     }
+
+    // Now that we're done rendering, release the thread=specific
+    // pointer we saved.  A simple app could skip this; but if the app
+    // asks for it (as we have in this example), then it should also
+    // destroy it when done with it.
     ssi->destroy_thread_info(thread_info);
 
     if (outputfiles.size() == 0)
         std::cout << "\n";
 
-    // write any images to disk
+    // Write the output images to disk
     for (size_t i = 0;  i < outputimgs.size();  ++i) {
         if (outputimgs[i]) {
-           outputimgs[i]->save();
+            outputimgs[i]->save();
             delete outputimgs[i];
+            outputimgs[i] = NULL;
         }
     }
+
+    // Print some debugging info
     if (debug || stats) {
+        double runtime = timer();
         std::cout << "\n";
         std::cout << "Setup: " << Strutil::timeintervalformat (setuptime,2) << "\n";
         std::cout << "Run  : " << Strutil::timeintervalformat (runtime,2) << "\n";
@@ -373,6 +603,8 @@ test_shade (int argc, const char *argv[])
         std::cout << shadingsys->getstats (5) << "\n";
     }
 
+    // We're done with the shading system now, destroy it
     ShadingSystem::destroy (shadingsys);
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Last week I worked on a project with somebody who was adding OSL to another app.  We started by saying "it's really just like running testshade from within this plugin, so simple", but actually I found myself spending most of the day answering questions about what testshade was really doing and realizing that it wasn't as clear as it could have been.

These things are good experiences -- I vowed to make testshade as instructive as possible, so that (especially in the absence of a fully, well-written "integration guide") examining testshade and reading its comments would tell you almost everything you needed to know about how to set up a Shading System and have it run shaders.

NO testshade functionality changes, this is strictly a reshuffling of the existing code and addition of detailed comments.  Nevertheless, the shuffling is so extensive, you may find the diffs worthless, and it will be easier to just look at the new code in isolation and decide whether it's now relatively self-explanatory.

I'm aware that it's still messy that we need an app to be aware of internals such as ShadingSystemImp.  As a next step, I'm going to actually improve the APIs to fix this.
