### PR TITLE
Constant fold add and sub for the mixed float/triple cases

### DIFF
--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -153,6 +153,16 @@ DECLFOLDER(constfold_add)
             int cind = rop.add_constant (A.typespec(), &result);
             rop.turn_into_assign (op, cind, "const fold");
             return 1;
+        } else if (A.typespec().is_triple() && B.typespec().is_float()) {
+            Vec3 result = *(Vec3 *)A.data() + Vec3(*(float *)B.data());
+            int cind = rop.add_constant (A.typespec(), &result);
+            rop.turn_into_assign (op, cind, "const fold");
+            return 1;
+        } else if (A.typespec().is_float() && B.typespec().is_triple()) {
+            Vec3 result = Vec3(*(float *)A.data()) + *(Vec3 *)B.data();
+            int cind = rop.add_constant (A.typespec(), &result);
+            rop.turn_into_assign (op, cind, "const fold");
+            return 1;
         }
     }
     return 0;
@@ -187,6 +197,16 @@ DECLFOLDER(constfold_sub)
             return 1;
         } else if (A.typespec().is_triple() && B.typespec().is_triple()) {
             Vec3 result = *(Vec3 *)A.data() - *(Vec3 *)B.data();
+            int cind = rop.add_constant (A.typespec(), &result);
+            rop.turn_into_assign (op, cind, "const fold");
+            return 1;
+        } else if (A.typespec().is_triple() && B.typespec().is_float()) {
+            Vec3 result = *(Vec3 *)A.data() - Vec3(*(float *)B.data());
+            int cind = rop.add_constant (A.typespec(), &result);
+            rop.turn_into_assign (op, cind, "const fold");
+            return 1;
+        } else if (A.typespec().is_float() && B.typespec().is_triple()) {
+            Vec3 result = Vec3(*(float *)A.data()) - *(Vec3 *)B.data();
             int cind = rop.add_constant (A.typespec(), &result);
             rop.turn_into_assign (op, cind, "const fold");
             return 1;


### PR DESCRIPTION
For + and -, we folded float OP float and vec OP vec, this adds constant folding to the mixed float OP vec and vec OP float cases.

Very minor speedup, but every little bit helps.
