### PR TITLE
Debugging mode: detect uninitialized values

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -269,7 +269,7 @@ endmacro ()
 TESTSUITE ( arithmetic array array-derivs array-range
             blackbody blendmath breakcont bug-locallifetime bug-outputinit
             cellnoise closure color comparison
-            component-range const-array-params debugnan
+            component-range const-array-params debugnan debug-uninit
             derivs derivs-muldiv-clobber error-dupes exit exponential
             function-earlyreturn function-simple function-outputelem
             geomath getsymbol-nonheap gettextureinfo hyperb

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -299,6 +299,12 @@ public:
         return m_simple.basetype == TypeDesc::STRING;
     }
 
+    /// Is it an int or an array of ints?
+    ///
+    bool is_int_based () const {
+        return m_simple.basetype == TypeDesc::INT;
+    }
+
     /// Is it a void?
     ///
     bool is_void () const {

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -84,8 +84,10 @@ public:
     ///    string colorspace      Name of RGB color space ("Rec709")
     ///    int range_checking     Generate extra code for component & array
     ///                              range checking (1)
-    ///    int debugnan           Add extra (expensive) code to pinpoint
+    ///    int debug_nan          Add extra (expensive) code to pinpoint
     ///                              when NaN/Inf happens (0).
+    ///    int debug_uninit       Add extra (expensive) code to pinpoint
+    ///                              use of uninitialized variables (0).
     ///    int compile_report     Issue info messages to the renderer for
     ///                              every shader compiled (0).
     ///    int max_warnings_per_thread  Number of warning calls that should be

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -785,6 +785,7 @@ public:
     TextureSystem *texturesys () const { return m_texturesys; }
 
     bool debug_nan () const { return m_debugnan; }
+    bool debug_uninit () const { return m_debug_uninit; }
     bool lockgeom_default () const { return m_lockgeom_default; }
     bool strict_messages() const { return m_strict_messages; }
     bool range_checking() const { return m_range_checking; }
@@ -917,6 +918,7 @@ private:
     bool m_lazyglobals;                   ///< Run lazily even if globals write?
     bool m_clearmemory;                   ///< Zero mem before running shader?
     bool m_debugnan;                      ///< Root out NaN's?
+    bool m_debug_uninit;                  ///< Find use of uninitialized vars?
     bool m_lockgeom_default;              ///< Default value of lockgeom
     bool m_strict_messages;               ///< Strict checking of message passing usage?
     bool m_range_checking;                ///< Range check arrays & components?
@@ -1356,6 +1358,7 @@ namespace Strings {
     extern OSLEXECPUBLIC ustring anisotropic, direction, do_filter, bandwidth, impulses;
     extern OSLEXECPUBLIC ustring op_dowhile, op_for, op_while, op_exit;
     extern OSLEXECPUBLIC ustring subimage, subimagename;
+    extern OSLEXECPUBLIC ustring uninitialized_string;
 }; // namespace Strings
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -850,6 +850,8 @@ public:
 
     /// Check for inf/nan in all written-to arguments of the op
     void llvm_generate_debugnan (const Opcode &op);
+    /// Check for uninitialized values in all read-from arguments to the op
+    void llvm_generate_debug_uninit (const Opcode &op);
 
     llvm::Function *layer_func () const { return m_layer_func; }
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -243,7 +243,7 @@ ustring do_filter("do_filter"), bandwidth("bandwidth"), impulses("impulses");
 ustring op_dowhile("dowhile"), op_for("for"), op_while("while");
 ustring op_exit("exit");
 ustring subimage("subimage"), subimagename("subimagename");
-
+ustring uninitialized_string("!!!uninitialized!!!");
 };
 
 
@@ -257,7 +257,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     : m_renderer(renderer), m_texturesys(texturesystem), m_err(err),
       m_statslevel (0), m_lazylayers (true),
       m_lazyglobals (false),
-      m_clearmemory (false), m_debugnan (false),
+      m_clearmemory (false), m_debugnan (false), m_debug_uninit(false),
       m_lockgeom_default (false), m_strict_messages(true),
       m_range_checking(true), m_unknown_coordsys_error(true),
       m_greedyjit(false), m_countlayerexecs(false),
@@ -625,7 +625,9 @@ ShadingSystemImpl::attribute (const std::string &name, TypeDesc type,
     ATTR_SET ("lazylayers", int, m_lazylayers);
     ATTR_SET ("lazyglobals", int, m_lazyglobals);
     ATTR_SET ("clearmemory", int, m_clearmemory);
-    ATTR_SET ("debugnan", int, m_debugnan);
+    ATTR_SET ("debug_nan", int, m_debugnan);
+    ATTR_SET ("debugnan", int, m_debugnan);  // back-compatible alias
+    ATTR_SET ("debug_uninit", int, m_debug_uninit);
     ATTR_SET ("lockgeom", int, m_lockgeom_default);
     ATTR_SET ("optimize", int, m_optimize);
     ATTR_SET ("opt_simplify_param", int, m_opt_simplify_param);
@@ -713,7 +715,9 @@ ShadingSystemImpl::getattribute (const std::string &name, TypeDesc type,
     ATTR_DECODE ("lazylayers", int, m_lazylayers);
     ATTR_DECODE ("lazyglobals", int, m_lazyglobals);
     ATTR_DECODE ("clearmemory", int, m_clearmemory);
-    ATTR_DECODE ("debugnan", int, m_debugnan);
+    ATTR_DECODE ("debug_nan", int, m_debugnan);
+    ATTR_DECODE ("debugnan", int, m_debugnan);  // back-compatible alias
+    ATTR_DECODE ("debug_uninit", int, m_debug_uninit);
     ATTR_DECODE ("lockgeom", int, m_lockgeom_default);
     ATTR_DECODE ("optimize", int, m_optimize);
     ATTR_DECODE ("opt_simplify_param", int, m_opt_simplify_param);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -60,6 +60,7 @@ static bool stats = false;
 static bool O0 = false, O1 = false, O2 = false;
 static bool pixelcenters = false;
 static bool debugnan = false;
+static bool debug_uninit = false;
 static int xres = 1, yres = 1;
 static std::string layername;
 static std::vector<std::string> connections;
@@ -122,7 +123,8 @@ add_shader (int argc, const char *argv[])
     else if (O0 || O1 || O2)
         shadingsys->attribute ("optimize", O2 ? 2 : (O1 ? 1 : 0));
     shadingsys->attribute ("lockgeom", 1);
-    shadingsys->attribute ("debugnan", debugnan);
+    shadingsys->attribute ("debug_nan", debugnan);
+    shadingsys->attribute ("debug_uninit", debug_uninit);
 
     for (int i = 0;  i < argc;  i++) {
         inject_params ();
@@ -181,7 +183,8 @@ getargs (int argc, const char *argv[])
                 "-O1", &O1, "Do a little runtime shader optimization",
                 "-O2", &O2, "Do lots of runtime shader optimization",
                 "--center", &pixelcenters, "Shade at output pixel 'centers' rather than corners",
-                "--debugnan", &debugnan, "Turn on 'debugnan' mode",
+                "--debugnan", &debugnan, "Turn on 'debug_nan' mode",
+                "--debuguninit", &debug_uninit, "Turn on 'debug_uninit' mode",
                 "--options %s", &extraoptions, "Set extra OSL options",
 //                "-v", &verbose, "Verbose output",
                 NULL);

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,0 +1,7 @@
+Compiled test.osl -> test.oso
+ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10
+
+Output Cout to Cout.tif
+ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10
+ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11
+[RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/debug-uninit/run.py
+++ b/testsuite/debug-uninit/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python 
+
+command = testshade("--debuguninit -o Cout Cout.tif test")

--- a/testsuite/debug-uninit/test.osl
+++ b/testsuite/debug-uninit/test.osl
@@ -1,0 +1,12 @@
+shader
+test (output color Cout = 0)
+{
+    int i_init = 0;
+    int i_uninit;
+    float f_init = 0.5;
+    float f_uninit;
+    string s_init = "";
+    string s_uninit;
+    Cout = color (f_uninit, (float)i_uninit, 0);
+    Cout *= texture (s_uninit, u, v);
+}


### PR DESCRIPTION
New ShadingSystem attribute "debug_uninit" tries to detect use of uninitialized values at runtime, somewhat similar to "debug_nan" operation.  The basic idea is that all temps and locals are pre-initialized to special values (NaN for floats, -INT_MAX for ints, "!!!uninitialized!!!" for strings).  Before every op, it checks all variables that are about to be read for these values.  It's not perfect -- you will get "false positive" results if you purposely assign those special values in your shader.  But I'm willing to bet that's a rare and unadvised case.

This is very expensive and so is off by default.  But it's a very handy way to zero in on exactly where you are using an uninialized value!

For consistency, also renamed "debugnan" to "debug_nan" (but retained the old name as a synonym for back compatibility).

Produces output like this:

```
ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10
ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10
ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11
```
