### PR TITLE
Review: splineinverse

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,7 +134,7 @@ TESTSUITE ( arithmetic array array-derivs array-range
             ieee_fp if incdec initops intbits layers layers-lazy
             logic loop matrix message miscmath missing-shader noise pnoise
             oslc-err-noreturn oslc-err-paramdefault
-            raytype shortcircuit spline string 
+            raytype shortcircuit spline splineinverse string 
             struct struct-array struct-array-mixture
             struct-err struct-layers struct-with-array 
             struct-within-struct ternary

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3366,18 +3366,25 @@ ignore the first and last data value, interpolating piecewise-linearly
 between $y_1$ and $y_{n-2}$.
 \apiend
 
-\begin{comment}
-\apiitem{float {\ce inversespline} (string basis, float v, float $\mathtt{y}_0$, ... float $\mathtt{y}_{n-1}$)\\
-float {\ce inversespline} (string basis, float v, float y[]) \\
-float {\ce inversespline} (string basis, float v, int nknots, float y[])}
-\indexapi{inversespline()}
+\apiitem{float {\ce splineinverse} (string basis, float v, float $\mathtt{y}_0$, ... float $\mathtt{y}_{n-1}$)\\
+float {\ce splineinverse} (string basis, float v, float y[]) \\
+float {\ce splineinverse} (string basis, float v, int nknots, float y[])}
+\indexapi{splineinverse()}
 
 Computes the \emph{inverse} of the {\cf spline()} function --- i.e., returns
 the value $x$ for which {\cf spline (basis, x, y...)} would return value
 $v$.  Results are undefined if the knots do not specifiy a monotonic
-(only increasing or only decreasing) spline.
+(only increasing or only decreasing) set of values.
+
+Note that the combination of {\cf spline} and {\cf splineinverse} makes
+it possible to compute a full spline-with-nonuniform-abscissae:
+\begin{smallcode}
+    \emph{type} spline (string basis, float x, int nknots, float abscissa[], \emph{type} value[]) {
+        float v = splineinverse (basis, x, nknots, abscissa);
+        return spline (basis, v, nknots, value);
+    }
+\end{smallcode}
 \apiend
-\end{comment}
 
 
 \section{Derivatives and area operators}

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1030,11 +1030,6 @@ ASTfunction_call::typecheck (TypeSpec expected)
 
 
 
-// FIXME -- should the type constructors be here?
-// FIXME -- spline, inversespline -- hard case!
-// FIXME -- regex, substr
-// FIXME -- light and shadow
-
 // Key:
 //    x - void (only used for first char to indicate void return type)
 //    i - int
@@ -1109,6 +1104,7 @@ static const char * builtin_func_args [] = {
     "sincos", "xfff", "xccc", "xppp", "xvvv", "xnnn", "!rw", NULL,
     "snoise", NOISE_ARGS, NULL,
     "spline", "fsff[]", "csfc[]", "psfp[]", "vsfv[]", "nsfn[]", "fsfif[]", "csfic[]", "psfip[]", "vsfiv[]", "nsfin[]", NULL,
+    "splineinverse", "fsff[]", "fsfif[]", NULL,
     "surfacearea", "f", NULL,
     "texture", "fsff.", "fsffffff.","csff.", "csffffff.", 
                "vsff.", "vsffffff.", "!tex", "!rw", "!deriv", NULL,

--- a/src/liboslexec/bsdf_cloth.cpp
+++ b/src/liboslexec/bsdf_cloth.cpp
@@ -608,7 +608,7 @@ public:
 
             // ellipse segment area
             // apply per-thread type fresnel here
-            AE = (fabs(det)*AC)/t_seg[threadPattern[i]].AR * F[threadPattern[i]];
+            AE = (fabsf(det)*AC)/t_seg[threadPattern[i]].AR * F[threadPattern[i]];
 
             //  grab the current single thread ellipse segment area in AE_st
             //  - to be used in LERP with AE_f (for when feature scale is under Nyquist limit (hopefully))

--- a/src/liboslexec/bsdf_cloth_fncs.cpp
+++ b/src/liboslexec/bsdf_cloth_fncs.cpp
@@ -57,13 +57,13 @@ schlick_fresnel(float cosNO, float R0) {
 float computeG_Smith(const Vec3 &N, Vec3 &H, const Vec3 &omega_out, float cosNI, float cosNO)
 {
     float cosNH = N.dot(H);
-    float cosHO = fabs(omega_out.dot(H));
+    float cosHO = fabsf(omega_out.dot(H));
 
     float cosNHdivHO = cosNH/cosHO;
     cosNHdivHO = std::max(cosNHdivHO, 0.00001f);
 
-    float fac1 = 2.f * fabs(cosNHdivHO * cosNO);
-    float fac2 = 2.f * fabs(cosNHdivHO * cosNI);
+    float fac1 = 2.f * fabsf(cosNHdivHO * cosNO);
+    float fac2 = 2.f * fabsf(cosNHdivHO * cosNI);
 
     return std::min(1.f, std::min(fac1, fac2));
 }
@@ -240,7 +240,7 @@ bool ray_circle(Point2 p1, Point2 p2, Point2 sc, float r, float *mu1, float *mu2
     //   intersecting it at one point (we don't care about this case)
     // if it's greater than zero the line intersects at two points.
     bb4ac = b * b - 4 * a * c;
-    if (fabs(a) < EPSILON || bb4ac <= 0.f) {
+    if (fabsf(a) < EPSILON || bb4ac <= 0.f) {
         *mu1 = 0;
         *mu2 = 0;
         return false;
@@ -519,7 +519,7 @@ float compute_AC(Point2 *rect, bool OUTSIDE)
     // Note: there aren't really 5 intersections, here.  This case of 4 intersections is just set to 5.
     //
     if(i == 5){
-        area = seg_area(theta[0]) + fabs(t_area(P0, P1, P2));
+        area = seg_area(theta[0]) + fabsf(t_area(P0, P1, P2));
         return area;
     }
 

--- a/src/liboslexec/bsdf_cloth_specular.cpp
+++ b/src/liboslexec/bsdf_cloth_specular.cpp
@@ -241,7 +241,7 @@ public:
 
                 // ellipse segment area
                 // apply per-thread type fresnel here
-                float AE = (fabs(det)*AC)/AR[m_thread_pattern[i]] * F[m_thread_pattern[i]];
+                float AE = (fabsf(det)*AC)/AR[m_thread_pattern[i]] * F[m_thread_pattern[i]];
 
                 //  grab the current single thread ellipse segment area in AE_st
                 //  - to be used in LERP with AE_f (for when feature scale is under Nyquist limit (hopefully))

--- a/src/liboslexec/dual.h
+++ b/src/liboslexec/dual.h
@@ -241,6 +241,41 @@ inline Dual2<T> operator/ (const T &aval, const Dual2<T> &b)
                      bvalinv * ( - aval_bval * b.dy()));
 }
 
+
+
+
+template<class T>
+inline bool operator< (const Dual2<T> &a, const Dual2<T> &b) {
+    return a.val() < b.val();
+}
+
+template<class T>
+inline bool operator< (const Dual2<T> &a, const T &b) {
+    return a.val() < b;
+}
+
+template<class T>
+inline bool operator> (const Dual2<T> &a, const Dual2<T> &b) {
+    return a.val() > b.val();
+}
+
+template<class T>
+inline bool operator> (const Dual2<T> &a, const T &b) {
+    return a.val() > b;
+}
+
+template<class T>
+inline bool operator<= (const Dual2<T> &a, const Dual2<T> &b) {
+    return a.val() <= b.val();
+}
+
+template<class T>
+inline bool operator>= (const Dual2<T> &a, const Dual2<T> &b) {
+    return a.val() >= b.val();
+}
+
+
+
 // f(x) = cos(x), f'(x) = -sin(x)
 template<class T>
 inline Dual2<T> cos (const Dual2<T> &a)
@@ -672,6 +707,15 @@ inline Dual2<T> dual_max (const Dual2<T> &x, const Dual2<T> &y)
    else 
       return y;
 }
+
+
+template<class T>
+inline Dual2<T> fabs (const Dual2<T> &x)
+{
+    return x.val() >= T(0) ? x : -x;
+}
+
+
 
 template<class T>
 inline Dual2<T> dual_clamp (const Dual2<T> &x, const Dual2<T> &minv, const Dual2<T> &maxv)

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -285,6 +285,10 @@ static const char *llvm_helper_function_table[] = {
     "osl_spline_dvdfdv", "xXXXXi",
     "osl_spline_dvdfv", "xXXXXi",
     "osl_spline_dvfdv", "xXXXXi",
+    "osl_splineinverse_fff", "xXXXXi",
+    "osl_splineinverse_dfdfdf", "xXXXXi",
+    "osl_splineinverse_dfdff", "xXXXXi",
+    "osl_splineinverse_dffdf", "xXXXXi",
     "osl_setmessage", "xXsLXisi",
     "osl_getmessage", "iXssLXiisi",
     "osl_pointcloud_search", "iXsXfiXXii*",
@@ -4011,7 +4015,7 @@ LLVMGEN (llvm_gen_spline)
              Knots.typespec().is_array() &&  
              (!has_knot_count || (has_knot_count && Knot_count.typespec().is_int())));
 
-    std::string name = "osl_spline_";
+    std::string name = Strutil::format("osl_%s_", op.opname().c_str());
     std::vector<llvm::Value *> args;
     // only use derivatives for result if:
     //   result has derivs and (value || knots) have derivs
@@ -4640,6 +4644,7 @@ initialize_llvm_generator_table ()
     INIT2 (smoothstep, llvm_gen_generic);
     INIT2 (snoise, llvm_gen_generic);
     INIT (spline);
+    INIT2 (splineinverse, llvm_gen_spline);
     INIT2 (sqrt, llvm_gen_generic);
     INIT2 (startswith, llvm_gen_generic);
     INIT2 (step, llvm_gen_generic);

--- a/testsuite/splineinverse/ref/out.txt
+++ b/testsuite/splineinverse/ref/out.txt
@@ -1,0 +1,50 @@
+Compiled test.osl -> test.oso
+u = 0.166667  (derivs 0.333333 0)
+splineinverse("linear", 0.166667) = 0.583333  (derivs 0.416667 0)
+spline("linear",0.583333) = 0.166667   (derivs 0.333333 0)
+  spline("linear",0) = 0
+  spline("linear",1) = 1
+
+splineinverse("catmull-rom", 0.166667) = 0.636126  (derivs 0.485242 0)
+spline("catmull-rom",0.636126) = 0.166667   (derivs 0.333333 0)
+  spline("catmull-rom",0) = 0
+  spline("catmull-rom",1) = 1
+
+splineinverse("bspline", 0.166667) = 0.569314  (derivs 0.462879 0)
+spline("bspline",0.569314) = 0.166667   (derivs 0.333333 0)
+  spline("bspline",0) = 0.00833333
+  spline("bspline",1) = 0.883333
+
+u = 0.5  (derivs 0.333333 0)
+splineinverse("linear", 0.5) = 0.821429  (derivs 0.119048 0)
+spline("linear",0.821429) = 0.5   (derivs 0.333333 0)
+  spline("linear",0) = 0
+  spline("linear",1) = 1
+
+splineinverse("catmull-rom", 0.5) = 0.826469  (derivs 0.103961 0)
+spline("catmull-rom",0.826469) = 0.5   (derivs 0.333333 0)
+  spline("catmull-rom",0) = 0
+  spline("catmull-rom",1) = 1
+
+splineinverse("bspline", 0.5) = 0.808612  (derivs 0.155984 0)
+spline("bspline",0.808612) = 0.5   (derivs 0.333333 0)
+  spline("bspline",0) = 0.00833333
+  spline("bspline",1) = 0.883333
+
+u = 0.833333  (derivs 0.333333 0)
+splineinverse("linear", 0.833333) = 0.940476  (derivs 0.119048 0)
+spline("linear",0.940476) = 0.833333   (derivs 0.333333 0)
+  spline("linear",0) = 0
+  spline("linear",1) = 1
+
+splineinverse("catmull-rom", 0.833333) = 0.927532  (derivs 0.111185 0)
+spline("catmull-rom",0.927532) = 0.833333   (derivs 0.333333 0)
+  spline("catmull-rom",0) = 0
+  spline("catmull-rom",1) = 1
+
+splineinverse("bspline", 0.833333) = 0.968067  (derivs 0.193972 0)
+spline("bspline",0.968067) = 0.833333   (derivs 0.333333 0)
+  spline("bspline",0) = 0.00833333
+  spline("bspline",1) = 0.883333
+
+

--- a/testsuite/splineinverse/run.py
+++ b/testsuite/splineinverse/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python 
+
+import os
+import sys
+
+path = ""
+command = ""
+if len(sys.argv) > 2 :
+    os.chdir (sys.argv[1])
+    path = sys.argv[2] + "/"
+
+# A command to run
+command = path + "oslc/oslc test.osl > out.txt"
+command = command + "; " + path + "testshade/testshade -g 3 1 --center test >> out.txt"
+
+# Outputs to check against references
+outputs = [ "out.txt" ]
+
+# Files that need to be cleaned up, IN ADDITION to outputs
+cleanfiles = [ ]
+
+
+# boilerplate
+sys.path = [".."] + sys.path
+import runtest
+ret = runtest.runtest (command, outputs, cleanfiles)
+sys.exit (ret)

--- a/testsuite/splineinverse/test.osl
+++ b/testsuite/splineinverse/test.osl
@@ -1,0 +1,28 @@
+
+void s (string basis, float y, float knots[])
+{
+    float x;
+    x = splineinverse (basis, y, knots);
+    printf ("splineinverse(\"%s\", %g) = %g  (derivs %g %g)\n",
+            basis, y, x, Dx(x), Dy(x));
+    float y2 = spline (basis, x, knots);
+    printf ("spline(\"%s\",%g) = %g   (derivs %g %g)\n",
+            basis, x, y, Dx(y), Dy(y));
+    if (fabs(y-y2) > 0.0001)
+        printf ("ERR! splineinverse doesn't appear to work\n");
+    printf ("  spline(\"%s\",%g) = %g\n", basis, 0.0, spline(basis,0.0,knots));
+    printf ("  spline(\"%s\",%g) = %g\n", basis, 1.0, spline(basis,1.0,knots));
+    printf ("\n");
+}
+
+
+
+shader test ()
+{
+    float knots[7] = { 0, 0, 0.05, 0.1, 0.3, 1, 1 };
+
+    printf ("u = %g  (derivs %g %g)\n", u, Dx(u), Dy(u));
+    s ("linear", u, knots);
+    s ("catmull-rom", u, knots);
+    s ("bspline", u, knots);
+}


### PR DESCRIPTION
Add splineinverse(), which is the inverse function to spline().  That is, if

```
y = spline (basisname, x, knots[])
```

then

```
x = splineinverse (basisname, y, knots[])
```

splineinverse only takes float knots (I hope the reason is obvious), and is only well-defined for knot sequences that define a monotonically-changing (increasing or decreasing) spline.

The main way this can be used cleverly is to use a splineinverse/spline pair as a way to make a spline function that takes nonuniformly spaced knots:

```
float xtmp = splineinverse (basis, x, abscissas[]);
y = spline (basis, x, values[]);
```

if you catch my drift.
