### PR TITLE
Fix confusing oddity about code generation for Ci = val * closure()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,7 +229,8 @@ TESTSUITE ( arithmetic array array-derivs array-range
             derivs derivs-muldiv-clobber error-dupes exponential
             function-earlyreturn function-simple function-outputelem
             geomath getsymbol-nonheap gettextureinfo hyperb
-            ieee_fp if incdec initops intbits layers layers-lazy
+            ieee_fp if incdec initops intbits
+            layers layers-Ciassign layers-lazy
             logic loop matrix message miscmath missing-shader
             noise noise-cell
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -728,11 +728,6 @@ public:
 private:
     // Special code generation for short-circuiting logical ops
     Symbol *codegen_logic (Symbol *dest);
-    // Special code generation for closure multiplies
-    Symbol *codegen_closure (Symbol *dest);
-    // Helper, for closure expressions only: does either subtree involve
-    // closure symbol s?
-    bool subtrees_involve_closure (Symbol *s);
 };
 
 

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1230,24 +1230,30 @@ ASTunary_expression::codegen (Symbol *dest)
 Symbol *
 ASTbinary_expression::codegen (Symbol *dest)
 {
-    // Special case for logal ops that short-circuit
+    // Special case for logic ops that short-circuit
     if (m_op == And || m_op == Or)
         return codegen_logic (dest);
-
-    // Special case for closure operations
-    if (typespec().is_closure())
-        return codegen_closure (dest);
 
     Symbol *lsym = left()->codegen ();
     Symbol *rsym = right()->codegen ();
     if (dest == NULL || ! equivalent (dest->typespec(), typespec()))
         dest = m_compiler->make_temporary (typespec());
 
-    // FIXME -- what about coerced types, do we need a temp and copy here?
+    // Special case for closure operations
+    if (typespec().is_closure()) {
+        ASSERT (m_op == Mul || m_op == Div || m_op == Add);
+        if (m_op == Mul || m_op == Div) {
+            // Need to coerce the weight into a color.
+            // N.B. The typecheck always reorders c=k*c into c=c*k.
+            rsym = coerce (rsym, TypeDesc::TypeColor, true);
+        }
+        emitcode (opword(), dest, lsym, rsym);
+        return dest;
+    }
 
     // Promote ints to float-like types, for mixed arithmetic
     if ((m_op == Mul || m_op == Div || m_op == Add || m_op == Sub)) {
-        if ((lsym->typespec().is_closure() || lsym->typespec().is_floatbased()) && rsym->typespec().is_int()) {
+        if (lsym->typespec().is_floatbased() && rsym->typespec().is_int()) {
             if (rsym->symtype() == SymTypeConst) {
                 float val = ((ConstantSymbol *)rsym)->floatval();
                 rsym = m_compiler->make_constant (val);
@@ -1256,7 +1262,7 @@ ASTbinary_expression::codegen (Symbol *dest)
                 rsym = m_compiler->make_temporary (lsym->typespec());
                 emitcode ("assign", rsym, tmp);  // type coercion
             }
-        } else if (lsym->typespec().is_int() && (rsym->typespec().is_closure() || rsym->typespec().is_floatbased())) {
+        } else if (lsym->typespec().is_int() && rsym->typespec().is_floatbased()) {
             if (lsym->symtype() == SymTypeConst) {
                 float val = ((ConstantSymbol *)lsym)->floatval();
                 lsym = m_compiler->make_constant (val);
@@ -1301,93 +1307,6 @@ ASTbinary_expression::codegen_logic (Symbol *dest)
     int donelabel = m_compiler->next_op_label ();
     m_compiler->pop_nesting (false);
     m_compiler->ircode(ifop).set_jump (falselabel, donelabel);
-    return dest;
-}
-
-
-
-bool
-ASTbinary_expression::subtrees_involve_closure (Symbol *s)
-{
-    if (m_op == Mul || m_op == Div) {
-        // N.B. The typecheck always reorders c=k*c into c=c*k.
-        ASSERT (left()->typespec().is_closure() &&
-                !right()->typespec().is_closure());
-        // There are only a couple cases here.  Either this node is
-        //     closure_variable * scalar             (is the var s?)
-        // or  closure_binary_expression * scalar    (recurse)
-        // or  closure_function * scalar             (definitely not s)
-        ASTNode *l = left().get();
-        if (l->nodetype() == variable_ref_node)
-            return ((ASTvariable_ref *)l)->sym() == s;
-        else if (l->nodetype() == binary_expression_node)
-            return ((ASTbinary_expression *)l)->subtrees_involve_closure (s);
-        else
-            return false;
-    } else if (m_op == Add) {
-        // There are only a couple cases here.  Left and right can each
-        // either be a closure variable (test it), a binary expression
-        // (recurse), or a closure function (definitely false).
-        bool left_uses_result = false, right_uses_result = false;
-        ASTNode *l = left().get(), *r = right().get();
-        if (l->nodetype() == variable_ref_node)
-            left_uses_result |= ((ASTvariable_ref *)l)->sym() == s;
-        else if (l->nodetype() == binary_expression_node)
-            left_uses_result |= ((ASTbinary_expression *)l)->subtrees_involve_closure (s);
-        if (r->nodetype() == variable_ref_node)
-            right_uses_result |= ((ASTvariable_ref *)l)->sym() == s;
-        else if (r->nodetype() == binary_expression_node)
-            right_uses_result |= ((ASTbinary_expression *)r)->subtrees_involve_closure (s);
-        return left_uses_result | right_uses_result;
-    }
-    ASSERT (0 && "unhandled closure op case");  // can't get here
-}
-
-
-
-Symbol *
-ASTbinary_expression::codegen_closure (Symbol *dest)
-{
-    if (dest == NULL || ! equivalent (dest->typespec(), typespec()))
-        dest = m_compiler->make_temporary (typespec());
-
-    if (m_op == Mul || m_op == Div) {
-        // Special handling of r = closure * k   (or closure/k)
-        // Instead of generating "closure tmp1 ... ; mul r tmp1 k", 
-        // generate the more efficient "closure r ... ; mul r r k".
-        // N.B. The typecheck always reorders c=k*c into c=c*k.
-        Symbol *lsym = left()->codegen (dest);
-        Symbol *rsym = coerce (right()->codegen(), TypeDesc::TypeColor, true);
-        emitcode (opword(), dest, lsym, rsym);
-    } else if (m_op == Add) {
-        ASSERT (left()->typespec().is_closure() &&
-                right()->typespec().is_closure());
-        // Special handling of r = closure1 + closure2, which in reality
-        // is often r = k1*closure1 + k2*closure2, and thus would lead to
-        // code like this:
-        //      mul tmp1 k1 c1 ; mul tmp2 k2 c2 ; add r tmp1 tmp2
-        // And note that the add (and maybe the muls) implicitly have
-        // a clear and copy in them. Instead, generate this:
-        //      mul r k1 c1; mul tmp2 k2 c2; add r r tmp2
-        // This results in one fewer temp, fewer copies.  BUT... must be
-        // careful of situations like r = k1*c1 + k2*r, where we might
-        // overwrite r too soon.
-        Symbol *lsym;
-        if (! subtrees_involve_closure (dest)) {
-            // None of the subtrees involve the destination, so use it
-            lsym = left()->codegen (dest);
-        } else {
-            // The subtrees involve the destination, so be safe and let it
-            // generate a new destination.
-            lsym = left()->codegen ();
-        }
-        Symbol *rsym = right()->codegen ();
-        emitcode (opword(), dest, lsym, rsym);
-    } else {
-        // I don't think this can happen
-        ASSERT (0 && "unhandled closure op case");
-    }
-
     return dest;
 }
 

--- a/testsuite/layers-Ciassign/a.osl
+++ b/testsuite/layers-Ciassign/a.osl
@@ -1,0 +1,7 @@
+shader a (output color out = 0)
+{
+    printf ("a start, Ci = '%s'\n", Ci);
+    Ci = color(1,0,0) * emission();
+    printf ("a end, Ci = '%s'\n", Ci);
+    out = color(0,1,u);
+}

--- a/testsuite/layers-Ciassign/b.osl
+++ b/testsuite/layers-Ciassign/b.osl
@@ -1,0 +1,6 @@
+shader b (color in = color(0,1,0))
+{
+    printf ("b start, Ci = '%s'\n", Ci);
+    Ci = in * emission();
+    printf ("b end, Ci = '%s'\n", Ci);
+}

--- a/testsuite/layers-Ciassign/ref/out.txt
+++ b/testsuite/layers-Ciassign/ref/out.txt
@@ -1,0 +1,8 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect alayer.out to blayer.in
+b start, Ci = ''
+a start, Ci = ''
+a end, Ci = '(1, 0, 0) * emission ()'
+b end, Ci = '(0, 1, 0.5) * emission ()'
+

--- a/testsuite/layers-Ciassign/run.py
+++ b/testsuite/layers-Ciassign/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python 
+
+command += testshade("-layer alayer a --layer blayer b --connect alayer out blayer in")


### PR DESCRIPTION
This was generating ops like this:

```
closure Ci "closurename"
mul Ci Ci val
```

But if 'val' is an input parameter, needed for the first time and therefore
triggering a call to an earlier layer, which itself assigns to Ci, you end
up with the following confusing sequence underneath:

```
closure Ci "emission"
useparam val      <--- this itself assigns something to Ci,
                        let's say 'diffuse', for the sake of example
mul Ci Ci val
```

Now that point, you will have Ci == diffuse_val, instead of the expected
emission_val.  Very counter-intuitive to debug, even though all caveats have
been given about having side effects on globals like Ci in earlier layers.

So this patch alters the code generation for binary ops involving closure
variables, if it notices that the destination is a global (Ci is the only
case at this point, but we keep the notion general) to the following:

```
closure tmp "closurename"
(useparam val)
mul Ci tmp val
```

And that is completely safe, even if the 'useparam' triggers execution of
a layer that also writes to Ci.  Ci will get what the later layer thinks
it's assigning, instead of a strange mashup of the two, as was the case
before.
