### PR TITLE
Review: More aggressive elision of ops that only write to symbols that won't be subsequently read

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -195,13 +195,17 @@ public:
     /// it's read, we can go back and remove the earlier assignment.
     void simple_sym_assign (int sym, int op);
 
+    /// Return true if assignments to A on this op have no effect because
+    /// they will not be subsequently used.
+    bool unread_after (const Symbol *A, int opnum);
+
     /// Replace R's instance value with new data.
     ///
     void replace_param_value (Symbol *R, const void *newdata);
 
     bool outparam_assign_elision (int opnum, Opcode &op);
 
-    bool useless_op_elision (Opcode &op);
+    bool useless_op_elision (Opcode &op, int opnum);
 
     void make_symbol_room (int howmany=1);
 


### PR DESCRIPTION
Slight improvement on the last set of optimizations -- instead of only culling assignments to output params that aren't subsequently used (or connected downstream), cull _any_ op that only writes to output params that won't be used.

Alas, it doesn't make a dramatic difference in performance.  I can see from the debugging logs that it does find some additional ops to remove, but apparently most of the cullable ops were 'assign' after all.  But let's do it anyway.
