### PR TITLE
Windows port: fix crash using boost foreach over std::pair

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -470,13 +470,19 @@ public:
     /// Return a begin/end Symbol* pair for the set of param symbols
     /// that is suitable to pass as a range for BOOST_FOREACH.
     friend std::pair<Symbol *,Symbol *> param_range (ShaderInstance *i) {
-        return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[i->firstparam()],
-                                           &i->m_instsymbols[i->lastparam()]);
+        if (i->firstparam() == i->lastparam())
+            return std::pair<Symbol*,Symbol*> (NULL, NULL);
+        else
+            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[i->firstparam()],
+                                               &i->m_instsymbols[i->lastparam()]);
     }
 
     friend std::pair<const Symbol *,const Symbol *> param_range (const ShaderInstance *i) {
-        return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[i->firstparam()],
-                                                       &i->m_instsymbols[i->lastparam()]);
+        if (i->firstparam() == i->lastparam())
+            return std::pair<const Symbol*,const Symbol*> (NULL, NULL);
+        else
+            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[i->firstparam()],
+                                                           &i->m_instsymbols[i->lastparam()]);
     }
 
     int Psym () const { return m_Psym; }


### PR DESCRIPTION
I could not get this working, there was a fix in this area recently but it didn't help. I've just worked around the issue and avoided doing this.
