### PR TITLE
Big thread contention speedup -- testing the m_groups_to_compile_count

### DIFF
--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -71,14 +71,8 @@ ShadingContext::execute (ShaderUse use, ShadingAttribState &sas,
                          ShaderGlobals &ssg, bool run)
 {
     DASSERT (use == ShadUseSurface);  // FIXME
-
     m_curuse = use;
     m_attribs = &sas;
-
-    if (shadingsys().m_groups_to_compile_count) {
-        // If we are greedily JITing, optimize/JIT everything now
-        shadingsys().optimize_all_groups ();
-    }
 
     // Optimize if we haven't already
     ShaderGroup &sgroup (sas.shadergroup (use));
@@ -86,6 +80,10 @@ ShadingContext::execute (ShaderUse use, ShadingAttribState &sas,
         sgroup.start_running ();
         if (! sgroup.optimized()) {
             shadingsys().optimize_group (sas, sgroup);
+            if (shadingsys().m_greedyjit && shadingsys().m_groups_to_compile_count) {
+                // If we are greedily JITing, optimize/JIT everything now
+                shadingsys().optimize_all_groups ();
+            }
         }
         if (sgroup.does_nothing())
             return false;


### PR DESCRIPTION
Big thread contention speedup -- testing the m_groups_to_compile_count
atomic on every execution was hurting perf for simple shaders called
very frequently (as happens for volume shading). Moving it to happen
only when shaders are compiled, not every execution, and even then
guarding it with the m_greedyjit (which is usually off) improves perf
substantially for a certain kind of scene we're trying to speed up.
