### PR TITLE
SPI-specific changes to build against Boost 1.51, also general Boost build update

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -45,6 +45,14 @@ ifeq ($(SP_ARCH), spinux1_x86_64)
          -DCMAKE_C_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.7.0-test/bin/gcc \
          -DCMAKE_CXX_COMPILER=/net/soft_scratch/apps/arnold/tools/gcc-4.7.0-test/bin/g++
     endif
+    ifeq (${SPCOMP2_USE_BOOSTVERS}, 1)
+    BOOSTVERS_UNDERSCORE = ${shell echo ${BOOSTVERS} | sed "s/\\./_/"}
+    MY_CMAKE_FLAGS += \
+        -DBOOST_CUSTOM=1 \
+        -DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
+        -DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
+        -DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt-${BOOSTVERS_UNDERSCORE}.so"
+    endif
 endif # SP_ARCH == spinux1_x86_64
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -67,22 +67,24 @@ endmacro ()
 ###########################################################################
 # Boost setup
 
-set (Boost_ADDITIONAL_VERSIONS "1.52" "1.51" "1.50" "1.49" "1.48"
-                               "1.47" "1.46" "1.45"
-                               "1.44" "1.43" "1.42" "1.41" "1.40")
+set (Boost_ADDITIONAL_VERSIONS "1.53" "1.52" "1.51" "1.50"
+                               "1.49" "1.48" "1.47" "1.46" "1.45"
+                               "1.44" "1.43" "1.42")
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
 endif ()
 set (Boost_USE_MULTITHREADED ON)
 if (BOOST_CUSTOM)
     set (Boost_FOUND true)
+    # N.B. For a custom version, the caller had better set up the variables
+    # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
     set (Boost_COMPONENTS filesystem regex system thread)
     if (USE_BOOST_WAVE)
         list (APPEND Boost_COMPONENTS wave)
     endif ()
 
-    find_package (Boost 1.40 REQUIRED 
+    find_package (Boost 1.42 REQUIRED 
                   COMPONENTS ${Boost_COMPONENTS}
                  )
 endif ()


### PR DESCRIPTION
Update the boost stuff to reflect new versions.

For SPI folks, add support for building against a particular non-facility-default Boost version that we have a need for.
