### PR TITLE
Review: LLVM_NAMESPACE lets you select a custom LLVM namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ ifneq (${LLVM_VERSION},)
 MY_CMAKE_FLAGS += -DLLVM_VERSION:STRING=${LLVM_VERSION}
 endif
 
+ifneq (${LLVM_NAMESPACE},)
+MY_CMAKE_FLAGS += -DLLVM_NAMESPACE:STRING=${LLVM_NAMESPACE}
+endif
+
 ifneq (${NAMESPACE},)
 MY_CMAKE_FLAGS += -DOSL_NAMESPACE:STRING=${NAMESPACE}
 endif
@@ -200,6 +204,7 @@ help:
 	@echo "  make USE_TBB=0 ...          Don't use TBB"
 	@echo "  make LLVM_VERSION=2.9 ...   Specify which LLVM version to use"
 	@echo "  make LLVM_DIRECTORY=xx ...  Specify where LLVM lives"
-	@echo "  make NAMESPACE=name         Wrap everything in another namespace"
+	@echo "  make LLVM_NAMESPACE=xx ...  Specify custom LLVM namespace"
+	@echo "  make NAMESPACE=name         Wrap OSL APIs in another namespace"
 	@echo "  make USE_BOOST_WAVE=1       Use Boost 'wave' insted of cpp"
 	@echo ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,11 @@ else ()
     set (USE_BOOST_WAVE OFF CACHE BOOL "Use Boost Wave as preprocessor")
 endif ()
 
+if (LLVM_NAMESPACE)
+    add_definitions ("-DLLVM_NAMESPACE=${LLVM_NAMESPACE}")
+endif ()
+
+
 set (CMAKE_MODULE_PATH
      "${PROJECT_SOURCE_DIR}/cmake/modules"
      "${PROJECT_SOURCE_DIR}/cmake")

--- a/src/liboslexec/llvm_headers.h
+++ b/src/liboslexec/llvm_headers.h
@@ -29,6 +29,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef OSL_LLVM_HEADERS_H
 #define OSL_LLVM_HEADERS_H
 
+#ifdef LLVM_NAMESPACE
+namespace llvm = LLVM_NAMESPACE;
+#endif
+
 #include <llvm/Bitcode/ReaderWriter.h>
 #include <llvm/Constants.h>
 #include <llvm/DerivedTypes.h>


### PR DESCRIPTION
LLVM is becoming popular enough that we've seen instances of apps that embed one version of LLVM, but also either want OSL or want to load a plugin that somebody has written that uses OSL, which in turn uses a _different_ version of LLVM.  The symbols clash with hilarious results that make waterboarding seem pleasant in comparison.

So, assuming you make a custom build of LLVM wherein you change the enclosing namespace (more on that later), these minor changes to OSL let you specify the alternate namespace for LLVM.  This will let your embedded OSL have its llvm completely sequestered from any other pesky instances that may exist on your system or within any other apps.
