### PR TITLE
Eliminate circumstances leading to an assertion, wasn't really a bug

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -457,13 +457,13 @@ public:
     /// Return a begin/end Symbol* pair for the set of param symbols
     /// that is suitable to pass as a range for BOOST_FOREACH.
     friend std::pair<Symbol *,Symbol *> param_range (ShaderInstance *i) {
-        return std::pair<Symbol*,Symbol*> (i->symbol(i->firstparam()),
-                                           i->symbol(i->lastparam()));
+        return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[i->firstparam()],
+                                           &i->m_instsymbols[i->lastparam()]);
     }
 
     friend std::pair<const Symbol *,const Symbol *> param_range (const ShaderInstance *i) {
-        return std::pair<const Symbol*,const Symbol*> (i->symbol(i->firstparam()),
-                                                       i->symbol(i->lastparam()));
+        return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[i->firstparam()],
+                                                       &i->m_instsymbols[i->lastparam()]);
     }
 
     int Psym () const { return m_Psym; }


### PR DESCRIPTION
ShaderInstance::param_range should return [begin,end), but the symbol()
function it used for the begin and end pointers would assert if past the
last symbol, which of course the "non-inclusive" end needed to be.  Ugh.
