### PR TITLE
Review: Add Dz() which is helpful for apps that use OSL to shade volumes.

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3386,16 +3386,21 @@ $v$.  Results are undefined if the knots do not specifiy a monotonic
 \index{functions!derivatives and area}
 \index{derivatives}
 
-\apiitem{float {\ce Dx} (float a), {\ce Dy} (float a) \\
-vector {\ce Dx} (point a), {\ce Dy} (point a) \\
-vector {\ce Dx} (vector a), {\ce Dy} (vector a)\\
-color {\ce Dx} (color a), {\ce Dy} (color a)}
+\apiitem{float {\ce Dx} (float a), {\ce Dy} (float a), {\ce Dz} (float a) \\
+vector {\ce Dx} (point a), {\ce Dy} (point a), {\ce Dz} (point a) \\
+vector {\ce Dx} (vector a), {\ce Dy} (vector a), {\ce Dz} (vector a)\\
+color {\ce Dx} (color a), {\ce Dy} (color a), {\ce Dz} (color a)}
 \indexapi{Dx()} \indexapi{Dy()}
 Compute an approximation to the partial derivatives of $a$ with respect to
 each of two principal directions, $\partial a / \partial x$ and
 $\partial a / \partial y$.  Depending on the renderer
 implementation, those directions may be aligned to the image plane,
 on the surface of the object, or something else.
+
+The {\cf Dz()} function is only meaningful for volumetric shading, and
+is expected to return {\cf 0} in other contexts.  It is also possible
+that particular OSL implementations may only return ``correct'' {\cf Dz}
+values for particular inputs (such as \P).
 \apiend
 
 \apiitem{float {\ce filterwidth} (float x) \\

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -252,6 +252,7 @@ private:
 /// All points, vectors and normals are given in "common" space.
 struct ShaderGlobals {
     Vec3 P, dPdx, dPdy;              /**< Position */
+    Vec3 dPdz;                       /**< z zeriv for volume shading */
     Vec3 I, dIdx, dIdy;              /**< Incident ray */
     Vec3 N;                          /**< Shading normal */
     Vec3 Ng;                         /**< True geometric normal */

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -927,7 +927,7 @@ ASTfunction_call::typecheck_builtin_specialcase ()
             // FIXME -- come back to this
         } else if (m_name == "calculatenormal") {
             argtakesderivs (1, true);
-        } else if (m_name == "Dx" || m_name == "Dy") {
+        } else if (m_name == "Dx" || m_name == "Dy" || m_name == "Dz") {
             argtakesderivs (1, true);
         } else if (m_name == "texture") {
             if (nargs == 3 || list_nth(args(),3)->typespec().is_string()) {
@@ -1082,6 +1082,7 @@ static const char * builtin_func_args [] = {
     "dict_value", "iis?", "!rw", NULL,
     "Dx", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "Dy", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
+    "Dz", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "displace", "xf", "xsf", "xv", "!deriv", NULL,
     "environment", "fsv.", "fsvvv.","csv.", "csvvv.", 
                "vsv.", "vsvvv.", "!tex", "!rw", "!deriv", NULL,

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -665,10 +665,6 @@ public:
 
     void operator delete (void *todel) { ::delete ((char *)todel); }
 
-    /// Return the precomputed heap offset of the named global, or -1 if
-    /// it's not precomputed.
-    int global_heap_offset (ustring name);
-
     /// Is the shading system in debug mode?
     ///
     bool debug () const { return m_debug; }
@@ -718,7 +714,6 @@ public:
 
 private:
     void printstats () const;
-    void init_global_heap_offsets ();
 
     /// Find the index of the named layer in the current shader group.
     /// If found, return the index >= 0 and put a pointer to the instance
@@ -785,8 +780,6 @@ private:
     ShaderUse m_group_use;                ///< Use of group
     ParamValueList m_pending_params;      ///< Pending Parameter() values
     ShadingAttribStateRef m_curattrib;    ///< Current shading attribute state
-    std::map<ustring,int> m_global_heap_offsets; ///< Heap offsets of globals
-    size_t m_global_heap_total;           ///< Heap size for globals
     mutable mutex m_mutex;                ///< Thread safety
     mutable thread_specific_ptr<PerThreadInfo> m_perthread_info;
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -176,7 +176,6 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_llvm_debug(false),
       m_commonspace_synonym("world"),
       m_in_group (false),
-      m_global_heap_total (0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0),
       m_stat_llvm_setup_time(0), m_stat_llvm_irgen_time(0),
@@ -197,8 +196,6 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_getattribute_time = 0;
     m_stat_getattribute_fail_time = 0;
     m_stat_getattribute_calls = 0;
-
-    init_global_heap_offsets ();
 
     // If client didn't supply an error handler, just use the default
     // one that echoes to the terminal.
@@ -979,59 +976,6 @@ ShadingSystemImpl::decode_connected_param (const char *connectionname,
         c.param = -1;  // mark as invalid
     }
     return c;
-}
-
-
-
-void
-ShadingSystemImpl::init_global_heap_offsets ()
-{
-    lock_guard lock (m_mutex);
-    if (m_global_heap_total > 0)
-        return;   // Already initialized
-
-    // FIXME -- these are all wrong (but luckily unused).  They don't 
-    // properly consider npoints, let alone derivs or alignment.  Ugh.
-    // Leave here for right now, anticipate future deletion or fixing.
-    const int triple_size = sizeof (Vec3);
-    m_global_heap_offsets[ustring("P")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("I")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("N")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("Ng")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("dPdu")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("dPdv")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("dPdtime")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-    m_global_heap_offsets[ustring("Ps")] = m_global_heap_total;
-    m_global_heap_total += triple_size;
-
-    m_global_heap_offsets[ustring("u")] = m_global_heap_total;
-    m_global_heap_total += sizeof (float);
-    m_global_heap_offsets[ustring("v")] = m_global_heap_total;
-    m_global_heap_total += sizeof (float);
-    m_global_heap_offsets[ustring("time")] = m_global_heap_total;
-    m_global_heap_total += sizeof (float);
-    m_global_heap_offsets[ustring("dtime")] = m_global_heap_total;
-    m_global_heap_total += sizeof (float);
-}
-
-
-
-int
-ShadingSystemImpl::global_heap_offset (ustring name)
-{
-    // FIXME -- these are all wrong.  I don't know what I was thinking
-    // when I wrote this.  But luckily, it also doesn't seem to be used
-    // now.
-    ASSERT (0);
-    std::map<ustring,int>::const_iterator f = m_global_heap_offsets.find (name);
-    return f != m_global_heap_offsets.end() ? f->second : -1;
 }
 
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -283,6 +283,7 @@ setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
     // Derivatives with respect to x,y
     sg.dPdx = Vec3 (sg.dudx, sg.dudy, 0.0f);
     sg.dPdy = Vec3 (sg.dvdx, sg.dvdy, 0.0f);
+    sg.dPdz = Vec3 (0.0f, 0.0f, 0.0f);  // just use 0 for volume tangent
     // Tangents of P with respect to surface u,v
     sg.dPdu = Vec3 (1.0f, 0.0f, 0.0f);
     sg.dPdv = Vec3 (0.0f, 1.0f, 0.0f);


### PR DESCRIPTION
Add Dz() which is helpful for apps that use OSL to shade volumes.  At present, we only correctly compute Dz(P), all other Dz() queries return 0.  This change Includes opportunistic removal of dead m_global_heap stuff left over from the interpreter days.

I realize that this is very limited support for Dz().  Think of this as "reserving" the API, but getting _one_ case right, which happens to be the only one that is desperately needed by at the moment somebody who is using OSL to do computations on a volumetric grid.  If the need arises later, we can always increase support to handle the general case, for example by implementing a Dual3 (tracking x, y, and z derivs) which the LLVM-generated code can use underneath when it knows that a shader group will need z derivatives (the usual case would still be surface shading, 2D derivs only).  But that's a _lot_ of work, so for now I propose only doing the work if/when needed down the road.
