### PR TITLE
Review: OSL side of OIIO namespace simplification

### DIFF
--- a/src/include/oslconfig.h
+++ b/src/include/oslconfig.h
@@ -45,14 +45,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenEXR/ImathMatrix.h>
 
 // All the things we need from OpenImageIO
+#include <OpenImageIO/version.h>
 #include <OpenImageIO/errorhandler.h>
 #include <OpenImageIO/texture.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
-#ifdef OIIO_NAMESPACE
+#if (OIIO_VERSION < 10100)
 namespace OIIO = OIIO_NAMESPACE;
-#else
-namespace OIIO = OpenImageIO;
 #endif
 
 // Extensions to Imath
@@ -97,17 +96,14 @@ typedef Imathx::Matrix22<Float> Matrix22;
 /// doesn't literally have to be OIIO's... it just needs to have the
 /// same API as OIIO's TextureSystem class, it's a purely abstract class
 /// anyway.
-typedef OIIO::TextureSystem TextureSystem;
-typedef OIIO::TextureOpt TextureOpt;
+using OIIO::TextureSystem;
+using OIIO::TextureOpt;
 
 // And some other things we borrow from OIIO...
-typedef OIIO::ErrorHandler ErrorHandler;
-
-#ifdef OIIO_NAMESPACE
+using OIIO::ErrorHandler;
 using OIIO::TypeDesc;
 using OIIO::ustring;
 using OIIO::ustringHash;
-#endif
 
 
 

--- a/src/liboslexec/constantpool.h
+++ b/src/liboslexec/constantpool.h
@@ -34,11 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/foreach.hpp>
 
 #include "OpenImageIO/thread.h"
-#ifdef OIIO_NAMESPACE
-namespace OIIO = OIIO_NAMESPACE;
-using OIIO::mutex;
-using OIIO::lock_guard;
-#endif
 
 using namespace OSL;
 using namespace OSL::pvt;
@@ -73,7 +68,7 @@ public:
     /// Allocate space enough for n T's, and return a pointer to the
     /// start of that space.
     T * alloc (size_t n) {
-        lock_guard lock (m_mutex);
+        OIIO::lock_guard lock (m_mutex);
         // Check each block in the block list to see if it has enough space
         BOOST_FOREACH (block_t &block, m_block_list) {
             size_t s = block.size();
@@ -99,7 +94,7 @@ private:
     std::list<block_t> m_block_list;  ///< List of memory blocks
     size_t m_quanta;   ///< How big each memory block is (in T's, not bytes)
     size_t m_total;    ///< Total memory allocated (bytes!)
-    mutex m_mutex;     ///< Thread-safe lock
+    OIIO::mutex m_mutex;  ///< Thread-safe lock
 };
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -63,17 +63,17 @@ namespace llvm {
   class JITMemoryManager;
 }
 
-#ifdef OIIO_NAMESPACE
 using OIIO::atomic_int;
 using OIIO::atomic_ll;
 using OIIO::RefCnt;
 using OIIO::ParamValueList;
+using OIIO::mutex;
+using OIIO::lock_guard;
 using OIIO::spin_mutex;
 using OIIO::spin_lock;
 using OIIO::thread_specific_ptr;
 using OIIO::ustringHash;
 namespace Strutil = OIIO::Strutil;
-#endif
 
 
 #ifdef OSL_NAMESPACE


### PR DESCRIPTION
OSL previously tried to simplify OIIO namespaces by defining an "OIIO" namespace alias.  We've moved this logic into OIIO itself in this pull request:  https://github.com/OpenImageIO/oiio/pull/325

This patch is the OSL-side that will make OSL work with both the new and old methods and does a bit of simplification.

There's also a more extensive OSL namespace refactor coming soon, but I want to do this in easy-to-swallow steps.
