### PR TITLE
Review: More runtime optimization debugging aids

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,7 @@ add_subdirectory (doc)
 macro ( TESTSUITE )
     foreach (_testname ${ARGN})
         # Run the test unoptimized
-        add_test ( ${_testname} env OPENIMAGEIOHOME=${OPENIMAGEIOHOME} python ${PROJECT_SOURCE_DIR}/../testsuite/${_testname}/run.py ${PROJECT_SOURCE_DIR}/../testsuite/${_testname} ${CMAKE_BINARY_DIR} )
+        add_test ( ${_testname} env OPENIMAGEIOHOME=${OPENIMAGEIOHOME} TESTSHADE_OPT=0 python ${PROJECT_SOURCE_DIR}/../testsuite/${_testname}/run.py ${PROJECT_SOURCE_DIR}/../testsuite/${_testname} ${CMAKE_BINARY_DIR} )
         # Run the same test again with aggressive -O2 runtime
         # optimization, triggered by setting TESTSHADE_OPT env variable
         add_test ( ${_testname}.opt env OPENIMAGEIOHOME=${OPENIMAGEIOHOME} TESTSHADE_OPT=2 python ${PROJECT_SOURCE_DIR}/../testsuite/${_testname}/run.py ${PROJECT_SOURCE_DIR}/../testsuite/${_testname} ${CMAKE_BINARY_DIR} )

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -840,6 +840,14 @@ private:
     bool m_unknown_coordsys_error;        ///< Error to use unknown xform name?
     bool m_greedyjit;                     ///< JIT as much as we can?
     int m_optimize;                       ///< Runtime optimization level
+    bool m_opt_constant_param;            ///< Turn instance params into const?
+    bool m_opt_constant_fold;             ///< Allow constant folding?
+    bool m_opt_stale_assign;              ///< Optimize stale assignments?
+    bool m_opt_elide_useless_ops;         ///< Optimize away useless ops?
+    bool m_opt_peephole;                  ///< Do some peephole optimizations?
+    bool m_opt_coalesce_temps;            ///< Coalesce temporary variables?
+    bool m_opt_assign;                    ///< Do various assign optimizations?
+    bool m_optimize_nondebug;             ///< Fully optimize non-debug!
     int m_llvm_debug;                     ///< More LLVM debugging output
     ustring m_debug_groupname;            ///< Name of sole group to debug
     ustring m_debug_layername;            ///< Name of sole layer to debug

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -48,30 +48,9 @@ namespace pvt {   // OSL::pvt
 /// Container for state that needs to be passed around
 class RuntimeOptimizer {
 public:
-    RuntimeOptimizer (ShadingSystemImpl &shadingsys, ShaderGroup &group)
-        : m_shadingsys(shadingsys),
-          m_thread(shadingsys.get_perthread_info()),
-          m_group(group),
-          m_inst(NULL),
-          m_next_newconst(0),
-          m_stat_opt_locking_time(0), m_stat_specialization_time(0),
-          m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
-          m_stat_llvm_irgen_time(0), m_stat_llvm_opt_time(0),
-          m_stat_llvm_jit_time(0),
-          m_llvm_context(NULL), m_llvm_module(NULL),
-          m_llvm_exec(NULL), m_builder(NULL),
-          m_llvm_passes(NULL), m_llvm_func_passes(NULL),
-          m_llvm_func_passes_optimized(NULL)
-    {
-        set_debug ();
-    }
+    RuntimeOptimizer (ShadingSystemImpl &shadingsys, ShaderGroup &group);
 
-    ~RuntimeOptimizer () {
-        delete m_builder;
-        delete m_llvm_passes;
-        delete m_llvm_func_passes;
-        delete m_llvm_func_passes_optimized;
-    }
+    ~RuntimeOptimizer ();
 
     void optimize_group ();
 
@@ -104,6 +83,9 @@ public:
 
     /// Are we in debugging mode?
     int debug() const { return m_debug; }
+
+    /// What's our current optimization level?
+    int optimize() const { return m_optimize; }
 
     /// Search the instance for a constant whose type and value match
     /// type and data[...].  Return -1 if no matching const is found.
@@ -718,6 +700,14 @@ private:
     int m_layer;                      ///< Layer we're optimizing
     ShaderInstance *m_inst;           ///< Instance we're optimizing
     int m_debug;                      ///< Current debug level
+    int m_optimize;                   ///< Current optimization level
+    bool m_opt_constant_param;            ///< Turn instance params into const?
+    bool m_opt_constant_fold;             ///< Allow constant folding?
+    bool m_opt_stale_assign;              ///< Optimize stale assignments?
+    bool m_opt_elide_useless_ops;         ///< Optimize away useless ops?
+    bool m_opt_peephole;                  ///< Do some peephole optimizations?
+    bool m_opt_coalesce_temps;            ///< Coalesce temporary variables?
+    bool m_opt_assign;                    ///< Do various assign optimizations?
 
     // All below is just for the one inst we're optimizing:
     std::vector<int> m_all_consts;    ///< All const symbol indices for inst

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -176,7 +176,12 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_lockgeom_default (false), m_strict_messages(true),
       m_range_checking(true), m_unknown_coordsys_error(true),
       m_greedyjit(false),
-      m_optimize (1),
+      m_optimize (2),
+      m_opt_constant_param(true), m_opt_constant_fold(true),
+      m_opt_stale_assign(true), m_opt_elide_useless_ops(true),
+      m_opt_peephole(true), m_opt_coalesce_temps(true),
+      m_opt_assign(true),
+      m_optimize_nondebug(false),
       m_llvm_debug(false),
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
@@ -474,6 +479,14 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("debugnan", int, m_debugnan);
     ATTR_SET ("lockgeom", int, m_lockgeom_default);
     ATTR_SET ("optimize", int, m_optimize);
+    ATTR_SET ("opt_constant_param", int, m_opt_constant_param);
+    ATTR_SET ("opt_constant_fold", int, m_opt_constant_fold);
+    ATTR_SET ("opt_stale_assign", int, m_opt_stale_assign);
+    ATTR_SET ("opt_elide_useless_ops", int, m_opt_elide_useless_ops);
+    ATTR_SET ("opt_peephole", int, m_opt_peephole);
+    ATTR_SET ("opt_coalesce_temps", int, m_opt_coalesce_temps);
+    ATTR_SET ("opt_assign", int, m_opt_assign);
+    ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
     ATTR_SET ("strict_messages", int, m_strict_messages);
     ATTR_SET ("range_checking", int, m_range_checking);
@@ -539,6 +552,14 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("debugnan", int, m_debugnan);
     ATTR_DECODE ("lockgeom", int, m_lockgeom_default);
     ATTR_DECODE ("optimize", int, m_optimize);
+    ATTR_DECODE ("opt_constant_param", int, m_opt_constant_param);
+    ATTR_DECODE ("opt_constant_fold", int, m_opt_constant_fold);
+    ATTR_DECODE ("opt_stale_assign", int, m_opt_stale_assign);
+    ATTR_DECODE ("opt_elide_useless_ops", int, m_opt_elide_useless_ops);
+    ATTR_DECODE ("opt_peephole", int, m_opt_peephole);
+    ATTR_DECODE ("opt_coalesce_temps", int, m_opt_coalesce_temps);
+    ATTR_DECODE ("opt_assign", int, m_opt_assign);
+    ATTR_DECODE ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
     ATTR_DECODE ("range_checking", int, m_range_checking);


### PR DESCRIPTION
More runtime optimization debugging aids: several new options allow
individual optimizations to be disabled (to quickly narrow down
potential problems when debugging runtime optimizations).

A new "optimize_nondebug" option, when used in conjunction with debug=1
and a named debug_groupname, will cause all the other (not being
debugged) groups to run with full optimization.  This helps speed up
debug runs when comparing one group optimized and not optimized, if
everything else is also unoptimized, the scenes take too long to render.

Also some very minor shifting around of the check for "only_groupname",
so that the stats correctly reflect the number of shader groups that were
fully compiled.

Aside: the "bug" I was chasing for two full days when I implemented these
turned out not to be a bug at all.  But at least I ended up with some more 
debugging tools, which will help make the next one easier to find.
