### PR TITLE
Constant folding of getattribute()

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -119,7 +119,7 @@ public:
     ///         opt_constant_param, opt_constant_fold, opt_stale_assign,
     ///         opt_elide_useless_ops, opt_elide_unconnected_outputs,
     ///         opt_peephole, opt_coalesce_temps, opt_assign, opt_mix
-    ///         opt_merge_instances
+    ///         opt_merge_instances, opt_fold_getattribute
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Turn on extra LLVM debug info (0)
     ///    int max_local_mem_KB   Error if shader group needs more than this
@@ -467,6 +467,13 @@ public:
     /// specified (object == ustring()), then the renderer should search *first*
     /// for the attribute on the currently shaded object, and next, if
     /// unsuccessful, on the currently shaded "scene". 
+    ///
+    /// Note to renderers: if renderstate is NULL, that means
+    /// get_attribute is being called speculatively by the runtime
+    /// optimizer, and it doesn't know which object the shader will be
+    /// run on. Be robust to this situation, return 'true' (retrieve the
+    /// attribute) if you can (known object and attribute name), but
+    /// otherwise just fail by returning 'false'.
     virtual bool get_attribute (void *renderstate, bool derivatives, 
                                 ustring object, TypeDesc type, ustring name, 
                                 void *val ) = 0;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -776,6 +776,7 @@ public:
     int optimize () const { return m_optimize; }
     int llvm_optimize () const { return m_llvm_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
+    bool fold_getattribute () { return m_opt_fold_getattribute; }
 
     ustring commonspace_synonym () const { return m_commonspace_synonym; }
 
@@ -914,6 +915,7 @@ private:
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_opt_mix;                       ///< Special 'mix' optimizations
     bool m_opt_merge_instances;           ///< Merge identical instances?
+    bool m_opt_fold_getattribute;         ///< Constant-fold getattribute()?
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!
     int m_llvm_optimize;                  ///< OSL optimization strategy
     int m_debug;                          ///< Debugging output

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -99,7 +99,6 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_opt_coalesce_temps(shadingsys.m_opt_coalesce_temps),
       m_opt_assign(shadingsys.m_opt_assign),
       m_opt_mix(shadingsys.m_opt_mix),
-      m_opt_merge_instances(shadingsys.m_opt_merge_instances),
       m_next_newconst(0), m_next_newtemp(0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
@@ -164,7 +163,6 @@ RuntimeOptimizer::set_debug ()
             m_opt_coalesce_temps = true;
             m_opt_assign = true;
             m_opt_mix = true;
-            m_opt_merge_instances = true;
         }
     }
     // if user said to only debug one layer, turn off debug if not it

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -830,6 +830,8 @@ public:
     /// Which optimization pass are we on?
     int optimization_pass () const { return m_pass; }
 
+    ShaderGlobals &dummy_shaderglobals () { return m_shaderglobals; }
+
     // Maximum number of new constant symbols that a constant-folding
     // function is able to add.
     static const int max_new_consts_per_fold = 10;
@@ -853,7 +855,6 @@ private:
     bool m_opt_coalesce_temps;            ///< Coalesce temporary variables?
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_opt_mix;                       ///< Do mix optimizations?
-    bool m_opt_merge_instances;           ///< Merge identical instances?
     ShaderGlobals m_shaderglobals;        ///< Dummy ShaderGlobals
 
     // All below is just for the one inst we're optimizing:

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -258,6 +258,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_opt_elide_unconnected_outputs(true),
       m_opt_peephole(true), m_opt_coalesce_temps(true),
       m_opt_assign(true), m_opt_mix(true), m_opt_merge_instances(true),
+      m_opt_fold_getattribute(true),
       m_optimize_nondebug(false),
       m_llvm_optimize(0),
       m_debug(false), m_llvm_debug(false),
@@ -426,7 +427,7 @@ ShadingSystemImpl::setup_op_descriptors ()
     OP (format,      printf,              format,        true);
     OP (functioncall, functioncall,       functioncall,  false);
     OP (ge,          compare_op,          ge,            true);
-    OP (getattribute, getattribute,       none,          false);
+    OP (getattribute, getattribute,       getattribute,  false);
     OP (getmatrix,   getmatrix,           getmatrix,     false);
     OP (getmessage,  getmessage,          getmessage,    false);
     OP (gettextureinfo, gettextureinfo,   gettextureinfo,false);
@@ -582,6 +583,7 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("opt_assign", int, m_opt_assign);
     ATTR_SET ("opt_mix", int, m_opt_mix);
     ATTR_SET ("opt_merge_instances", int, m_opt_merge_instances);
+    ATTR_SET ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
@@ -661,6 +663,7 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("opt_assign", int, m_opt_assign);
     ATTR_DECODE ("opt_mix", int, m_opt_mix);
     ATTR_DECODE ("opt_merge_instances", int, m_opt_merge_instances);
+    ATTR_DECODE ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_DECODE ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_DECODE ("llvm_optimize", int, m_llvm_optimize);
     ATTR_DECODE ("debug", int, m_debug);

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -192,6 +192,13 @@ bool
 SimpleRenderer::get_attribute (void *renderstate, bool derivatives, ustring object,
                                TypeDesc type, ustring name, void *val)
 {
+    // In order to test getattribute(), respond positively to
+    // "options"/"blahblah"
+    if (object == "options" && name == "blahblah" &&
+        type == TypeDesc::TypeFloat) {
+        *(float *)val = 3.14159;
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Constant folding of getattribute()

If both the attribute and object names are constants. This is especially
handy for shaders that use getattribute() to query global renderer
options.  If this behavior is not desired (e.g., in a renderer where
users are free to alter global options without wanting to invalidate an
optimized shader), just set the ShadingSystem attribute
"opt_fold_getattribute" to 0 (it defaults to 1).
