### PR TITLE
Review: greedyjit

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -174,7 +174,7 @@ public:
 
     /// Return a reference-counted (but opaque) reference to the current
     /// shading attribute state maintained by the ShadingSystem.
-    virtual ShadingAttribStateRef state () const = 0;
+    virtual ShadingAttribStateRef state () = 0;
 
     /// Clear the current shading attribute state, i.e., no shaders
     /// specified.
@@ -237,6 +237,11 @@ public:
     /// describes it, or 0 for an unrecognized name.  (This retrieves
     /// data passed in via attribute("raytypes")).
     virtual int raytype_bit (ustring name) = 0;
+
+    /// If option "greedyjit" was set, this call will trigger all
+    /// shader groups that have not yet been compiled to do so with the
+    /// specified number of threads (0 means use all available HW cores).
+    virtual void optimize_all_groups (int nthreads=0) = 0;
 
 private:
     // Make delete private and unimplemented in order to prevent apps

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -82,6 +82,11 @@ ShadingContext::execute (ShaderUse use, ShadingAttribState &sas,
     m_attribs = &sas;
     m_closures_allotted = 0;
 
+    if (shadingsys().m_groups_to_compile_count) {
+        // If we are greedily JITing, optimize/JIT everything now
+        shadingsys().optimize_all_groups ();
+    }
+
     // Optimize if we haven't already
     ShaderGroup &sgroup (sas.shadergroup (use));
     if (sgroup.nlayers()) {


### PR DESCRIPTION
New SS option "greedyjit", if nonzero, will remember all created shader groups and optimize/JIT them all up front, concurrently, without locking, the first time any one executes.

This may end up optimizing/JITing shader groups that never need to execute, and also may worsen "time to first pixel."  But if you tend to JIT most of the shaders you specified anyway, this will make sure it's done with perfect parallelism, no locking.

Even if a renderer doesn't want this enabled generally, turning it on selectively is also great for debugging problems with OSL compilation, since it forces all shaders to optimize/jit very early in the render.  It sucks when there's a bug in OSL's optimizer, showing up only in a shader that's first used 7 hours into a render.  Not that I have any experience with that, no sir.

N.B. The app itself doesn't need to be aware of the multithreading; this spawns a bunch of new threads for the compilation, which will subsequently be terminated when all the shaders have been compiled.  It will make as many threads as there are cores, which, if there are several renders on the box simultaneously, may briefly be "over-threading".  But I don't see much harm in that, it should be for only a tiny fraction of the time of a render and doesn't retain any more memory than it would have originally (just the JITed bytes).
