### PR TITLE
Review: Fix bug in SS::convert_value, where for int conversions it didn't honor 

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -121,9 +121,12 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
     }
 
     if (srctype == TypeDesc::TypeInt && dsttype.basetype == TypeDesc::FLOAT) {
-        // int -> any-float-based ... up-convert to float and recurse
-        float f = (float) (*(const int *)src);
-        return convert_value (dst, dsttype, &f, TypeDesc::TypeFloat);
+        if (dst && src) {
+            // int -> any-float-based ... up-convert to float and recurse
+            float f = (float) (*(const int *)src);
+            return convert_value (dst, dsttype, &f, TypeDesc::TypeFloat);
+        }
+        return convert_value (NULL, dsttype, NULL, TypeDesc::TypeFloat);
     }
 
     if (srctype == TypeDesc::TypeFloat) {


### PR DESCRIPTION
Passing NULL for the src/dst parameters is supposed to mean that convert_value() just says whether the proposed conversion is allowed by the type conversion rules, but not actually do the copy.

There was a bug where for int conversions, it still tried to perform the copy, which would crash when passed NULL.
