### PR TITLE
Review: Thread-parallel LLVM/JIT of shader groups

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -4691,9 +4691,122 @@ RuntimeOptimizer::build_llvm_instance (bool groupentry)
 
 
 
+/// OSL_Dummy_JITMemoryManager - Create a shell that passes on requests
+/// to a real JITMemoryManager underneath, but can be retained after the
+/// dummy is destroyed.  Also, we don't pass along any deallocations.
+class OSL_Dummy_JITMemoryManager : public llvm::JITMemoryManager {
+protected:
+    llvm::JITMemoryManager *mm;
+public:
+    OSL_Dummy_JITMemoryManager(llvm::JITMemoryManager *realmm) : mm(realmm) { }
+    virtual ~OSL_Dummy_JITMemoryManager() { }
+    virtual void setMemoryWritable() { mm->setMemoryWritable(); }
+    virtual void setMemoryExecutable() { mm->setMemoryExecutable(); }
+    virtual void setPoisonMemory(bool poison) { mm->setPoisonMemory(poison); }
+    virtual void AllocateGOT() { mm->AllocateGOT(); }
+    bool isManagingGOT() const { return mm->isManagingGOT(); }
+    virtual uint8_t *getGOTBase() const { return mm->getGOTBase(); }
+    virtual uint8_t *startFunctionBody(const llvm::Function *F,
+                                       uintptr_t &ActualSize) {
+        return mm->startFunctionBody (F, ActualSize);
+    }
+    virtual uint8_t *allocateStub(const llvm::GlobalValue* F, unsigned StubSize,
+                                  unsigned Alignment) {
+        return mm->allocateStub (F, StubSize, Alignment);
+    }
+    virtual void endFunctionBody(const llvm::Function *F,
+                                 uint8_t *FunctionStart, uint8_t *FunctionEnd) {
+        mm->endFunctionBody (F, FunctionStart, FunctionEnd);
+    }
+    virtual uint8_t *allocateSpace(intptr_t Size, unsigned Alignment) {
+        return mm->allocateSpace (Size, Alignment);
+    }
+    virtual uint8_t *allocateGlobal(uintptr_t Size, unsigned Alignment) {
+        return mm->allocateGlobal (Size, Alignment);
+    }
+    virtual void deallocateFunctionBody(void *Body) {
+        // DON'T DEALLOCATE mm->deallocateFunctionBody (Body);
+    }
+    virtual uint8_t* startExceptionTable(const llvm::Function* F,
+                                         uintptr_t &ActualSize) {
+        return mm->startExceptionTable (F, ActualSize);
+    }
+    virtual void endExceptionTable(const llvm::Function *F, uint8_t *TableStart,
+                                   uint8_t *TableEnd, uint8_t* FrameRegister) {
+        mm->endExceptionTable (F, TableStart, TableEnd, FrameRegister);
+    }
+    virtual void deallocateExceptionTable(void *ET) {
+        // DON'T DEALLOCATE mm->deallocateExceptionTable(ET);
+    }
+    virtual bool CheckInvariants(std::string &s) {
+        return mm->CheckInvariants(s);
+    }
+    virtual size_t GetDefaultCodeSlabSize() {
+        return mm->GetDefaultCodeSlabSize();
+    }
+    virtual size_t GetDefaultDataSlabSize() {
+        return mm->GetDefaultDataSlabSize();
+    }
+    virtual size_t GetDefaultStubSlabSize() {
+        return mm->GetDefaultStubSlabSize();
+    }
+    virtual unsigned GetNumCodeSlabs() { return mm->GetNumCodeSlabs(); }
+    virtual unsigned GetNumDataSlabs() { return mm->GetNumDataSlabs(); }
+    virtual unsigned GetNumStubSlabs() { return mm->GetNumStubSlabs(); }
+};
+
+
+
 void
 RuntimeOptimizer::build_llvm_group ()
 {
+    // At this point, we already hold the lock for this group, by virtue
+    // of ShadingSystemImpl::optimize_group.
+    Timer timer;
+    m_shadingsys.SetupLLVM ();
+
+    if (! m_thread->llvm_context)
+        m_thread->llvm_context = new llvm::LLVMContext();
+
+    if (! m_thread->llvm_jitmm) {
+        m_thread->llvm_jitmm = llvm::JITMemoryManager::CreateDefaultMemManager();
+        spin_lock lock (m_shadingsys.m_llvm_mutex);  // lock m_llvm_jitmm_hold
+        m_shadingsys.m_llvm_jitmm_hold.push_back (shared_ptr<llvm::JITMemoryManager>(m_thread->llvm_jitmm));
+    }
+
+    ASSERT (! m_llvm_module);
+    // Load the LLVM bitcode and parse it into a Module
+    const char *data = osl_llvm_compiled_ops_block;
+    llvm::MemoryBuffer* buf = llvm::MemoryBuffer::getMemBuffer (llvm::StringRef(data, osl_llvm_compiled_ops_size));
+    std::string err;
+#ifdef OSL_LLVM_NO_BITCODE
+    m_llvm_module = new llvm::Module("llvm_ops", *llvm_context());
+#else
+    // Load the LLVM bitcode and parse it into a Module
+    m_llvm_module = llvm::ParseBitcodeFile (buf, *m_thread->llvm_context, &err);
+    if (err.length())
+        m_shadingsys.error ("ParseBitcodeFile returned '%s'\n", err.c_str());
+    delete buf;
+#endif
+
+    // Create the ExecutionEngine
+    ASSERT (! m_llvm_exec);
+    err.clear ();
+    llvm::JITMemoryManager *mm = new OSL_Dummy_JITMemoryManager(m_thread->llvm_jitmm);
+    m_llvm_exec = llvm::ExecutionEngine::createJIT (m_llvm_module, &err, mm);
+    if (! m_llvm_exec) {
+        m_shadingsys.error ("Failed to create engine: %s\n", err.c_str());
+        DASSERT (0);
+        return;
+    }
+    // Force it to JIT as soon as we ask it for the code pointer,
+    // don't take any chances that it might JIT lazily, since we
+    // will be stealing the JIT code memory from under its nose and
+    // destroying the Module & ExecutionEngine.
+    m_llvm_exec->DisableLazyCompilation ();
+
+    m_stat_llvm_setup_time += timer.lap();
+
     // Set up m_num_used_layers to be the number of layers that are
     // actually used, and m_layer_remap[] to map original layer numbers
     // to the shorter list of actually-called layers.
@@ -4708,7 +4821,6 @@ RuntimeOptimizer::build_llvm_group ()
             m_layer_remap[layer] = -1;
     }
 
-    Timer timer;
     initialize_llvm_group ();
 
     // Generate the LLVM IR for each layer
@@ -4721,7 +4833,7 @@ RuntimeOptimizer::build_llvm_group ()
         if (index != -1) funcs[index] = build_llvm_instance (lastlayer);
     }
     llvm::Function* entry_func = funcs[m_num_used_layers-1];
-    m_stat_llvm_irgen_time = timer();  timer.reset();  timer.start();
+    m_stat_llvm_irgen_time += timer.lap();
 
     // Optimize the LLVM IR unless it's just a ret void group (1 layer, 1 BB, 1 inst == retvoid)
     bool skip_optimization = m_num_used_layers == 1 && entry_func->size() == 1 && entry_func->front().size() == 1;
@@ -4752,8 +4864,6 @@ RuntimeOptimizer::build_llvm_group ()
 #endif
     }
 
-    m_stat_llvm_opt_time = timer();  timer.reset();  timer.start();
-
     if (shadingsys().llvm_debug())
         llvm::outs() << "func after opt  = " << *entry_func << "\n";
 
@@ -4767,9 +4877,10 @@ RuntimeOptimizer::build_llvm_group ()
         llvm::WriteBitcodeToFile (llvm_module(), out);
     }
 
-    // Force the JIT to happen now, while we have the lock
-    llvm::ExecutionEngine* ee = shadingsys().ExecutionEngine();
-    RunLLVMGroupFunc f = (RunLLVMGroupFunc) ee->getPointerToFunction(entry_func);
+    m_stat_llvm_opt_time += timer.lap();
+
+    // Force the JIT to happen now
+    RunLLVMGroupFunc f = (RunLLVMGroupFunc) m_llvm_exec->getPointerToFunction(entry_func);
     m_group.llvm_compiled_version (f);
 
     // Remove the IR for the group layer functions, we've already JITed it
@@ -4780,28 +4891,15 @@ RuntimeOptimizer::build_llvm_group ()
         funcs[i]->deleteBody();
     }
 
-#if 1
     // Free the exec and module to reclaim all the memory.  This definitely
     // saves memory, and has almost no effect on runtime.
-    delete shadingsys().m_llvm_exec;
+    delete m_llvm_exec;
+    m_llvm_exec = NULL;
+
     // N.B. Destroying the EE should have destroyed the module as well.
-    shadingsys().m_llvm_exec = NULL;
-    shadingsys().m_llvm_module = NULL;
-#endif
+    m_llvm_module = NULL;
 
-#if 0
-    // Enable this code to delete the whole context after processing the
-    // group.  We did this experiment to see how much memory was being
-    // held in the context.  Answer: nothing appreciable, not worth the
-    // extra work of constant creation and tear-down.
-    delete m_llvm_passes;  m_llvm_passes = NULL;
-    delete m_llvm_func_passes;  m_llvm_func_passes = NULL;
-    delete m_llvm_func_passes_optimized;  m_llvm_func_passes_optimized = NULL;
-    delete shadingsys().m_llvm_context;
-    shadingsys().m_llvm_context = NULL;
-#endif
-
-    m_stat_llvm_jit_time = timer();
+    m_stat_llvm_jit_time += timer();
 }
 
 
@@ -4813,8 +4911,7 @@ RuntimeOptimizer::initialize_llvm_group ()
     // static spin_mutex mutex;
     // spin_lock lock (mutex);
 
-    m_llvm_context = m_shadingsys.llvm_context ();
-    m_llvm_module = m_shadingsys.m_llvm_module;
+    m_llvm_context = m_thread->llvm_context;
     ASSERT (m_llvm_context && m_llvm_module);
 
     llvm_setup_optimization_passes ();
@@ -4887,123 +4984,19 @@ RuntimeOptimizer::initialize_llvm_group ()
 
 
 
-/// OSL_Dummy_JITMemoryManager - Create a shell that passes on requests
-/// to a real JITMemoryManager underneath, but can be retained after the
-/// dummy is destroyed.  Also, we don't pass along any deallocations.
-class OSL_Dummy_JITMemoryManager : public llvm::JITMemoryManager {
-protected:
-    llvm::JITMemoryManager *mm;
-public:
-    OSL_Dummy_JITMemoryManager(llvm::JITMemoryManager *realmm) : mm(realmm) { }
-    virtual ~OSL_Dummy_JITMemoryManager() { }
-    virtual void setMemoryWritable() { mm->setMemoryWritable(); }
-    virtual void setMemoryExecutable() { mm->setMemoryExecutable(); }
-    virtual void setPoisonMemory(bool poison) { mm->setPoisonMemory(poison); }
-    virtual void AllocateGOT() { mm->AllocateGOT(); }
-    bool isManagingGOT() const { return mm->isManagingGOT(); }
-    virtual uint8_t *getGOTBase() const { return mm->getGOTBase(); }
-    virtual uint8_t *startFunctionBody(const llvm::Function *F,
-                                       uintptr_t &ActualSize) {
-        return mm->startFunctionBody (F, ActualSize);
-    }
-    virtual uint8_t *allocateStub(const llvm::GlobalValue* F, unsigned StubSize,
-                                  unsigned Alignment) {
-        return mm->allocateStub (F, StubSize, Alignment);
-    }
-    virtual void endFunctionBody(const llvm::Function *F,
-                                 uint8_t *FunctionStart, uint8_t *FunctionEnd) {
-        mm->endFunctionBody (F, FunctionStart, FunctionEnd);
-    }
-    virtual uint8_t *allocateSpace(intptr_t Size, unsigned Alignment) {
-        return mm->allocateSpace (Size, Alignment);
-    }
-    virtual uint8_t *allocateGlobal(uintptr_t Size, unsigned Alignment) {
-        return mm->allocateGlobal (Size, Alignment);
-    }
-    virtual void deallocateFunctionBody(void *Body) {
-        // DON'T DEALLOCATE mm->deallocateFunctionBody (Body);
-    }
-    virtual uint8_t* startExceptionTable(const llvm::Function* F,
-                                         uintptr_t &ActualSize) {
-        return mm->startExceptionTable (F, ActualSize);
-    }
-    virtual void endExceptionTable(const llvm::Function *F, uint8_t *TableStart,
-                                   uint8_t *TableEnd, uint8_t* FrameRegister) {
-        mm->endExceptionTable (F, TableStart, TableEnd, FrameRegister);
-    }
-    virtual void deallocateExceptionTable(void *ET) {
-        // DON'T DEALLOCATE mm->deallocateExceptionTable(ET);
-    }
-    virtual bool CheckInvariants(std::string &s) {
-        return mm->CheckInvariants(s);
-    }
-    virtual size_t GetDefaultCodeSlabSize() {
-        return mm->GetDefaultCodeSlabSize();
-    }
-    virtual size_t GetDefaultDataSlabSize() {
-        return mm->GetDefaultDataSlabSize();
-    }
-    virtual size_t GetDefaultStubSlabSize() {
-        return mm->GetDefaultStubSlabSize();
-    }
-    virtual unsigned GetNumCodeSlabs() { return mm->GetNumCodeSlabs(); }
-    virtual unsigned GetNumDataSlabs() { return mm->GetNumDataSlabs(); }
-    virtual unsigned GetNumStubSlabs() { return mm->GetNumStubSlabs(); }
-};
-
-
-
 void
 ShadingSystemImpl::SetupLLVM ()
 {
-    if (! m_llvm_context) {
-        // First time through -- basic LLVM context setup
+    // Some global LLVM initialization for the first thread that
+    // gets here.
+    spin_lock llvm_lock (m_llvm_mutex);
+    if (! m_llvm_initialized) {
         info ("Setting up LLVM");
         llvm::DisablePrettyStackTrace = true;
         llvm::llvm_start_multithreaded ();  // enable it to be thread-safe
-        m_llvm_context = new llvm::LLVMContext();
         llvm::InitializeNativeTarget();
-
         initialize_llvm_generator_table ();
-    }
-
-    if (! m_llvm_jitmm)
-        m_llvm_jitmm = llvm::JITMemoryManager::CreateDefaultMemManager();
-
-    if (! m_llvm_module) {
-#ifdef OSL_LLVM_NO_BITCODE
-        m_llvm_module = new llvm::Module("llvm_ops", *llvm_context());
-#else
-        // Load the LLVM bitcode and parse it into a Module
-        const char *data = osl_llvm_compiled_ops_block;
-        llvm::MemoryBuffer* buf = llvm::MemoryBuffer::getMemBuffer (llvm::StringRef(data, osl_llvm_compiled_ops_size));
-        std::string err;
-        m_llvm_module = llvm::ParseBitcodeFile (buf, *llvm_context(), &err);
-        if (err.length())
-            error ("ParseBitcodeFile returned '%s'\n", err.c_str());
-        delete buf;
-#endif
-    }
-
-    // Create the ExecutionEngine
-    if (m_llvm_exec
-        && false /* FIXME -- leak the EE for now */) {
-        m_llvm_exec->addModule (m_llvm_module);
-    } else {
-        std::string error_msg;
-        llvm::JITMemoryManager *mm = new OSL_Dummy_JITMemoryManager(m_llvm_jitmm);
-        m_llvm_exec = llvm::ExecutionEngine::createJIT (m_llvm_module,
-                                                        &error_msg, mm);
-        // Force it to JIT as soon as we ask it for the code pointer,
-        // don't take any chances that it might JIT lazily, since we
-        // will be stealing the JIT code memory from under its nose and
-        // destroying the Module & ExecutionEngine.
-        m_llvm_exec->DisableLazyCompilation ();
-        if (! m_llvm_exec) {
-            error ("Failed to create engine: %s\n", error_msg.c_str());
-            DASSERT (0);
-            return;
-        }
+        m_llvm_initialized = true;
     }
 }
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3493,19 +3493,9 @@ RuntimeOptimizer::optimize_group ()
     m_stat_specialization_time = rop_timer();
 
     Timer timer;
-    // Let's punt on multithreading LLVM for the time being,
-    // just make a big lock.
-    static mutex llvm_mutex;
-    lock_guard llvm_lock (llvm_mutex);
-    m_stat_opt_locking_time = timer();
-
-    m_shadingsys.SetupLLVM ();
-    m_stat_llvm_setup_time = timer() - m_stat_opt_locking_time;
     build_llvm_group ();
-
     m_stat_total_llvm_time = timer();
-
-
+    
     m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
           new_nsyms, old_nsyms,
           100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -50,13 +50,16 @@ namespace pvt {   // OSL::pvt
 class RuntimeOptimizer {
 public:
     RuntimeOptimizer (ShadingSystemImpl &shadingsys, ShaderGroup &group)
-        : m_shadingsys(shadingsys), m_group(group),
+        : m_shadingsys(shadingsys),
+          m_thread(shadingsys.get_perthread_info()),
+          m_group(group),
           m_inst(NULL), m_next_newconst(0),
           m_stat_opt_locking_time(0), m_stat_specialization_time(0),
           m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
           m_stat_llvm_irgen_time(0), m_stat_llvm_opt_time(0),
           m_stat_llvm_jit_time(0),
-          m_llvm_context(NULL), m_llvm_module(NULL), m_builder(NULL),
+          m_llvm_context(NULL), m_llvm_module(NULL),
+          m_llvm_exec(NULL), m_builder(NULL),
           m_llvm_passes(NULL), m_llvm_func_passes(NULL),
           m_llvm_func_passes_optimized(NULL)
     {
@@ -629,6 +632,7 @@ public:
 
 private:
     ShadingSystemImpl &m_shadingsys;
+    PerThreadInfo *m_thread;
     ShaderGroup &m_group;             ///< Group we're optimizing
     int m_layer;                      ///< Layer we're optimizing
     ShaderInstance *m_inst;           ///< Instance we're optimizing
@@ -655,6 +659,7 @@ private:
     // LLVM stuff
     llvm::LLVMContext *m_llvm_context;
     llvm::Module *m_llvm_module;
+    llvm::ExecutionEngine *m_llvm_exec;
     AllocationMap m_named_values;
     std::map<const Symbol*,int> m_param_order_map;
     llvm::IRBuilder<> *m_builder;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -102,6 +102,25 @@ ShadingSystem::~ShadingSystem ()
 
 
 
+PerThreadInfo::PerThreadInfo ()
+    : llvm_context(NULL), llvm_jitmm(NULL)
+{
+}
+
+
+
+PerThreadInfo::~PerThreadInfo ()
+{
+    delete llvm_context;
+    // N.B. Do NOT delete the jitmm -- another thread may need the code!
+    // Don't worry, we stashed a pointer in the shadingsys.
+
+    while (! context_pool.empty())
+        delete pop_context ();
+}
+
+
+
 ShadingContext *
 PerThreadInfo::pop_context ()
 {
@@ -110,13 +129,6 @@ PerThreadInfo::pop_context ()
     return sc;
 }
 
-
-
-PerThreadInfo::~PerThreadInfo ()
-{
-    while (! context_pool.empty())
-        delete pop_context ();
-}
 
 
 
@@ -168,11 +180,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0),
       m_stat_llvm_setup_time(0), m_stat_llvm_irgen_time(0),
-      m_stat_llvm_opt_time(0), m_stat_llvm_jit_time(0),
-      m_llvm_context (NULL),
-      m_llvm_module (NULL),
-      m_llvm_exec (NULL),
-      m_llvm_jitmm (NULL)
+      m_stat_llvm_opt_time(0), m_stat_llvm_jit_time(0)
 {
     m_stat_shaders_loaded = 0;
     m_stat_shaders_requested = 0;
@@ -257,18 +265,6 @@ ShadingSystemImpl::~ShadingSystemImpl ()
     printstats ();
     // N.B. just let m_texsys go -- if we asked for one to be created,
     // we asked for a shared one.
-
-    delete m_llvm_exec;
-    // NOTE(boulos): Deleting the execution engine should in theory
-    // clean up the module. Calling delete on the module here results
-    // in a crash (suggesting theory meets practice).
-
-    // delete m_llvm_module;
-
-    delete m_llvm_context;
-
-    // Delete the retained JIT memory manager
-    delete m_llvm_jitmm;
 
     // FIXME(boulos): According to the docs, we should also call
     // llvm_shutdown once we're done. However, ~ShadingSystemImpl
@@ -585,12 +581,15 @@ ShadingSystemImpl::getstats (int level) const
     out << "        Instance param values: " << m_stat_mem_inst_paramvals.memstat() << '\n';
     out << "        Instance connections:  " << m_stat_mem_inst_connections.memstat() << '\n';
 
-    if (m_llvm_jitmm) {
-        size_t jitmem = m_llvm_jitmm->GetDefaultCodeSlabSize() * m_llvm_jitmm->GetNumCodeSlabs()
-            + m_llvm_jitmm->GetDefaultDataSlabSize() * m_llvm_jitmm->GetNumDataSlabs()
-            + m_llvm_jitmm->GetDefaultStubSlabSize() * m_llvm_jitmm->GetNumStubSlabs();
-        out << "    LLVM JIT memory: " << Strutil::memformat(jitmem) << '\n';
+    size_t jitmem = 0;
+    for (size_t i = 0;  i < m_llvm_jitmm_hold.size();  ++i) {
+        llvm::JITMemoryManager *mm = m_llvm_jitmm_hold[i].get();
+        if (mm)
+            jitmem += mm->GetDefaultCodeSlabSize() * mm->GetNumCodeSlabs()
+                    + mm->GetDefaultDataSlabSize() * mm->GetNumDataSlabs()
+                    + mm->GetDefaultStubSlabSize() * mm->GetNumStubSlabs();
     }
+    out << "    LLVM JIT memory: " << Strutil::memformat(jitmem) << '\n';
 
     return out.str();
 }


### PR DESCRIPTION
We had a big single lock around all the LLVM compilation, so no two threads could JIT shaders at the same time (though of course, once compiled, threads may execute shaders simultaneously). I have done a refactor that gives each thread its own llvm::Context and various other structures that let threads independently compile separate shader groups in parallel.

The amount of locking goes down by quite a bit, though it's no silver bullet: if two threads both need the same not-yet-compiled shader group at the same time, one of them is going to wait while the other compiles, and that still happens quite often.
