### PR TITLE
oslc: Array indexing of undeclared variable hit an assertion.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -441,7 +441,7 @@ ASTindex::ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index)
     else if (expr->typespec().is_triple()) // component access
         m_typespec = TypeDesc::FLOAT;
     else {
-        ASSERT (0 && "botched ASTindex");
+        error ("indexing into non-array or non-component type");
     }
 }
 
@@ -459,7 +459,7 @@ ASTindex::ASTindex (OSLCompilerImpl *comp, ASTNode *expr,
              expr->typespec().elementtype().is_triple())
         m_typespec = TypeDesc::FLOAT;
     else {
-        ASSERT (0 && "botched ASTindex");
+        error ("indexing into non-array or non-component type");
     }
 }
 


### PR DESCRIPTION
This could happen for constructs like float 'float a = b[0]', if b was
never declared at all. The real error is use of undeclared 'b', but in
the chain of events that followed, it hit an assertion.
