### PR TITLE
Fix warnings from gcc 4.6

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -35,6 +35,12 @@ ifeq ($(SP_ARCH), spinux1_x86_64)
 	    -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
 	    -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     endif
+    ifeq (${COMPILER}, gcc463)
+    MY_CMAKE_FLAGS += \
+         -DCMAKE_C_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.6.3-test/bin/gcc \
+         -DCMAKE_CXX_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.6.3-test/bin/g++
+    endif
+    
 
 endif # SP_ARCH == spinux1_x86_64
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -695,7 +695,7 @@ typedef std::vector<Symbol *> SymbolPtrVec;
 class Opcode {
 public:
     Opcode (ustring op, ustring method, size_t firstarg=0, size_t nargs=0)
-        : m_firstarg((int)firstarg), m_method(method)
+        : m_firstarg((int)firstarg), m_method(method), m_sourceline(0)
     {
         reset (op, nargs);   // does most of the heavy lifting
     }

--- a/src/include/oslclosure.h
+++ b/src/include/oslclosure.h
@@ -441,12 +441,16 @@ struct ClosureComponent : public ClosureColor
         const int     & integer() const { return value.integer; }
         float         & flt()           { return value.flt; }
         const float   & flt()     const { return value.flt; }
-        Color3        & color()         { return *((Color3 *)(void *)&value); }
-        const Color3  & color()   const { return *((Color3 *)(void *)&value); }
-        Vec3          & vector()        { return *((Vec3 *)(void *)&value); }
-        const Vec3    & vector()  const { return *((Vec3 *)(void *)&value); }
-        ustring       & str()           { return *((ustring *)(void *)&value); }
-        const ustring & str()     const { return *((ustring *)(void *)&value); }
+        Color3        & color()         { return *(Color3*)       raw_data(); }
+        const Color3  & color()   const { return *(const Color3*) raw_data(); }
+        Vec3          & vector()        { return *(Vec3*)         raw_data(); }
+        const Vec3    & vector()  const { return *(const Vec3*)   raw_data(); }
+        ustring       & str()           { return *(ustring*)      raw_data(); }
+        const ustring & str()     const { return *(const ustring*)raw_data(); }
+
+    private:
+        char*       raw_data()       { return reinterpret_cast<char*>(&value); }
+        const char* raw_data() const { return reinterpret_cast<const char*>(&value); }
     };
 
     int    id;       ///< Id of the component

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -351,7 +351,7 @@ SymbolTable::print ()
             const FunctionSymbol *f = (const FunctionSymbol *) s;
             const char *args = f->argcodes().c_str();
             int advance = 0;
-            TypeSpec rettype = m_comp.type_from_code (args, &advance);
+            //TypeSpec rettype = m_comp.type_from_code (args, &advance); // FIXME: unused?
             args += advance;
             std::cout << " function (" << m_comp.typelist_from_code(args) << ") ";
         }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2498,7 +2498,7 @@ LLVMGEN (llvm_gen_getattribute)
     Symbol& Attribute   = *rop.opargsym (op, attrib_slot);
     Symbol& Destination = *rop.opargsym (op, dest_slot);
 
-    TypeDesc attribute_type = Destination.typespec().simpletype();
+    //TypeDesc attribute_type = Destination.typespec().simpletype(); // FIXME: unused?
     bool     dest_derivs    = Destination.has_derivs();
 
     DASSERT (!Result.typespec().is_closure_based() &&

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1938,10 +1938,10 @@ DECLFOLDER(constfold_texture)
     // Symbol &S = *rop.opargsym (op, 2);
     // Symbol &T = *rop.opargsym (op, 3);
 
-    bool user_derivs = false;
+    //bool user_derivs = false; // FIXME: unused?
     int first_optional_arg = 4;
     if (op.nargs() > 4 && rop.opargsym(op,4)->typespec().is_float()) {
-        user_derivs = true;
+        //user_derivs = true;
         first_optional_arg = 8;
         DASSERT (rop.opargsym(op,5)->typespec().is_float());
         DASSERT (rop.opargsym(op,6)->typespec().is_float());
@@ -3613,14 +3613,14 @@ RuntimeOptimizer::optimize_group ()
 
         // For our parameters that require derivatives, mark their
         // upstream connections as also needing derivatives.
-        bool any = false;
+        //bool any = false; // FIXME: unused?
         BOOST_FOREACH (Connection &c, inst()->m_connections) {
             if (inst()->symbol(c.dst.param)->has_derivs()) {
                 Symbol *source = m_group[c.srclayer]->symbol(c.src.param);
                 if (! source->typespec().is_closure_based() &&
                     source->typespec().elementtype().is_floatbased()) {
                     source->has_derivs (true);
-                    any = true;
+                    //any = true;
                 }
             }
         }


### PR DESCRIPTION
Fix problems with type-punned pointers and variables that are set but not used. Also fix one un-initialized variable.
