### PR TITLE
Review: getmatrix()

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -247,20 +247,62 @@ public:
     virtual ~RendererServices () { }
 
     /// Get the 4x4 matrix that transforms by the specified
-    /// transformation at the given time.
+    /// transformation at the given time.  Return true if ok, false
+    /// on error.
     virtual bool get_matrix (Matrix44 &result, TransformationPtr xform,
                              float time) = 0;
 
     /// Get the 4x4 matrix that transforms by the specified
-    /// transformation at the given time.  The default implementation is
-    /// to use get_matrix and invert it, but a particular renderer may
-    /// have a better technique and overload the implementation.
+    /// transformation at the given time.  Return true if ok, false on
+    /// error.  The default implementation is to use get_matrix and
+    /// invert it, but a particular renderer may have a better technique
+    /// and overload the implementation.
     virtual bool get_inverse_matrix (Matrix44 &result, TransformationPtr xform,
                                      float time);
 
+    /// Get the 4x4 matrix that transforms by the specified
+    /// transformation.  Return true if ok, false on error.  Since no
+    /// time value is given, also return false if the transformation may
+    /// be time-varying.
+    virtual bool get_matrix (Matrix44 &result, TransformationPtr xform) = 0;
+
+    /// Get the 4x4 matrix that transforms by the specified
+    /// transformation.  Return true if ok, false on error.  Since no
+    /// time value is given, also return false if the transformation may
+    /// be time-varying.  The default implementation is to use
+    /// get_matrix and invert it, but a particular renderer may have a
+    /// better technique and overload the implementation.
+    virtual bool get_inverse_matrix (Matrix44 &result, TransformationPtr xform);
+
     /// Get the 4x4 matrix that transforms points from the named
     /// 'from' coordinate system to "common" space at the given time.
+    /// Returns true if ok, false if the named matrix is not known.
     virtual bool get_matrix (Matrix44 &result, ustring from, float time) = 0;
+
+    /// Get the 4x4 matrix that transforms points from "common" space to
+    /// the named 'to' coordinate system to at the given time.  The
+    /// default implementation is to use get_matrix and invert it, but a
+    /// particular renderer may have a better technique and overload the
+    /// implementation.
+    virtual bool get_inverse_matrix (Matrix44 &result, ustring to, float time);
+
+    /// Get the 4x4 matrix that transforms 'from' to "common" space.
+    /// Since there is no time value passed, return false if the
+    /// transformation may be time-varying (as well as if it's not found
+    /// at all).
+    virtual bool get_matrix (Matrix44 &result, ustring from) = 0;
+
+    /// Get the 4x4 matrix that transforms points from "common" space to
+    /// the named 'to' coordinate system.  Since there is no time value
+    /// passed, return false if the transformation may be time-varying
+    /// (as well as if it's not found at all).  The default
+    /// implementation is to use get_matrix and invert it, but a
+    /// particular renderer may have a better technique and overload the
+    /// implementation.
+    virtual bool get_inverse_matrix (Matrix44 &result, ustring to);
+
+    /// Get the 4x4 matrix that transforms points from the named
+    /// 'from' coordinate system to "common" space at the given time.
 
     /// Get the named attribute from the renderer and if found then
     /// write it into 'val'.  Otherwise, return false.  If no object is
@@ -286,13 +328,6 @@ public:
 
     /// Does the current object have the named user-data associated with it?
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate) = 0;
-
-    /// Get the 4x4 matrix that transforms points from "common" space to
-    /// the named 'to' coordinate system to at the given time.  The
-    /// default implementation is to use get_matrix and invert it, but a
-    /// particular renderer may have a better technique and overload the
-    /// implementation.
-    virtual bool get_inverse_matrix (Matrix44 &result, ustring to, float time);
 
     /// Filtered 2D texture lookup for a single point.
     ///

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -374,8 +374,8 @@ static const char *llvm_helper_function_table[] = {
     "osl_div_mf", "xXXf",
     "osl_div_fm", "xXfX",
     "osl_div_m_ff", "xXff",
-    "osl_prepend_matrix_from", "xXXs",
-    "osl_get_from_to_matrix", "xXXss",
+    "osl_prepend_matrix_from", "iXXs",
+    "osl_get_from_to_matrix", "iXXss",
     "osl_transpose_mm", "xXX",
     "osl_determinant_fm", "fX",
 
@@ -2544,6 +2544,30 @@ LLVMGEN (llvm_gen_matrix)
 
 
 
+/// int getmatrix (fromspace, tospace, M)
+LLVMGEN (llvm_gen_getmatrix)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    int nargs = op.nargs();
+    ASSERT (nargs == 4);
+    Symbol& Result = *rop.opargsym (op, 0);
+    Symbol& From = *rop.opargsym (op, 1);
+    Symbol& To = *rop.opargsym (op, 2);
+    Symbol& M = *rop.opargsym (op, 3);
+
+    llvm::Value *args[4];
+    args[0] = rop.sg_void_ptr();  // shader globals
+    args[1] = rop.llvm_void_ptr(M);  // matrix result
+    args[2] = rop.llvm_load_value(From);
+    args[3] = rop.llvm_load_value(To);
+    llvm::Value *result = rop.llvm_call_function ("osl_get_from_to_matrix", args, 4);
+    rop.llvm_store_value (result, Result);
+    rop.llvm_zero_derivs (M);
+    return true;
+}
+
+
+
 // Derivs
 LLVMGEN (llvm_gen_DxDy)
 {
@@ -4306,6 +4330,7 @@ initialize_llvm_generator_table ()
     //stdosl.h INIT (fresnel);
     INIT2 (ge, llvm_gen_compare_op);
     INIT (getattribute);
+    INIT (getmatrix);
     INIT (getmessage);
     INIT (gettextureinfo);
     INIT2 (gt, llvm_gen_compare_op);

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -65,9 +65,31 @@ RendererServices::get_inverse_matrix (Matrix44 &result,
 
 
 bool
+RendererServices::get_inverse_matrix (Matrix44 &result, TransformationPtr xform)
+{
+    bool ok = get_matrix (result, xform);
+    if (ok)
+        result.invert ();
+    return ok;
+}
+
+
+
+bool
 RendererServices::get_inverse_matrix (Matrix44 &result, ustring to, float time)
 {
     bool ok = get_matrix (result, to, time);
+    if (ok)
+        result.invert ();
+    return ok;
+}
+
+
+
+bool
+RendererServices::get_inverse_matrix (Matrix44 &result, ustring to)
+{
+    bool ok = get_matrix (result, to);
     if (ok)
         result.invert ();
     return ok;

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -519,7 +519,10 @@ int iscameraray () { return raytype("camera"); }
 int isdiffuseray () { return raytype("diffuse"); }
 int isglossyray () { return raytype("glossy"); }
 int isshadowray () { return raytype("shadow"); }
-
+int getmatrix (string fromspace, string tospace, output matrix M) BUILTIN;
+int getmatrix (string fromspace, output matrix M) {
+    return getmatrix (fromspace, "current", M);
+}
 
 
 // Miscellaneous

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -63,6 +63,34 @@ SimpleRenderer::get_matrix (Matrix44 &result, ustring from, float time)
 }
 
 
+
+bool
+SimpleRenderer::get_matrix (Matrix44 &result, TransformationPtr xform)
+{
+    // SimpleRenderer doesn't understand motion blur and transformations
+    // are just simple 4x4 matrices.
+    result = *(OSL::Matrix44 *)xform;
+    return true;
+}
+
+
+
+bool
+SimpleRenderer::get_matrix (Matrix44 &result, ustring from)
+{
+    // SimpleRenderer doesn't understand motion blur, so we never fail
+    // on account of time-varying transformations.
+    TransformMap::const_iterator found = m_named_xforms.find (from);
+    if (found != m_named_xforms.end()) {
+        result = *(found->second);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+
+
 void
 SimpleRenderer::name_transform (const char *name, const OSL::Matrix44 &xform)
 {

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -57,6 +57,9 @@ public:
                              float time);
     virtual bool get_matrix (Matrix44 &result, ustring from, float time);
 
+    virtual bool get_matrix (Matrix44 &result, TransformationPtr xform);
+    virtual bool get_matrix (Matrix44 &result, ustring from);
+
     void name_transform (const char *name, const Transformation &xform);
 
     virtual bool get_array_attribute (void *renderstate, bool derivatives, 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -487,12 +487,8 @@ test_shade (int argc, const char *argv[])
 
     // Now we should have a valid shading state, to get a reference to it.
     ShadingAttribStateRef shaderstate = shadingsys->state ();
-
     if (outputfiles.size() != 0)
         std::cout << "\n";
-
-    // Set up the image outputs requested on the command line
-    setup_output_images (shadingsys, shaderstate);
 
     // Set up the named transformations, including shader and object.
     // For this test application, we just do this statically; in a real
@@ -500,6 +496,9 @@ test_shade (int argc, const char *argv[])
     // be static, but shader and object spaces may be different for each
     // object.
     setup_transformations (rend, Mshad, Mobj);
+
+    // Set up the image outputs requested on the command line
+    setup_output_images (shadingsys, shaderstate);
 
     // Set up shader globals and a little test grid of points to shade.
     ShaderGlobals shaderglobals;

--- a/testsuite/matrix/ref/out.txt
+++ b/testsuite/matrix/ref/out.txt
@@ -24,6 +24,9 @@ Testing matrix from-to construction:
   matrix ("shader", "object") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -1 -1 0 1)
   matrix ("object", "shader") = (0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 0 1.4142 0 1)
 
+Testing getmatrix for unknown space name:
+  'foobar' matrix not found, as expected
+
 
 Testing matrix component access:
   M = 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
@@ -76,6 +79,9 @@ Testing matrix from-to construction:
   matrix ("object", "common") = (0 1 0 0 -1 0 0 0 0 0 1 0 0 1 0 1)
   matrix ("shader", "object") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -1 -1 0 1)
   matrix ("object", "shader") = (0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 0 1.4142 0 1)
+
+Testing getmatrix for unknown space name:
+  'foobar' matrix not found, as expected
 
 
 Testing matrix component access:
@@ -130,6 +136,9 @@ Testing matrix from-to construction:
   matrix ("shader", "object") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -1 -1 0 1)
   matrix ("object", "shader") = (0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 0 1.4142 0 1)
 
+Testing getmatrix for unknown space name:
+  'foobar' matrix not found, as expected
+
 
 Testing matrix component access:
   M = 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
@@ -182,6 +191,9 @@ Testing matrix from-to construction:
   matrix ("object", "common") = (0 1 0 0 -1 0 0 0 0 0 1 0 0 1 0 1)
   matrix ("shader", "object") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -1 -1 0 1)
   matrix ("object", "shader") = (0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 0 1.4142 0 1)
+
+Testing getmatrix for unknown space name:
+  'foobar' matrix not found, as expected
 
 
 Testing matrix component access:

--- a/testsuite/matrix/test.osl
+++ b/testsuite/matrix/test.osl
@@ -3,8 +3,19 @@
 
 void matrix_fromto (string from, string to)
 {
-    printf ("  matrix (\"%s\", \"%s\") = (%.5g)\n", from, to, pretty(matrix (from, to)));
-    printf ("  matrix (\"%s\", \"%s\") = (%.5g)\n", to, from, pretty(matrix (to, from)));
+    matrix M, Mg;
+    int ok;
+    M = matrix (from, to);
+    printf ("  matrix (\"%s\", \"%s\") = (%.5g)\n", from, to, pretty(M));
+    ok = getmatrix (from, to, Mg);
+    if (!ok || M != Mg)
+        printf ("  Hey, matrix ctr didn't match getmatrix!\n");
+
+    M = matrix (to, from);
+    printf ("  matrix (\"%s\", \"%s\") = (%.5g)\n", to, from, pretty(M));
+    ok = getmatrix (to, from, Mg);
+    if (!ok || M != Mg)
+        printf ("  Hey, matrix ctr didn't match getmatrix!\n");
 }
 
 
@@ -48,12 +59,22 @@ test ()
                 a, pretty(matrix ("shader", a, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)));
     }
 
-    // Test "from-to" matrix construction
+    // Test "from-to" matrix construction and getmatrix calls
     {
         printf ("\nTesting matrix from-to construction:\n");
         matrix_fromto ("common", "shader");
         matrix_fromto ("common", "object");
         matrix_fromto ("shader", "object");
+    }
+
+    // Test getmatrix with an unknown space
+    {
+        printf ("\nTesting getmatrix for unknown space name:\n");
+        matrix M;
+        if (getmatrix ("foobar", "common", M))
+            printf ("  found???\n");
+        else
+            printf ("  'foobar' matrix not found, as expected\n");
     }
 
     {


### PR DESCRIPTION
This adds a new built-in OSL function:

  int getmatrix (string fromspace, string tospace, output matrix M)

This is similar to the matrix(from,to) constructor, but it puts the matrix in M and returns 1 if the coord systems were known, 0 if either of the names were not known coordinate systems.  This lets a shader gracefully handle an unknown matrix name.

In addition, I took the opportunity to expand the runtime optimization of the matrix constructor -- previously it would fold matrix("foo","foo") into the constant identity matrix, but now it will check for arbitrary names (e.g., matrix("myspace","common")) and if they are not time-dependent transformations can turn it into a constant matrix.  Same with getmatrix.

This required adding some new get_matrix and get_inverse_matrix varieties to RendererServices, in order to get (and detect) time-invariant transformations.
