### PR TITLE
Allow a shader param to mask a global built-in function with only a warning

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -188,6 +188,7 @@ public:
     void sourceline (int line) { m_sourceline = line; }
 
     void error (const char *format, ...);
+    void warning (const char *format, ...);
 
     bool is_lvalue () const { return m_is_lvalue; }
 


### PR DESCRIPTION
Allow a shader param to mask a global built-in function with only a warning. Also improve scope conflict error messages by pointing out the file and line where the previous declaration was.
