### PR TITLE
Fix missing compile error when using a function as a variable

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -396,6 +396,10 @@ ASTvariable_ref::ASTvariable_ref (OSLCompilerImpl *comp, ustring name)
         // find the things that almost matched and offer suggestions.
         return;
     }
+    if (m_sym->symtype() == SymTypeFunction) {
+        error ("function '%s' can't be used as a variable", name.c_str());
+        return;
+    }
     m_typespec = m_sym->typespec();
 }
 


### PR DESCRIPTION
oslc compiles this without error:

```
float some_function(float f)
{
    return f;
}

shader test()
{
    float f = some_function;
}
```

but when run with testshade it would give this:

```
ERROR: Parsing shader test: unknown arg some_function
src/liboslexec/loadshader.cpp:389: Failed assertion 'm_nargs == i'
```
