### PR TITLE
Review: optimizer debugging infrastructure

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -842,6 +842,7 @@ private:
     int m_optimize;                       ///< Runtime optimization level
     int m_llvm_debug;                     ///< More LLVM debugging output
     ustring m_debug_groupname;            ///< Name of sole group to debug
+    ustring m_debug_layername;            ///< Name of sole layer to debug
     ustring m_only_groupname;             ///< Name of sole group to compile
     std::string m_searchpath;             ///< Shader search path
     std::vector<std::string> m_searchpath_dirs; ///< All searchpath dirs

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -90,10 +90,30 @@ RuntimeOptimizer::set_inst (int newlayer)
     m_layer = newlayer;
     m_inst = m_group[m_layer];
     ASSERT (m_inst != NULL);
+    set_debug ();
     m_all_consts.clear ();
     m_symbol_aliases.clear ();
     m_block_aliases.clear ();
     m_param_aliases.clear ();
+}
+
+
+
+void
+RuntimeOptimizer::set_debug ()
+{
+    // start with the shading system's idea of debugging level
+    m_debug = shadingsys().debug();
+
+    // if user said to only debug one group, turn off debug if not it
+    if (shadingsys().m_debug_groupname &&
+        shadingsys().m_debug_groupname != m_group.name())
+        m_debug = 0;
+    // if user said to only debug one layer, turn off debug if not it
+    if (inst() && shadingsys().m_debug_layername &&
+        shadingsys().m_debug_layername != inst()->layername()) {
+        m_debug = 0;
+    }
 }
 
 
@@ -148,7 +168,7 @@ void
 RuntimeOptimizer::turn_into_assign (Opcode &op, int newarg, const char *why)
 {
     int opnum = &op - &(inst()->ops()[0]);
-    if (debug() > 1 && op.opname() != u_nop)
+    if (debug() > 1)
         std::cout << "turned op " << opnum
                   << " from " << op.opname() << " to "
                   << opargsym(op,0)->name() << " = " << opargsym(op,1)->name()
@@ -201,14 +221,37 @@ RuntimeOptimizer::turn_into_assign_one (Opcode &op, const char *why)
 
 
 // Turn the op into a no-op
-void
+int
 RuntimeOptimizer::turn_into_nop (Opcode &op, const char *why)
 {
-    if (debug() > 1)
-        std::cout << "turned op " << (&op - &(inst()->ops()[0]))
-                  << " from " << op.opname() << " to nop"
+    if (op.opname() != u_nop) {
+        if (debug())
+            std::cout << "turned op " << (&op - &(inst()->ops()[0]))
+                      << " from " << op.opname() << " to nop"
+                      << (why ? " : " : "") << (why ? why : "") << "\n";
+        op.reset (u_nop, 0);
+        return 1;
+    }
+    return 0;
+}
+
+
+
+int
+RuntimeOptimizer::turn_into_nop (int begin, int end, const char *why)
+{
+    int changed = 0;
+    for (int i = begin;  i != end;  ++i) {
+        Opcode &op (inst()->ops()[i]);
+        if (op.opname() != u_nop) {
+            op.reset (u_nop, 0);
+            ++changed;
+        }
+    }
+    if (debug() > 1 && changed)
+        std::cout << "turned ops " << begin << "-" << (end-1) << " into nop"
                   << (why ? " : " : "") << (why ? why : "") << "\n";
-    op.reset (u_nop, 0);
+    return changed;
 }
 
 
@@ -1028,21 +1071,10 @@ DECLFOLDER(constfold_if)
         }
         int changed = 0;
         if (result > 0) {
-            for (int i = op.jump(0), e = op.jump(1);  i < e;  ++i) {
-                if (rop.inst()->ops()[i].opname() != u_nop) {
-                    rop.turn_into_nop (rop.inst()->ops()[i], "elide 'else'");
-                    ++changed;
-                }
-            }
-            rop.turn_into_nop (op, "elide 'else'");
-            ++changed;
+            changed += rop.turn_into_nop (op.jump(0), op.jump(1), "elide 'else'");
+            changed += rop.turn_into_nop (op, "elide 'else'");
         } else if (result == 0) {
-            for (int i = opnum, e = op.jump(0);  i < e;  ++i) {
-                if (rop.inst()->ops()[i].opname() != u_nop) {
-                    rop.turn_into_nop (rop.inst()->ops()[i], "elide 'if'");
-                    ++changed;
-                }
-            }
+            changed += rop.turn_into_nop (opnum, op.jump(0), "elide 'if'");
         }
         return changed;
     }
@@ -2292,8 +2324,9 @@ RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
     if (m_shadingsys.optimize() >= 2) {
         std::map<int,int>::iterator i = m_stale_syms.find(sym);
         if (i != m_stale_syms.end()) {
-            turn_into_nop (inst()->ops()[i->second],
-                           Strutil::format("remove stale value assignment, reassigned on op %d", opnum).c_str());
+            Opcode &uselessop (inst()->ops()[i->second]);
+            turn_into_nop (uselessop,
+                           Strutil::format("remove stale value assignment to %s, reassigned on op %d", opargsym(uselessop,0)->name().c_str(), opnum).c_str());
         }
     }
     m_stale_syms[sym] = opnum;
@@ -2375,8 +2408,7 @@ RuntimeOptimizer::make_param_use_instanceval (Symbol *R)
 
     // Get rid of any init ops
     if (R->has_init_ops()) {
-        for (int i = R->initbegin();  i < R->initend();  ++i)
-            turn_into_nop (inst()->ops()[i], "init ops not needed");
+        turn_into_nop (R->initbegin(), R->initend(), "init ops not needed");
         R->initbegin (0);
         R->initend (0);
     }
@@ -2860,12 +2892,10 @@ RuntimeOptimizer::optimize_instance ()
         // Elide unconnected parameters that are never read.
         FOREACH_PARAM (Symbol &s, inst()) {
             if (!s.connected_down() && ! s.everread()) {
-                for (int i = s.initbegin(), e = s.initend();  i < e;  ++i)
-                    turn_into_nop (inst()->ops()[i],
-                                   "remove init ops of unread param");
+                changed += turn_into_nop (s.initbegin(), s.initend(),
+                                          "remove init ops of unread param");
                 s.set_initrange ();
                 s.clear_rw ();
-                ++changed;
             }
         }
 
@@ -2889,9 +2919,8 @@ RuntimeOptimizer::optimize_instance ()
     if (inst()->unused()) {
         // Not needed.  Remove all its connections and ops.
         inst()->connections().clear ();
-        for (int i = 0, e = (int)inst()->ops().size()-1;  i < e;  ++i)
-            turn_into_nop (inst()->ops()[i],
-                           "eliminate layer with no outward connections");
+        turn_into_nop (0, (int)inst()->ops().size()-1,
+                       "eliminate layer with no outward connections");
         BOOST_FOREACH (Symbol &s, inst()->symbols())
             s.clear_rw ();
     }
@@ -2904,9 +2933,8 @@ RuntimeOptimizer::optimize_instance ()
     FOREACH_PARAM (Symbol &s, inst()) {
         if (s.symtype() == SymTypeParam && ! s.everused() &&
                 s.initbegin() < s.initend()) {
-            for (int i = s.initbegin();  i < s.initend();  ++i)
-                turn_into_nop (inst()->ops()[i],
-                               "remove init ops of unused param");
+            turn_into_nop (s.initbegin(), s.initend(),
+                           "remove init ops of unused param");
             s.set_initrange (0, 0);
         }
     }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -467,6 +467,7 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("greedyjit", int, m_greedyjit);
     ATTR_SET_STRING ("commonspace", m_commonspace_synonym);
     ATTR_SET_STRING ("debug_groupname", m_debug_groupname);
+    ATTR_SET_STRING ("debug_layername", m_debug_layername);
     ATTR_SET_STRING ("only_groupname", m_only_groupname);
 
     // cases for special handling
@@ -532,6 +533,7 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE_STRING ("commonspace", m_commonspace_synonym);
     ATTR_DECODE_STRING ("colorspace", m_colorspace);
     ATTR_DECODE_STRING ("debug_groupname", m_debug_groupname);
+    ATTR_DECODE_STRING ("debug_layername", m_debug_layername);
     ATTR_DECODE_STRING ("only_groupname", m_only_groupname);
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);


### PR DESCRIPTION
Infrastructure to make debugging the optimizer easier.  Includes a new "debug_layername" option that will restrict debugging info to print only for a particular named layer, and also some cleanup of various optimization-related debugging logs.

N.B. This incorporates https://github.com/imageworks/OpenShadingLanguage/pull/93
That's under review separately, you can ignore that small part for this review.
I will merge them separately.
