### PR TITLE
Update src/liboslexec/opcolor.cpp

### DIFF
--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -410,7 +410,6 @@ ShadingSystemImpl::set_colorspace (ustring colorspace)
                 lastT = T;
                 bb_spectrum spec (T);
                 Color3 rgb = XYZ_to_RGB (spectrum_to_XYZ (spec));
-                clamp_zero (rgb);
                 rgb = colpow (rgb, 1.0f/BB_TABLE_YPOWER);
                 m_blackbody_table.push_back (rgb);
                 // std::cout << "Table[" << i << "; T=" << T << "] = " << rgb << "\n";
@@ -467,7 +466,6 @@ ShadingSystemImpl::blackbody_rgb (float T)
     // Otherwise, compute for real
     bb_spectrum spec (T);
     Color3 rgb = XYZ_to_RGB (spectrum_to_XYZ (spec));
-    clamp_zero (rgb);
     return rgb;
 }
 
@@ -488,7 +486,6 @@ OSL_SHADEOP void osl_wavelength_color_vf (void *sg, void *out, float lambda)
 //    constrain_rgb (rgb);
     rgb *= 1.0/2.52;    // Empirical scale from lg to make all comps <= 1
 //    norm_rgb (rgb);
-    clamp_zero (rgb);
     *(Color3 *)out = rgb;
 }
 


### PR DESCRIPTION
After converting XYZ colors to RGB they should not be clamped at zero. RGB values with negative weights may be out of gamut for sRGB calibrated displays, but they still represent real colors and are needed as such during rendering.
