### PR TITLE
Merge identical shader instances within a group.

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -578,6 +578,7 @@ public:
     ValueSource valuesource () const { return (ValueSource) m_valuesource; }
     void valuesource (ValueSource v) { m_valuesource = v; }
     const char *valuesourcename () const;
+    static const char *valuesourcename (ValueSource v);
 
     int fieldid () const { return m_fieldid; }
     void fieldid (int id) { m_fieldid = id; }
@@ -818,6 +819,15 @@ public:
     /// Return the entire argtakesderivs at once with a full bitfield.
     ///
     unsigned int argtakesderivs_all () const { return m_argtakesderivs; }
+
+    /// Are two opcodes identical enough to merge their instances?  Note
+    /// that this isn't a true 'equal', we don't compare fields that
+    /// won't matter for that purpose.
+    friend bool equivalent (const Opcode &a, const Opcode &b) {
+        return a.m_op == b.m_op &&
+            a.m_firstarg == b.m_firstarg && a.m_nargs == b.m_nargs &&
+            std::equal(&a.m_jump[0], &a.m_jump[max_jumps], &b.m_jump[0]);
+    }
 
 private:
     ustring m_op;                   ///< Name of opcode

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -119,6 +119,7 @@ public:
     ///         opt_constant_param, opt_constant_fold, opt_stale_assign,
     ///         opt_elide_useless_ops, opt_elide_unconnected_outputs,
     ///         opt_peephole, opt_coalesce_temps, opt_assign, opt_mix
+    ///         opt_merge_instances
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Turn on extra LLVM debug info (0)
     ///    int max_local_mem_KB   Error if shader group needs more than this

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -108,9 +108,9 @@ StructSpec::mangled () const
 
 
 const char *
-Symbol::valuesourcename () const
+Symbol::valuesourcename (ValueSource v)
 {
-    switch (valuesource()) {
+    switch (v) {
     case DefaultVal   : return "default";
     case InstanceVal  : return "instance";
     case GeomVal      : return "geom";
@@ -118,6 +118,14 @@ Symbol::valuesourcename () const
     }
     ASSERT(0 && "unknown valuesource");
     return NULL;
+}
+
+
+
+const char *
+Symbol::valuesourcename () const
+{
+    return valuesourcename (valuesource());
 }
 
 

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -1,10 +1,5 @@
 SET ( liboslexec_srcs
           shadingsys.cpp closure.cpp
-          bsdf.cpp bsdf_diffuse.cpp bsdf_microfacet.cpp bsdf_phong.cpp
-          bsdf_westin.cpp bsdf_ashikhmin_velvet.cpp
-          bsdf_cloth_fncs.cpp bsdf_cloth.cpp bsdf_cloth_specular.cpp
-          bsdf_reflection.cpp bsdf_refraction.cpp bsdf_transparent.cpp bsdf_ward.cpp
-          bssrdf.cpp bsdf_hair.cpp bsdf_fakefur.cpp
           emissive.cpp background.cpp debug.cpp dictionary.cpp
           vol_subsurface.cpp
           context.cpp gabornoise.cpp instance.cpp 
@@ -17,6 +12,11 @@ SET ( liboslexec_srcs
           lpexp.cpp lpeparse.cpp automata.cpp accum.cpp
           opclosure.cpp builtin_closures.cpp
           llvm_gen.cpp llvm_instance.cpp llvm_util.cpp
+          bsdf.cpp bsdf_diffuse.cpp bsdf_microfacet.cpp bsdf_phong.cpp
+          bsdf_westin.cpp bsdf_ashikhmin_velvet.cpp
+          bsdf_cloth_fncs.cpp bsdf_cloth.cpp bsdf_cloth_specular.cpp
+          bsdf_reflection.cpp bsdf_refraction.cpp bsdf_transparent.cpp bsdf_ward.cpp
+          bssrdf.cpp bsdf_hair.cpp bsdf_fakefur.cpp
           ../liboslcomp/ast.cpp ../liboslcomp/codegen.cpp
           ../liboslcomp/oslcomp.cpp ../liboslcomp/symtab.cpp
           ../liboslcomp/typecheck.cpp

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -85,6 +85,42 @@ ShaderMaster::findsymbol (ustring name) const
 
 
 
+void *
+ShaderMaster::param_default_storage (int index)
+{
+    const Symbol *sym = symbol(index);
+    TypeDesc t = sym->typespec().simpletype();
+    if (t.basetype == TypeDesc::INT) {
+        return &m_idefaults[sym->dataoffset()];
+    } else if (t.basetype == TypeDesc::FLOAT) {
+        return &m_fdefaults[sym->dataoffset()];
+    } else if (t.basetype == TypeDesc::STRING) {
+        return &m_sdefaults[sym->dataoffset()];
+    } else {
+        return NULL;
+    }
+}
+
+
+
+const void *
+ShaderMaster::param_default_storage (int index) const
+{
+    const Symbol *sym = symbol(index);
+    TypeDesc t = sym->typespec().simpletype();
+    if (t.basetype == TypeDesc::INT) {
+        return &m_idefaults[sym->dataoffset()];
+    } else if (t.basetype == TypeDesc::FLOAT) {
+        return &m_fdefaults[sym->dataoffset()];
+    } else if (t.basetype == TypeDesc::STRING) {
+        return &m_sdefaults[sym->dataoffset()];
+    } else {
+        return NULL;
+    }
+}
+
+
+
 void
 ShaderMaster::resolve_syms ()
 {

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -105,6 +105,7 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_opt_coalesce_temps(shadingsys.m_opt_coalesce_temps),
       m_opt_assign(shadingsys.m_opt_assign),
       m_opt_mix(shadingsys.m_opt_mix),
+      m_opt_merge_instances(shadingsys.m_opt_merge_instances),
       m_next_newconst(0), m_next_newtemp(0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
@@ -169,6 +170,7 @@ RuntimeOptimizer::set_debug ()
             m_opt_coalesce_temps = true;
             m_opt_assign = true;
             m_opt_mix = true;
+            m_opt_merge_instances = true;
         }
     }
     // if user said to only debug one layer, turn off debug if not it
@@ -4020,6 +4022,8 @@ RuntimeOptimizer::optimize_group ()
     size_t old_nsyms = 0, old_nops = 0;
     for (int layer = 0;  layer < nlayers;  ++layer) {
         set_inst (layer);
+        if (inst()->unused())
+            continue;
         m_inst->copy_code_from_master ();
         if (debug() && optimize() >= 1) {
             std::cout.flush ();
@@ -4044,8 +4048,13 @@ RuntimeOptimizer::optimize_group ()
             optimize_instance ();
     }
 
+    // Try merging instances again, now that we've optimized
+    shadingsys().merge_instances (group(), true);
+
     for (int layer = nlayers-1;  layer >= 0;  --layer) {
         set_inst (layer);
+        if (inst()->unused())
+            continue;
         track_variable_dependencies ();
 
         // For our parameters that require derivatives, mark their
@@ -4067,6 +4076,9 @@ RuntimeOptimizer::optimize_group ()
         if (! inst()->unused())
             post_optimize_instance ();
     }
+
+    // Last chance to eliminate duplicate instances
+    shadingsys().merge_instances (group(), true);
 
     // Get rid of nop instructions and unused symbols.
     size_t new_nsyms = 0, new_nops = 0;
@@ -4267,6 +4279,118 @@ ShadingSystemImpl::optimize_all_groups (int nthreads)
                 optimize_group (*sas, sgroup);
         }
     }
+}
+
+
+
+int
+ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
+{
+    // Look through the shader group for pairs of nodes/layers that
+    // actually do exactly the same thing, and eliminate one of the
+    // rundantant shaders, carefully rewiring all its outgoing
+    // connections to later layers to refer to the one we keep.
+    //
+    // It turns out that in practice, it's not uncommon to have
+    // duplicate nodes.  For example, some materials are "layered" --
+    // like a character skin shader that has separate sub-networks for
+    // skin, oil, wetness, and so on -- and those different sub-nets
+    // often reference the same texture maps or noise functions by
+    // repetition.  Yes, ideally, the redundancies would be eliminated
+    // before they were fed to the renderer, but in practice that's hard
+    // and for many scenes we get substantial savings of time (mostly
+    // because of reduced texture calls) and instance memory by finding
+    // these redundancies automatically.  The amount of savings is quite
+    // scene dependent, as well as probably very dependent on the
+    // general shading and lookdev approach of the studio.  But it was
+    // very helpful for us in many cases.
+    //
+    // The basic loop below looks very inefficient, O(n^2) in number of
+    // instances in the group. But it's really not -- a few seconds (sum
+    // of all threads) for even our very complex scenes. This is because
+    // most potential pairs have a very fast rejection case if they are
+    // not using the same master.  Since there's no appreciable cost to
+    // the brute force approach, it seems silly to have a complex scheme
+    // to try to reduce the number of pairings.
+
+    if (! m_opt_merge_instances)
+        return 0;
+
+    Timer timer;                // Time we spend looking for and doing merges
+    int merges = 0;             // number of merges we do
+    size_t connectionmem = 0;   // Connection memory we free
+    int nlayers = group.nlayers();
+
+    // Loop over all layers...
+    for (int a = 0;  a < nlayers;  ++a) {
+        if (group[a]->unused())    // Don't merge a layer that's not used
+            continue;
+        // Check all later layers...
+        for (int b = a+1;  b < nlayers;  ++b) {
+            if (group[b]->unused())    // Don't merge a layer that's not used
+                continue;
+
+            // Now we have two used layers, a and b, to examine.
+            // See if they are mergeable (identical).  All the heavy
+            // lifting is done by ShaderInstance::mergeable().
+            if (! group[a]->mergeable (*group[b], group))
+                continue;
+
+            // The two nodes a and b are mergeable, so merge them.
+            ShaderInstance *A = group[a];
+            ShaderInstance *B = group[b];
+            ++merges;
+
+            // We'll keep A, get rid of B.  For all layers later than B,
+            // check its incoming connections and replace all references
+            // to B with references to A.
+            for (int j = b+1;  j < nlayers;  ++j) {
+                ShaderInstance *inst = group[j];
+                if (inst->unused())  // don't bother if it's unused
+                    continue;
+                for (int c = 0, ce = inst->nconnections();  c < ce;  ++c) {
+                    Connection &con = inst->connection(c);
+                    if (con.srclayer == b) {
+                        con.srclayer = a;
+                        if (B->symbols().size()) {
+                            ASSERT (A->symbol(con.src.param)->name() ==
+                                    B->symbol(con.src.param)->name());
+                        }
+                    }
+                }
+            }
+
+            // Mark parameters of B as no longer connected
+            for (int p = B->firstparam();  p < B->lastparam();  ++p) {
+                if (B->symbols().size())
+                    B->symbol(p)->connected_down(false);
+                if (B->m_instoverrides.size())
+                    B->instoverride(p)->connected_down(false);
+            }
+            // B won't be used, so mark it as having no outgoing
+            // connections and clear its incoming connections (which are
+            // no longer used).
+            B->outgoing_connections (false);
+            B->run_lazily (true);
+            connectionmem += B->clear_connections ();
+            ASSERT (B->unused());
+        }
+    }
+
+    {
+        // Adjust stats
+        spin_lock lock (m_stat_mutex);
+        m_stat_mem_inst_connections -= connectionmem;
+        m_stat_mem_inst -= connectionmem;
+        m_stat_memory -= connectionmem;
+        if (post_opt)
+            m_stat_merged_inst_opt += merges;
+        else
+            m_stat_merged_inst += merges;
+        m_stat_inst_merge_time += timer();
+    }
+
+    return merges;
 }
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -837,6 +837,7 @@ private:
     bool m_opt_coalesce_temps;            ///< Coalesce temporary variables?
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_opt_mix;                       ///< Do mix optimizations?
+    bool m_opt_merge_instances;           ///< Merge identical instances?
     ShaderGlobals m_shaderglobals;        ///< Dummy ShaderGlobals
 
     // All below is just for the one inst we're optimizing:


### PR DESCRIPTION
In complex shader networks/groups, sometimes there are (inadvertently, for convenience, or as an artifact of the lookdev tools) multiple nodes/layers that are exact copies of each other.  For example, at SPI, our character shaders are often organized into sub-nets for conceptual "layers" (skin, oil, wet, etc.), each of which is structurally similar and often may contain true redundancies including texture-reading shaders that reference the same textures at the same coordinates.

This patch adds code that searches shader networks for pairs of shaders that are identical -- same code, same parameter values, same upstream connections, etc. -- and eliminate the redundant one, redirecting downstream connections from the excised one to the retained one.

The cost for this is small: 3-4 seconds for our very complex scenes that take many hours to render.  The results vary from scene to scene; sometimes there's no change, but other shots have up to a 20% improvement in both time and memory.

This new optimization can be disabled by setting the attribute "opt_merge_instances" to 0.
