### PR TITLE
Nuke "size" from register_closure API

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -224,7 +224,7 @@ public:
     ///
     virtual std::string getstats (int level=1) const = 0;
 
-    virtual void register_closure(const char *name, int id, const ClosureParam *params, int size,
+    virtual void register_closure(const char *name, int id, const ClosureParam *params,
                                   PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare) = 0;
 
     void register_builtin_closures();

--- a/src/liboslexec/builtin_closures.cpp
+++ b/src/liboslexec/builtin_closures.cpp
@@ -192,11 +192,8 @@ void ShadingSystem::register_builtin_closures()
     for (int cid = 0; cid < NBUILTIN_CLOSURES; ++cid)
     {
         BuiltinClosure *clinfo = &builtin_closures[cid];
-        int j;
-        for (j = 0; clinfo->params[j].type != TypeDesc(); ++j);
-        int size = clinfo->params[j].offset;
         ASSERT(clinfo->id == cid);
-        register_closure (clinfo->name, cid, clinfo->params, size, clinfo->prepare, generic_closure_setup, generic_closure_compare);
+        register_closure (clinfo->name, cid, clinfo->params, clinfo->prepare, generic_closure_setup, generic_closure_compare);
     }
 }
 

--- a/src/liboslexec/closure_test.cpp
+++ b/src/liboslexec/closure_test.cpp
@@ -114,7 +114,7 @@ int main()
     ShadingContext *context = shadingsys->get_context();
 
     ClosureParam my_params[] = { CLOSURE_FINISH_PARAM(MyClosure) };
-    shadingsys->register_closure("my", MY_ID, my_params, sizeof(MyClosure), NULL, NULL, my_compare);
+    shadingsys->register_closure("my", MY_ID, my_params, NULL, NULL, my_compare);
     ClosureColor *A = create_component (context, Color3(.1, .1, .1), 0.33f);
     // Add another component with different params.  It should now look
     // like two components, not combine with the others.

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -600,7 +600,7 @@ public:
         CompareClosureFunc        compare;
     };
 
-    void register_closure (const char *name, int id, const ClosureParam *params, int size,
+    void register_closure (const char *name, int id, const ClosureParam *params,
                            PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare);
 
     const ClosureEntry *get_entry (ustring name) const;
@@ -724,7 +724,7 @@ public:
     float *alloc_float_constants (size_t n) { return m_float_pool.alloc (n); }
     ustring *alloc_string_constants (size_t n) { return m_string_pool.alloc (n); }
 
-    virtual void register_closure(const char *name, int id, const ClosureParam *params, int size,
+    virtual void register_closure(const char *name, int id, const ClosureParam *params,
                                   PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare);
     const ClosureRegistry::ClosureEntry *find_closure(ustring name) const {
         return m_closure_registry.get_entry(name);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -432,7 +432,7 @@ ShadingSystemImpl::setup_op_descriptors ()
 
 
 void
-ShadingSystemImpl::register_closure(const char *name, int id, const ClosureParam *params, int size,
+ShadingSystemImpl::register_closure(const char *name, int id, const ClosureParam *params,
                                     PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare)
 {
     for (int i = 0; params && params[i].type != TypeDesc(); ++i) {
@@ -441,7 +441,7 @@ ShadingSystemImpl::register_closure(const char *name, int id, const ClosureParam
             return;
         }
     }
-    m_closure_registry.register_closure(name, id, params, size, prepare, setup, compare);
+    m_closure_registry.register_closure(name, id, params, prepare, setup, compare);
 }
 
 
@@ -1306,7 +1306,7 @@ ShadingSystemImpl::raytype_bit (ustring name)
 
 
 
-void ClosureRegistry::register_closure(const char *name, int id, const ClosureParam *params, int size,
+void ClosureRegistry::register_closure(const char *name, int id, const ClosureParam *params,
                                        PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare)
 {
     if (m_closure_table.size() <= (size_t)id)
@@ -1316,14 +1316,18 @@ void ClosureRegistry::register_closure(const char *name, int id, const ClosurePa
     entry.name = name;
     entry.nformal = 0;
     entry.nkeyword = 0;
-    for (int i = 0; params && params[i].type != TypeDesc(); ++i) {
+    entry.struct_size = 0; /* params could be NULL */
+    for (int i = 0; params; ++i) {
+        if (params[i].type == TypeDesc()) {
+            entry.struct_size = params[i].offset;
+            break;
+        }
         entry.params.push_back(params[i]);
         if (params[i].key == NULL)
             entry.nformal ++;
         else
             entry.nkeyword ++;
     }
-    entry.struct_size = size;
     entry.prepare = prepare;
     entry.setup = setup;
     entry.compare = compare;


### PR DESCRIPTION
This parameter is not necessary at all as the size
of the struct is present in the last entry of the
params list.
