### PR TITLE
Windows port: add OSL_STATIC_LIBRARY define to disable dllimport/dllexport

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,11 @@ if (CMAKE_COMPILER_IS_GNUCC AND GCC_VERSION VERSION_LESS 4.3)
     add_definitions ("-DBOOST_NO_TYPEID")
 endif ()
 
+# Needed to disable dllimport/dllexport for static library
+if (BUILDSTATIC)
+    add_definitions ("-DOSL_STATIC_LIBRARY")
+endif()
+
 if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
     # CMake doesn't automatically know what do do with
     # include_directories(SYSTEM...) when using clang or gcc.

--- a/src/include/export.h
+++ b/src/include/export.h
@@ -67,9 +67,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// another.
 
 #if defined(_MSC_VER) || defined(__CYGWIN__)
-  #define OSL_DLL_IMPORT __declspec(dllimport)
-  #define OSL_DLL_EXPORT __declspec(dllexport)
-  #define OSL_DLL_LOCAL
+  #if defined(OSL_STATIC_LIBRARY)
+    #define OSL_DLL_IMPORT
+    #define OSL_DLL_EXPORT
+    #define OSL_DLL_LOCAL
+  #else
+    #define OSL_DLL_IMPORT __declspec(dllimport)
+    #define OSL_DLL_EXPORT __declspec(dllexport)
+    #define OSL_DLL_LOCAL
+  #endif
+  #define OSL_LLVM_EXPORT __declspec(dllexport)
 #else
   #if __GNUC__ >= 4
     #define OSL_DLL_IMPORT __attribute__ ((visibility ("default")))
@@ -80,6 +87,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #define OSL_DLL_EXPORT
     #define OSL_DLL_LOCAL
   #endif
+  #define OSL_LLVM_EXPORT OSL_DLL_EXPORT
 #endif
 
 

--- a/src/include/oslquery.h
+++ b/src/include/oslquery.h
@@ -78,13 +78,13 @@ public:
         { }
     };
 
-    OSLQUERYPUBLIC OSLQuery ();
-    OSLQUERYPUBLIC ~OSLQuery ();
+    OSLQuery ();
+    ~OSLQuery ();
 
     /// Get info on the named shader with optional searcphath.  Return
     /// true for success, false if the shader could not be found or
     /// opened properly.
-    OSLQUERYPUBLIC bool open (const std::string &shadername,
+    bool open (const std::string &shadername,
                const std::string &searchpath=std::string());
 
     /// Return the shader type: "surface", "displacement", "volume",

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -29,8 +29,6 @@ if (NOT BUILDSTATIC)
         ../liboslcomp/symtab.cpp
         ../liboslcomp/typecheck.cpp
         )
-
-    add_definitions ( -Doslcomp_EXPORTS )
 endif ()
 
 include_directories ( ${CMAKE_SOURCE_DIR}/liboslcomp )
@@ -109,7 +107,6 @@ endif ()
 
 if (BUILDSTATIC)
     ADD_LIBRARY ( oslexec STATIC ${liboslexec_srcs} )
-    ADD_DEFINITIONS (-DBUILD_STATIC=1)
 else ()
     ADD_LIBRARY ( oslexec SHARED ${liboslexec_srcs} )
 endif ()

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -132,7 +132,7 @@ struct OpDescriptor {
 
 
 // Prefix for OSL shade up declarations, so LLVM can find them
-#define OSL_SHADEOP extern "C" OSLEXECPUBLIC
+#define OSL_SHADEOP extern "C" OSL_LLVM_EXPORT
 
 
 
@@ -690,7 +690,7 @@ private:
 class OSLEXECPUBLIC ShadingSystemImpl : public ShadingSystem
 {
 public:
-    OSLEXECPUBLIC ShadingSystemImpl (RendererServices *renderer=NULL,
+    ShadingSystemImpl (RendererServices *renderer=NULL,
                        TextureSystem *texturesystem=NULL,
                        ErrorHandler *err=NULL);
     virtual ~ShadingSystemImpl ();

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1472,7 +1472,7 @@ const ClosureRegistry::ClosureEntry *ClosureRegistry::get_entry(ustring name)con
 OSL_NAMESPACE_EXIT
 
 
-#ifndef BUILD_STATIC
+#ifndef OSL_STATIC_LIBRARY
 // Symbols needed to resolve some linkage issues because we pull some
 // components in from liboslcomp.
 int oslparse() { return 0; }


### PR DESCRIPTION
The application linking against OSL needs to define this if wants to link against a static OSL library on Windows. However we still dllexport symbols needed by LLVM.

Also fix build errors adding dllimport/dllexport on class members when the class had them already.
