### PR TITLE
Fix for slow compile and optimize times in the derivative tracking code

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -287,7 +287,8 @@ public:
 
     /// For each symbol, have a list of the symbols it depends on (or that
     /// depends on it).
-    typedef std::map<int, std::set<int> > SymDependency;
+    typedef std::set<int> SymIntSet;
+    typedef std::map<int, SymIntSet> SymDependency;
 
     void syms_used_in_op (Opcode &op,
                           std::vector<int> &rsyms, std::vector<int> &wsyms);
@@ -295,6 +296,8 @@ public:
     void track_variable_dependencies ();
 
     void add_dependency (SymDependency &dmap, int A, int B);
+
+    void mark_symbol_derivatives (SymDependency &symdeps, SymIntSet &visited, int d);
 
     void mark_outgoing_connections ();
 


### PR DESCRIPTION
I got a report from a user that compiling this file gave 3GB+ memory usage and very long compile times.
http://download.blender.org/ftp/incoming/osl/slow_derivative_tracking.osl

It appears there is a O(n^2) time and memory behavior in the code that tracks which variables need derivatives. The fix itself is not very complex and the bad behavior seems to be there to make some debugging code work that is not compiled by default.

Note that the provided .osl will not actually work correctly when executed, it's unfinished code, but it should demonstrate the slow compilation.
