### PR TITLE
ShadeExec API overhaul - make it so the app doesn't need ShadingSystemImpl

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,5 +1,5 @@
-file (GLOB public_headers "*.h")
-
+set (public_headers accum.h export.h genclosure.h optautomata.h oslclosure.h
+                    oslcomp.h oslconfig.h oslexec.h oslquery.h  )
 message (STATUS "Create oslversion.h from oslversion.h.in")
 configure_file (oslversion.h.in ${CMAKE_BINARY_DIR}/include/oslversion.h @ONLY)
 list (APPEND public_headers ${CMAKE_BINARY_DIR}/include/oslversion.h)

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -396,6 +396,9 @@ Dictionary::dict_value (int nodeID, ustring attribname,
 }
 
 
+}; // namespace pvt
+
+
 
 int
 ShadingContext::dict_find (ustring dictionaryname, ustring query)
@@ -448,7 +451,6 @@ ShadingContext::free_dict_resources ()
 
 
 
-}; // namespace pvt
 }; // namespace OSL
 #ifdef OSL_NAMESPACE
 }; // end namespace OSL_NAMESPACE

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1028,7 +1028,7 @@ OSL_SHADEOP int
 osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
                 const char *pattern, int fullmatch)
 {
-    extern int osl_regex_impl2 (OSL::pvt::ShadingContext *ctx, ustring subject,
+    extern int osl_regex_impl2 (OSL::ShadingContext *ctx, ustring subject,
                                int *results, int nresults, ustring pattern,
                                int fullmatch);
 

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Heavy lifting of OSL regex operations.
 OSL_SHADEOP int
-osl_regex_impl2 (OSL::pvt::ShadingContext *ctx, ustring subject_,
+osl_regex_impl2 (OSL::ShadingContext *ctx, ustring subject_,
                  int *results, int nresults, ustring pattern,
                  int fullmatch)
 {


### PR DESCRIPTION
For far too long, we've required apps to reach way into the guts of ShadingSystemImpl and ShadingContext in order to invoke shaders.

This change overhauls the ShadingSystem API to expose the few things that you need to be able to do.  It's not a huge change, you can see from testshade.cpp that it's pretty straightforward, and no longer needs oslexec_pvt.h!  

(For the Arnold people reading, there will be a separate internal review for Arnold, it no longer needs access to any OSL internals not in the public headers.)
