### PR TITLE
Fix IF token conflict with old GCC versions

### DIFF
--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -90,7 +90,7 @@ static std::stack<TypeSpec> typespec_stack; // just for function_declaration
 %token <i> COLORTYPE FLOATTYPE INTTYPE MATRIXTYPE 
 %token <i> NORMALTYPE POINTTYPE STRINGTYPE VECTORTYPE VOIDTYPE
 %token <i> CLOSURE OUTPUT PUBLIC STRUCT
-%token <i> BREAK CONTINUE DO ELSE FOR IF ILLUMINATE ILLUMINANCE RETURN WHILE
+%token <i> BREAK CONTINUE DO ELSE FOR IF_TOKEN ILLUMINATE ILLUMINANCE RETURN WHILE
 %token <i> RESERVED
 
 
@@ -601,12 +601,12 @@ scoped_statements
         ;
 
 conditional_statement
-        : IF '(' expression ')' statement
+        : IF_TOKEN '(' expression ')' statement
                 {
                     $$ = new ASTconditional_statement (oslcompiler, $3, $5);
                     $$->sourceline (@1.first_line);
                 }
-        | IF '(' expression ')' statement ELSE statement
+        | IF_TOKEN '(' expression ')' statement ELSE statement
                 {
                     $$ = new ASTconditional_statement (oslcompiler, $3, $5, $7);
                     $$->sourceline (@1.first_line);

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -142,7 +142,7 @@ void preprocess (const char *yytext);
 "else"			{  SETLINE;  return (yylval.i=ELSE); }
 "float"			{  SETLINE;  return (yylval.i=FLOATTYPE); }
 "for"			{  SETLINE;  return (yylval.i=FOR); }
-"if"			{  SETLINE;  return (yylval.i=IF); }
+"if"			{  SETLINE;  return (yylval.i=IF_TOKEN); }
 "illuminance"	        {  SETLINE;  return (yylval.i=ILLUMINANCE); }
 "illuminate"	        {  SETLINE;  return (yylval.i=ILLUMINATE); }
 "int"		        {  SETLINE;  return (yylval.i=INTTYPE); }

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -32,11 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <stack>
 
-/* fix for GCC version < 4.4 conflict with boost */
-#ifdef IF
-#undef IF
-#endif
-
 #include <boost/unordered_map.hpp>
 
 #include "OpenImageIO/typedesc.h"


### PR DESCRIPTION
Better fix for old GCC versions that give a conflict between IF token used for parsing and a template in boost headers with the same name.
