### PR TITLE
Review: Police local+temp memory use of optimized shaders.  

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -344,6 +344,8 @@ RuntimeOptimizer::llvm_alloca (const TypeSpec &type, bool derivs,
     llvm::Type *alloctype = llvm_type (elemtype);
     int arraylen = std::max (1, type.arraylength());
     int n = arraylen * (derivs ? 3 : 1);
+    size_t size = type.is_closure() ? sizeof(void *)*arraylen : type.simpletype().size();
+    m_llvm_local_mem += size * (derivs ? 3 : 1);
     llvm::ConstantInt* numalloc = (llvm::ConstantInt*)llvm_constant(n);
     return builder().CreateAlloca(alloctype, numalloc, name);
 }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -860,6 +860,7 @@ private:
     ustring m_commonspace_synonym;        ///< Synonym for "common" space
     std::vector<ustring> m_raytypes;      ///< Names of ray types
     ustring m_colorspace;                 ///< What RGB colors mean
+    int m_max_local_mem_KB;               ///< Local storage can a shader use
 
     // Derived/cached calculations from options:
     Color3 m_Red, m_Green, m_Blue;        ///< Color primaries (xyY)
@@ -905,7 +906,7 @@ private:
     double m_stat_getattribute_time;      ///< Stat: time spent in getattribute
     double m_stat_getattribute_fail_time; ///< Stat: time spent in getattribute
     atomic_ll m_stat_getattribute_calls;  ///< Stat: Number of getattribute
-
+    int m_stat_max_llvm_local_mem;        ///< Stat: max LLVM local mem
     PeakCounter<off_t> m_stat_memory;     ///< Stat: all shading system memory
 
     PeakCounter<off_t> m_stat_mem_master; ///< Stat: master-related mem

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3676,7 +3676,6 @@ RuntimeOptimizer::optimize_group ()
             std::swap (inst()->symbols(), nosyms);
             symmem += vectorbytes(nosyms);
         }
-
     }
     {
         // adjust memory stats
@@ -3689,6 +3688,8 @@ RuntimeOptimizer::optimize_group ()
         ss.m_stat_preopt_ops += old_nops;
         ss.m_stat_postopt_syms += new_nsyms;
         ss.m_stat_postopt_ops += new_nops;
+        ss.m_stat_max_llvm_local_mem = std::max (ss.m_stat_max_llvm_local_mem,
+                                                  m_llvm_local_mem);
     }
 
     if (m_group.name()) {
@@ -3705,12 +3706,13 @@ RuntimeOptimizer::optimize_group ()
           new_nops, old_nops,
           100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
     }
-    m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit)",
+    m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
                        m_stat_total_llvm_time+m_stat_specialization_time,
                        m_stat_specialization_time, 
                        m_stat_opt_locking_time, m_stat_llvm_setup_time,
                        m_stat_llvm_irgen_time, m_stat_llvm_opt_time,
-                       m_stat_llvm_jit_time);
+                       m_stat_llvm_jit_time,
+                       m_llvm_local_mem/1024);
 }
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -835,6 +835,7 @@ private:
     llvm::PointerType *m_llvm_type_setup_closure_func;
     llvm::PassManager *m_llvm_passes;
     llvm::FunctionPassManager *m_llvm_func_passes;
+    int m_llvm_local_mem;             // Amount of memory we use for locals
 
     // Persistant data shared between layers
     bool m_unknown_message_sent;      ///< Somebody did a non-const setmessage

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -198,11 +198,13 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_debug(false), m_llvm_debug(false),
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
+      m_max_local_mem_KB(1024),
       m_in_group (false),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0),
       m_stat_llvm_setup_time(0), m_stat_llvm_irgen_time(0),
-      m_stat_llvm_opt_time(0), m_stat_llvm_jit_time(0)
+      m_stat_llvm_opt_time(0), m_stat_llvm_jit_time(0),
+      m_stat_max_llvm_local_mem(0)
 {
     m_stat_shaders_loaded = 0;
     m_stat_shaders_requested = 0;
@@ -507,6 +509,7 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("range_checking", int, m_range_checking);
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_SET ("greedyjit", int, m_greedyjit);
+    ATTR_SET ("max_local_mem_KB", int, m_max_local_mem_KB);
     ATTR_SET_STRING ("commonspace", m_commonspace_synonym);
     ATTR_SET_STRING ("debug_groupname", m_debug_groupname);
     ATTR_SET_STRING ("debug_layername", m_debug_layername);
@@ -587,6 +590,8 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE_STRING ("debug_groupname", m_debug_groupname);
     ATTR_DECODE_STRING ("debug_layername", m_debug_layername);
     ATTR_DECODE_STRING ("only_groupname", m_only_groupname);
+    ATTR_DECODE ("max_local_mem_KB", int, m_max_local_mem_KB);
+
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);
     ATTR_DECODE ("stat:instances_compiled", int, m_stat_instances_compiled);
@@ -815,6 +820,8 @@ ShadingSystemImpl::getstats (int level) const
     }
 
     out << "  Regex's compiled: " << m_stat_regexes << "\n";
+    out << "  Largest generated function local memory size: "
+        << m_stat_max_llvm_local_mem/1024 << " KB\n";
     if (m_stat_getattribute_calls) {
         out << "  getattribute calls: " << m_stat_getattribute_calls << " ("
             << Strutil::timeintervalformat (m_stat_getattribute_time, 2) << ")\n";


### PR DESCRIPTION
Police local+temp memory use of optimized shaders.  Track how much each needs,
print in the stats the biggest, throw an error if it's bigger than the limit
set in the new option "max_local_mem_KB".
