### PR TITLE
Small optimization to SimplePool.alloc

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1063,10 +1063,12 @@ public:
     }
 
     char * alloc(size_t size, size_t alignment=1) {
+        // Alignment must be power of two
+        DASSERT ((alignment & (alignment - 1)) == 0);
         // Fail if beyond allocation limits or senseless alignment
-        if (size > BlockSize || (size % alignment) != 0)
+        if (size > BlockSize || (size & (alignment - 1)) != 0)
             return NULL;
-        m_block_offset -= (m_block_offset % alignment); // Fix up alignment
+        m_block_offset -= (m_block_offset & (alignment - 1)); // Fix up alignment
         if (size <= m_block_offset) {
             // Enough space in current block
             m_block_offset -= size;


### PR DESCRIPTION
I found SimplePool.alloc taking up about 4% of render time in some of my simpler tests scenes. This changes speeds up those scenes consistently by about 3%.

It seems that all the places that call this already use powers of two, and similar system functions like posix_memalign also require the alignment parameter to be a power of two.
