### PR TITLE
Werror compilation error on g++ version 4.7.2 when using partio

### DIFF
--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -403,7 +403,7 @@ RendererServices::pointcloud_write (ShaderGlobals *sg,
         }
     }
 
-    return false;
+    return ok;
 #else
     return false;
 #endif


### PR DESCRIPTION
Addressed compilation error caused by using the -Werror option on g++ 4.7.2.
(This is the default option given in the ./src/CMakeLists.txt file)

Return boolean variable "ok" instead of hardcoded "false" in USE_PARTIO section of the
code.
(This section of the code is only compiled if the partio library is installed)
