### PR TITLE
Load OSO from memory buffer

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -217,6 +217,11 @@ public:
     ///
     virtual bool ConnectShaders (const char *srclayer, const char *srcparam,
                                  const char *dstlayer, const char *dstparam)=0;
+    
+    // Load OSO data from memory buffer, overriding shader lookups in the
+    // shader search path
+    virtual bool LoadMemoryShader (const char *shadername,
+                                   const char *buffer)=0;
 
     /// Return a reference-counted (but opaque) reference to the current
     /// shading attribute state maintained by the ShadingSystem.

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -684,6 +684,8 @@ public:
     virtual bool ShaderGroupEnd (void);
     virtual bool ConnectShaders (const char *srclayer, const char *srcparam,
                                  const char *dstlayer, const char *dstparam);
+    virtual bool LoadMemoryShader (const char *shadername,
+                                   const char *buffer);
     virtual ShadingAttribStateRef state ();
     virtual void clear_state ();
 

--- a/src/liboslexec/osoreader.h
+++ b/src/liboslexec/osoreader.h
@@ -57,7 +57,12 @@ public:
     /// Read in the oso file, parse it, call the various callbacks.
     /// Return true if the file was correctly parsed, false if there was
     /// an unrecoverable error reading the file.
-    virtual bool parse (const std::string &filename);
+    virtual bool parse_file (const std::string &filename);
+
+    /// Read in OSO from memory, parse, call the various callbacks.
+    /// Return true if the OSO code was correctly parsed, false if there was
+    /// an unrecoverable error reading.
+    virtual bool parse_memory (const std::string &buffer);
 
     /// Declare the shader version.
     ///

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -290,7 +290,7 @@ OSLQuery::open (const std::string &shadername,
         return false;
     }
 
-    bool ok = oso.parse (filename);
+    bool ok = oso.parse_file (filename);
     return ok;
 }
 


### PR DESCRIPTION
We use this function for Blender to support packing everything into a single .blend file (for easy distribution).
