### PR TITLE
When constant-folding 'gettextureinfo', upon failure, don't suppress the...

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -114,6 +114,7 @@ public:
                       TypeDesc datatype=TypeDesc::UNKNOWN);
     int add_constant (float c) { return add_constant(TypeDesc::TypeFloat, &c); }
     int add_constant (int c) { return add_constant(TypeDesc::TypeInt, &c); }
+    int add_constant (ustring s) { return add_constant(TypeDesc::TypeString, &s); }
 
     /// Create a new temporary variable of the given type, return its index.
     int add_temp (const TypeSpec &type);


### PR DESCRIPTION
When constant-folding 'gettextureinfo', upon failure, don't suppress the
error message and assume it will get re-issued at shade time; instead,
constant fold the gettextureinfo op into a call to error()!

For those following along, this is really part 2 of:
https://github.com/OpenImageIO/oiio/pull/504
If you turn on the "one_error_per_file" option in OIIO, you need this.
