### PR TITLE
Allow whole-array assignment:  array1 = array2

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -1957,6 +1957,18 @@ following example:
     }
 \end{code}
 
+It is allowed in OSL to copy an entire array at once using the {\cf =}
+operator, provided that the arrays contain elements of the same type
+and that the destination array is at least as long as the source
+array.  For example:
+
+\begin{code}
+    float array[4], anotherarray[4];
+    ...
+    anotherarray = array;
+\end{code}
+
+
 \section{Structures}
 \label{sec:types:struct}
 \indexapi{struct} \index{types!structures} \index{structures|see{{\cf struct}}}

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -389,9 +389,19 @@ ASTassign_expression::typecheck (TypeSpec expected)
 
     ASSERT (m_op == Assign);  // all else handled by binary_op
 
-    // We don't currently support assignment of whole arrays
+    // Handle array case
     if (vt.is_array() || et.is_array()) {
-        error ("Can't assign entire arrays");
+        if (vt.is_array() && et.is_array() &&
+            vt.arraylength() >= et.arraylength()) {
+            if (vt.structure() && (vt.structure() == et.structure())) {
+                return m_typespec = vt;
+            }
+            if (equivalent(vt.elementtype(), et.elementtype()) &&
+                !vt.structure() && !et.structure()) {
+                return m_typespec = vt;
+            }
+        }
+        error ("Cannot assign '%s' to '%s'", type_c_str(et), type_c_str(vt));
         return TypeSpec();
     }
 

--- a/testsuite/array/ref/out.txt
+++ b/testsuite/array/ref/out.txt
@@ -20,124 +20,12 @@ marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
 
 Test varying array assignment and reference:
 After carray[2] = color(u,v,4)...
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0 0 4)]
-Verify compile of functions with array parameters of unspecified length:
-	length of s is 3
-Test message passing an array: imess = [10 11 12]
+carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0.5 0.5 4)]
 
-Test array of closures:
-C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-Testing message passing of array of closures:
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
+Test whole-array assignment:
+farray = [10.5 14 15.5]
+after farray2 = farray, farray2 = [10.5 14 15.5]
 
-
-Test basic array initialization and referencing:
-iarray = [10 11 12]
-farray = [10.5 11.5 12]
-carray = [(0.1 0.2 0.3) (0.2 0.2 0.2) (0.3 0.3 0.3)]
-marray = [(1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1) (2 0 0 0 0 2 0 0 0 0 2 0 0 0 0 2) (3 0 0 0 0 3 0 0 0 0 3 0 0 0 0 3)]
-sarray = ["Able" "Baker" "Charlie"]
-arraylength(carray) = 3
-parameter cparamarray = [(0 1 2) (3 4 5)]
-
-Test array element assignment:
-After 'farray[1] = 14; farray[2] = 15.5;'...
-  farray = [10.5 14 15.5]
-carray[1][2] = 0.2
-after 'carray[1][2] = 3.1', carray[1][2] = 3.1
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0.3 0.3 0.3)]
-marray[2][1][1] = 3, marray[2][1][2] = 0
-after 'marray[2][1][3] = 100',
-marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
-
-Test varying array assignment and reference:
-After carray[2] = color(u,v,4)...
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (1 0 4)]
-Verify compile of functions with array parameters of unspecified length:
-	length of s is 3
-Test message passing an array: imess = [10 11 12]
-
-Test array of closures:
-C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-Testing message passing of array of closures:
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-
-
-Test basic array initialization and referencing:
-iarray = [10 11 12]
-farray = [10.5 11.5 12]
-carray = [(0.1 0.2 0.3) (0.2 0.2 0.2) (0.3 0.3 0.3)]
-marray = [(1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1) (2 0 0 0 0 2 0 0 0 0 2 0 0 0 0 2) (3 0 0 0 0 3 0 0 0 0 3 0 0 0 0 3)]
-sarray = ["Able" "Baker" "Charlie"]
-arraylength(carray) = 3
-parameter cparamarray = [(0 1 2) (3 4 5)]
-
-Test array element assignment:
-After 'farray[1] = 14; farray[2] = 15.5;'...
-  farray = [10.5 14 15.5]
-carray[1][2] = 0.2
-after 'carray[1][2] = 3.1', carray[1][2] = 3.1
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0.3 0.3 0.3)]
-marray[2][1][1] = 3, marray[2][1][2] = 0
-after 'marray[2][1][3] = 100',
-marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
-
-Test varying array assignment and reference:
-After carray[2] = color(u,v,4)...
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0 1 4)]
-Verify compile of functions with array parameters of unspecified length:
-	length of s is 3
-Test message passing an array: imess = [10 11 12]
-
-Test array of closures:
-C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-Testing message passing of array of closures:
-pca  C[0] = (1, 1, 1) * diffuse ((0, 0, 1))
-pca  C[1] = (0.5, 0.5, 0.5) * reflection ((0, 0, 1), 0)
-pca  C[2] = (0.25, 0.25, 0.25) * refraction ((0, 0, 1), 1.5)
-
-
-Test basic array initialization and referencing:
-iarray = [10 11 12]
-farray = [10.5 11.5 12]
-carray = [(0.1 0.2 0.3) (0.2 0.2 0.2) (0.3 0.3 0.3)]
-marray = [(1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1) (2 0 0 0 0 2 0 0 0 0 2 0 0 0 0 2) (3 0 0 0 0 3 0 0 0 0 3 0 0 0 0 3)]
-sarray = ["Able" "Baker" "Charlie"]
-arraylength(carray) = 3
-parameter cparamarray = [(0 1 2) (3 4 5)]
-
-Test array element assignment:
-After 'farray[1] = 14; farray[2] = 15.5;'...
-  farray = [10.5 14 15.5]
-carray[1][2] = 0.2
-after 'carray[1][2] = 3.1', carray[1][2] = 3.1
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (0.3 0.3 0.3)]
-marray[2][1][1] = 3, marray[2][1][2] = 0
-after 'marray[2][1][3] = 100',
-marray[2] = (3 0 0 0 0 3 0 100 0 0 3 0 0 0 0 3)
-
-Test varying array assignment and reference:
-After carray[2] = color(u,v,4)...
-carray = [(0.1 0.2 0.3) (0.2 0.2 3.1) (1 1 4)]
 Verify compile of functions with array parameters of unspecified length:
 	length of s is 3
 Test message passing an array: imess = [10 11 12]

--- a/testsuite/array/run.py
+++ b/testsuite/array/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python 
 
-command = testshade("-g 2 2 test")
+command = testshade("test")

--- a/testsuite/array/test.osl
+++ b/testsuite/array/test.osl
@@ -49,6 +49,14 @@ test (color cparamarray[2] = { color(0,1,2), color(3,4,5) })
     carray[2] = color (u, v, 4);
     printf ("carray = [(%g) (%g) (%g)]\n", carray[0], carray[1], carray[2]);
 
+    printf ("\nTest whole-array assignment:\n");
+    float farray2[3];
+    farray2 = farray;
+    printf ("farray = [%g %g %g]\n",
+            farray[0], farray[1], farray[2]);
+    printf ("after farray2 = farray, farray2 = [%g %g %g]\n\n",
+            farray2[0], farray2[1], farray2[2]);
+
     test_unspecified_length (sarray);
 
     {

--- a/testsuite/struct-array/ref/out.txt
+++ b/testsuite/struct-array/ref/out.txt
@@ -8,4 +8,6 @@ b.a[1].f == 3.14159
 test struct assignment to and from one array element:
 after c=a[2], c = { 15, 1 1 1 }
 after a[3]=c, a[3] = { 15, 1 1 1 }
+test array-of-struct assignmment:
+a2 = a; float f2; f = a2[2].f;  ==> 15 (should be 15)
 

--- a/testsuite/struct-array/test.osl
+++ b/testsuite/struct-array/test.osl
@@ -41,4 +41,12 @@ test ()
     printf ("after c=a[2], c = { %g, %g }\n", c.f, c.p);
     a[3] = c;
     printf ("after a[3]=c, a[3] = { %g, %g }\n", a[3].f, a[3].p);
+
+    printf ("test array-of-struct assignmment:\n");
+    Astruct a2[5];
+    a2 = a;
+    float f2;
+    f2 = a[2].f;
+    printf ("a2 = a; float f2; f = a2[2].f;  ==> %g (should be %g)\n", f2, f);
+    
 }


### PR DESCRIPTION
The work was just on the compiler side; the runtime was already able to copy whole arrays.

This is a lot easier and less expensive than having to write a loop over all the elements when copying an entire array.

It only works for '=', the math assignments (+=, *=, etc.) do not operate on arrays.
