### PR TITLE
Fix for freebsd 8.2 compile

### DIFF
--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -125,6 +125,14 @@ using OIIO::isnan;
 using OIIO::isfinite;
 #endif
 
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#if __FreeBSD_version < 803000
+// freebsd before 8.3 doesn't have log2f - use OIIO lib replacement
+using OIIO::log2f;
+#endif
+#endif
+
 // Handy re-casting macros
 #define USTR(cstr) (*((ustring *)&cstr))
 #define MAT(m) (*(Matrix44 *)m)


### PR DESCRIPTION
A simple fix for freebsd build to use the log2f replacement from OIIO when needed (freebsd < v8.3)
