### PR TITLE
oslc better error checking for calling a variable as if it were a function

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -888,6 +888,11 @@ ASTfunction_call::ASTfunction_call (OSLCompilerImpl *comp, ustring name,
         error ("function '%s' was not declared in this scope", name.c_str());
         // FIXME -- would be fun to troll through the symtab and try to
         // find the things that almost matched and offer suggestions.
+        return;
+    }
+    if (m_sym->symtype() != SymTypeFunction) {
+        error ("'%s' is not a function", name.c_str());
+        return;
     }
 }
 

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1221,9 +1221,7 @@ OSLCompilerImpl::type_from_code (const char *code, int *advance)
     case '*' : break; // anything will match, so keep 'UNKNOWN'
     case '.' : break; // anything will match, so keep 'UNKNOWN'
     default:
-        std::cerr << "Don't know how to decode type code '" 
-                  << code << "' " << (int)code[0] << "\n";
-        ASSERT (0);   // FIXME
+        ASSERTMSG (0, "Don't know how to decode type code '%d'", (int)code[0]);
         if (advance)
             *advance = 1;
         return TypeSpec();


### PR DESCRIPTION
Haha, a construct like this:

```
float x = dPdu(u);
```

i.e., a function call that used the identifier of a variable (in this case the global variable dPdu) as if it were a function call, would lead to a comical series of errors.

Put in code to catch this right away and give a helpful error message.

Fixed an assertion that I was hitting to make it more modern and compact.
