### PR TITLE
Review: Tighten up the code generation for processing optional texture parameters

### DIFF
--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1363,19 +1363,37 @@ osl_texture_set_firstchannel (void *opt, int x)
 OSL_SHADEOP void
 osl_texture_set_swrap (void *opt, const char *x)
 {
-    ((TextureOpt *)opt)->swrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt *)opt)->swrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
 osl_texture_set_twrap (void *opt, const char *x)
 {
-    ((TextureOpt *)opt)->twrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt *)opt)->twrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
 osl_texture_set_rwrap (void *opt, const char *x)
 {
-    ((TextureOpt *)opt)->rwrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt *)opt)->rwrap = TextureOpt::decode_wrapmode(USTR(x));
+}
+
+OSL_SHADEOP void
+osl_texture_set_swrap_code (void *opt, int mode)
+{
+    ((TextureOpt *)opt)->swrap = (TextureOpt::Wrap)mode;
+}
+
+OSL_SHADEOP void
+osl_texture_set_twrap_code (void *opt, int mode)
+{
+    ((TextureOpt *)opt)->twrap = (TextureOpt::Wrap)mode;
+}
+
+OSL_SHADEOP void
+osl_texture_set_rwrap_code (void *opt, int mode)
+{
+    ((TextureOpt *)opt)->rwrap = (TextureOpt::Wrap)mode;
 }
 
 OSL_SHADEOP void
@@ -1431,14 +1449,16 @@ osl_texture_set_time (void *opt, float x)
 OSL_SHADEOP void
 osl_texture_set_interp_name (void *opt, const char *modename)
 {
-    if (modename == Strings::smartbicubic)
-        ((TextureOpt *)opt)->interpmode = TextureOpt::InterpSmartBicubic;
-    else if (modename == Strings::linear)
-        ((TextureOpt *)opt)->interpmode = TextureOpt::InterpBilinear;
-    else if (modename == Strings::cubic)
-        ((TextureOpt *)opt)->interpmode = TextureOpt::InterpBicubic;
-    else if (modename == Strings::closest)
-        ((TextureOpt *)opt)->interpmode = TextureOpt::InterpClosest;
+    int mode = tex_interp_to_code (USTR(modename));
+    if (mode >= 0)
+        ((TextureOpt *)opt)->interpmode = (TextureOpt::InterpMode)mode;
+}
+
+
+OSL_SHADEOP void
+osl_texture_set_interp_code (void *opt, int mode)
+{
+    ((TextureOpt *)opt)->interpmode = (TextureOpt::InterpMode)mode;
 }
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1136,8 +1136,25 @@ namespace Strings {
     extern ustring wrap, swrap, twrap, rwrap;
     extern ustring black, clamp, periodic, mirror;
     extern ustring firstchannel, fill, alpha;
-    extern ustring interp, closest, linear, cubic, smartbicubic;
+    extern ustring interp, closest, linear, cubic, smartcubic;
 }; // namespace Strings
+
+
+
+inline int
+tex_interp_to_code (ustring modename)
+{
+    int mode = -1;
+    if (modename == Strings::smartcubic)
+        mode = TextureOpt::InterpSmartBicubic;
+    else if (modename == Strings::linear)
+        mode = TextureOpt::InterpBilinear;
+    else if (modename == Strings::cubic)
+        mode = TextureOpt::InterpBicubic;
+    else if (modename == Strings::closest)
+        mode = TextureOpt::InterpClosest;
+    return mode;
+}
 
 
 }; // namespace OSL

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -55,8 +55,8 @@ public:
           m_stat_opt_locking_time(0), m_stat_specialization_time(0),
           m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
           m_stat_llvm_irgen_time(0), m_stat_llvm_opt_time(0),
-          m_stat_llvm_jit_time(0)
-        , m_llvm_context(NULL), m_llvm_module(NULL), m_builder(NULL),
+          m_stat_llvm_jit_time(0),
+          m_llvm_context(NULL), m_llvm_module(NULL), m_builder(NULL),
           m_llvm_passes(NULL), m_llvm_func_passes(NULL),
           m_llvm_func_passes_optimized(NULL)
     {

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -142,7 +142,7 @@ ustring black ("black"), clamp ("clamp");
 ustring periodic ("periodic"), mirror ("mirror");
 ustring firstchannel ("firstchannel"), fill ("fill"), alpha ("alpha");
 ustring interp("interp"), closest("closest"), linear("linear");
-ustring cubic("cubic"), smartbicubic("smartbicubic");
+ustring cubic("cubic"), smartcubic("smartcubic");
 };
 
 


### PR DESCRIPTION
Tighten up the code generation for processing optional texture parameters.

The optional parameters to texture calls ("width", "blur", "wrap", etc.)
were set by many shaders based on parameters, which are generally constants
by the time we do runtime optimizations, and furthermore frequently were
redundantly setting the options to their default values.

So this change will skip generation of LLVM IR that would have set texture
options to their existing default values.  Additionally, for "interp" and
"wrap" options, it will do the string-to-enum conversion at optimization time
rather than for every texture call, if the argument is a constant string.

Also found a latent bug where we would not properly handle integer arguments
to "blur" and "width", which we now properly convert to float when generating
IR.  Another bug where were were incorrectly comparing interp strings against
"smartbicubic" when in fact according to the spec it should be "smartcubic".

This whole thing ought to improve performance slightly when there are lots
of texture calls, but I'm still doing some tests to see if it's a measurable amount.
