### PR TITLE
Review: boost/hash.h cleanup

### DIFF
--- a/src/include/optautomata.h
+++ b/src/include/optautomata.h
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef OPTAUTOMATA_H
 #define OPTAUTOMATA_H
 
-#include <OpenImageIO/hash.h>
 #include <OpenImageIO/ustring.h>
 
 #include <vector>

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -32,7 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <stack>
 
-#include "OpenImageIO/hash.h"
+#include <boost/unordered_map.hpp>
+
 #include "OpenImageIO/typedesc.h"
 #include "OpenImageIO/ustring.h"
 
@@ -165,11 +166,7 @@ private:
 ///
 class SymbolTable {
 public:
-#ifdef OIIO_HAVE_BOOST_UNORDERED_MAP
     typedef boost::unordered_map<ustring, Symbol *,ustringHash> ScopeTable;
-#else
-    typedef hash_map<ustring, Symbol *,ustringHash> ScopeTable;
-#endif
     typedef std::vector<ScopeTable> ScopeTableStack;
     typedef SymbolPtrVec::iterator iterator;
     typedef SymbolPtrVec::const_iterator const_iterator;

--- a/src/liboslexec/automata.h
+++ b/src/liboslexec/automata.h
@@ -34,9 +34,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <list>
 #include <vector>
 
+#include <boost/unordered_map.hpp>
+#include <boost/unordered_set.hpp>
+
 #include "oslconfig.h"
 
-#include <OpenImageIO/hash.h>
 
 OSL_NAMESPACE_ENTER
 
@@ -46,8 +48,6 @@ OSL_NAMESPACE_ENTER
 // General container for integer sets
 typedef std::set<int> IntSet; // probably faster to test for equality, unions and so
 
-#ifdef OIIO_HAVE_BOOST_UNORDERED_MAP
-
 typedef boost::unordered_set<ustring, ustringHash> SymbolSet;
 // This is for the transition table used in DfAutomata::State
 typedef boost::unordered_map<ustring, int, ustringHash> SymbolToInt;
@@ -55,18 +55,6 @@ typedef boost::unordered_map<ustring, int, ustringHash> SymbolToInt;
 // has several movements for each symbol
 typedef boost::unordered_map<ustring, IntSet, ustringHash> SymbolToIntList;
 typedef boost::unordered_map<int, int> HashIntInt;
-
-#else  // !OIIO_HAVE_BOOST_UNORDERED_MAP
-
-typedef hash_set<ustring, ustringHash> SymbolSet;
-// This is for the transition table used in DfAutomata::State
-typedef hash_map<ustring, int, ustringHash> SymbolToInt;
-// And this is for the transition table in NdfAutomata which
-// has several movements for each symbol
-typedef hash_map<ustring, IntSet, ustringHash> SymbolToIntList;
-typedef hash_map<int, int> HashIntInt;
-
-#endif // OIIO_HAVE_BOOST_UNORDERED_MAP
 
 // For the rules in the deterministic states, we don't need a real set
 // cause when converting from the NDF automata we will never find the same

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -37,8 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 
 #include <boost/regex_fwd.hpp>
+#include <boost/unordered_map.hpp>
 
-#include "OpenImageIO/hash.h"
 #include "OpenImageIO/ustring.h"
 #include "OpenImageIO/thread.h"
 #include "OpenImageIO/paramlist.h"
@@ -754,11 +754,7 @@ public:
 
     virtual void optimize_all_groups (int nthreads=0);
 
-#ifdef OIIO_HAVE_BOOST_UNORDERED_MAP
     typedef boost::unordered_map<ustring,OpDescriptor,ustringHash> OpDescriptorMap;
-#else
-    typedef hash_map<ustring,OpDescriptor,ustringHash> OpDescriptorMap;
-#endif
 
     /// Look up OpDescriptor for the named op, return NULL for unknown op.
     ///
@@ -1159,11 +1155,7 @@ private:
     std::vector<char> m_heap;           ///< Heap memory
     size_t m_closures_allotted;         ///< Closure memory allotted
     int m_curuse;                       ///< Current use that we're running
-#ifdef OIIO_HAVE_BOOST_UNORDERED_MAP
     typedef boost::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;
-#else
-    typedef hash_map<ustring, boost::regex*, ustringHash> RegexMap;
-#endif
     RegexMap m_regex_map;               ///< Compiled regex's
     MessageList m_messages;             ///< Message blackboard
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
+#include <boost/unordered_map.hpp>
 
-#include <OpenImageIO/hash.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/thread.h>
 


### PR DESCRIPTION
Get rid of boost <=1.36 idioms inherited through OIIO hash.h (no longer needed).
