### PR TITLE
Fix noise() generating NaN when called with a value larger than INT_MAX

### DIFF
--- a/src/liboslexec/noiseimpl.h
+++ b/src/liboslexec/noiseimpl.h
@@ -296,8 +296,9 @@ inline int imod(int a, int b) {
 // FIXME: already implemented inside OIIO but can't easily override it for duals
 //        inside a different namespace
 inline float floorfrac(float x, int* i) {
-    *i = quick_floor(x);
-    return x - *i;
+    float fx = floorf(x);
+    *i = (int)fx;
+    return x - fx;
 }
 
 inline Dual2<float> floorfrac(const Dual2<float> &x, int* i) {


### PR DESCRIPTION
I'm not happy with this fix though, it's slower and this is a pretty performance critical function. Maybe someone has an idea on how to solve this better? Or maybe it doesn't even need to be solved?
