### PR TITLE
Review: Optimization debug help

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -665,9 +665,9 @@ public:
 
     void operator delete (void *todel) { ::delete ((char *)todel); }
 
-    /// Is the shading system in debug mode?
+    /// Is the shading system in debug mode, and if so, how verbose?
     ///
-    bool debug () const { return m_debug; }
+    int debug () const { return m_debug; }
 
     /// Return a pointer to the renderer services object.
     ///
@@ -778,7 +778,7 @@ private:
 
     // Options
     int m_statslevel;                     ///< Statistics level
-    bool m_debug;                         ///< Debugging output
+    int m_debug;                          ///< Debugging output
     bool m_lazylayers;                    ///< Evaluate layers on demand?
     bool m_lazyglobals;                   ///< Run lazily even if globals write?
     bool m_clearmemory;                   ///< Zero mem before running shader?

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -97,6 +97,9 @@ public:
 
     TextureSystem *texturesys () const { return shadingsys().texturesys(); }
 
+    /// Are we in debugging mode?
+    int debug() const { return shadingsys().debug(); }
+
     /// Search the instance for a constant whose type and value match
     /// type and data[...].  Return -1 if no matching const is found.
     int find_constant (const TypeSpec &type, const void *data);
@@ -110,21 +113,21 @@ public:
     /// Turn the op into a simple assignment of the new symbol index to the
     /// previous first argument of the op.  That is, changes "OP arg0 arg1..."
     /// into "assign arg0 newarg".
-    void turn_into_assign (Opcode &op, int newarg);
+    void turn_into_assign (Opcode &op, int newarg, const char *why=NULL);
 
     /// Turn the op into a simple assignment of zero to the previous
     /// first argument of the op.  That is, changes "OP arg0 arg1 ..."
     /// into "assign arg0 zero".
-    void turn_into_assign_zero (Opcode &op);
+    void turn_into_assign_zero (Opcode &op, const char *why=NULL);
 
     /// Turn the op into a simple assignment of one to the previous
     /// first argument of the op.  That is, changes "OP arg0 arg1 ..."
     /// into "assign arg0 one".
-    void turn_into_assign_one (Opcode &op);
+    void turn_into_assign_one (Opcode &op, const char *why=NULL);
 
     /// Turn the op into a no-op.
     ///
-    void turn_into_nop (Opcode &op);
+    void turn_into_nop (Opcode &op, const char *why=NULL);
 
     void find_constant_params (ShaderGroup &group);
 
@@ -242,6 +245,12 @@ public:
     /// Search for pairs of ops to perform peephole optimization on.
     /// 
     int peephole2 (int opnum);
+
+    /// Helper: return the symbol index of the symbol that is the argnum-th
+    /// argument to the given op.
+    int oparg (const Opcode &op, int argnum) {
+        return inst()->arg (op.firstarg()+argnum);
+    }
 
     /// Helper: return the ptr to the symbol that is the argnum-th
     /// argument to the given op.

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -62,6 +62,7 @@ static std::vector<ustring> outputvarnames;
 static std::vector<OIIO::ImageBuf*> outputimgs;
 static std::string dataformatname = "";
 static bool debug = false;
+static bool debug2 = false;
 static bool verbose = false;
 static bool stats = false;
 static bool O0 = false, O1 = true, O2 = false;
@@ -122,7 +123,7 @@ inject_params ()
 static int
 add_shader (int argc, const char *argv[])
 {
-    shadingsys->attribute ("debug", (int)debug);
+    shadingsys->attribute ("debug", debug2 ? 2 : (debug ? 1 : 0));
     const char *opt_env = getenv ("TESTSHADE_OPT");  // overrides opt
     if (opt_env)
         shadingsys->attribute ("optimize", atoi(opt_env));
@@ -159,6 +160,7 @@ getargs (int argc, const char *argv[])
                 "--help", &help, "Print help message",
                 "-v", &verbose, "Verbose messages",
                 "--debug", &debug, "Lots of debugging info",
+                "--debug2", &debug2, "Even more debugging info",
                 "--stats", &stats, "Print run statistics",
                 "-g %d %d", &xres, &yres, "Make an X x Y grid of shading points",
                 "-o %L %L", &outputvars, &outputfiles,


### PR DESCRIPTION
Optimization debug help: turn SS::debug into an int with levels, at high levels create a detailed log of code transformations and why they were done.

Only kicking in when debug >= 2, this really helps me figure out how code gets transformed during our runtime optimization.  We don't get a lot of optimizer bugs, but when they occasionally crop up, it's very time consuming to figure out what's happening and why.  This gives me a trail of breadcrumbs to work with.  I can get a log that looks like:

 turned op 12 from div to $tmp5 = $const2 : div by 1
 turned op 14 from neg to $tmp6 = $const2 : const fold
 turned op 15 from assign to nop : replace symbol with constant
 turned op 34 from assign to ___307_z = $const4 : coerce to correct type
