### PR TITLE
Review: OSLCompilerImpl::retrive_source more gracefully handle EOF

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -824,8 +824,10 @@ OSLCompilerImpl::retrieve_source (ustring filename, int line)
     // Now read lines up to and including the file we want.
     char buf[10240];
     while (m_last_sourceline < line) {
-        fgets (buf, sizeof(buf), m_sourcefile);
-        ++m_last_sourceline;
+        if (fgets (buf, sizeof(buf), m_sourcefile))
+            ++m_last_sourceline;
+        else
+            break;
     }
 
     // strip trailing newline


### PR DESCRIPTION
OSLCompilerImpl::retrive_source more gracefully handle cases where the source file ends before we hit the line number we were looking for.

This is a long-lost patch suggested by an email from Brent Van Lommel, so I'm crediting him with it.
