### PR TITLE
Review: Restore compatibility with OIIO <= 1.0 by guarding use of the new 'subimagename'

### DIFF
--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1243,7 +1243,9 @@ osl_texture_set_subimage (void *opt, int subimage)
 OSL_SHADEOP void
 osl_texture_set_subimagename (void *opt, const char *subimagename)
 {
+#if OIIO_VERSION >= 10100
     ((TextureOpt *)opt)->subimagename = USTR(subimagename);
+#endif
 }
 
 


### PR DESCRIPTION
Sorry, forgot to put the name of the new structure member in an appropriate #if guard.
