### PR TITLE
ShadingSystem attribute 'compile_report' cuts down on useless chatter

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -75,9 +75,58 @@ public:
                                   ErrorHandler *err=NULL);
     static void destroy (ShadingSystem *x);
 
-    /// Set an attribute controlling the texture system.  Return true
+    /// Set an attribute controlling the shading system.  Return true
     /// if the name and type were recognized and the attrib was set.
-    /// Documented attributes:
+    /// Documented attributes are as follows:
+    /// 1. Attributes that should be exposed to users:
+    ///    int statistics:level   Automatically print OSL statistics (0).
+    ///    string searchpath:shader  Colon-separated path to search for .oso
+    ///    string colorspace      Name of RGB color space ("Rec709")
+    ///    int range_checking     Generate extra code for component & array
+    ///                              range checking (1)
+    ///    int debugnan           Add extra (expensive) code to pinpoint
+    ///                              when NaN/Inf happens (0).
+    ///    int compile_report     Issue info messages to the renderer for
+    ///                              every shader compiled (0).
+    /// 2. Attributes that should be set by applications/renderers that
+    /// incorporate OSL:
+    ///    string commonspace     Name of "common" coord system ("world")
+    ///    string[] raytypes      Array of ray type names
+    ///    int unknown_coordsys_error  Should errors be issued when unknown
+    ///                                   coord system names are used?
+    ///    int strict_messages    Issue error if a message is set after
+    ///                              being queried (1).
+    ///    int lazylayers         Evaluate shader layers only when their
+    ///                              outputs are first needed (1)
+    ///    int lazyglobals        Run layers lazily even if they write to
+    ///                              globals (0)
+    ///    int greedyjit          Optimize and compile all shaders up front,
+    ///                              versus only as needed (0).
+    ///    int lockgeom           Default 'lockgeom' value for shader params
+    ///                              that don't specify it (0).  Lockgeom
+    ///                              means a param CANNOT be overridden by
+    ///                              interpolated geometric parameters.
+    /// 3. Attributes that that are intended for developers debugging
+    /// liboslexec itself:
+    /// These attributes may be helpful for liboslexec developers or
+    /// for debugging, but probably not for using OSL in production:
+    ///    int debug              Set debug output level (0)
+    ///    int clearmemory        Zero out working memory before each shade (0)
+    ///    int optimize           Runtime optimization level (2)
+    ///       And there are several int options that, if set to 0, will turn
+    ///       off individual classes of runtime optimizations:
+    ///         opt_constant_param, opt_constant_fold, opt_stale_assign,
+    ///         opt_elide_useless_ops, opt_elide_unconnected_outputs,
+    ///         opt_peephole, opt_coalesce_temps, opt_assign
+    ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
+    ///    int llvm_debug         Turn on extra LLVM debug info (0)
+    ///    int max_local_mem_KB   Error if shader group needs more than this
+    ///                              much local storage to execute (1024K)
+    ///    string debug_groupname Name of shader group -- debug only this one
+    ///    string debug_layername Name of shader layer -- debug only this one
+    ///    int optimize_nondebug  If 1, fully optimize shaders that are not
+    ///                              designated as the debug shaders.
+    ///    string only_groupname  Compile only this one group (skip all others)
     ///
     virtual bool attribute (const std::string &name, TypeDesc type,
                             const void *val) = 0;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -744,8 +744,6 @@ public:
     ///
     TextureSystem *texturesys () const { return m_texturesys; }
 
-    bool allow_rebind () const { return m_rebind; }
-
     bool debug_nan () const { return m_debugnan; }
     bool lockgeom_default () const { return m_lockgeom_default; }
     bool strict_messages() const { return m_strict_messages; }
@@ -869,7 +867,6 @@ private:
     bool m_lazylayers;                    ///< Evaluate layers on demand?
     bool m_lazyglobals;                   ///< Run lazily even if globals write?
     bool m_clearmemory;                   ///< Zero mem before running shader?
-    bool m_rebind;                        ///< Allow rebinding?
     bool m_debugnan;                      ///< Root out NaN's?
     bool m_lockgeom_default;              ///< Default value of lockgeom
     bool m_strict_messages;               ///< Strict checking of message passing usage?
@@ -898,6 +895,7 @@ private:
     std::vector<ustring> m_raytypes;      ///< Names of ray types
     ustring m_colorspace;                 ///< What RGB colors mean
     int m_max_local_mem_KB;               ///< Local storage can a shader use
+    bool m_compile_report;
 
     // Derived/cached calculations from options:
     Color3 m_Red, m_Green, m_Blue;        ///< Color primaries (xyY)

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3911,27 +3911,29 @@ RuntimeOptimizer::optimize_group ()
                                                   m_llvm_local_mem);
     }
 
-    if (m_group.name()) {
-        m_shadingsys.info ("Optimized shader group %s:", m_group.name().c_str());
-        m_shadingsys.info ("    New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
-          new_nsyms, old_nsyms,
-          100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
-          new_nops, old_nops,
-          100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
-    } else {
-        m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
-          new_nsyms, old_nsyms,
-          100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
-          new_nops, old_nops,
-          100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
+    if (m_shadingsys.m_compile_report) {
+        if (m_group.name()) {
+            m_shadingsys.info ("Optimized shader group %s:", m_group.name().c_str());
+            m_shadingsys.info ("    New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+              new_nsyms, old_nsyms,
+              100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
+              new_nops, old_nops,
+              100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
+        } else {
+            m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+              new_nsyms, old_nsyms,
+              100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
+              new_nops, old_nops,
+              100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
+        }
+        m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
+                           m_stat_total_llvm_time+m_stat_specialization_time,
+                           m_stat_specialization_time, 
+                           m_stat_opt_locking_time, m_stat_llvm_setup_time,
+                           m_stat_llvm_irgen_time, m_stat_llvm_opt_time,
+                           m_stat_llvm_jit_time,
+                           m_llvm_local_mem/1024);
     }
-    m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
-                       m_stat_total_llvm_time+m_stat_specialization_time,
-                       m_stat_specialization_time, 
-                       m_stat_opt_locking_time, m_stat_llvm_setup_time,
-                       m_stat_llvm_irgen_time, m_stat_llvm_opt_time,
-                       m_stat_llvm_jit_time,
-                       m_llvm_local_mem/1024);
 }
 
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -248,7 +248,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     : m_renderer(renderer), m_texturesys(texturesystem), m_err(err),
       m_statslevel (0), m_lazylayers (true),
       m_lazyglobals (false),
-      m_clearmemory (false), m_rebind (false), m_debugnan (false),
+      m_clearmemory (false), m_debugnan (false),
       m_lockgeom_default (false), m_strict_messages(true),
       m_range_checking(true), m_unknown_coordsys_error(true),
       m_greedyjit(false),
@@ -264,6 +264,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
       m_max_local_mem_KB(1024),
+      m_compile_report(false),
       m_in_group (false),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0),
@@ -561,7 +562,6 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("lazylayers", int, m_lazylayers);
     ATTR_SET ("lazyglobals", int, m_lazyglobals);
     ATTR_SET ("clearmemory", int, m_clearmemory);
-    ATTR_SET ("rebind", int, m_rebind);
     ATTR_SET ("debugnan", int, m_debugnan);
     ATTR_SET ("lockgeom", int, m_lockgeom_default);
     ATTR_SET ("optimize", int, m_optimize);
@@ -581,6 +581,7 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_SET ("greedyjit", int, m_greedyjit);
     ATTR_SET ("max_local_mem_KB", int, m_max_local_mem_KB);
+    ATTR_SET ("compile_report", int, m_compile_report);
     ATTR_SET_STRING ("commonspace", m_commonspace_synonym);
     ATTR_SET_STRING ("debug_groupname", m_debug_groupname);
     ATTR_SET_STRING ("debug_layername", m_debug_layername);
@@ -636,7 +637,6 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("lazylayers", int, m_lazylayers);
     ATTR_DECODE ("lazyglobals", int, m_lazyglobals);
     ATTR_DECODE ("clearmemory", int, m_clearmemory);
-    ATTR_DECODE ("rebind", int, m_rebind);
     ATTR_DECODE ("debugnan", int, m_debugnan);
     ATTR_DECODE ("lockgeom", int, m_lockgeom_default);
     ATTR_DECODE ("optimize", int, m_optimize);
@@ -662,6 +662,7 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE_STRING ("debug_layername", m_debug_layername);
     ATTR_DECODE_STRING ("only_groupname", m_only_groupname);
     ATTR_DECODE ("max_local_mem_KB", int, m_max_local_mem_KB);
+    ATTR_DECODE ("compile_report", int, m_compile_report);
 
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE ("stat:groups", int, m_stat_groups);


### PR DESCRIPTION
ShadingSystem attributes: add 'compile_report' to control whether or not info messages sent for each shader optimized & compiled (default to 0, nobody cares about those details but me when debugging);
remove unused 'rebind' attribute; add better attribute docs to header.
