### PR TITLE
Review: Make empty instances statistic more accurate.

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1079,6 +1079,7 @@ RuntimeOptimizer::build_llvm_group ()
     m_group.does_nothing(skip_optimization);
     if (skip_optimization) {
         m_shadingsys.m_stat_empty_groups += 1;
+        m_shadingsys.m_stat_empty_instances += 1;  // the one layer is empty
     } else {
         m_llvm_passes->run (*llvm_module());
     }


### PR DESCRIPTION
When we're down to just one layer and we determine it's empty and cull the whole group, we should count that layer, in addition to the group, in the statistics about how many empty things we culled.
