### PR TITLE
Review: fix minor type checking bug

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -835,6 +835,10 @@ private:
     /// Typecheck all polymorphic versions, return UNKNOWN if no match was
     /// found, or a real type if there was a match.  Also, upon matching,
     /// re-jigger m_sym to point to the specific polymorphic match.
+    /// Allow arguments to be coerced (e.g., substituting a vector where
+    /// a point was expected, or a float where a color was expected) only
+    /// if coerce is true; allow return value to be coerced only if
+    /// expected is TypeSpec() (i.e., unknown).
     TypeSpec typecheck_all_poly (TypeSpec expected, bool coerce);
 
     /// Handle all the special cases for built-ins.  This includes

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -818,7 +818,7 @@ ASTfunction_call::typecheck_all_poly (TypeSpec expected, bool coerce)
         code += advance;
         if (check_arglist (m_name.c_str(), args(), code, coerce)) {
             // Return types also must match if not coercible
-            if (coerce || expected == TypeSpec() || expected == returntype) {
+            if (expected == TypeSpec() || expected == returntype) {
                 m_sym = poly;
                 return returntype;
             }


### PR DESCRIPTION
Minor type checking bug could cause non-exactly-matching polymorphic functions to coerce return value even when that was not intended.
