### PR TITLE
Initialize LLVM up front rather than lazily

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -598,7 +598,7 @@ private:
 
 
 
-class OSLEXECPUBLIC ShadingSystemImpl : public ShadingSystem
+class ShadingSystemImpl : public ShadingSystem
 {
 public:
     ShadingSystemImpl (RendererServices *renderer=NULL,
@@ -830,7 +830,6 @@ private:
 
     // LLVM stuff
     spin_mutex m_llvm_mutex;
-    atomic_int m_llvm_initialized;
     // Can't throw away jitmm's until we're totally done
     std::vector<shared_ptr<llvm::JITMemoryManager> > m_llvm_jitmm_hold;
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -237,6 +237,8 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     };
     const int nraytypes = sizeof(raytypes)/sizeof(raytypes[0]);
     attribute ("raytypes", TypeDesc(TypeDesc::STRING,nraytypes), raytypes);
+
+    SetupLLVM ();
 }
 
 


### PR DESCRIPTION
This fixes the mysterious crash when calling createJIT, which was
actually due to m_llvm_initialized not being initialized to 0 in the
constructor.
Removed the lock around createJIT which is no longer necessary.
