### PR TITLE
Add query function for closure info

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -284,6 +284,13 @@ public:
 
     virtual void register_closure(const char *name, int id, const ClosureParam *params,
                                   PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare) = 0;
+    /// Query either by name or id an existing closure. If name is non
+    /// NULL it will use it for the search, otherwise id would be used
+    /// and the name will be placed in name if successful. Also return
+    /// pointer to the params array in the last argument. All args are
+    /// optional but at least one of name or id must non NULL.
+    virtual bool query_closure(const char **name, int *id,
+                               const ClosureParam **params) = 0;
 
     void register_builtin_closures();
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -803,6 +803,8 @@ public:
 
     virtual void register_closure(const char *name, int id, const ClosureParam *params,
                                   PrepareClosureFunc prepare, SetupClosureFunc setup, CompareClosureFunc compare);
+    virtual bool query_closure(const char **name, int *id,
+                               const ClosureParam **params);
     const ClosureRegistry::ClosureEntry *find_closure(ustring name) const {
         return m_closure_registry.get_entry(name);
     }


### PR DESCRIPTION
I need this to correctly report errors in the render. Well, I could do it without this, but with this function I don't need duplicated data and everything is centralized in OSL.
