### PR TITLE
Fix issue compiling LLVM bitcode against different OpenEXR version

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -54,7 +54,6 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
     SET ( ${srclist} ${${srclist}} ${llvm_bc_cpp} )
     EXEC_PROGRAM ( ${LLVM_DIRECTORY}/bin/llvm-config ARGS --cxxflags OUTPUT_VARIABLE LLVM_COMPILE_FLAGS )
     set (LLVM_COMPILE_FLAGS "${LLVM_COMPILE_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -O3 --combine")
-    LIST (APPEND LLVM_COMPILE_FLAGS "-I${ILMBASE_INCLUDE_DIR}")
     if (OSL_NAMESPACE)
         LIST (APPEND LLVM_COMPILE_FLAGS "-DOSL_NAMESPACE=${OSL_NAMESPACE}")
     endif ()
@@ -88,12 +87,15 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
     # Command to turn the .cpp file into LLVM assembly language .s, into
     # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
     ADD_CUSTOM_COMMAND ( OUTPUT ${llvm_bc_cpp}
-      COMMAND ${LLVM_BC_GENERATOR} ${LLVM_COMPILE_FLAGS}
+      COMMAND ${LLVM_BC_GENERATOR}
       -I${CMAKE_CURRENT_SOURCE_DIR}
       -I${CMAKE_SOURCE_DIR}/include
       -I${CMAKE_BINARY_DIR}/include
-      -I${OPENIMAGEIO_INCLUDES} -I${ILMBASE_INCLUDE_DIR}
-      -I${Boost_INCLUDE_DIRS} -O3 -S -emit-llvm -o ${llvm_asm} ${llvm_src}
+      -I${OPENIMAGEIO_INCLUDES}
+      -I${ILMBASE_INCLUDE_DIR}
+      -I${Boost_INCLUDE_DIRS}
+      ${LLVM_COMPILE_FLAGS}
+      -O3 -S -emit-llvm -o ${llvm_asm} ${llvm_src}
 
       COMMAND ${LLVM_DIRECTORY}/bin/llvm-as -f -o ${llvm_bc} ${llvm_asm}
       COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash ${llvm_bc} ${llvm_bc_cpp}


### PR DESCRIPTION
Reorder include directories for building LLVM bitcode so that the openimageio, ilmbase and boost directories are ahead of any system directories given by llvm-config --cxxflags.

This avoids the LLVM bitcode getting compiled against different library versions than the rest of the code if multiple versions are installed, by making the include directory order the same for both.

The specific case where this happend was with llvm+clang and openexr 1.7 installed in the same directory, but trying to build against openexr 2.0 located somewhere else. This would then give a runtime error with some shaders:

LLVM ERROR: Program used external function '_ZN3Iex7BaseExcC2EPKc' which could not be resolved!
