### PR TITLE
Windows port: various fixes for the cmake build system

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,12 @@ endif ()
 ##   if you find the need to turn this on, as OSL classes
 ##   extending LLVM ones will cause linker errors (unless you
 ##   rebuild LLVM with rtti enabled)
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti" )
+
+if (NOT MSVC)
+	set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti" )
+else ()
+	set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-" )
+endif()
 
 # For gcc < 4.3, Boost needs some extra help detecting that we've
 # disabled RTTI.
@@ -70,6 +75,12 @@ if (CMAKE_COMPILER_IS_GNUCC AND GCC_VERSION VERSION_LESS 4.3)
     add_definitions ("-DBOOST_NO_RTTI")
     add_definitions ("-DBOOST_NO_TYPEID")
 endif ()
+
+# Needed for static boost libraries on Windows
+if (WIN32 AND Boost_USE_STATIC_LIBS)
+    add_definitions ("-DBOOST_ALL_NO_LIB")
+    add_definitions ("-DBOOST_THREAD_USE_LIB")
+endif()
 
 if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
     # CMake doesn't automatically know what do do with

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -97,11 +97,11 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
 ENDMACRO ( )
 
-if (NOT MSVC)
+if (NOT WIN32)
     LLVM_COMPILE ( llvm_ops.cpp liboslexec_srcs )
 else ()
-    # With MSVC, we don't compile llvm_ops.cpp to LLVM bitcode, due to
-    # clang being unable to compile MSVC C++ header files at this time.
+    # With MSVC/Mingw, we don't compile llvm_ops.cpp to LLVM bitcode, due
+    # to clang being unable to compile MSVC C++ header files at this time.
     # Instead it is part of the regular build process.
     ADD_DEFINITIONS (-DOSL_LLVM_NO_BITCODE)
     SET (liboslexec_srcs ${liboslexec_srcs} llvm_ops.cpp)


### PR DESCRIPTION
Disable RTTI for visual studio as well, fix for static boost linking, and don't use LLVM bitcode for mingw build.
