### PR TITLE
Review: Fix escape sequences in string literals

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1512,16 +1512,6 @@ LLVMGEN (llvm_gen_printf)
                 }
             }
             ++arg;
-        } else if (*format == '\\') {
-            // Escape sequence
-            ++format;  // skip the backslash
-            switch (*format) {
-            case 'n' : s += '\n';     break;
-            case 'r' : s += '\r';     break;
-            case 't' : s += '\t';     break;
-            default:   s += *format;  break;  // Catches '\\' also!
-            }
-            ++format;
         } else {
             // Everything else -- just copy the character and advance
             s += *format++;

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -102,6 +102,35 @@ using namespace OSL::pvt;
 
 #define yylval osolval
 
+// Turn escape sequences into real characters.
+static std::string
+unescape_chars (const std::string &unescaped)
+{
+    std::string s = unescaped;
+    for (size_t i = 0, len = s.length();  i < len;  ++i) {
+        if (s[i] == '\\') {
+            char c = s[i+1];
+            if (c == 'n' || c == 't' || c == 'v' || c == 'b' || 
+                c == 'r' || c == 'f' || c == 'a' || c == '\\' || c == '\"') {
+                s.erase (i, 1);
+                --len;
+                switch (c) {
+                case 'n' : s[i] = '\n'; break;
+                case 't' : s[i] = '\t'; break;
+                case 'v' : s[i] = '\v'; break;
+                case 'b' : s[i] = '\b'; break;
+                case 'r' : s[i] = '\r'; break;
+                case 'f' : s[i] = '\f'; break;
+                case 'a' : s[i] = '\a'; break;
+                // default case: the deletion is enough (backslash and quote)
+                }
+            }
+        }
+    }
+    return s;
+}
+
+
 %}
 
 /* Declare modes */
@@ -192,7 +221,8 @@ using namespace OSL::pvt;
 
 {STR}                   {
                             // grab the material between the quotes
-                            ustring s (YYText(), 1, strlen(YYText())-2);
+                            std::string escaped (YYText(), 1, strlen(YYText())-2);
+                            ustring s (unescape_chars(escaped));
                             yylval.s = s.c_str();
                             // std::cerr << "lex string '" << yylval.s << "'\n";
                             return STRING_LITERAL;

--- a/testsuite/string/ref/out.txt
+++ b/testsuite/string/ref/out.txt
@@ -3,6 +3,11 @@ test string operations:
 
 Testing abutting string literals: "foobarbaz"
 
+foo\nbar
+blah 'foo\nbar
+'
+blah2 'foo\\'
+
 formtted string: 'P = 0 0 1'
 
 concat("foo", "bar", "baz") = "foobarbaz"
@@ -47,6 +52,11 @@ regex_match ("foobar.baz", "(f[Oo]{2}).*(.az)") = 1
 test string operations:
 
 Testing abutting string literals: "foobarbaz"
+
+foo\nbar
+blah 'foo\nbar
+'
+blah2 'foo\\'
 
 formtted string: 'P = 1 0 1'
 
@@ -93,6 +103,11 @@ test string operations:
 
 Testing abutting string literals: "foobarbaz"
 
+foo\nbar
+blah 'foo\nbar
+'
+blah2 'foo\\'
+
 formtted string: 'P = 0 1 1'
 
 concat("foo", "bar", "baz") = "foobarbaz"
@@ -137,6 +152,11 @@ regex_match ("foobar.baz", "(f[Oo]{2}).*(.az)") = 1
 test string operations:
 
 Testing abutting string literals: "foobarbaz"
+
+foo\nbar
+blah 'foo\nbar
+'
+blah2 'foo\\'
 
 formtted string: 'P = 1 1 1'
 

--- a/testsuite/string/test.osl
+++ b/testsuite/string/test.osl
@@ -67,6 +67,13 @@ test ()
     printf ("Testing abutting string literals: \"%s\"\n",
             "foo" "bar" "baz");
 
+    // Test escape sequences
+    printf ("\n");
+    printf ("foo\\nbar\n");  // should print:  foo\bar
+    printf ("blah '%s'\n", "foo\\nbar\n");  // should print: blah 'foo\bar
+                                            //                    '
+    printf ("blah2 '%s'\n", "foo\\\\");     // should print: blah2 'foo\\'
+
     // Test format
     printf ("\n");
     string s = format ("P = %g", P);


### PR DESCRIPTION
Fix escape sequences in string literals -- we were only doing the right thing for printf-like format strings, not other string literals.

The solution is to un-escape all string literals as they are parsed from the oso, and then to eliminate our prior unescaping of the format strings.
