### PR TITLE
Fix errors not finding the LLVM library when running oslc to compile the shaders

### DIFF
--- a/src/oslc/CMakeLists.txt
+++ b/src/oslc/CMakeLists.txt
@@ -1,5 +1,14 @@
 SET ( oslc_srcs oslcmain.cpp )
+
+# don't want to link oslexec but oslcomp uses these symbols
+if (BUILDSTATIC)
+    LIST(APPEND oslc_srcs
+        ../liboslexec/oslexec.cpp
+        ../liboslexec/typespec.cpp)
+endif ()
+
 ADD_EXECUTABLE ( oslc ${oslc_srcs} )
 LINK_ILMBASE ( oslc )
-TARGET_LINK_LIBRARIES ( oslc oslcomp oslexec ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+TARGET_LINK_LIBRARIES ( oslc oslcomp ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 INSTALL ( TARGETS oslc RUNTIME DESTINATION bin )
+


### PR DESCRIPTION
As far as I know, oslc should not be linked to oslexec so I removed it.

I've had this happen on mac where oslc depended on @executable_path/../lib/libLLVM-3.2svn.dylib, but that doesn't work when oslc is still in build/macosx/oslc/oslc instead of installed in /opt/local/bin.

Note this commit uses the BUILDSTATIC option added in another pull request, but committing either of them separately should work.
