### PR TITLE
Minor improvement to recent exit() fix 

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3430,7 +3430,8 @@ LLVMGEN (llvm_gen_return)
     Opcode &op (rop.inst()->ops()[opnum]);
     ASSERT (op.nargs() == 0);
     if (op.opname() == op_exit) {
-        // If it's a real "exit", totally jump out of the shader instance
+        // If it's a real "exit", totally jump out of the shader instance.
+        // The exit instance block will be created if it doesn't yet exist.
         rop.builder().CreateBr (rop.llvm_exit_instance_block());
     } else {
         // If it's a "return", jump to the exit point of the function.

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -820,7 +820,7 @@ RuntimeOptimizer::build_llvm_instance (bool groupentry)
     m_llvm_groupdata_ptr = arg_it++;
 
     llvm::BasicBlock *entry_bb = llvm_new_basic_block (unique_layer_name);
-    m_exit_instance_block = llvm_new_basic_block (unique_layer_name+"_exit_");
+    m_exit_instance_block = NULL;
 
     // Set up a new IR builder
     delete m_builder;
@@ -935,8 +935,10 @@ RuntimeOptimizer::build_llvm_instance (bool groupentry)
     }
     // llvm_gen_debug_printf ("done copying connections");
 
-    builder().CreateBr (m_exit_instance_block);
-    builder().SetInsertPoint (m_exit_instance_block);
+    if (llvm_has_exit_instance_block()) {
+        builder().CreateBr (m_exit_instance_block);
+        builder().SetInsertPoint (m_exit_instance_block);
+    }
 
     // All done
     // llvm_gen_debug_printf (std::string("exit layer ")+inst()->shadername());

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -818,7 +818,17 @@ public:
 
     /// Return the basic block of the exit for the whole instance.
     ///
-    llvm::BasicBlock *llvm_exit_instance_block () const {
+    bool llvm_has_exit_instance_block () const {
+        return m_exit_instance_block;
+    }
+
+    /// Return the basic block of the exit for the whole instance.
+    ///
+    llvm::BasicBlock *llvm_exit_instance_block () {
+        if (! m_exit_instance_block) {
+            std::string name = Strutil::format ("%s_%d_exit_", inst()->layername().c_str(), inst()->id());
+            m_exit_instance_block = llvm_new_basic_block (name);
+        }
         return m_exit_instance_block;
     }
 


### PR DESCRIPTION
Minor improvement to recent exit() fix -- if the shader has no exit() call,
do not generate the extra branch & basic block.

This turns out to be important -- if we put the branch in there
unconditionally, and everything else is optimized away, it no longer looks
like the post-optimized IR is "empty", so the shader isn't flagged as
empty.  When displacement shaders are empty, our renderer handles the
dicing differently.  Hilarity ensues.
