### PR TITLE
Improve error reporting when parsing oso, especially for unknown instructions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,7 +253,8 @@ TESTSUITE ( arithmetic array array-derivs array-range
             texture-firstchannel texture-interp texture-simple
             texture-smallderivs texture-swirl
             texture-width texture-withderivs texture-wrap
-            transform transformc trig typecast vecctr vector
+            transform transformc trig typecast
+            unknown-instruction vecctr vector
             wavelength_color xml )
 
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3427,5 +3427,13 @@ LLVMGEN (llvm_gen_return)
 
 
 
+LLVMGEN (llvm_gen_end)
+{
+    // Dummy routine needed only for the op_descriptor table
+    return false;
+}
+
+
+
 }; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -405,6 +405,7 @@ ShadingSystemImpl::setup_op_descriptors ()
     OP (Dy,          DxDy,                none,          true);
     OP (Dz,          Dz,                  none,          true);
     OP (dowhile,     loop_op,             none,          false);
+    OP (end,         end,                 none,          false);
     OP (endswith,    generic,             endswith,      true);
     OP (environment, environment,         none,          true);
     OP (eq,          compare_op,          eq,            true);

--- a/testsuite/unknown-instruction/ref/out.txt
+++ b/testsuite/unknown-instruction/ref/out.txt
@@ -1,0 +1,4 @@
+ERROR: Parsing shader "test": instruction "blahblah" is not known. Maybe compiled with a too-new oslc?
+ERROR: Unable to read "test.oso"
+ERROR: Could not find shader "test"
+

--- a/testsuite/unknown-instruction/run.py
+++ b/testsuite/unknown-instruction/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python 
+
+# Test what happens when an oso file contains an unknown instruction
+
+command = testshade("test")

--- a/testsuite/unknown-instruction/test.oso
+++ b/testsuite/unknown-instruction/test.oso
@@ -1,0 +1,14 @@
+OpenShadingLanguage 1.00
+# Compiled by oslc 1.3.0
+shader test
+oparam	float	fout	0 		 %read{2147483647,-1} %write{2147483647,-1}
+global	point	P	 %read{0,0} %write{2147483647,-1}
+temp	int	$tmp1	 %read{2147483647,-1} %write{0,0}
+const	string	$const1	""		 %read{0,0} %write{2147483647,-1}
+const	string	$const2	"foo"		 %read{0,0} %write{2147483647,-1}
+const	float	$const3	1		 %read{0,0} %write{2147483647,-1}
+code ___main___
+# test.osl:4
+#     pointcloud_write ("", P, "foo", 1.0);
+	blahblah	$tmp1 $const1 P $const2 $const3 	%filename{"test.osl"} %line{4} %argrw{"wrrrr"}
+	end


### PR DESCRIPTION
Improve error reporting when parsing oso, especially for unknown instructions.

In particular, when you previously compiled a shader that used a new feature (e.g., an OSL function / oso op that didn't exist before) then tried to use that .oso file with an older OSL-based renderer that didn't understand the new function, it gave a pretty cryptic error message:

  Unsupported op blahblah in layer mylayer

And to make matters worse, it did this as the shader was being fed to LLVM, rather than when first parsed.

This patch makes the message much more intuitive, as well as being issued as soon as the oso file is parsed. To wit:

  Parsing shader "test": instruction "blahblah" is not known. Maybe compiled with a too-new oslc?

This will happen earlier in the render, every time the oso is parsed (not only if the shader happens to be executed, triggering a JIT), and hopefully will make it more obvious that the most likely culprit is using an old renderer with a shader compiled with a newer oslc.
