### PR TITLE
Review: Add pointcloud statistics, and constant-fold pointcloud_search

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -960,13 +960,15 @@ RuntimeOptimizer::llvm_assign_impl (Symbol &Result, Symbol &Src,
         return true;
     }
 
-    // Copying of entire arrays
+    // Copying of entire arrays.  It's ok if the array lengths don't match,
+    // it will only copy up to the length of the smaller one.  The compiler
+    // will ensure they are the same size, except for certain cases where
+    // the size difference is intended (by the optimizer).
     if (result_t.is_array() && src_t.is_array() && arrayindex == -1) {
-        ASSERT (assignable(result_t.elementtype(), src_t.elementtype()) &&
-                result_t.arraylength() == src_t.arraylength());
+        ASSERT (assignable(result_t.elementtype(), src_t.elementtype()));
         llvm::Value *resultptr = llvm_void_ptr (Result);
         llvm::Value *srcptr = llvm_void_ptr (Src);
-        int len = Result.size();
+        int len = std::min (Result.size(), Src.size());
         int align = result_t.is_closure_based() ? (int)sizeof(void*) :
                                        (int)result_t.simpletype().basesize();
         if (Result.has_derivs() && Src.has_derivs()) {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -777,6 +777,8 @@ public:
             return NULL;
     }
 
+    void pointcloud_stats (int search, int get, int results);
+
 private:
     void printstats () const;
 
@@ -906,6 +908,12 @@ private:
     double m_stat_getattribute_time;      ///< Stat: time spent in getattribute
     double m_stat_getattribute_fail_time; ///< Stat: time spent in getattribute
     atomic_ll m_stat_getattribute_calls;  ///< Stat: Number of getattribute
+    long long m_stat_pointcloud_searches;
+    long long m_stat_pointcloud_searches_total_results;
+    int m_stat_pointcloud_max_results;
+    int m_stat_pointcloud_failures;
+    long long m_stat_pointcloud_gets;
+
     int m_stat_max_llvm_local_mem;        ///< Stat: max LLVM local mem
     PeakCounter<off_t> m_stat_memory;     ///< Stat: all shading system memory
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -85,6 +85,8 @@ public:
 
     TextureSystem *texturesys () const { return shadingsys().texturesys(); }
 
+    RendererServices *renderer () const { return shadingsys().renderer(); }
+
     /// Are we in debugging mode?
     int debug() const { return m_debug; }
 
@@ -97,8 +99,7 @@ public:
 
     /// Search for a constant whose type and value match type and data[...],
     /// returning its index if one exists, or else creating a new constant
-    /// and returning its index.  If copy is true, allocate new space and
-    /// copy the data if no matching constant was found.
+    /// and returning its index.
     int add_constant (const TypeSpec &type, const void *data);
 
     /// Turn the op into a simple assignment of the new symbol index to the


### PR DESCRIPTION
Add pointcloud statistics, and constant-fold pointcloud_search calls when the
position is a constant if the search returns few enough results, by doing the
query at optimization times and putting the results into new constant arrays.

For those wondering why we were doing something that would allow pointcloud_search
to be foldable in the first place: it was a case where a simulation was putting certain
results into a point cloud -- it wasn't big, on the order of 100 points -- as a convenient way
to get that data to the shader for a particular effect.  The shader was searching the cloud
with infinite radius, which we realized was just a way to read the full cloud into arrays and
process every point in it, thus it would do the same thing if the lookup point itself was
constant, and therefore could be expressed in a way that it could be constant folded 
entirely (i.e., the query done once up front and results put into constant arrays that the
shader could access in lieu of doing shade-time queries).

Unfortunately, I'm sorry to report that on the particular case I hoped to speed up, this work did
not help appreciably. It seemed so "obvious" that the expense of the shader would be all
about doing those identical pointcloud_search calls needlessly on every point shaded, that
I never tested this hypothesis before spending several days making this optimization 
work correctly.  But I was wrong.  The query was fast, and the time was all
going into the point-by-point processing done on the _results_ of the query (as I have since
verified in other ways).  Oh well, next time I'll make a better test first. 

In any case, the work to has been done, and maybe it will help in other circumstances, 
so I seek to commit it anyway.
