### PR TITLE
More shared_ptr ambiguity fixes

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -33,12 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "OpenImageIO/dassert.h"
 
+#ifdef OSL_USING_CPLUSPLUS11
 #include <boost/tr1/memory.hpp>
-using std::tr1::shared_ptr;
-
+#endif
 
 OSL_NAMESPACE_ENTER
 namespace pvt {
+
+using std::tr1::shared_ptr;
 
 class ASTNode;
 class StructSpec;

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "OpenImageIO/dassert.h"
 
-#ifdef OSL_USING_CPLUSPLUS11
+#ifndef OSL_USING_CPLUSPLUS11
 #include <boost/tr1/memory.hpp>
 #endif
 

--- a/src/include/oslconfig.h
+++ b/src/include/oslconfig.h
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /////////////////////////////////////////////////////////////////////////
 
 // Test if we are using C++11
-#if (__cplusplus >= 201103L)
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1700)
 #define OSL_USING_CPLUSPLUS11 1
 #endif
 


### PR DESCRIPTION
MSVC 2012 is strange ;) 
- moved another using std::tr1::shared_ptr into the namespace.
- encasulated an include statement into a ifndef
- expanded an #if statement by (_MSC_VER >= 1700) beacause VC 2012
  defines __cplusplus = 199711L but delivers C++11 libs.

Now it builds fine here too.
