### PR TITLE
Fix missing output of shader parameters when returning from a block

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -942,6 +942,11 @@ RuntimeOptimizer::build_llvm_instance (bool groupentry)
 
     build_llvm_code (inst()->maincodebegin(), inst()->maincodeend());
 
+    if (llvm_has_exit_instance_block()) {
+        builder().CreateBr (m_exit_instance_block);
+        builder().SetInsertPoint (m_exit_instance_block);
+    }
+
     // Transfer all of this layer's outputs into the downstream shader's
     // inputs.
     for (int layer = m_layer+1;  layer < group().nlayers();  ++layer) {
@@ -962,11 +967,6 @@ RuntimeOptimizer::build_llvm_instance (bool groupentry)
         }
     }
     // llvm_gen_debug_printf ("done copying connections");
-
-    if (llvm_has_exit_instance_block()) {
-        builder().CreateBr (m_exit_instance_block);
-        builder().SetInsertPoint (m_exit_instance_block);
-    }
 
     // All done
     // llvm_gen_debug_printf (std::string("exit layer ")+inst()->shadername());


### PR DESCRIPTION
If you have these two shaders:

```
shader test_a(output float f = 0.0)
{
    if(P[0] >= 0.0) {
        f = 1.0;
        return;
    }
}
```

```
shader test_b(float f = 2.0)
{
    printf("%f\n", f);
}
```

and connect them like this:

```
./testshade --layer layer_a test_a --layer layer_b test_b --connect layer_a f layer_b f
```

Then it will output `0.0`. When removing the `return;` statement from the first shader, which you would expect to have no influence, the output will be `1.0`.

The `return;` statement would skip transferring the layer outputs into downstream shader's inputs, so I moved that code into the `exit_instance_block`. The tests pass with this fix, though I feel like I'm missing something obvious as I would expect someone to have encountered this bug already.
