### PR TITLE
Improvement to oslc function type checking

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -826,9 +826,11 @@ private:
     /// re-jigger m_sym to point to the specific polymorphic match.
     /// Allow arguments to be coerced (e.g., substituting a vector where
     /// a point was expected, or a float where a color was expected) only
-    /// if coerce is true; allow return value to be coerced only if
-    /// expected is TypeSpec() (i.e., unknown).
-    TypeSpec typecheck_all_poly (TypeSpec expected, bool coerce);
+    /// if coerceargs is true.  For return values, allow spatial triples to
+    /// mutually match if 'equivreturn' is true, and allow any coercive
+    /// return type if 'expected' is TypeSpec() (i.e., unknown).
+    TypeSpec typecheck_all_poly (TypeSpec expected, bool coerceargs,
+                                 bool equivreturn);
 
     /// Handle all the special cases for built-ins.  This includes
     /// irregular patterns of which args are read vs written, special 


### PR DESCRIPTION
Improvement to oslc function type checking -- allow more nuanced matching
of return types.  First we check for identical return types, then we test
allowing non-identical spatial triples to match, then finally we allow
any return type to match.
