### PR TITLE
Constant fold Dx, Dy, Dz, area, filterwidth when passed a constant

### DIFF
--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2246,5 +2246,19 @@ DECLFOLDER(constfold_warning)
 
 
 
+DECLFOLDER(constfold_deriv)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
+    if (A.is_constant()) {
+        rop.turn_into_assign_zero (op, "const fold - deriv of constant");
+        return 1;
+    }
+    return 0;
+}
+
+
+
+
 }; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -385,7 +385,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (acos,        generic,             acos,          true);
     OP (add,         add,                 add,           true);
     OP (and,         andor,               and,           true);
-    OP (area,        area,                none,          true);
+    OP (area,        area,                deriv,         true);
     OP (aref,        aref,                aref,          true);
     OP (arraycopy,   arraycopy,           none,          false);
     OP (arraylength, arraylength,         arraylength,   true);
@@ -420,9 +420,9 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (distance,    generic,             none,          true);
     OP (div,         div,                 div,           true);
     OP (dot,         generic,             dot,           true);
-    OP (Dx,          DxDy,                none,          true);
-    OP (Dy,          DxDy,                none,          true);
-    OP (Dz,          Dz,                  none,          true);
+    OP (Dx,          DxDy,                deriv,         true);
+    OP (Dy,          DxDy,                deriv,         true);
+    OP (Dz,          Dz,                  deriv,         true);
     OP (dowhile,     loop_op,             none,          false);
     OP (end,         end,                 none,          false);
     OP (endswith,    generic,             endswith,      true);
@@ -436,7 +436,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (exp2,        generic,             exp2,          true);
     OP (expm1,       generic,             expm1,         true);
     OP (fabs,        generic,             abs,           true);
-    OP (filterwidth, filterwidth,         none,          true);
+    OP (filterwidth, filterwidth,         deriv,         true);
     OP (floor,       generic,             floor,         true);
     OP (fmod,        modulus,             none,          true);
     OP (for,         loop_op,             none,          false);


### PR DESCRIPTION
Fairly simple -- notice when these functions take a constant value (it can happen) and don't just generate "return 0" for the LLVM code, go even farther than know that it'll be zero while doing runtime optimization (which could cascade into other optimizations).

Unfortunately, the several scenes I tried did not experience any significant speedup. But others could benefit from this, and I don't see any possible harm.
