### PR TITLE
Explicitly declare renderer outputs

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -94,6 +94,9 @@ public:
     /// incorporate OSL:
     ///    string commonspace     Name of "common" coord system ("world")
     ///    string[] raytypes      Array of ray type names
+    ///    string[] renderer_outputs
+    ///                           Array of names of renderer outputs (AOVs)
+    ///                              that should not be optimized away.
     ///    int unknown_coordsys_error  Should errors be issued when unknown
     ///                                   coord system names are used?
     ///    int strict_messages    Issue error if a message is set after

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -938,6 +938,7 @@ private:
     std::vector<std::string> m_searchpath_dirs; ///< All searchpath dirs
     ustring m_commonspace_synonym;        ///< Synonym for "common" space
     std::vector<ustring> m_raytypes;      ///< Names of ray types
+    std::vector<ustring> m_renderer_outputs; ///< Names of renderer outputs
     ustring m_colorspace;                 ///< What RGB colors mean
     int m_max_local_mem_KB;               ///< Local storage can a shader use
     bool m_compile_report;

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -348,6 +348,9 @@ public:
         return inst()->argsymbol (op.firstarg()+argnum);
     }
 
+    /// Is the named symbol among the renderer outputs?
+    bool is_renderer_output (ustring name) const;
+
     /// Create an llvm function for the whole shader group, JIT it,
     /// and store the llvm::Function* handle to it with the ShaderGroup.
     void build_llvm_group ();

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -671,6 +671,12 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
             m_raytypes.push_back (ustring(((const char **)val)[i]));
         return true;
     }
+    if (name == "renderer_outputs" && type.basetype == TypeDesc::STRING) {
+        m_renderer_outputs.clear ();
+        for (size_t i = 0;  i < type.numelements();  ++i)
+            m_renderer_outputs.push_back (ustring(((const char **)val)[i]));
+        return true;
+    }
     return false;
 #undef ATTR_SET
 #undef ATTR_SET_STRING

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -78,7 +78,6 @@ static OSL::Matrix44 Mshad;  // "shader" space to "common" space matrix
 static OSL::Matrix44 Mobj;   // "object" space to "common" space matrix
 
 
-
 static void
 inject_params ()
 {
@@ -123,10 +122,6 @@ add_shader (int argc, const char *argv[])
         shadingsys->attribute ("optimize", O2 ? 2 : (O1 ? 1 : 0));
     shadingsys->attribute ("lockgeom", 1);
     shadingsys->attribute ("debugnan", debugnan);
-    // Must be sure we do not optimize away assignments to unconnected
-    // output params -- our use of shadingsys->get_symbol() depends on
-    // this for how testshade can dump any output to an image file.
-    shadingsys->attribute ("opt_elide_unconnected_outputs", 0);
 
     for (int i = 0;  i < argc;  i++) {
         inject_params ();
@@ -308,6 +303,16 @@ static void
 setup_output_images (ShadingSystem *shadingsys,
                      ShadingAttribStateRef &shaderstate)
 {
+    // Tell the shading system which outputs we want
+    if (outputvars.size()) {
+        std::vector<const char *> aovnames (outputvars.size());
+        for (size_t i = 0; i < outputvars.size(); ++i)
+            aovnames[i] = outputvars[i].c_str();
+        shadingsys->attribute ("renderer_outputs",
+                               TypeDesc(TypeDesc::STRING,(int)aovnames.size()),
+                               &aovnames[0]);
+    }
+
     ShadingContext *ctx = shadingsys->get_context ();
     // Because we can only call get_symbol on something that has been
     // set up to shade (or executed), we call execute() but tell it not

--- a/testsuite/debugnan/ref/out.txt
+++ b/testsuite/debugnan/ref/out.txt
@@ -1,3 +1,4 @@
 Compiled test.osl -> test.oso
 ERROR: Detected nan value in Cout at test.osl:5
 
+Output Cout to Cout.tif

--- a/testsuite/debugnan/run.py
+++ b/testsuite/debugnan/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python 
 
-command = testshade("--debugnan -g 2 2 test")
+command = testshade("--debugnan -g 2 2 -o Cout Cout.tif test")


### PR DESCRIPTION
New ShadingSystem attribute "renderer_outputs" enumerates the renderer outputs
(AOVs) explicitly, so that elision of unused outputs can be done with
full understanding of which params will or will not be used.
Beware: if you use "opt_elide_unconnected_outputs", you MUST pass
"renderer_outputs" or your outputs may be eliminated!
