### PR TITLE
Review: Use a more modern cpp on Mac OS X.

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -235,7 +235,15 @@ preprocess (const std::string &filename,
 #define pclose _pclose
 #endif
 
+#ifdef __APPLE__
+    // Default /usr/bin/cpp on Apple is very bare bones, doesn't seem to
+    // support all the preprocessor directives (like # and ##), but the
+    // explicit gcc 4.2 one does.  Watch out for needed changes to this
+    // with future OS X releases.
+    std::string cppcommand = "/usr/bin/cpp-4.2 -xc -nostdinc ";
+#else
     std::string cppcommand = "/usr/bin/cpp -xc -nostdinc ";
+#endif
 
     cppcommand += options;
 


### PR DESCRIPTION
On OSX, /usr/bin/cpp is very old and seems to lack certain modern preprocessor doodads (including that it doesn't understand # and ##, how can that be?).  I found that by using /usr/bin/cpp-4.2, things are much nicer.
