### PR TITLE
Windows port: fix crash with visual studio in insert_code

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1419,9 +1419,11 @@ ASTtype_constructor::codegen (Symbol *dest)
         argdest.push_back (argval);
     }
     if (nargs == 1)
-        emitcode ("assign", argdest.size(), &argdest[0]);
+        emitcode ("assign",
+                  argdest.size(), (argdest.size())? &argdest[0]: NULL);
     else
-        emitcode (typespec().string().c_str(), argdest.size(), &argdest[0]);
+        emitcode (typespec().string().c_str(),
+                  argdest.size(), (argdest.size())? &argdest[0]: NULL);
     return dest;
 }
 
@@ -1576,7 +1578,8 @@ ASTfunction_call::codegen (Symbol *dest)
             argdest_return_offset++;
         }
         // Emit the actual op
-        emitcode (isclosure ? "closure" : m_name.c_str(), argdest.size(), &argdest[0]);
+        emitcode (isclosure ? "closure" : m_name.c_str(),
+                  argdest.size(), (argdest.size())? &argdest[0]: NULL);
         // Propagate derivative-taking info to the opcode
         m_compiler->lastop().set_argbits (m_argread, m_argwrite,
                                           m_argtakesderivs);

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1720,13 +1720,16 @@ LLVMGEN (llvm_gen_generic)
                                                      &(args[1]), op.nargs()-1);
             rop.llvm_store_value (r, Result);
         } else {
-            rop.llvm_call_function (name.c_str(), &(args[0]), op.nargs());
+            rop.llvm_call_function (name.c_str(),
+                                    (args.size())? &(args[0]): NULL, op.nargs());
         }
         rop.llvm_zero_derivs (Result);
     } else {
         // Cases with derivs
         ASSERT (Result.has_derivs() && any_deriv_args);
-        rop.llvm_call_function (name.c_str(), &(args[0]), op.nargs(), true);
+        rop.llvm_call_function (name.c_str(),
+                                (args.size())? &(args[0]): NULL, op.nargs(),
+                                true);
     }
     return true;
 }

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -737,7 +737,9 @@ RuntimeOptimizer::llvm_call_function (const char *name,
         else
             valargs[i] = llvm_load_value (s);
     }
-    return llvm_call_function (name, &valargs[0], (int)valargs.size());
+    return llvm_call_function (name,
+                               (valargs.size())? &valargs[0]: NULL,
+                               (int)valargs.size());
 }
 
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -490,8 +490,10 @@ RuntimeOptimizer::insert_code (int opnum, ustring opname,
                                const std::vector<int> &args_to_add,
                                bool recompute_rw_ranges, int relation)
 {
-    insert_code (opnum, opname, (const int *)&args_to_add[0],
-                 (const int *)&args_to_add[args_to_add.size()],
+    const int *argsbegin = (args_to_add.size())? &args_to_add[0]: NULL;
+    const int *argsend = argsbegin + args_to_add.size();
+
+    insert_code (opnum, opname, argsbegin, argsend,
                  recompute_rw_ranges, relation);
 }
 


### PR DESCRIPTION
Taking the address of the first element of an empty vector will crash due to security checks.

An alternative would be to disable these checks with /GS-
http://msdn.microsoft.com/en-us/library/8dbf701c(v=vs.80).aspx
