### PR TITLE
rayroughness()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,9 @@ TESTSUITE ( arithmetic array array-derivs array-range
             pnoise pnoise-cell pnoise-gabor pnoise-perlin pnoise-uperlin
             oslc-err-noreturn oslc-err-paramdefault
             pointcloud
-            raytype render-background render-bumptest render-cornell render-furnace-diffuse
+            rayroughness raytype
+            render-background render-bumptest
+            render-cornell render-furnace-diffuse
             render-microfacet render-oren-nayar render-veachmis render-ward
             shortcircuit spline splineinverse string 
             struct struct-array struct-array-mixture

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4912,6 +4912,19 @@ OSL, but is expected to include at a minimum \qkw{camera},
 exception that camera rays should be of class \qkw{camera} and no other.
 \apiend
 
+\apiitem{float {\ce rayroughness} ()}
+\indexapi{rayroughness()}
+Returns a measure of how much ``roughness'' has been encountered in the
+ray path from the camera to the current shading point: {\cf 0} indicates
+a direct view or specular surfaces only, {\cf 1} indicates at least one
+step of purely diffuse scattering, with intermediate values indicating
+increasing amounts of incoherent scattering.  The precise definition
+is purposely undefined, and is renderer-dependent.  The purpose of this
+function is to allow shaders to take various shortcuts when they know
+that the point being shaded will be viewed through a sufficiently
+diffuse or incoherent series of scatterings.
+\apiend
+
 
 \section{Dictionary Lookups}
 \label{sec:stdlib:dictionaries}

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -307,6 +307,7 @@ struct ShaderGlobals {
     float surfacearea;               /**< Total area of the object (defined by
                                           light shaders for energy normalization) */
     int raytype;                     /**< Bit field of ray type flags */
+    float rayroughness;              /**< Accumulated roughness of incident ray */
     int flipHandedness;              /**< flips the result of calculatenormal() */
     int backfacing;                  /**< True if we want are shading the
                                           backside of the surface */

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3263,6 +3263,20 @@ LLVMGEN (llvm_gen_raytype)
 
 
 
+// float rayroughness ()
+LLVMGEN (llvm_gen_rayroughness)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    DASSERT (op.nargs() == 1);
+    Symbol& Result = *rop.opargsym (op, 0);
+    llvm::Value *ret = rop.llvm_call_function ("osl_rayroughness",
+                                               rop.sg_void_ptr());
+    rop.llvm_store_value (ret, Result);
+    return true;
+}
+
+
+
 // color blackbody (float temperatureK)
 // color wavelength_color (float wavelength_nm)  // same function signature
 LLVMGEN (llvm_gen_blackbody)

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1688,6 +1688,12 @@ OSL_SHADEOP int osl_raytype_bit (void *sg_, int bit)
 }
 
 
+OSL_SHADEOP float osl_rayroughness (void *sg_)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_; 
+    return sg->rayroughness;
+}
+
 
 
 /***********************************************************************

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -459,6 +459,7 @@ ShadingSystemImpl::setup_op_descriptors ()
     OP (printf,      printf,              none,          false);
     OP (psnoise,     noise,               none,          true);
     OP (radians,     generic,             none,          true);
+    OP (rayroughness,rayroughness,        none,          true);
     OP (raytype,     raytype,             none,          true);
     OP (regex_match, regex,               none,          false);
     OP (regex_search, regex,              regex_search,  false);

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -510,6 +510,7 @@ closure color cloth(normal N, float s, float t, color diff_warp, color diff_weft
 
 
 // Renderer state
+float rayroughness () BUILTIN;
 int raytype (string typename) BUILTIN;
 // the individual 'isFOOray' functions are deprecated
 int iscameraray () { return raytype("camera"); }

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -74,6 +74,7 @@ static int sparamindex = 0;
 static ErrorHandler errhandler;
 static int iters = 1;
 static std::string raytype = "camera";
+static float rayroughness = 0.0f;
 static SimpleRenderer rend;  // RendererServices
 static OSL::Matrix44 Mshad;  // "shader" space to "common" space matrix
 static OSL::Matrix44 Mobj;   // "object" space to "common" space matrix
@@ -181,6 +182,7 @@ getargs (int argc, const char *argv[])
                     &connections, &connections, &connections, &connections,
                     "Connect fromlayer fromoutput tolayer toinput",
                 "--raytype %s", &raytype, "Set the raytype",
+                "--rayroughness %f", &rayroughness, "Set the ray roughness",
                 "--iters %d", &iters, "Number of iterations",
                 "-O0", &O0, "Do no runtime shader optimization",
                 "-O1", &O1, "Do a little runtime shader optimization",
@@ -263,6 +265,9 @@ setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
 
     // Just make it look like all shades are the result of 'raytype' rays.
     sg.raytype = shadingsys->raytype_bit (ustring(raytype));
+
+    // Set ray roughness as specified on the command line
+    sg.rayroughness = rayroughness;
 
     // Set up u,v to vary across the "patch", and also their derivatives.
     // Note that since u & x, and v & y are aligned, we only need to set

--- a/testsuite/rayroughness/ref/out.txt
+++ b/testsuite/rayroughness/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+ray roughness = 0.125
+

--- a/testsuite/rayroughness/run.py
+++ b/testsuite/rayroughness/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python 
+
+command = testshade("--rayroughness 0.125 test")

--- a/testsuite/rayroughness/test.osl
+++ b/testsuite/rayroughness/test.osl
@@ -1,0 +1,4 @@
+shader test ()
+{
+    printf ("ray roughness = %g\n", rayroughness());
+}


### PR DESCRIPTION
This adds an OSL function rayroughness() (and from the point of view of a renderer, a new ShaderGlobals field with the same name, that the renderer is expected to set).

The exact meaning is purposely not well defined, and may be renderer-dependent, but the gist is that it represents a metric of how diffusely the scattering has been between the camera and the point being shaded -- 0 means a direct view or only coherent mirror-like reflection or refraction, 1 means it's totally incoherent and diffuse.

The gist is to allow shaders to take different kinds of shortcuts if they know they are shading points that won't be viewed coherently.  For example, blurring texture lookups or leaving off high-detailed noise functions.  The accumulated roughness is, in theory, a better way to based these things than simply the ray type (for example, a ray with "glossy" in its history may still have a very low roughness on that glossy scatter, and so it would be unwise for it to start losing noise octaves).  
