### PR TITLE
Windows port: fix crash using fmod() on Windows 32 bit.

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -618,6 +618,13 @@ LLVMGEN (llvm_gen_modulus)
     bool is_float = Result.typespec().is_floatbased();
     int num_components = type.aggregate;
 
+#ifdef OSL_LLVM_NO_BITCODE
+    // On Windows 32 bit this calls an unknown instruction, probably need to
+    // link with LLVM compiler-rt to fix, for now just fall back to op
+    if (is_float)
+        return llvm_gen_generic (rop, opnum);
+#endif
+
     // The following should handle f%f, v%v, v%f, i%i
     // That's all that should be allowed by oslc.
     for (int i = 0; i < num_components; i++) {

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -354,6 +354,8 @@ static const char *llvm_helper_function_table[] = {
     UNARY_OP_IMPL(abs),
     UNARY_OP_IMPL(fabs),
 
+    BINARY_OP_IMPL(fmod),
+
     "osl_smoothstep_ffff", "ffff",
     "osl_smoothstep_dfffdf", "xXffX",
     "osl_smoothstep_dffdff", "xXfXf",

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -574,6 +574,18 @@ inline Dual2<float> fabsf (const Dual2<float> &x) {
 MAKE_UNARY_PERCOMPONENT_OP (abs, fabsf, fabsf);
 MAKE_UNARY_PERCOMPONENT_OP (fabs, fabsf, fabsf);
 
+inline float safe_fmod (float a, float b) {
+    if (b == 0.0f)
+        return 0.0f;
+    else
+        return std::fmod (a, b);
+}
+
+inline Dual2<float> safe_fmod (const Dual2<float> &a, const Dual2<float> &b) {
+    return Dual2<float> (safe_fmod (a.val(), b.val()), a.dx(), a.dy());
+}
+
+MAKE_BINARY_PERCOMPONENT_OP (fmod, safe_fmod, safe_fmod);
 
 OSL_SHADEOP float osl_smoothstep_ffff(float e0, float e1, float x) { return smoothstep(e0, e1, x); }
 


### PR DESCRIPTION
 This generates an instruction which doesn't seem to be supported, probably need compiler-rt
for this but I couldn't get it working, so now it's compiled as a function.

Relevant LLVM reports:
http://llvm.org/bugs/show_bug.cgi?id=5053
http://llvm.org/bugs/show_bug.cgi?id=5052
http://lists.cs.uiuc.edu/pipermail/llvmdev/2012-October/053917.html

I'm not happy about this fix, but it works and I haven't gotten reports about other crashes.
