### PR TITLE
Review: Be more aggressive in freeing shader instance memory that's no longer nee

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -797,15 +797,11 @@ private:
     PeakCounter<int> m_stat_contexts;     ///< Stat: shading contexts
     int m_stat_groups;                    ///< Stat: shading groups
     int m_stat_groupinstances;            ///< Stat: total inst in all groups
+    atomic_int m_stat_groups_compiled;    ///< Stat: groups compiled
     atomic_int m_stat_regexes;            ///< Stat: how many regex's compiled
     atomic_ll m_layers_executed_uncond;   ///< Stat: Unconditional execs
     atomic_ll m_layers_executed_lazy;     ///< Stat: On-demand execs
     atomic_ll m_layers_executed_never;    ///< Stat: Layers never executed
-    atomic_ll m_stat_binds;               ///< Stat: Number of binds;
-    atomic_ll m_stat_rebinds;             ///< Stat: Number of rebinds;
-    atomic_ll m_stat_paramstobind;        ///< Stat: All params in bound shaders
-    atomic_ll m_stat_paramsbound;         ///< Stat: Number of params bound
-    atomic_ll m_stat_instructions_run;    ///< Stat: total instructions run
     atomic_int m_stat_total_syms;         ///< Stat: total syms in all insts
     atomic_int m_stat_syms_with_derivs;   ///< Stat: syms with derivatives
     double m_stat_optimization_time;      ///< Stat: time spent optimizing
@@ -829,8 +825,6 @@ private:
     PeakCounter<off_t> m_stat_mem_master_defaults;
     PeakCounter<off_t> m_stat_mem_master_consts;
     PeakCounter<off_t> m_stat_mem_inst;   ///< Stat: instance-related mem
-    PeakCounter<off_t> m_stat_mem_inst_ops;
-    PeakCounter<off_t> m_stat_mem_inst_args;
     PeakCounter<off_t> m_stat_mem_inst_syms;
     PeakCounter<off_t> m_stat_mem_inst_paramvals;
     PeakCounter<off_t> m_stat_mem_inst_connections;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -186,15 +186,11 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_shaders_requested = 0;
     m_stat_groups = 0;
     m_stat_groupinstances = 0;
+    m_stat_groups_compiled = 0;
     m_stat_regexes = 0;
     m_layers_executed_uncond = 0;
     m_layers_executed_lazy = 0;
     m_layers_executed_never = 0;
-    m_stat_binds = 0;
-    m_stat_rebinds = 0;
-    m_stat_paramstobind = 0;
-    m_stat_paramsbound = 0;
-    m_stat_instructions_run = 0;
     m_stat_total_syms = 0;
     m_stat_syms_with_derivs = 0;
     m_stat_optimization_time = 0;
@@ -381,6 +377,7 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("range_checking", int, m_range_checking);
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);
+    ATTR_DECODE ("stat:groups_compiled", int, m_stat_groups_compiled);
     ATTR_DECODE ("stat:instances", int, m_stat_groupinstances);
     ATTR_DECODE ("stat:memory_current", long long, m_stat_memory.current());
     ATTR_DECODE ("stat:memory_peak", long long, m_stat_memory.peak());
@@ -508,12 +505,12 @@ ShadingSystemImpl::getstats (int level) const
     out << "    Loaded:    " << m_stat_shaders_loaded << "\n";
     out << "    Masters:   " << m_stat_shaders_loaded << "\n";
     out << "    Instances: " << m_stat_instances << "\n";
-    out << "  Shading contexts: " << m_stat_contexts << "\n";
     out << "  Shading groups:   " << m_stat_groups << "\n";
     out << "    Total instances in all groups: " << m_stat_groupinstances << "\n";
     float iperg = (float)m_stat_groupinstances/std::max(m_stat_groups,1);
     out << "    Avg instances per group: " 
         << Strutil::format ("%.1f", iperg) << "\n";
+    out << "  Shading contexts: " << m_stat_contexts << "\n";
 
     long long totalexec = m_layers_executed_uncond + m_layers_executed_lazy +
                           m_layers_executed_never;
@@ -529,20 +526,10 @@ ShadingSystemImpl::getstats (int level) const
                             (long long)m_layers_executed_never,
                             (100.0*m_layers_executed_never) * inv_totalexec);
 
-    out << Strutil::format ("  Binds:  %lld\n",
-                            (long long)m_stat_binds);
-    out << Strutil::format ("  Rebinds:  %lld / %lld  (%.1f%%)\n",
-                            (long long)m_stat_rebinds, totalexec,
-                            (100.0*m_stat_rebinds) * inv_totalexec);
-    out << Strutil::format ("  Params bound:  %lld / %lld  (%.1f%%)\n",
-                            (long long)m_stat_paramsbound,
-                            (long long)m_stat_paramstobind,
-                            (100.0*m_stat_paramsbound)/std::max((int)m_stat_paramstobind, 1));
-    out << Strutil::format ("  Total instructions run:  %lld\n",
-                            (long long)m_stat_instructions_run);
     out << Strutil::format ("  Derivatives needed on %d / %d symbols (%.1f%%)\n",
                             (int)m_stat_syms_with_derivs, (int)m_stat_total_syms,
                             (100.0*(int)m_stat_syms_with_derivs)/std::max((int)m_stat_total_syms,1));
+    out << "  Shading groups compiled: " << m_stat_groups_compiled << "\n";
     out << "  Runtime optimization cost: "
         << Strutil::timeintervalformat (m_stat_optimization_time, 2) << "\n";
     out << "    locking:                   "
@@ -575,8 +562,6 @@ ShadingSystemImpl::getstats (int level) const
     out << "        Master defaults:       " << m_stat_mem_master_defaults.memstat() << '\n';
     out << "        Master consts:         " << m_stat_mem_master_consts.memstat() << '\n';
     out << "    Instance memory: " << m_stat_mem_inst.memstat() << '\n';
-    out << "        Instance ops:          " << m_stat_mem_inst_ops.memstat() << '\n';
-    out << "        Instance args:         " << m_stat_mem_inst_args.memstat() << '\n';
     out << "        Instance syms:         " << m_stat_mem_inst_syms.memstat() << '\n';
     out << "        Instance param values: " << m_stat_mem_inst_paramvals.memstat() << '\n';
     out << "        Instance connections:  " << m_stat_mem_inst_connections.memstat() << '\n';


### PR DESCRIPTION
Be more aggressive in freeing shader instance memory that's no longer needed after optimization and LLVM JIT (in particular, we do not need to retain the op and arg vectors at all).  Also clean up stats a bit, including getting rid of stats that have been meaningless for a long time.
