### PR TITLE
Windows port: fix build errors in testshade/testrender.

### DIFF
--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <OpenImageIO/fmath.h>
+
 #include "dual_vec.h"
 #include "oslconfig.h"
 #include <vector>
-#include <limits>
-#include <cmath>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <cmath>
-#include <dlfcn.h>
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>

--- a/src/testshade/testshade_dso.cpp
+++ b/src/testshade/testshade_dso.cpp
@@ -29,7 +29,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <iostream>
 #include <cstdlib>
+
+#ifdef __linux__
 #include <dlfcn.h>
+#endif
 
 #include <OpenImageIO/plugin.h>
 using namespace OIIO;


### PR DESCRIPTION
raytracer.h was using M_1_PI which needs OpenImageIO/fmath.h and testshade was using dlfcn.h which does not exists on Windows.
