### PR TITLE
OSL strtoi, strtof, split

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -63,7 +63,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
  \bigskip \\
 }
-\date{{\large Date: 13 Dec, 2012 \\
+\date{{\large Date: 20 Dec, 2012 \\
 %(with corrections, 22 Feb, 2012)
 }}
 
@@ -3706,6 +3706,34 @@ otherwise return 0.
 \indexapi{startswith()}
 Return 1 if string {\cf s} ends with the substring {\cf suffix},
 otherwise return 0.
+\apiend
+
+\apiitem{int {\ce strtoi} (string str)}
+\indexapi{srttoi()}
+Convert/decode the initial part of {\cf str} to an {\cf int} 
+representation.  Base 10 is assumed.
+The return value will be {\cf 0} if the string doesn't appear to hold
+valid representation of the destination type.
+\apiend
+
+\apiitem{float {\ce strtof} (string str)}
+\indexapi{strtof()}
+Convert/decode the initial part of {\cf str} to a {\cf float} representation.
+The return value will be {\cf 0} if the string doesn't appear to hold
+valid representation of the destination type.
+\apiend
+
+\apiitem{int {\ce split} (string str, output string results[], string sep, int maxsplit) \\
+int {\ce split} (string str, output string results[], string sep) \\
+int {\ce split} (string str, output string results[])}
+\indexapi{split()}
+
+Fills the {\cf result} array with the words in the string {\cf str},
+using {\cf sep} as the delimiter string.  If {\cf maxsplit} is supplied,
+at most {\cf maxsplit} splits are done.  If {\cf sep} is {\cf ""} (or if
+not supplied), any whitespace string is a separator.  The value returned
+is the number of elements (separated strings) written to the {\cf results}
+array.
 \apiend
 
 \apiitem{string {\ce substr} (string s, int start, int length)\\

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -917,6 +917,8 @@ ASTfunction_call::typecheck_builtin_specialcase ()
             argwriteonly (5);
         } else if (m_name == "pointcloud_search") {
             mark_optional_output(5, pointcloud_out_args);
+        } else if (m_name == "split") {
+            argwriteonly (2);
         } else if (func()->texture_args()) {
             mark_optional_output(2, tex_out_args);
         }
@@ -1142,6 +1144,7 @@ static const char * builtin_func_args [] = {
     "snoise", NOISE_ARGS, NULL,
     "spline", "fsff[]", "csfc[]", "psfp[]", "vsfv[]", "nsfn[]", "fsfif[]", "csfic[]", "psfip[]", "vsfiv[]", "nsfin[]", NULL,
     "splineinverse", "fsff[]", "fsfif[]", NULL,
+    "split", "iss[]si", "iss[]s", "iss[]", "!rw", NULL,
     "surfacearea", "f", NULL,
     "texture", "fsff.", "fsffffff.","csff.", "csffffff.", 
                "vsff.", "vsffffff.", "!tex", "!rw", "!deriv", NULL,

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3289,6 +3289,43 @@ LLVMGEN (llvm_gen_dict_value)
 
 
 
+LLVMGEN (llvm_gen_split)
+{
+    // int split (string str, output string result[], string sep, int maxsplit)
+    Opcode &op (rop.inst()->ops()[opnum]);
+    DASSERT (op.nargs() >= 3 && op.nargs() <= 5);
+    Symbol& R       = *rop.opargsym (op, 0);
+    Symbol& Str     = *rop.opargsym (op, 1);
+    Symbol& Results = *rop.opargsym (op, 2);
+    DASSERT (R.typespec().is_int() && Str.typespec().is_string() &&
+             Results.typespec().is_array() &&
+             Results.typespec().simpletype() == TypeDesc::TypeString);
+
+    llvm::Value *args[5];
+    args[0] = rop.llvm_load_value (Str);
+    args[1] = rop.llvm_void_ptr (Results);
+    if (op.nargs() >= 4) {
+        Symbol& Sep = *rop.opargsym (op, 3);
+        DASSERT (Sep.typespec().is_string());
+        args[2] = rop.llvm_load_value (Sep);
+    } else {
+        args[2] = rop.llvm_constant ("");
+    }
+    if (op.nargs() >= 5) {
+        Symbol& Maxsplit = *rop.opargsym (op, 4);
+        DASSERT (Maxsplit.typespec().is_int());
+        args[3] = rop.llvm_load_value (Maxsplit);
+    } else {
+        args[3] = rop.llvm_constant (Results.typespec().arraylength());
+    }
+    args[4] = rop.llvm_constant (Results.typespec().arraylength());
+    llvm::Value *ret = rop.llvm_call_function ("osl_split", &args[0], 5);
+    rop.llvm_store_value (ret, R);
+    return true;
+}
+
+
+
 LLVMGEN (llvm_gen_raytype)
 {
     // int raytype (string name)

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -273,6 +273,7 @@ static const char *llvm_helper_function_table[] = {
     "osl_wavelength_color_vf", "xXXf",
     "osl_luminance_fv", "xXXX",
     "osl_luminance_dfdv", "xXXX",
+    "osl_split", "isXsii",
 
 #ifdef OSL_LLVM_NO_BITCODE
     "osl_assert_nonnull", "xXs",

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1102,6 +1102,18 @@ osl_endswith_iss (const char *s, const char *substr)
         return strncmp (s+USTR(s).length()-len, substr, len) == 0;
 }
 
+OSL_SHADEOP int
+osl_strtoi_is (const char *str)
+{
+    return strtol(str, NULL, 10);
+}
+
+OSL_SHADEOP float
+osl_strtof_fs (const char *str)
+{
+    return (float)strtod(str, NULL);
+}
+
 OSL_SHADEOP const char *
 osl_substr_ssii (const char *s, int start, int length)
 {

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -36,9 +36,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdarg>
 
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/fmath.h>
+
 #include "oslexec_pvt.h"
 
 #include <boost/regex.hpp>
+
+#define USTR(cstr) (*((ustring *)&cstr))
+
 
 
 // Heavy lifting of OSL regex operations.
@@ -118,4 +124,19 @@ osl_warning (ShaderGlobals *sg, const char* format_str, ...)
     std::string s = Strutil::vformat (format_str, args);
     va_end (args);
     sg->context->shadingsys().warning (s);
+}
+
+
+
+OSL_SHADEOP int
+osl_split (const char *str, ustring *results, const char *sep,
+           int maxsplit, int resultslen)
+{
+    maxsplit = OIIO::clamp (maxsplit, 0, resultslen);
+    std::vector<std::string> splits;
+    Strutil::split (USTR(str).string(), splits, USTR(sep).string(), maxsplit);
+    int n = std::min (maxsplit, (int)splits.size());
+    for (int i = 0;  i < n;  ++i)
+        results[i] = ustring(splits[i]);
+    return n;
 }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -491,10 +491,13 @@ ShadingSystemImpl::setup_op_descriptors ()
     OP (snoise,      noise,               none,          true);
     OP (spline,      spline,              none,          true);
     OP (splineinverse, spline,            none,          true);
+    OP (split,       split,               split,         false);
     OP (sqrt,        generic,             sqrt,          true);
     OP (startswith,  generic,             none,          true);
     OP (step,        generic,             none,          true);
     OP (strlen,      generic,             strlen,        true);
+    OP (strtoi,      generic,             strtoi,        true);
+    OP (strtof,      generic,             strtof,        true);
     OP (sub,         sub,                 sub,           true);
     OP (substr,      generic,             none,          true);
     OP (surfacearea, get_simple_SG_field, none,          true);

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -422,6 +422,8 @@ int startswith (string s, string prefix) BUILTIN;
 int endswith (string s, string suffix) BUILTIN;
 string substr (string s, int start, int len) BUILTIN;
 string substr (string s, int start) { return substr (s, start, strlen(s)); }
+float strtof (string str) BUILTIN;
+int strtoi (string str) BUILTIN;
 
 // Define concat in terms of shorter concat
 string concat (string a, string b, string c) {

--- a/testsuite/string/ref/out.txt
+++ b/testsuite/string/ref/out.txt
@@ -36,6 +36,14 @@ endswith ("abcdef", "") = 1
 endswith ("", "abc") = 0
 endswith ("", "") = 1
 
+strtoi("-23") = -23
+strtof("3.14") = 3.140000
+
+testing split " 2 4	6    8" by "":
+	4:  "2" "4" "6" "8"
+testing split "3,6,9,12" by ",":
+	4:  "3" "6" "9" "12"
+
 regex_match ("foo", "f") = 0
 regex_match ("foo", "f[Oo]{2}") = 1
 regex_match ("foo", ".*o") = 1
@@ -85,6 +93,14 @@ endswith ("abcdef", "ghiabcdef") = 0
 endswith ("abcdef", "") = 1
 endswith ("", "abc") = 0
 endswith ("", "") = 1
+
+strtoi("-23") = -23
+strtof("3.14") = 3.140000
+
+testing split " 2 4	6    8" by "":
+	4:  "2" "4" "6" "8"
+testing split "3,6,9,12" by ",":
+	4:  "3" "6" "9" "12"
 
 regex_match ("foo", "f") = 0
 regex_match ("foo", "f[Oo]{2}") = 1
@@ -136,6 +152,14 @@ endswith ("abcdef", "") = 1
 endswith ("", "abc") = 0
 endswith ("", "") = 1
 
+strtoi("-23") = -23
+strtof("3.14") = 3.140000
+
+testing split " 2 4	6    8" by "":
+	4:  "2" "4" "6" "8"
+testing split "3,6,9,12" by ",":
+	4:  "3" "6" "9" "12"
+
 regex_match ("foo", "f") = 0
 regex_match ("foo", "f[Oo]{2}") = 1
 regex_match ("foo", ".*o") = 1
@@ -185,6 +209,14 @@ endswith ("abcdef", "ghiabcdef") = 0
 endswith ("abcdef", "") = 1
 endswith ("", "abc") = 0
 endswith ("", "") = 1
+
+strtoi("-23") = -23
+strtof("3.14") = 3.140000
+
+testing split " 2 4	6    8" by "":
+	4:  "2" "4" "6" "8"
+testing split "3,6,9,12" by ",":
+	4:  "3" "6" "9" "12"
 
 regex_match ("foo", "f") = 0
 regex_match ("foo", "f[Oo]{2}") = 1

--- a/testsuite/string/test.osl
+++ b/testsuite/string/test.osl
@@ -58,6 +58,19 @@ void test_endswith (string s, string substr)
 
 
 
+void test_split (string s, string sep)
+{
+    printf ("testing split \"%s\" by \"%s\":\n", s, sep);
+    string results[10];
+    int r = split (s, results, sep);
+    printf ("\t%d: ", r);
+    for (int i = 0;  i < r;  ++i)
+        printf (" \"%s\"", results[i]);
+    printf ("\n");
+}
+
+
+
 shader
 test ()
 {
@@ -114,6 +127,18 @@ test ()
     test_endswith ("abcdef", "");
     test_endswith ("", "abc");
     test_endswith ("", "");
+
+    // Conversion
+    printf ("\n");
+    string conv = "-23";
+    printf ("strtoi(\"%s\") = %d\n", conv, strtoi(conv));
+    conv = "3.14";
+    printf ("strtof(\"%s\") = %f\n", conv, strtof(conv));
+
+    // Split
+    printf ("\n");
+    test_split (" 2 4\t6    8", "");
+    test_split ("3,6,9,12", ",");
 
     // Regular expressions
     printf ("\n");


### PR DESCRIPTION
Convert string to int or float, and a way to split or "tokenize" a string (a la Strutil::split).

All three can be fully constant-folded.
