### PR TITLE
Allow closures as parameters to closures

### DIFF
--- a/src/include/genclosure.h
+++ b/src/include/genclosure.h
@@ -60,6 +60,8 @@ struct ClosureParam {
     { TypeDesc::TypeVector, reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 #define CLOSURE_STRING_PARAM(st, fld) \
     { TypeDesc::TypeString, reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
+#define CLOSURE_CLOSURE_PARAM(st, fld) \
+    { TypeDesc::PTR, reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 
 #define CLOSURE_INT_ARRAY_PARAM(st, fld, n) \
     { TypeDesc(TypeDesc::INT,   TypeDesc::SCALAR, TypeDesc::NOXFORM, n),reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }


### PR DESCRIPTION
Minor surgery to allow closure parameters to closures. This opens the door to closure modifiers and such. Had to fix llvm_gen_closure cause it was storing the result too early and causing an infinite loop.
