### PR TITLE
Remove aastep from specification and compiler

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3611,32 +3611,6 @@ $p$ (as $p$ is computed at all points on the currently-shading surface),
 taking into account surface orientation.
 \apiend
 
-\apiitem{float {\ce aastep} (float edge, float s) \\
-float {\ce aastep} (float edge, float s, float ds) \\
-float {\ce aastep} (float edge, float s, float dedge, float ds)
-\smallskip \\
-float {\ce aastep} (float edge, float s, string filter) \\
-float {\ce aastep} (float edge, float s, float ds, string filter) \\
-float {\ce aastep} (float edge, float s, float dedge, float ds, string filter)}
-\indexapi{aastep()}
-Computes an antialiased step function, similar to {\cf step(edge,s)} but
-filtering the edge to take into account how rapidly {\cf s} and {\cf edge}
-are changing over the surface.  If the differentials {\cf ds} and/or
-{\cf dedge} are not passed explicitly, they will be automatically 
-computed (using {\cf aastep()}).
-
-The optional {\cf filter} parameter specifies which filter should be
-used: \qkw{catmull-rom}, \qkw{box}, \qkw{triangle}, or \qkw{gaussian}.
-If no {\cf filter} parameter is supplied, a Catmull-Rom filter will be
-used.
-
-%\begin{annotate}
-%\QUESTION This is similar to RenderMan's ``filterstep'', but not quite.
-%Is it better to call it ``filterstep'' even if it doesn't exactly match,
-%or should we stick to the changed name to match the changed functionality?
-%\end{annotate}
-\apiend
-
 
 \section{Displacement functions}
 \label{sec:stdlib:displace}

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1019,12 +1019,6 @@ ASTfunction_call::typecheck_builtin_specialcase ()
         size_t nargs = listlength(args());
         if (m_name == "area") {
             argtakesderivs (1, true);
-        } else if (m_name == "aastep") {
-            // all but the 5-arg version take derivs of edge param
-            argtakesderivs (1, nargs<5);
-            // aastep(f,f) and aastep(f,f,str) take derivs of s param
-            if (nargs == 2 || list_nth(args(),2)->typespec().is_string())
-                argtakesderivs (2, true);
         } else if (m_name == "bump" || m_name == "displace") {
             // FIXME -- come back to this
         } else if (m_name == "calculatenormal") {
@@ -1188,7 +1182,6 @@ ASTfunction_call::typecheck (TypeSpec expected)
 
 static const char * builtin_func_args [] = {
 
-    "aastep", "fff", "ffff", "fffff", "fffs", "ffffs", "fffffs", "!deriv", NULL,
     "area", "fp", "!deriv", NULL,
     "arraylength", "i?[]", NULL,
     "backfacing", "i", NULL,


### PR DESCRIPTION
Missing aastep was reported to me as a bug, it compiles ok but the implementation does not exist.

I don't know if we actually want to do this, or if the solution is to implement this function. The fact that no one has noticed this up to now maybe indicates that it's very important to have this.
