### PR TITLE
skip point-cloud lookups if the pointcloud has no points

### DIFF
--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -203,6 +203,10 @@ RendererServices::pointcloud_search (ShaderGlobals *sg,
         return 0;
     }
 
+    // Early exit if the pointcloud contains no particles.
+    if (cloud->numParticles() == 0)
+       return 0;
+
     // If we need derivs of the distances, we'll need access to the 
     // found point's positions.
     Partio::ParticleAttribute *pos_attr = NULL;


### PR DESCRIPTION
We're having a problem where we're seeing a crash in partio while trying to read from a pointcloud file with 0 particles in it.  This is an early exit if the pointcloud is "empty".
