### PR TITLE
Fix for building from a chroot

### DIFF
--- a/src/cmake/platform.cmake
+++ b/src/cmake/platform.cmake
@@ -1,16 +1,25 @@
 ###########################################################################
 # Figure out what platform we're on, and set some variables appropriately
 
+# CMAKE_SYSTEM_PROCESSOR should not be used because it indicates the platform
+# we are building on, but when cross compiling or using a chroot this is not
+# what we want to use
+if ("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+    set (SYSTEM_PROCESSOR "x86_64")
+else()
+    set (SYSTEM_PROCESSOR "i686")
+endif()
+
 message (STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
 message (STATUS "CMAKE_SYSTEM_VERSION = ${CMAKE_SYSTEM_VERSION}")
-message (STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
+message (STATUS "SYSTEM_PROCESSOR = ${SYSTEM_PROCESSOR}")
 
 if (UNIX)
     message (STATUS "Unix! ${CMAKE_SYSTEM_NAME}")
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         set (platform "linux")
         set (CXXFLAGS "${CXXFLAGS} -DLINUX")
-        if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+        if (${SYSTEM_PROCESSOR} STREQUAL "x86_64")
             set (platform "linux64")
             set (CXXFLAGS "${CXXFLAGS} -DLINUX64")
         endif ()
@@ -31,3 +40,5 @@ if (platform)
 else ()
     message (FATAL_ERROR "'platform' not defined")
 endif ()
+
+unset(SYSTEM_PROCESSOR)


### PR DESCRIPTION
We build 32 bit linux binaries on a 64 bit system, and it wasn't correctly detecting linux/linux64 as the platform then.
