### PR TITLE
boost wave fixes:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ ifneq (${NAMESPACE},)
 MY_CMAKE_FLAGS += -DOSL_NAMESPACE:STRING=${NAMESPACE}
 endif
 
+ifneq (${USE_BOOST_WAVE},)
+MY_CMAKE_FLAGS += -DUSE_BOOST_WAVE:BOOL=${USE_BOOST_WAVE}
+endif
+
 ifdef DEBUG
 MY_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE:STRING=Debug
 endif
@@ -197,4 +201,5 @@ help:
 	@echo "  make LLVM_VERSION=2.9 ...   Specify which LLVM version to use"
 	@echo "  make LLVM_DIRECTORY=xx ...  Specify where LLVM lives"
 	@echo "  make NAMESPACE=name         Wrap everything in another namespace"
+	@echo "  make USE_BOOST_WAVE=1       Use Boost 'wave' insted of cpp"
 	@echo ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ if (CMAKE_COMPILER_IS_GNUCC AND GCC_VERSION VERSION_LESS 4.3)
     add_definitions ("-DBOOST_NO_TYPEID")
 endif ()
 
-if (CMAKE_COMPILER_IS_CLANG)
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
     # CMake doesn't automatically know what do do with
     # include_directories(SYSTEM...) when using clang.
     set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "OpenImageIO/strutil.h"
 #include "OpenImageIO/sysutil.h"
+#include "OpenImageIO/strutil.h"
 #include "OpenImageIO/dassert.h"
 #include "OpenImageIO/filesystem.h"
 
@@ -136,7 +137,6 @@ static bool
 preprocess (const std::string &filename,
             const std::string &stdinclude,
             const std::vector<std::string> &defines,
-            const std::vector<std::string> &undefines,
             const std::vector<std::string> &includepaths,
             std::string &result)
 {
@@ -144,17 +144,18 @@ preprocess (const std::string &filename,
     boost::wave::util::file_position_type current_position;
 
     try {
-        // Read file contents into string
+        // Read file contents into a string
         std::ifstream instream (filename.c_str());
-
         if (! instream.is_open()) {
-            std::cerr << "Could not open '" << filename.c_str() << "'\n";
+            std::cerr << "Could not open '" << filename << "'\n";
             return false;
         }
 
         instream.unsetf (std::ios::skipws);
-        std::string instring (std::istreambuf_iterator<char>(instream.rdbuf()),
-            std::istreambuf_iterator<char>());
+        std::string instring = OIIO::Strutil::format("#include \"%s\"\n", stdinclude)
+            + std::string (std::istreambuf_iterator<char>(instream.rdbuf()),
+                           std::istreambuf_iterator<char>());
+        instream.close ();
 
         typedef boost::wave::cpplexer::lex_token<> token_type;
         typedef boost::wave::cpplexer::lex_iterator<token_type> lex_iterator_type;
@@ -163,12 +164,12 @@ preprocess (const std::string &filename,
         // Setup wave context
         context_type ctx (instring.begin(), instring.end(), filename.c_str());
 
-        for (size_t i = 0; i < defines.size(); ++i)
-            ctx.add_macro_definition (defines[i].c_str());
-
-        for (size_t i = 0; i < undefines.size(); ++i)
-            ctx.remove_macro_definition (undefines[i].c_str());
-
+        for (size_t i = 0; i < defines.size(); ++i) {
+            if (defines[i][1] == 'D')
+                ctx.add_macro_definition (defines[i].c_str()+2);
+            else if (defines[i][1] == 'U')
+                ctx.remove_macro_definition (defines[i].c_str()+2);
+        }
         for (size_t i = 0; i < includepaths.size(); ++i) {
             ctx.add_sysinclude_path (includepaths[i].c_str());
             ctx.add_include_path (includepaths[i].c_str());
@@ -177,8 +178,18 @@ preprocess (const std::string &filename,
         context_type::iterator_type first = ctx.begin();
         context_type::iterator_type last = ctx.end();
 
+#if 0
+        // N.B. The force_include() method is buggy, see
+        // https://svn.boost.org/trac/boost/ticket/6838
+        // It turns out that it screws up all file/line tracking therafter.
+        // So instead, we simply force a '#include "stdosl.h"' as the first
+        // line (see above) and then doctor the subsequent line numbers to
+        // subtract one in osllex.h.  Oh, the tangled web we weave when 
+        // we attempt to work around boost bugs.
+
         // Add standard include
         first.force_include (stdinclude.c_str(), true);
+#endif
 
         // Get result
         while (first != last) {
@@ -292,11 +303,13 @@ OSLCompilerImpl::compile (const std::string &filename,
 
 #ifdef USE_BOOST_WAVE
     std::vector<std::string> defines;
-    std::vector<std::string> undefines;
     std::vector<std::string> includepaths;
 #else
     std::string cppoptions;
 #endif
+
+    m_cwd = boost::filesystem::initial_path().string();
+    m_main_filename = filename;
 
     // Determine where the installed shader include directory is, and
     // look for ../shaders/stdosl.h and force it to include.
@@ -353,11 +366,9 @@ OSLCompilerImpl::compile (const std::string &filename,
 #ifdef USE_BOOST_WAVE
         } else if (options[i].c_str()[0] == '-' && options[i].size() > 2) {
             // options meant for the preprocessor
-            if(options[i].c_str()[1] == 'D')
+            if (options[i].c_str()[1] == 'D' || options[i].c_str()[1] == 'U')
                 defines.push_back(options[i].substr(2));
-            else if(options[i].c_str()[1] == 'U')
-                undefines.push_back(options[i].substr(2));
-            else if(options[i].c_str()[1] == 'I')
+            else if (options[i].c_str()[1] == 'I')
                 includepaths.push_back(options[i].substr(2));
 #else
         } else {
@@ -372,7 +383,7 @@ OSLCompilerImpl::compile (const std::string &filename,
     std::string preprocess_result;
 
 #ifdef USE_BOOST_WAVE
-    if (! preprocess(filename, stdinclude, defines, undefines, includepaths, preprocess_result)) {
+    if (! preprocess(filename, stdinclude, defines, includepaths, preprocess_result)) {
 #else
     if (! preprocess(filename, stdinclude, cppoptions, preprocess_result)) {
 #endif

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -282,6 +282,9 @@ public:
                                  SymbolPtrVec &opargs, SymbolPtrVec &allsyms, 
                                  SymbolPtrVec &params);
 
+    const std::string main_filename () const { return m_main_filename; }
+    const std::string cwd () const { return m_cwd; }
+
 private:
     void initialize_globals ();
     void initialize_builtin_funcs ();
@@ -348,6 +351,8 @@ private:
     ustring m_filename;       ///< Current file we're parsing
     int m_lineno;             ///< Current line we're parsing
     std::string m_output_filename; ///< Output filename
+    std::string m_main_filename; ///< Main input filename
+    std::string m_cwd;        ///< Current working directory
     ASTNode::ref m_shader;    ///< The shader's syntax tree
     bool m_err;               ///< Has an error occurred?
     SymbolTable m_symtab;     ///< Symbol table

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -259,15 +259,35 @@ preprocess (const char *yytext)
             p += 4;
         int line = atoi (p);
         if (line > 0) {
-            oslcompiler->lineno (line);
 	    const char *f = strchr (yytext, '\"');
 	    if (f) {
                 ++f;  // increment to past the quote
 	        int len = 0;  // count of chars within quotes
 	        while (f[len] && f[len] != '\"')
 		    ++len;
-	        oslcompiler->filename (ustring (f, len));
+                std::string filename (f, len);
+                // Make it relative to the working directory, so error output
+                // isn't hugely cluttered (and also to make Boost::wave's
+                // error output match the standard cpp.
+                if (filename.find (oslcompiler->cwd()) == 0) {
+                    filename.erase (0, oslcompiler->cwd().size());
+                    if (filename.size() && 
+                        (filename[0] == '/' || filename[0] == '\\'))
+                        filename.erase (0, 1);
+                }
+	        oslcompiler->filename (ustring (filename));
+#ifdef USE_BOOST_WAVE
+                // Spooky workaround for Boost Wave bug: force_include
+                // is broken and doesn't give us the right lines/files, so
+                // instead we forcefully insert a '#include "stdosl.h"' into
+                // the stream ourselves, but this in turn makes the rest
+                // of the main file all have line counts one line off!
+                // So we fix it here, ugh.
+                if (filename == oslcompiler->main_filename())
+                    --line;
+#endif
             }
+            oslcompiler->lineno (line);
 	} else {
             fprintf (stderr, "Error: \"%s\", line %d:\n"
                      "\tUnrecognized preprocessor command: #%s\n",


### PR DESCRIPTION
- add BOOST_WAVE= directive to the top level Makefile
- Fix bug where we lost proper ordering of -D and -U when using wave
- Turns out we need -isystem defined for gcc as well as clang, or else
  the warnings in Boost wave will abort compilation.
