### PR TITLE
New function: pointcloud_write

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -44,7 +44,7 @@
 
 \def\langname{Open Shading Language\xspace}
 \def\product{{\sffamily Open Shading Language}\xspace}
-\def\versionnumber{1.1}
+\def\versionnumber{1.3}
 \def\productver{\product\ {\sffamily \versionnumber}\xspace}
 
 
@@ -63,7 +63,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
  \bigskip \\
 }
-\date{{\large Date: 14 Mar, 2012 \\
+\date{{\large Date: 21 Sep, 2012 \\
 %(with corrections, 22 Feb, 2012)
 }}
 
@@ -4022,10 +4022,6 @@ variable specified.  This allows for RGBA lookups in a single call to
 \apiend
 
 
-%FIXME
-%spatialdbsave
-%spatialdbquery
-
 \newpage
 \apiitem{int {\ce gettextureinfo} (string texturename, string paramname,\\
 \bigspc\bigspc output \emph{type} destination)}
@@ -4087,7 +4083,7 @@ type in the metadata or other header information of the texture file.
 \apiitem{int {\ce pointcloud_search} (string ptcname, point pos, float radius,\\
 \bigspc\bigspc      int maxpoints, int sort,
                        string attr, Type data[],\\
-\bigspc\bigspc         [ string attrN, Type dataN[], ... ] )}
+\bigspc\bigspc         ..., string attrN, Type dataN[] )}
 \indexapi{pointcloud_search}
 
 Search the named point cloud for points within {\cf radius} of {\cf pos},
@@ -4151,6 +4147,26 @@ in the following example:
                                "temperature", temp);
 \end{code}
 \apiend
+
+
+
+\apiitem{int {\ce pointcloud_write} (string ptcname, point pos, \\
+\bigspc\bigspc  string attr1, \emph{type} data1, ...)}
+\indexapi{pointcloud_write}
+
+Save the tuple (\emph{attr1}, \emph{data1}, ..., \emph{attrN},
+\emph{dataN}) at position \emph{pos} in a named point cloud.  The point
+cloud will be saved when the frame is finished computing.  Return 1 if
+successful, 0 for failure, which could include the attributes not
+matching names or types at different positions in the point cloud.
+
+Example:
+\begin{code}
+      color C = ...;
+      int ok = pointcloud_write ("particles.ptc", P, "normal", N, "color", C);
+\end{code}
+\apiend
+
 
 \newpage
 \section{Light and Shadows}

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -482,19 +482,19 @@ public:
                                    void *data);
 
 
-    /// Lookup nearest points in a point cloud. It will search for points
-    /// around the given center within the specified radius. A list of indices
-    /// is returned so the programmer can later retrieve attributes with
-    /// pointcloud_get. The indices array is mandatory, but distances can be NULL.
-    /// If a derivs_offset > 0 is given, derivatives will be computed for
-    /// distances (when provided).
+    /// Lookup nearest points in a point cloud. It will search for
+    /// points around the given center within the specified radius. A
+    /// list of indices is returned so the programmer can later retrieve
+    /// attributes with pointcloud_get. The indices array is mandatory,
+    /// but distances can be NULL.  If a derivs_offset > 0 is given,
+    /// derivatives will be computed for distances (when provided).
     ///
     /// Return the number of points found, always < max_points
     virtual int pointcloud_search (ShaderGlobals *sg,
                                    ustring filename, const OSL::Vec3 &center,
                                    float radius, int max_points, bool sort,
                                    size_t *out_indices,
-                                   float *out_distances, int derivs_offset) = 0;
+                                   float *out_distances, int derivs_offset);
 
     /// Retrieve an attribute for an index list. The result is another array
     /// of the requested type stored in out_data.
@@ -502,7 +502,16 @@ public:
     /// Return 1 if the attribute is found, 0 otherwise.
     virtual int pointcloud_get (ustring filename, size_t *indices, int count,
                                 ustring attr_name, TypeDesc attr_type,
-                                void *out_data) = 0;
+                                void *out_data);
+
+    /// Write a point to the named pointcloud, which will be saved 
+    /// at the end of the frame.  Return true if everything is ok,
+    /// false if there was an error.
+    virtual bool pointcloud_write (ShaderGlobals *sg,
+                                   ustring filename, const OSL::Vec3 &pos,
+                                   int nattribs, const ustring *names,
+                                   const TypeDesc *types,
+                                   const void **data);
 
     /// Options for the trace call.
     struct TraceOpt {

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1119,6 +1119,7 @@ static const char * builtin_func_args [] = {
     "pnoise", PGNOISE_ARGS, PNOISE_ARGS, "!deriv", NULL,
     "pointcloud_search", "ispfi.", "ispfii.", "!rw", NULL,
     "pointcloud_get", "isi[]is?[]", "!rw", NULL,
+    "pointcloud_write", "isp.", NULL,
     "printf", "xs*", "!printf", NULL,
     "psnoise", PNOISE_ARGS, NULL,
     "random", "f", "c", "p", "v", "n", NULL,

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -266,6 +266,8 @@ static const char *llvm_helper_function_table[] = {
     "osl_getmessage", "iXssLXiisi",
     "osl_pointcloud_search", "iXsXfiiXXii*",
     "osl_pointcloud_get", "iXsXisLX",
+    "osl_pointcloud_write", "iXsXiXXX",
+    "osl_pointcloud_write_helper", "xXXXisLX",
     "osl_blackbody_vf", "xXXf",
     "osl_wavelength_color_vf", "xXXf",
     "osl_luminance_fv", "xXXX",

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1575,7 +1575,6 @@ osl_trace (void *sg_, void *opt_, void *Pos_, void *dPosdx_, void *dPosdy_,
 
 
 
-#if 1
 OSL_SHADEOP int osl_get_attribute(void *sg_,
                              int   dest_derivs,
                              void *obj_name_,
@@ -1589,33 +1588,13 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
     const ustring &obj_name  = USTR(obj_name_);
     const ustring &attr_name = USTR(attr_name_);
 
-#if 1
     return sg->context->osl_get_attribute (sg->renderstate, sg->objdata,
                                            dest_derivs, obj_name, attr_name,
                                            array_lookup, index,
                                            *(const TypeDesc *)attr_type,
                                            attr_dest);
-#else
-    if (array_lookup)
-        return sg->context->renderer()->get_array_attribute(sg->renderstate,  
-                                                  sg->objdata,
-                                                  dest_derivs,
-                                                  obj_name,
-                                                  *(TypeDesc *)attr_type,
-                                                  attr_name,
-                                                  index,
-                                                  attr_dest);
-    else
-        return sg->context->renderer()->get_attribute(sg->renderstate,  
-                                                  sg->objdata,
-                                                  dest_derivs,
-                                                  obj_name,
-                                                  *(TypeDesc *)attr_type,
-                                                  attr_name,
-                                                  attr_dest);
-#endif
 }
-#endif
+
 
 
 inline Vec3 calculatenormal(void *P_, bool flipHandedness)

--- a/src/liboslexec/opcloud.cpp
+++ b/src/liboslexec/opcloud.cpp
@@ -72,6 +72,8 @@ osl_pointcloud_search (ShaderGlobals *sg, const char *filename, void *center, fl
     return count;
 }
 
+
+
 OSL_SHADEOP int
 osl_pointcloud_get (ShaderGlobals *sg, const char *filename, void *in_indices, int count,
                     const char *attr_name, long long attr_type, void *out_data)
@@ -87,4 +89,30 @@ osl_pointcloud_get (ShaderGlobals *sg, const char *filename, void *in_indices, i
                                                     TYPEDESC(attr_type), out_data);
 
 }
+
+
+
+OSL_SHADEOP void
+osl_pointcloud_write_helper (ustring *names, TypeDesc *types, void **values,
+                             int index, const char *name, long long type,
+                             void *val)
+{
+    names[index] = USTR(name);
+    types[index] = TYPEDESC(type);
+    values[index] = val;
+}
+
+
+
+OSL_SHADEOP int
+osl_pointcloud_write (ShaderGlobals *sg, const char *filename, const Vec3 *pos,
+                      int nattribs, const ustring *names,
+                      const TypeDesc *types, const void **values)
+{
+    RendererServices *renderer (sg->context->renderer());
+    return renderer->pointcloud_write (sg, USTR(filename), *pos,
+                                       nattribs, names, types, values);
+}
+
+
 

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -190,4 +190,39 @@ RendererServices::get_texture_info (ustring filename, int subimage,
 }
 
 
+
+int
+RendererServices::pointcloud_search (ShaderGlobals *sg,
+                                     ustring filename, const OSL::Vec3 &center,
+                                     float radius, int max_points, bool sort,
+                                     size_t *out_indices,
+                                     float *out_distances, int derivs_offset)
+{
+    return 0;
+}
+
+
+
+int
+RendererServices::pointcloud_get (ustring filename, size_t *indices, int count,
+                                  ustring attr_name, TypeDesc attr_type,
+                                  void *out_data)
+{
+    return 0;
+}
+
+
+
+bool
+RendererServices::pointcloud_write (ShaderGlobals *sg,
+                                    ustring filename, const OSL::Vec3 &pos,
+                                    int nattribs, const ustring *names,
+                                    const TypeDesc *types,
+                                    const void **data)
+{
+    return false;
+}
+
+
+
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -56,6 +56,7 @@ static ustring u_nop    ("nop"),
                u_continue ("continue"),
                u_return ("return"),
                u_useparam ("useparam"),
+               u_pointcloud_write ("pointcloud_write"),
                u_setmessage ("setmessage"),
                u_getmessage ("getmessage");
 
@@ -2733,6 +2734,11 @@ RuntimeOptimizer::useless_op_elision (Opcode &op, int opnum)
         }
         // If we get this far, nothing written had any effect
         if (writes_something) {
+            // Enumerate exceptions -- ops that write something, but have
+            // side effects that means they shouldn't be eliminated.
+            if (op.opname() == u_pointcloud_write)
+                return false;
+            // It's a useless op, eliminate it
             turn_into_nop (op, "eliminated op whose writes will never be read");
             return true;
         }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -684,6 +684,7 @@ public:
     llvm::Type *llvm_type_bool() { return m_llvm_type_bool; }
     llvm::Type *llvm_type_longlong() { return m_llvm_type_longlong; }
     llvm::Type *llvm_type_void() { return m_llvm_type_void; }
+    llvm::Type *llvm_type_typedesc() { return llvm_type_longlong(); }
     llvm::PointerType *llvm_type_prepare_closure_func() { return m_llvm_type_prepare_closure_func; }
     llvm::PointerType *llvm_type_setup_closure_func() { return m_llvm_type_setup_closure_func; }
     llvm::PointerType *llvm_type_int_ptr() { return m_llvm_type_int_ptr; }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -456,6 +456,7 @@ ShadingSystemImpl::setup_op_descriptors ()
     OP (point,       construct_triple,    triple,        true);
     OP (pointcloud_search, pointcloud_search, pointcloud_search, false);
     OP (pointcloud_get, pointcloud_get,   none,          false);
+    OP (pointcloud_write, pointcloud_write, none,        false);
     OP (pow,         generic,             pow,           true);
     OP (printf,      printf,              none,          false);
     OP (psnoise,     noise,               none,          true);

--- a/src/testrender/simplerend.cpp
+++ b/src/testrender/simplerend.cpp
@@ -181,23 +181,6 @@ SimpleRenderer::has_userdata (ustring name, TypeDesc type, void *renderstate)
     return false;
 }
 
-int
-SimpleRenderer::pointcloud_search (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, bool sort,
-                                   size_t *out_indices,
-                                   float *out_distances, int derivs_offset)
-{
-    return 0;
-}
-
-int
-SimpleRenderer::pointcloud_get (ustring filename, size_t *indices, int count,
-                                ustring attr_name, TypeDesc attr_type,
-                                void *out_data)
-{
-    return 0;
-}
 
 };  // namespace OSL
 

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -56,15 +56,6 @@ public:
                                void *renderstate, void *val);
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate);
 
-    virtual int pointcloud_search (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, 
-                                   bool sort, size_t *out_indices,
-                                   float *out_distances, int derivs_offset);
-    virtual int pointcloud_get (ustring filename, size_t *indices, int count,
-                                ustring attr_name, TypeDesc attr_type,
-                                void *out_data);
-
     // implementation specific method to setup internals:
     void name_transform (const char *name, const Matrix44& xform);
     void camera_params (const Matrix44& world_to_camera, float hfov, int xres, int yres);

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -207,22 +207,4 @@ SimpleRenderer::has_userdata (ustring name, TypeDesc type, void *renderstate)
     return false;
 }
 
-int
-SimpleRenderer::pointcloud_search (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, bool sort,
-                                   size_t *out_indices,
-                                   float *out_distances, int derivs_offset)
-{
-    return 0;
-}
-
-int
-SimpleRenderer::pointcloud_get (ustring filename, size_t *indices, int count,
-                                ustring attr_name, TypeDesc attr_type,
-                                void *out_data)
-{
-    return 0;
-}
-
 OSL_NAMESPACE_EXIT

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -66,16 +66,6 @@ public:
                                void *renderstate, void *val);
     virtual bool has_userdata (ustring name, TypeDesc type, void *renderstate);
 
-    virtual int pointcloud_search (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, 
-                                   bool sort, size_t *out_indices,
-                                   float *out_distances, int derivs_offset);
-
-    virtual int pointcloud_get (ustring filename, size_t *indices, int count,
-                                ustring attr_name, TypeDesc attr_type,
-                                void *out_data);
-
     // Super simple camera and display parameters.  Many options not
     // available, no motion blur, etc.
     void camera_params (const Matrix44 &world_to_camera, ustring projection,


### PR DESCRIPTION
I had request from our shading department for a special-purpose function that would allow shaders to be able to write data to pointclouds, and save them at the end of rendering.

This adds:

```
int pointcloud_write (string filename, point position, string attrib1, TYPE data1, ...)
```

The underlying implementation, as with the pointcloud lookup functions, lives on the renderer side (though I'm considering making a good default implementation as part of OSL), accessible through the RendererServices API.

In the process, I made shell default implementations of pointcloud_get and pointcloud_search in the base class (rather than pure virtual) and removed the empty shells from testshade and testrender.
