### PR TITLE
Huge speedups for OSLQuery API

### DIFF
--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -147,6 +147,8 @@ symbols_opt
 codemarker
         : CODE IDENTIFIER ENDOFLINE
                 {
+                    if (! OSOReader::osoreader->parse_code_section())
+                        YYACCEPT;
                     OSOReader::osoreader->codemarker ($2);
                 }
         ;
@@ -181,6 +183,9 @@ symbols
 symbol
         : SYMTYPE typespec arraylen_opt IDENTIFIER 
                 {
+                    if ((SymType)$1 == SymTypeTemp &&
+                        OSOReader::osoreader->stop_parsing_at_temp_symbols())
+                        YYACCEPT;
                     TypeSpec typespec = current_typespec;
                     if ($3)
                         typespec.make_array ($3);

--- a/src/liboslexec/osoreader.h
+++ b/src/liboslexec/osoreader.h
@@ -89,9 +89,18 @@ public:
     ///
     virtual void symdefault (const char *def) { }
 
+    /// Return true for parsers whose only purpose is to read the header up
+    /// to params, to stop parsing as soon as we start encountering temps in
+    /// the symbol table.
+    virtual bool stop_parsing_at_temp_symbols () { return false; }
+
     /// Add a hint.
     ///
     virtual void hint (const char *hintstring) { }
+
+    /// Return true if this parser cares about the code, false if parsing
+    /// of oso may terminate once the symbol table has been parsed.
+    virtual bool parse_code_section () { return true; }
 
     /// New code section marker designating subsequent instructions.
     ///

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -116,6 +116,8 @@ public:
     virtual void symdefault (const char *def);
     virtual void hint (const char *hintstring);
     virtual void codemarker (const char *name);
+    virtual bool parse_code_section () { return false; }
+    virtual bool stop_parsing_at_temp_symbols () { return true; }
 
 private:
     OSLQuery &m_query;


### PR DESCRIPTION
Allow OSOReader subclasses to specify whether they should end parsing
upon hitting the code section and/or upon hitting the temps in the symbol
table, and have the OSO parser 'YYACCEPT' when those conditions are hit.
(N.B. Params and globals will always be first in the symbol table.)

The OSOReaderQuery subclass says, terminate parsing upon either of those
conditions.  This makes OSLQuery -- used by applications to catalog the
parameters of a compiled shader, but not caring about anything else --
able to parse just the very beginning of the file and then stop.

For our most absurdly large shaders, this speeds up OSLQuery times by
20x, from about 0.9s for our very biggest shaders to < 0.04s.
