### PR TITLE
Review: Fix pointcloud_search to optinally take a 'sort' parameter, as originally documented.

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -467,8 +467,10 @@ public:
     /// distances (when provided).
     ///
     /// Return the number of points found, always < max_points
-    virtual int pointcloud_search (ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, size_t *out_indices,
+    virtual int pointcloud_search (ShaderGlobals *sg,
+                                   ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, bool sort,
+                                   size_t *out_indices,
                                    float *out_distances, int derivs_offset) = 0;
 
     /// Retrieve an attribute for an index list. The result is another array

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1123,7 +1123,7 @@ static const char * builtin_func_args [] = {
     "hash", NOISE_ARGS, NULL,
     "noise", GNOISE_ARGS, NOISE_ARGS, "!deriv", NULL,
     "pnoise", PGNOISE_ARGS, PNOISE_ARGS, "!deriv", NULL,
-    "pointcloud_search", "ispfi.", "!rw", NULL,
+    "pointcloud_search", "ispfi.", "ispfii.", "!rw", NULL,
     "pointcloud_get", "isi[]is?[]", "!rw", NULL,
     "printf", "xs*", "!printf", NULL,
     "psnoise", PNOISE_ARGS, NULL,

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -278,7 +278,7 @@ static const char *llvm_helper_function_table[] = {
     "osl_splineinverse_dffdf", "xXXXXi",
     "osl_setmessage", "xXsLXisi",
     "osl_getmessage", "iXssLXiisi",
-    "osl_pointcloud_search", "iXsXfiXXii*",
+    "osl_pointcloud_search", "iXsXfiiXXii*",
     "osl_pointcloud_get", "iXsXisLX",
     "osl_blackbody_vf", "xXXf",
     "osl_wavelength_color_vf", "xXXf",

--- a/src/liboslexec/opcloud.cpp
+++ b/src/liboslexec/opcloud.cpp
@@ -33,13 +33,14 @@ inline TypeDesc TYPEDESC(long long x) { return (*(const TypeDesc *)&x); }
 
 OSL_SHADEOP int
 osl_pointcloud_search (ShaderGlobals *sg, const char *filename, void *center, float radius,
-                       int max_points, void *out_indices, void *out_distances, int derivs_offset,
+                       int max_points, int sort, void *out_indices, void *out_distances, int derivs_offset,
                        int nattrs, ...)
 {
     size_t *indices = (size_t *)alloca (sizeof(size_t) * max_points);
 
-    int count = sg->context->renderer()->pointcloud_search (USTR(filename), *((Vec3 *)center), radius, max_points,
-                                                            indices, (float *)out_distances, derivs_offset);
+    int count = sg->context->renderer()->pointcloud_search (sg, USTR(filename),
+                               *((Vec3 *)center), radius, max_points, sort,
+                               indices, (float *)out_distances, derivs_offset);
     va_list args;
     va_start (args, nattrs);
     for (int i = 0; i < nattrs; i++)

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -212,8 +212,10 @@ SimpleRenderer::has_userdata (ustring name, TypeDesc type, void *renderstate)
 }
 
 int
-SimpleRenderer::pointcloud_search (ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, size_t *out_indices,
+SimpleRenderer::pointcloud_search (ShaderGlobals *sg,
+                                   ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, bool sort,
+                                   size_t *out_indices,
                                    float *out_distances, int derivs_offset)
 {
     return 0;

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -72,8 +72,10 @@ public:
                                void *renderstate, void *val);
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate);
 
-    virtual int pointcloud_search (ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, size_t *out_indices,
+    virtual int pointcloud_search (ShaderGlobals *sg,
+                                   ustring filename, const OSL::Vec3 &center,
+                                   float radius, int max_points, 
+                                   bool sort, size_t *out_indices,
                                    float *out_distances, int derivs_offset);
 
     virtual int pointcloud_get (ustring filename, size_t *indices, int count,


### PR DESCRIPTION
Fix pointcloud_search to optinally take a 'sort' parameter, as originally documented.

This necessitates adding a flag all the way down the chain to RendererServices::pointcloud_search.
