### PR TITLE
filterwidth code gen bug when arg had no derivs -- wrong variable cleared

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1542,7 +1542,7 @@ LLVMGEN (llvm_gen_filterwidth)
         rop.llvm_zero_derivs (Result);
     } else {
         // No derivs to be had
-        rop.llvm_assign_zero (Src);
+        rop.llvm_assign_zero (Result);
     }
 
     return true;


### PR DESCRIPTION
oops.  Been there forever, but until I added aastep (implemented with filterwidth), apparently it was unusual to pass an arg to filterwidth that didn't have derivs (such as a constant), so never encountered the bug before.
