### PR TITLE
Review: Overhaul the LLVM JIT optimization strategy

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -713,6 +713,7 @@ public:
     bool range_checking() const { return m_range_checking; }
     bool unknown_coordsys_error() const { return m_unknown_coordsys_error; }
     int optimize () const { return m_optimize; }
+    int llvm_optimize () const { return m_llvm_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
 
     ustring commonspace_synonym () const { return m_commonspace_synonym; }
@@ -828,7 +829,6 @@ private:
 
     // Options
     int m_statslevel;                     ///< Statistics level
-    int m_debug;                          ///< Debugging output
     bool m_lazylayers;                    ///< Evaluate layers on demand?
     bool m_lazyglobals;                   ///< Run lazily even if globals write?
     bool m_clearmemory;                   ///< Zero mem before running shader?
@@ -848,6 +848,8 @@ private:
     bool m_opt_coalesce_temps;            ///< Coalesce temporary variables?
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!
+    int m_llvm_optimize;                  ///< OSL optimization strategy
+    int m_debug;                          ///< Debugging output
     int m_llvm_debug;                     ///< More LLVM debugging output
     ustring m_debug_groupname;            ///< Name of sole group to debug
     ustring m_debug_layername;            ///< Name of sole layer to debug

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -42,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "runtimeoptimize.h"
 #include "../liboslcomp/oslcomp_pvt.h"
 #include "dual.h"
-#include "llvm_headers.h"
 using namespace OSL;
 using namespace OSL::pvt;
 
@@ -106,8 +105,7 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_stat_llvm_jit_time(0),
       m_llvm_context(NULL), m_llvm_module(NULL),
       m_llvm_exec(NULL), m_builder(NULL),
-      m_llvm_passes(NULL), m_llvm_func_passes(NULL),
-      m_llvm_func_passes_optimized(NULL)
+      m_llvm_passes(NULL), m_llvm_func_passes(NULL)
 {
     set_debug ();
 }
@@ -119,7 +117,6 @@ RuntimeOptimizer::~RuntimeOptimizer ()
     delete m_builder;
     delete m_llvm_passes;
     delete m_llvm_func_passes;
-    delete m_llvm_func_passes_optimized;
 }
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -745,10 +745,6 @@ public:
 
     void llvm_setup_optimization_passes ();
 
-    /// Do LLVM optimization on the partcular function func.  If
-    /// interproc is true, also do full interprocedural optimization.
-    void llvm_do_optimization (llvm::Function *func, bool interproc=false);
-
 private:
     ShadingSystemImpl &m_shadingsys;
     PerThreadInfo *m_thread;
@@ -821,7 +817,6 @@ private:
     llvm::PointerType *m_llvm_type_setup_closure_func;
     llvm::PassManager *m_llvm_passes;
     llvm::FunctionPassManager *m_llvm_func_passes;
-    llvm::FunctionPassManager *m_llvm_func_passes_optimized;
 
     // Persistant data shared between layers
     bool m_unknown_message_sent;      ///< Somebody did a non-const setmessage

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -179,7 +179,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
                                       TextureSystem *texturesystem,
                                       ErrorHandler *err)
     : m_renderer(renderer), m_texturesys(texturesystem), m_err(err),
-      m_statslevel (0), m_debug (false), m_lazylayers (true),
+      m_statslevel (0), m_lazylayers (true),
       m_lazyglobals (false),
       m_clearmemory (false), m_rebind (false), m_debugnan (false),
       m_lockgeom_default (false), m_strict_messages(true),
@@ -191,7 +191,8 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_opt_peephole(true), m_opt_coalesce_temps(true),
       m_opt_assign(true),
       m_optimize_nondebug(false),
-      m_llvm_debug(false),
+      m_llvm_optimize(0),
+      m_debug(false), m_llvm_debug(false),
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
       m_in_group (false),
@@ -496,6 +497,7 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("opt_coalesce_temps", int, m_opt_coalesce_temps);
     ATTR_SET ("opt_assign", int, m_opt_assign);
     ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
+    ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
     ATTR_SET ("strict_messages", int, m_strict_messages);
     ATTR_SET ("range_checking", int, m_range_checking);
@@ -553,7 +555,6 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     lock_guard guard (m_mutex);  // Thread safety
     ATTR_DECODE_STRING ("searchpath:shader", m_searchpath);
     ATTR_DECODE ("statistics:level", int, m_statslevel);
-    ATTR_DECODE ("debug", int, m_debug);
     ATTR_DECODE ("lazylayers", int, m_lazylayers);
     ATTR_DECODE ("lazyglobals", int, m_lazyglobals);
     ATTR_DECODE ("clearmemory", int, m_clearmemory);
@@ -569,6 +570,8 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("opt_coalesce_temps", int, m_opt_coalesce_temps);
     ATTR_DECODE ("opt_assign", int, m_opt_assign);
     ATTR_DECODE ("optimize_nondebug", int, m_optimize_nondebug);
+    ATTR_DECODE ("llvm_optimize", int, m_llvm_optimize);
+    ATTR_DECODE ("debug", int, m_debug);
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
     ATTR_DECODE ("range_checking", int, m_range_checking);


### PR DESCRIPTION
Been sitting on this for a while, sorry.

Overhaul the LLVM JIT optimization strategy in the wake of adding LLVM 3.0 support.  Remove lots of dead code and comments.

New attribute "llvm_optimize" controls the optimization passes.  The default, 0, means to use the same optimization passes we always did. When compiling against LLVM 3.0, values 1-3 correspond to using approximately the set of optimizations that clang would use for -O1, -O2, -O3.  Possibly values >3 will someday mean other pass sets or strategies.  At this point, it's all experimental, and I don't particularly recommend anything other than 0 (old pass strategy), but I'm doing benchmarks to find out if anything else is significantly better.
