### PR TITLE
convert README to README.rst restructured text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-.. contents :: :local:
+Table of contents
+------------------
+
+* Introduction
+* How OSL is different
+* What OSL consists of
+* Building OSL
+* Current state of the project and road map
+* Contacts
+* Credits
+
 
 Introduction
 ------------
@@ -257,25 +267,22 @@ development avenues for OSL than we would be able to do alone.
 Contacts
 --------
 
-OSL home page at SPI:    http://opensource.imageworks.com/?p=osl
+[OSL home page at SPI](http://opensource.imageworks.com/?p=osl)
 
-OSL GitHub page:
-     https://github.com/imageworks/OpenShadingLanguage
 
-Read or subscribe to the OSL development mail list:
-     http://groups.google.com/group/osl-dev
+[OSL GitHub page](https://github.com/imageworks/OpenShadingLanguage)
+
+[Read or subscribe to the OSL development mail list](http://groups.google.com/group/osl-dev)
 
 Email the lead architect:  lg AT imageworks DOT com
 
-Most recent PDF of the OSL language specification:
-    https://github.com/imageworks/OpenShadingLanguage/blob/master/src/doc/osl-languagespec.pdf
+[Most recent PDF of the OSL language specification](https://github.com/imageworks/OpenShadingLanguage/blob/master/src/doc/osl-languagespec.pdf
+)
 
-Sony Pictures Imageworks main open source page:
-     http://opensource.imageworks.com
+[Sony Pictures Imageworks main open source page](http://opensource.imageworks.com)
 
 If you want to contribute code back to the project, you'll need to
-sign `a Contributor License Agreement <http://opensource.imageworks.com/cla/>`_.
-
+sign [a Contributor License Agreement](http://opensource.imageworks.com/cla/).
 
 
 Credits
@@ -295,7 +302,7 @@ The main developers of OSL are (in order of joining the project):
 
 * Solomon Boulos
 
-*Adam Martinez
+* Adam Martinez
 
 We cannot possibly express sufficient gratitude to the managers at Sony
 Pictures Imageworks who allowed this project to proceed, supported it
@@ -316,10 +323,12 @@ and studios involved.)
 The OSL implementation incorporates or depends upon several other open
 source packages:
 
-OpenImageIO (c) Larry Gritz, et al.     http://www.openimageio.org
+[OpenImageIO (c) Larry Gritz, et al](http://www.openimageio.org)
 
-Boost - various authors                 http://www.boost.org
+[Boost - various authors](http://www.boost.org)
 
-IlmBase (c) Industrial Light & Magic.   http://www.openexr.com
+[IlmBase (c) Industrial Light & Magic](http://www.openexr.com)
 
-LLVM Compiler Infrastructure            http://llvm.org
+[LLVM Compiler Infrastructure](http://llvm.org)
+
+


### PR DESCRIPTION
Using .rst extension allows Github and other tools process the README as restructured text. 

This means that on Github you get nice HTML formatted output from your README content instead of plain text view. 

Also, the table of contents is automatically generated with proper quick jump links.
