### PR TITLE
Review: have a way to name shader groups, and debugging aids

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -161,7 +161,7 @@ public:
 
     /// Signal the start of a new shader group.
     ///
-    virtual bool ShaderGroupBegin (void) = 0;
+    virtual bool ShaderGroupBegin (const char *groupname=NULL) = 0;
 
     /// Signal the end of a new shader group.
     ///

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -562,7 +562,11 @@ public:
 #endif
     }
 
+    void name (ustring name) { m_name = name; }
+    ustring name () const { return m_name; }
+
 private:
+    ustring m_name;
     std::vector<ShaderInstanceRef> m_layers;
     RunLLVMGroupFunc m_llvm_compiled_version;
     size_t m_llvm_groupdata_size;
@@ -637,7 +641,7 @@ public:
     virtual bool Shader (const char *shaderusage,
                          const char *shadername=NULL,
                          const char *layername=NULL);
-    virtual bool ShaderGroupBegin (void);
+    virtual bool ShaderGroupBegin (const char *groupname=NULL);
     virtual bool ShaderGroupEnd (void);
     virtual bool ConnectShaders (const char *srclayer, const char *srcparam,
                                  const char *dstlayer, const char *dstparam);
@@ -837,6 +841,8 @@ private:
     bool m_greedyjit;                     ///< JIT as much as we can?
     int m_optimize;                       ///< Runtime optimization level
     int m_llvm_debug;                     ///< More LLVM debugging output
+    ustring m_debug_groupname;            ///< Name of sole group to debug
+    ustring m_only_groupname;             ///< Name of sole group to compile
     std::string m_searchpath;             ///< Shader search path
     std::vector<std::string> m_searchpath_dirs; ///< All searchpath dirs
     ustring m_commonspace_synonym;        ///< Synonym for "common" space
@@ -854,6 +860,7 @@ private:
     // State
     bool m_in_group;                      ///< Are we specifying a group?
     ShaderUse m_group_use;                ///< Use of group
+    ustring m_group_name;                 ///< Name of group
     ParamValueList m_pending_params;      ///< Pending Parameter() values
     ShadingAttribStateRef m_curattrib;    ///< Current shading attribute state
     mutable mutex m_mutex;                ///< Thread safety

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3399,8 +3399,16 @@ RuntimeOptimizer::collapse_ops ()
 void
 RuntimeOptimizer::optimize_group ()
 {
-    Timer rop_timer;
+    if (shadingsys().m_only_groupname &&
+        shadingsys().m_only_groupname != m_group.name()) {
+        m_group.does_nothing (true);
+        return;
+    }
 
+    Timer rop_timer;
+    if (debug())
+        m_shadingsys.info ("About to optimize shader group %s:",
+                           m_group.name().c_str());
     int nlayers = (int) m_group.nlayers ();
 
     // Clear info about which messages have been set
@@ -3523,11 +3531,20 @@ RuntimeOptimizer::optimize_group ()
         ss.m_stat_postopt_ops += new_nops;
     }
 
-    m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+    if (m_group.name()) {
+        m_shadingsys.info ("Optimized shader group %s:", m_group.name().c_str());
+        m_shadingsys.info ("    New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
           new_nsyms, old_nsyms,
           100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
           new_nops, old_nops,
           100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
+    } else {
+        m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+          new_nsyms, old_nsyms,
+          100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
+          new_nops, old_nops,
+          100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
+    }
     m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit)",
                        m_stat_total_llvm_time+m_stat_specialization_time,
                        m_stat_specialization_time, 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -98,7 +98,11 @@ public:
     TextureSystem *texturesys () const { return shadingsys().texturesys(); }
 
     /// Are we in debugging mode?
-    int debug() const { return shadingsys().debug(); }
+    int debug() const {
+        return shadingsys().debug() &&
+            (!shadingsys().m_debug_groupname ||
+             shadingsys().m_debug_groupname == m_group.name());
+    }
 
     /// Search the instance for a constant whose type and value match
     /// type and data[...].  Return -1 if no matching const is found.


### PR DESCRIPTION
Allow the app to pass a name to ShaderGroupBegin to name the group.

Add two new debugging attributes:
1. debug_groupname - when set, in conjunction with debug=1, debugs ONLY the named group.
2. only_groupname - when set, ONLY optimizes and JITs the named group, all others will act like empty shaders.

These are very helpful to me when debugging possible OSL bugs involving scenes with -- I swear I am not making this up -- thousands of shader groups and several hundred thousand shader instances.
