### PR TITLE
Another fix for windows crash with FOREACH_PARAM

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -473,16 +473,16 @@ public:
         if (i->firstparam() == i->lastparam())
             return std::pair<Symbol*,Symbol*> (NULL, NULL);
         else
-            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[i->firstparam()],
-                                               &i->m_instsymbols[i->lastparam()]);
+            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
+                                               &i->m_instsymbols[0] + i->lastparam());
     }
 
     friend std::pair<const Symbol *,const Symbol *> param_range (const ShaderInstance *i) {
         if (i->firstparam() == i->lastparam())
             return std::pair<const Symbol*,const Symbol*> (NULL, NULL);
         else
-            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[i->firstparam()],
-                                                           &i->m_instsymbols[i->lastparam()]);
+            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
+                                                           &i->m_instsymbols[0] + i->lastparam());
     }
 
     int Psym () const { return m_Psym; }


### PR DESCRIPTION
It was still accessing an element beyond the end of the vector which could crash in some other cases.
