### PR TITLE
Review: fix assertion hit

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -283,6 +283,9 @@ ASTNode::coerce (Symbol *sym, const TypeSpec &type, bool acceptfloat)
     if (equivalent (sym->typespec(), type))
         return sym;   // No coercion necessary
 
+    if (type.is_closure())
+        return sym;   // No coercion necessary
+
     if (acceptfloat && sym->typespec().is_float())
         return sym;
 


### PR DESCRIPTION
We don't coerce closures, and it leads to an assertion to do some of the things later in this function if you don't take the early out.  So just return early from this function in that case, and all is well.
