### PR TITLE
Review: optimize unused parameters

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -637,9 +637,9 @@ public:
     int lastwrite () const  { return m_lastwrite; }
     int firstuse () const   { return std::min (firstread(), firstwrite()); }
     int lastuse () const    { return std::max (lastread(), lastwrite()); }
-    bool everused () const  { return lastuse() >= 0; }
     bool everread () const  { return lastread() >= 0; }
     bool everwritten () const { return lastwrite() >= 0; }
+    bool everused () const  { return everread() || everwritten(); }
     void set_read (int first, int last) {
         m_firstread = first;  m_lastread = last;
     }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -244,6 +244,8 @@ public:
 
     void mark_outgoing_connections ();
 
+    int remove_unused_params ();
+
     /// Squeeze out unused symbols from an instance that has been
     /// optimized.
     void collapse_syms ();
@@ -753,6 +755,10 @@ public:
     llvm::Function *layer_func () const { return m_layer_func; }
 
     void llvm_setup_optimization_passes ();
+
+    bool opt_elide_unconnected_outputs () const {
+        return m_opt_elide_unconnected_outputs;
+    }
 
 private:
     ShadingSystemImpl &m_shadingsys;


### PR DESCRIPTION
More careful identification and removal of params (input and output) that
are both unused in the shader and not connected downstream.  Previously,
this analysis could be foiled by init ops, which would make it look like
the params were used, and thus the params would not be culled.
