### PR TITLE
Check format/printf/error/warning format string versus argument

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,7 +274,8 @@ TESTSUITE ( arithmetic array array-derivs array-range
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter
             noise-perlin noise-uperlin noise-simplex noise-usimplex
             pnoise pnoise-cell pnoise-gabor pnoise-perlin pnoise-uperlin
-            oslc-err-arrayindex oslc-err-closuremul oslc-err-intoverflow
+            oslc-err-arrayindex oslc-err-closuremul
+            oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-paramdefault
             pointcloud pointcloud-fold
             raytype render-background render-bumptest render-cornell render-furnace-diffuse

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3698,14 +3698,13 @@ positions.
 Much as in C, {\cf printf()} takes a format string {\cf fmt} and an
 argument list, and prints the resulting formatted string to the console.
 
-Where the {\cf fmt} contains the characters {\cf \%d}, {\cf \%i}, {\cf \%f},
-{\cf \%g}, and {\cf \%s}, {\cf printf} will substitute arguments, in
-order.  The {\cf \%d} and {\cf \%i} arguments expect an {\cf int}
-argument; {\cf \%f} and {\cf \%g} expect a \float, \color, point-like,
-or \matrix argument (for multi-component types such as \color, the
-format will be applied to each of the components); and {\cf \%s} expects
-a {\cf string} argument.  In addition, {\cf \%d} and {\cf \%i} will also
-print \float's, truncating and printing them as if they were integers.
+Where the {\cf fmt} contains a format string similar to {\cf printf} in
+the C language. The {\cf \%d}, {\cf \%i}, {\cf \%o}, and {\cf \%x}
+arguments expect an {\cf int} argument.  The {\cf \%f}, {\cf \%g}, and
+{\cf \%e} expect a \float, \color, point-like, or \matrix argument (for
+multi-component types such as \color, the format will be applied to each
+of the components).  The {\cf \%s} expects a {\cf string} or 
+{\cf closure} argument.
 
 All of the substition commands follow the usual C/C++ formatting rules,
 so format commands such as {\cf "\%6.2f"}, etc., should work as

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -835,6 +835,11 @@ private:
     /// checks for printf- and texture-like, etc.
     void typecheck_builtin_specialcase ();
 
+    /// Make sure the printf-like format string matches the list of
+    /// arguments poitned to by arg.  If ok, return true, otherwise
+    /// return false and call an appropriate error().
+    bool typecheck_printf_args (const char *format, ASTNode *arg);
+
     /// Is the argument number 'arg' read by the op?
     ///
     bool argread (int arg) const;

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -268,7 +268,7 @@ LLVMGEN (llvm_gen_printf)
                    *format != 'p' && *format != 's' && *format != 'u' &&
                    *format != 'v' && *format != 'x' && *format != 'X')
                 ++format;
-            ++format; // Also eat the format char
+            char formatchar = *format++;  // Also eat the format char
             if (arg >= op.nargs()) {
                 rop.shadingsys().error ("Mismatch between format string and arguments (%s:%d)",
                                         op.sourcefile().c_str(), op.sourceline());
@@ -281,6 +281,22 @@ LLVMGEN (llvm_gen_printf)
             TypeDesc simpletype (sym.typespec().simpletype());
             int num_elements = simpletype.numelements();
             int num_components = simpletype.aggregate;
+            if ((sym.typespec().is_closure_based() ||
+                 simpletype.basetype == TypeDesc::STRING)
+                && formatchar != 's') {
+                ourformat[ourformat.length()-1] = 's';
+            }
+            if (simpletype.basetype == TypeDesc::INT && formatchar != 'd' &&
+                formatchar != 'i' && formatchar != 'o' && formatchar != 'u' &&
+                formatchar != 'x' && formatchar != 'X') {
+                ourformat[ourformat.length()-1] = 'd';
+            }
+            if (simpletype.basetype == TypeDesc::FLOAT && formatchar != 'f' &&
+                formatchar != 'g' && formatchar != 'c' && formatchar != 'e' &&
+                formatchar != 'm' && formatchar != 'n' && formatchar != 'p' &&
+                formatchar != 'v') {
+                ourformat[ourformat.length()-1] = 'f';
+            }
             // NOTE(boulos): Only for debug mode do the derivatives get printed...
             for (int a = 0;  a < num_elements;  ++a) {
                 llvm::Value *arrind = simpletype.arraylen ? rop.llvm_constant(a) : NULL;

--- a/testsuite/oslc-err-format/ref/out.txt
+++ b/testsuite/oslc-err-format/ref/out.txt
@@ -1,0 +1,8 @@
+test.osl:5: warning: printf() uses a format string that is not a constant.
+test.osl:7: error: printf has mismatched format string and arguments (arg 2 needs %d, %i, %o, %x, or %X)
+test.osl:8: error: printf has mismatched format string and arguments (arg 3 needs %f, %g, or %e)
+test.osl:9: error: printf has mismatched format string and arguments (arg 2 needs %d, %i, %o, %x, or %X)
+test.osl:10: error: printf has mismatched format string and arguments (arg 2 needs %d, %i, %o, %x, or %X)
+test.osl:11: error: printf has mismatched format string and arguments (not enough args)
+test.osl:12: error: printf has mismatched format string and arguments (too many args)
+FAILED test.osl

--- a/testsuite/oslc-err-format/run.py
+++ b/testsuite/oslc-err-format/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python 
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-format/test.osl
+++ b/testsuite/oslc-err-format/test.osl
@@ -1,0 +1,13 @@
+shader test(output color Cout = 0, string fmtstring = "non-const %d %s")
+{
+    int i = 3;
+    string s = "blah";
+    printf (fmtstring, i, s);
+    printf ("good %3d %s\n", i, s);
+    printf ("bad  %3f %s\n", i, s);
+    printf ("bad  %3i %s\n", i, u);
+    printf ("bad  %s %d\n", i, s);
+    printf ("bad  %s % % xxx\n", i, s);
+    printf ("bad  %d %d\n", i);
+    printf ("bad  %d %d\n", i, i, i);
+}


### PR DESCRIPTION
Check format/printf/error/warning format string versus argument
and substitute a valid default format for the argument if there's a mismatch.
(Better than crashing because we push the wrong types on the stack only
to be found deep in vsprintf!)
