### PR TITLE
Extend SimpleRenderer/testshade to handle several standard named coordinate systems

### DIFF
--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -37,6 +37,37 @@ namespace OSL_NAMESPACE {
 
 namespace OSL {
 
+static ustring u_camera("camera"), u_screen("screen");
+static ustring u_NDC("NDC"), u_raster("raster");
+static ustring u_perspective("perspective");
+
+
+
+SimpleRenderer::SimpleRenderer ()
+{
+    Matrix44 M;  M.makeIdentity();
+    camera_params (M, u_perspective, 90.0f,
+                   0.1f, 1000.0f, 256, 256);
+}
+
+
+
+void
+SimpleRenderer::camera_params (const Matrix44 &world_to_camera,
+                               ustring projection, float hfov,
+                               float hither, float yon,
+                               int xres, int yres)
+{
+    m_world_to_camera = world_to_camera;
+    m_projection = projection;
+    m_fov = hfov;
+    m_hither = hither;
+    m_yon = yon;
+    m_xres = xres;
+    m_yres = yres;
+}
+
+
 
 bool
 SimpleRenderer::get_matrix (Matrix44 &result, TransformationPtr xform,
@@ -83,6 +114,61 @@ SimpleRenderer::get_matrix (Matrix44 &result, ustring from)
     TransformMap::const_iterator found = m_named_xforms.find (from);
     if (found != m_named_xforms.end()) {
         result = *(found->second);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+
+
+bool
+SimpleRenderer::get_inverse_matrix (Matrix44 &result, ustring to, float time)
+{
+    if (to == u_camera || to == u_screen || to == u_NDC || to == u_raster) {
+        Matrix44 M = m_world_to_camera;
+        if (to == u_screen || to == u_NDC || to == u_raster) {
+            float depthrange = (double)m_yon-(double)m_hither;
+            static ustring u_perspective("perspective");
+            if (m_projection == u_perspective) {
+                float tanhalffov = tanf (0.5f * m_fov * M_PI/180.0);
+                Matrix44 camera_to_screen (1/tanhalffov, 0, 0, 0,
+                                           0, 1/tanhalffov, 0, 0,
+                                           0, 0, m_yon/depthrange, 1,
+                                           0, 0, -m_yon*m_hither/depthrange, 0);
+                M = M * camera_to_screen;
+            } else {
+                Matrix44 camera_to_screen (1, 0, 0, 0,
+                                           0, 1, 0, 0,
+                                           0, 0, 1/depthrange, 0,
+                                           0, 0, -m_hither/depthrange, 1);
+                M = M * camera_to_screen;
+            }
+            if (to == u_NDC || to == u_raster) {
+                float screenleft = -1.0, screenwidth = 2.0;
+                float screenbottom = -1.0, screenheight = 2.0;
+                Matrix44 screen_to_ndc (1/screenwidth, 0, 0, 0,
+                                        0, 1/screenheight, 0, 0,
+                                        0, 0, 1, 0,
+                                        -screenleft/screenwidth, -screenbottom/screenheight, 0, 1);
+                M = M * screen_to_ndc;
+                if (to == u_raster) {
+                    Matrix44 ndc_to_raster (m_xres, 0, 0, 0,
+                                            0, m_yres, 0, 0,
+                                            0, 0, 1, 0,
+                                            0, 0, 0, 1);
+                    M = M * ndc_to_raster;
+                }
+            }
+        }
+        result = M;
+        return true;
+    }
+
+    TransformMap::const_iterator found = m_named_xforms.find (to);
+    if (found != m_named_xforms.end()) {
+        result = *(found->second);
+        result.invert();
         return true;
     } else {
         return false;

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -50,7 +50,7 @@ public:
     // Just use 4x4 matrix for transformations
     typedef Matrix44 Transformation;
 
-    SimpleRenderer () { }
+    SimpleRenderer ();
     ~SimpleRenderer () { }
 
     virtual bool get_matrix (Matrix44 &result, TransformationPtr xform,
@@ -59,6 +59,7 @@ public:
 
     virtual bool get_matrix (Matrix44 &result, TransformationPtr xform);
     virtual bool get_matrix (Matrix44 &result, ustring from);
+    virtual bool get_inverse_matrix (Matrix44 &result, ustring to, float time);
 
     void name_transform (const char *name, const Transformation &xform);
 
@@ -79,10 +80,19 @@ public:
                                 ustring attr_name, TypeDesc attr_type,
                                 void *out_data);
 
+    // Super simple camera and display parameters.  Many options not
+    // available, no motion blur, etc.
+    void camera_params (const Matrix44 &world_to_camera, ustring projection,
+                        float hfov, float hither, float yon,
+                        int xres, int yres);
+                        
 private:
     typedef std::map <ustring, shared_ptr<Transformation> > TransformMap;
     TransformMap m_named_xforms;
-
+    Matrix44 m_world_to_camera;
+    ustring m_projection;
+    float m_fov, m_hither, m_yon;
+    int m_xres, m_yres;
 };
 
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -216,6 +216,10 @@ static void
 setup_transformations (SimpleRenderer &rend, OSL::Matrix44 &Mshad,
                        OSL::Matrix44 &Mobj)
 {
+    Matrix44 M (1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1);
+    rend.camera_params (M, ustring("perspective"), 90.0f,
+                        0.1f, 1000.0f, xres, yres);
+
     // Make a "shader" space that is translated one unit in x and rotated
     // 45deg about the z axis.
     Mshad.makeIdentity ();


### PR DESCRIPTION
Extend SimpleRenderer/testshade to handle several standard named coordinate systems such as camera, screen, ndc, raster.  This makes it easier to use testshade as a harness for testing shaders that use those named systems, without errors.
