### PR TITLE
Fix some string formatting that was generating warnings on 32 bit platforms

### DIFF
--- a/src/liboslexec/automata.cpp
+++ b/src/liboslexec/automata.cpp
@@ -263,7 +263,7 @@ NdfAutomata::tostr()const
     std::string s;
     for (size_t i = 0; i < m_states.size(); ++i) {
         char temp[32];
-        snprintf(temp, 32, "%ld : ", i);
+        snprintf(temp, 32, "%d : ", (int)i);
         s += temp + m_states[i]->tostr() + "\n";
     }
     return s;
@@ -411,7 +411,7 @@ DfAutomata::tostr()const
     std::string s;
     for (size_t i = 0; i < m_states.size(); ++i) {
         char temp[32];
-        snprintf(temp, 32, "%ld : ", i);
+        snprintf(temp, 32, "%d : ", (int)i);
         s += temp + m_states[i]->tostr() + "\n";
     }
     return s;


### PR DESCRIPTION
On 32 bits, the size_t doesn't match the %d.
Simple solution is to simply the whole function by using the Strutil::format, which by its use of "tinyformat" underneath, is type-safe and will do the right thing in addition to simplifying the appearance of the function.
