### PR TITLE
Important bug fixes for the recent peephole optimizations:

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,7 +267,8 @@ endmacro ()
 # special installed tests.
 #TESTSUITE ( oslc-empty )
 TESTSUITE ( aastep arithmetic array array-derivs array-range
-            blackbody blendmath breakcont bug-locallifetime bug-outputinit
+            blackbody blendmath breakcont
+            bug-locallifetime bug-outputinit bug-peep
             cellnoise closure color comparison
             component-range const-array-params debugnan debug-uninit
             derivs derivs-muldiv-clobber error-dupes exit exponential

--- a/testsuite/bug-peep/ref/out.txt
+++ b/testsuite/bug-peep/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled test.osl -> test.oso
+S=0 T=0    outS=0 outT=0
+S=1 T=0    outS=0 outT=2
+S=0 T=1    outS=1 outT=0
+S=1 T=1    outS=1 outT=2
+

--- a/testsuite/bug-peep/run.py
+++ b/testsuite/bug-peep/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python 
+
+command = testshade("-g 2 2 test")

--- a/testsuite/bug-peep/test.osl
+++ b/testsuite/bug-peep/test.osl
@@ -1,0 +1,36 @@
+// Regression for a peephole optimization bug
+
+
+void transformST (
+    float S, float T, float Scale_S, float Scale_T,
+    float Offset_S, float Offset_T,
+    int Swap_ST_On,
+    output float outS, output float outT
+    )
+{
+    outS = S * Scale_S - Offset_S;
+    outT = T * Scale_T - Offset_T;
+    if (Swap_ST_On) {
+        float tmpF = outS;
+        outS = outT;
+        outT = tmpF;
+    }
+}
+
+
+shader test (
+    float S = u,
+    float T = v,
+    float Scale_S = 2, float Scale_T = 1.0,
+    float Offset_S = 0.0, float Offset_T = 0.0,
+    int Swap_ST_On = 1,
+    output float outS = 0.0,
+    output float outT = 0.0
+    )
+{
+    outS = S;
+    outT = T;
+    transformST (S, T, Scale_S, Scale_T, Offset_S, Offset_T, Swap_ST_On,
+                 outS, outT);
+    printf ("S=%g T=%g    outS=%g outT=%g\n", S, T, outS, outT);
+}


### PR DESCRIPTION
- If you change an instruction so that a symbol was written to in a spot
  where it wasn't before, you MUST call block_unalias() to make sure to
  end any notion of its being an alias for another symbol at that point
  or later in the code block.
- Two code transformations that were legal only if a particular symbol
  was not subsequently read neglected to consider that output parameters
  or globals may be "read" after the shader is done executing and so not
  having later read instructions within the shader is not a reliable
  indicator.
