### PR TITLE
Review: matrix param initialization by constants

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -653,13 +653,40 @@ ASTvariable_declaration::param_one_default_literal (const Symbol *sym,
             f = lit->intval();
         else if (islit && lit->typespec().is_float())
             f = lit->floatval();
-        else {
-            f = 0;  // FIXME?
+        else if (init && init->typespec() == type &&
+                   init->nodetype() == ASTNode::type_constructor_node) {
+            ASTtype_constructor *ctr = (ASTtype_constructor *) init;
+            ASTNode::ref val = ctr->args();
+            float f[16];
+            int nargs = 0;
+            for (int c = 0;  c < 16;  ++c) {
+                if (val.get())
+                    ++nargs;
+                if (val.get() && val->nodetype() == ASTNode::literal_node) {
+                    f[c] = ((ASTliteral *)val.get())->floatval ();
+                    val = val->next();
+                } else {
+                    f[c] = 0;
+                    completed = false;
+                }
+            }
+            if (nargs == 1)
+                out += Strutil::format ("%.8g %.8g %.8g %.8g %.8g %.8g %.8g %.8g ",
+                                        f[0], f[0], f[0], f[0], f[0], f[0], f[0], f[0])
+                     + Strutil::format ("%.8g %.8g %.8g %.8g %.8g %.8g %.8g %.8g ",
+                                        f[0], f[0], f[0], f[0], f[0], f[0], f[0], f[0]);
+            else
+                out += Strutil::format ("%.8g %.8g %.8g %.8g %.8g %.8g %.8g %.8g ",
+                                        f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7])
+                     + Strutil::format ("%.8g %.8g %.8g %.8g %.8g %.8g %.8g %.8g",
+                                        f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15]);
+        } else {
+            f = 0;
+            std::string s = Strutil::format ("%.8g ", f);
+            for (int i = 0;  i < 16;  ++i)
+                out += s;
             completed = false;
         }
-        std::string s = Strutil::format ("%.8g ", f);
-        for (int i = 0;  i < 16;  ++i)
-            out += s;
     } else if (type.is_string()) {
         if (islit && lit->typespec().is_string())
             out += Strutil::format ("\"%s\" ", lit->strval());


### PR DESCRIPTION
Matrix parms initialized by m=matrix(consta,constb,...) should statically initialize, not need init ops.

This makes it similar to triples, and makes oslinfo work sensibly for
a wider variety of cases.

To clarify, consider this shader:

```
shader test (point p = point(1,2,3),
             matrix m = matrix(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15))
{ }
```

oslc will recognize that even though p is initialized by a point() operator (that is, code that assembled the point from individual floats), since those floats are all constants, it gets rid of that code ("initialization ops") and just statically sets the default values of p to [1 2 3].  This is reflected in the .oso file, and also makes the output of "oslinfo" very sensible.

However, before this patch, it will not similarly transform the initialization of matrices like m.  This makes the "oslinfo" output misleading (and, perhaps, has a very minor performance penalty, but probably nothing you'll ever notice.

This patch fixes it, by recognizing constant matrices used shader parameter initializers, and promoting them to static initializers instead of runtime-executed "init ops."
