### PR TITLE
Review: Additional stats on how many instances/groups compile

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -4892,6 +4892,7 @@ RuntimeOptimizer::build_llvm_group ()
         else
             m_layer_remap[layer] = -1;
     }
+    m_shadingsys.m_stat_empty_instances += m_group.nlayers()-m_num_used_layers;
 
     initialize_llvm_group ();
 
@@ -4911,7 +4912,9 @@ RuntimeOptimizer::build_llvm_group ()
     bool skip_optimization = m_num_used_layers == 1 && entry_func->size() == 1 && entry_func->front().size() == 1;
     // Label the group as being retvoid or not.
     m_group.does_nothing(skip_optimization);
-    if (!skip_optimization) {
+    if (skip_optimization) {
+        m_shadingsys.m_stat_empty_groups += 1;
+    } else {
 #if 0
       // First do the simple function passes
       m_llvm_func_passes->doInitialization();

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -790,7 +790,10 @@ private:
     PeakCounter<int> m_stat_contexts;     ///< Stat: shading contexts
     int m_stat_groups;                    ///< Stat: shading groups
     int m_stat_groupinstances;            ///< Stat: total inst in all groups
+    atomic_int m_stat_instances_compiled; ///< Stat: instances compiled
     atomic_int m_stat_groups_compiled;    ///< Stat: groups compiled
+    atomic_int m_stat_empty_instances;    ///< Stat: shaders empty after opt
+    atomic_int m_stat_empty_groups;       ///< Stat: groups empty after opt
     atomic_int m_stat_regexes;            ///< Stat: how many regex's compiled
     atomic_ll m_layers_executed_uncond;   ///< Stat: Unconditional execs
     atomic_ll m_layers_executed_lazy;     ///< Stat: On-demand execs

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3524,6 +3524,7 @@ ShadingSystemImpl::optimize_group (ShadingAttribState &attribstate,
     m_stat_llvm_opt_time += rop.m_stat_llvm_opt_time;
     m_stat_llvm_jit_time += rop.m_stat_llvm_jit_time;
     m_stat_groups_compiled += 1;
+    m_stat_instances_compiled += group.nlayers();
 }
 
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -185,7 +185,10 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_shaders_requested = 0;
     m_stat_groups = 0;
     m_stat_groupinstances = 0;
+    m_stat_instances_compiled = 0;
     m_stat_groups_compiled = 0;
+    m_stat_empty_instances = 0;
+    m_stat_empty_groups = 0;
     m_stat_regexes = 0;
     m_layers_executed_uncond = 0;
     m_layers_executed_lazy = 0;
@@ -374,7 +377,10 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("range_checking", int, m_range_checking);
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);
+    ATTR_DECODE ("stat:instances_compiled", int, m_stat_instances_compiled);
     ATTR_DECODE ("stat:groups_compiled", int, m_stat_groups_compiled);
+    ATTR_DECODE ("stat:empty_instances", int, m_stat_empty_instances);
+    ATTR_DECODE ("stat:empty_groups", int, m_stat_empty_groups);
     ATTR_DECODE ("stat:instances", int, m_stat_groupinstances);
     ATTR_DECODE ("stat:memory_current", long long, m_stat_memory.current());
     ATTR_DECODE ("stat:memory_peak", long long, m_stat_memory.peak());
@@ -526,7 +532,14 @@ ShadingSystemImpl::getstats (int level) const
     out << Strutil::format ("  Derivatives needed on %d / %d symbols (%.1f%%)\n",
                             (int)m_stat_syms_with_derivs, (int)m_stat_total_syms,
                             (100.0*(int)m_stat_syms_with_derivs)/std::max((int)m_stat_total_syms,1));
-    out << "  Shading groups compiled: " << m_stat_groups_compiled << "\n";
+    out << "  Compiled " << m_stat_groups_compiled << " groups, "
+        << m_stat_instances_compiled << " instances\n";
+    out << "  After optimization, " << m_stat_empty_instances 
+        << " empty instances ("
+        << (int)(100.0f*m_stat_empty_instances/m_stat_instances_compiled)
+        << "%)\n";
+    out << "  After optimization, " << m_stat_empty_groups << " empty groups ("
+        << (int)(100.0f*m_stat_empty_groups/m_stat_groups_compiled)<< "%)\n";
     out << "  Runtime optimization cost: "
         << Strutil::timeintervalformat (m_stat_optimization_time, 2) << "\n";
     out << "    locking:                   "


### PR DESCRIPTION
Additional stats on how many instances/groups compile, and how many are empty after optimization.

Looks like this (and yes, these are actual stats from a render):

   Shading groups:   836
     Total instances in all groups: 130687
     Avg instances per group: 156.3
   ...
   Compiled 709 groups, 106615 instances
   After optimization, 83299 empty instances, 275 empty groups
