### PR TITLE
Shader header file improvements

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -312,6 +312,14 @@ OSLCompilerImpl::compile (const std::string &filename,
         path = path / "shaders";
         bool found = false;
         if (boost::filesystem::exists (path)) {
+#ifdef USE_BOOST_WAVE
+            includepaths.push_back(path.string());
+#else
+            // pass along to cpp
+            cppoptions += "\"-I";
+            cppoptions += path.string();
+            cppoptions += "\" ";
+#endif
             path = path / "stdosl.h";
             if (boost::filesystem::exists (path)) {
                 stdinclude = path.string();

--- a/src/shaders/oslutil.h
+++ b/src/shaders/oslutil.h
@@ -26,8 +26,8 @@
 /////////////////////////////////////////////////////////////////////////////
 
 
-#ifndef PATTERNS_H
-#define PATTERNS_H
+#ifndef OSLUTIL_H
+#define OSLUTIL_H
 
 // Return wireframe opacity factor [0, 1] given a geometry type in
 // ("triangles", "polygons" or "patches"), and a line_width in raster
@@ -85,4 +85,4 @@ float wireframe(string edge_type, float line_width) { return wireframe(edge_type
 float wireframe(string edge_type) { return wireframe(edge_type, 1.0, 1); }
 float wireframe() { return wireframe("polygons", 1.0, 1); }
 
-#endif /* PATTERNS_H */
+#endif /* OSLUTIL_H */


### PR DESCRIPTION
Rename patterns.h to oslutil.h
Automatically put distribution headers into the include search path
