### PR TITLE
Careful quoting of paths in cmake helps if filepaths have spaces.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ set (CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 message (STATUS "Project source dir = ${PROJECT_SOURCE_DIR}")
 message (STATUS "Project build dir = ${CMAKE_BINARY_DIR}")
 
-if (${PROJECT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message (FATAL_ERROR "Not allowed to run in-source build!")
 endif ()
 
@@ -179,9 +179,9 @@ include (oiio)
 include (externalpackages)
 include (flexbison)
 include_directories (
-      ${CMAKE_SOURCE_DIR}/include
-      ${CMAKE_BINARY_DIR}/include
-      ${OPENIMAGEIO_INCLUDES}
+      "${CMAKE_SOURCE_DIR}/include"
+      "${CMAKE_BINARY_DIR}/include"
+      "${OPENIMAGEIO_INCLUDES}"
   )
 
 
@@ -241,8 +241,8 @@ add_subdirectory (doc)
 
 # Make a copy of the testsuite into the build area
 if (DEFINED CMAKE_VERSION AND NOT CMAKE_VERSION VERSION_LESS 2.8)
-    file (COPY ${PROJECT_SOURCE_DIR}/../testsuite
-          DESTINATION ${CMAKE_BINARY_DIR})
+    file (COPY "${PROJECT_SOURCE_DIR}/../testsuite"
+          DESTINATION "${CMAKE_BINARY_DIR}")
 endif()
 
 macro ( TESTSUITE )
@@ -258,7 +258,7 @@ macro ( TESTSUITE )
         if (_ats_LABEL MATCHES "broken")
             set (_testname "${_testname}-broken")
         endif ()
-        set (_runtest python ${CMAKE_BINARY_DIR}/testsuite/runtest.py
+        set (_runtest python "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
                              ${_testdir} ${_extra_test_args})
         if (MSVC_IDE)
             set (_runtest ${_runtest} --devenv-config $<CONFIGURATION>
@@ -333,10 +333,11 @@ set (CPACK_PACKAGE_VENDOR "Sony Pictures Imageworks")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenShadingLanguage is...")
 set (CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/doc/Description.txt")
 set (CPACK_PACKAGE_FILE_NAME OSL-${OSL_LIBRARY_VERSION_MAJOR}.${OSL_LIBRARY_VERSION_MINOR}.${OSL_LIBRARY_VERSION_PATCH}-${platform})
-#set (CPACK_PACKAGE_INSTALL_DIRECTORY ${PROJECT_SOURCE_DIR}/..)
-exec_program ("cmake -E copy ${PROJECT_SOURCE_DIR}/../LICENSE ${CMAKE_BINARY_DIR}/License.txt")
+file (COPY "${PROJECT_SOURCE_DIR}/../LICENSE" DESTINATION "${CMAKE_BINARY_DIR}")
+file (RENAME "${CMAKE_BINARY_DIR}/LICENSE" "${CMAKE_BINARY_DIR}/License.txt")
 set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_BINARY_DIR}/License.txt")
-exec_program ("cmake -E copy ${PROJECT_SOURCE_DIR}/../README.md ${CMAKE_BINARY_DIR}/Readme.txt")
+file (COPY "${PROJECT_SOURCE_DIR}/../README.md" DESTINATION "${CMAKE_BINARY_DIR}")
+file (RENAME "${CMAKE_BINARY_DIR}/README.md" "${CMAKE_BINARY_DIR}/Readme.txt")
 set (CPACK_RESOURCE_FILE_README "${CMAKE_BINARY_DIR}/Readme.txt")
 set (CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/doc/Welcome.txt")
 #set (CPACK_PACKAGE_EXECUTABLES I'm not sure what this is for)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -2,14 +2,13 @@
 # Find libraries
 
 setup_path (THIRD_PARTY_TOOLS_HOME 
-#            "${PROJECT_SOURCE_DIR}/../../external/dist/${platform}"
             "unknown"
             "Location of third party libraries in the external project")
 
 # Add all third party tool directories to the include and library paths so
 # that they'll be correctly found by the various FIND_PACKAGE() invocations.
-if (THIRD_PARTY_TOOLS_HOME AND EXISTS ${THIRD_PARTY_TOOLS_HOME})
-    set (CMAKE_INCLUDE_PATH "${THIRD_PARTY_TOOLS_HOME}/include" ${CMAKE_INCLUDE_PATH})
+if (THIRD_PARTY_TOOLS_HOME AND EXISTS "${THIRD_PARTY_TOOLS_HOME}")
+    set (CMAKE_INCLUDE_PATH "${THIRD_PARTY_TOOLS_HOME}/include" "${CMAKE_INCLUDE_PATH}")
     # Detect third party tools which have been successfully built using the
     # lock files which are placed there by the external project Makefile.
     file (GLOB _external_dir_lockfiles "${THIRD_PARTY_TOOLS_HOME}/*.d")
@@ -100,10 +99,10 @@ find_package (ZLIB)
 if (USE_PARTIO)
     find_library (PARTIO_LIBRARIES
                   NAMES partio
-                  PATHS ${PARTIO_HOME}/lib)
+                  PATHS "${PARTIO_HOME}/lib")
     find_path (PARTIO_INCLUDE_DIR
                NAMES Partio.h
-               PATHS ${PARTIO_HOME}/include)
+               PATHS "${PARTIO_HOME}/include")
     if (PARTIO_INCLUDE_DIR AND PARTIO_LIBRARIES)
         set (PARTIO_FOUND TRUE)
         add_definitions ("-DUSE_PARTIO=1")
@@ -135,7 +134,7 @@ if (USE_EXTERNAL_PUGIXML)
     find_package (PugiXML REQUIRED)
     # insert include path to pugixml first, to ensure that the external
     # pugixml is found, and not the one in OIIO's include directory.
-    include_directories (BEFORE ${PUGIXML_INCLUDE_DIR})
+    include_directories (BEFORE "${PUGIXML_INCLUDE_DIR}")
 endif()
 # end Pugixml setup
 ###########################################################################
@@ -146,9 +145,9 @@ endif()
 
 # try to find llvm-config, with a specific version if specified
 if(LLVM_DIRECTORY)
-  FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION} HINTS ${LLVM_DIRECTORY}/bin NO_CMAKE_PATH)
+  FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION} HINTS "${LLVM_DIRECTORY}/bin" NO_CMAKE_PATH)
   if(NOT LLVM_CONFIG)
-    FIND_PROGRAM(LLVM_CONFIG llvm-config HINTS ${LLVM_DIRECTORY}/bin NO_CMAKE_PATH)
+    FIND_PROGRAM(LLVM_CONFIG llvm-config HINTS "${LLVM_DIRECTORY}/bin" NO_CMAKE_PATH)
   endif()
 else()
   FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION})

--- a/src/cmake/flexbison.cmake
+++ b/src/cmake/flexbison.cmake
@@ -72,12 +72,12 @@ IF ( FLEX_EXECUTABLE AND BISON_EXECUTABLE )
         INCLUDE_DIRECTORIES ( ${CMAKE_CURRENT_BINARY_DIR} )
         INCLUDE_DIRECTORIES ( ${CMAKE_CURRENT_SOURCE_DIR} )
         ADD_CUSTOM_COMMAND ( OUTPUT ${bisonoutputcxx} 
-          COMMAND ${BISON_EXECUTABLE} -dv -p ${prefix} -o ${bisonoutputcxx} ${CMAKE_CURRENT_SOURCE_DIR}/${bisonsrc}
+          COMMAND ${BISON_EXECUTABLE} -dv -p ${prefix} -o ${bisonoutputcxx} "${CMAKE_CURRENT_SOURCE_DIR}/${bisonsrc}"
           MAIN_DEPENDENCY ${bisonsrc}
           DEPENDS ${${compiler_headers}}
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
         ADD_CUSTOM_COMMAND ( OUTPUT ${flexoutputcxx} 
-          COMMAND ${FLEX_EXECUTABLE} -+ -o ${flexoutputcxx} ${CMAKE_CURRENT_SOURCE_DIR}/${flexsrc} 
+          COMMAND ${FLEX_EXECUTABLE} -+ -o ${flexoutputcxx} "${CMAKE_CURRENT_SOURCE_DIR}/${flexsrc}"
           MAIN_DEPENDENCY ${flexsrc}
           DEPENDS ${${compiler_headers}}
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )

--- a/src/cmake/oiio.cmake
+++ b/src/cmake/oiio.cmake
@@ -16,7 +16,7 @@ find_library ( OPENIMAGEIO_LIBRARY
                NAMES OpenImageIO
                HINTS ${OPENIMAGEIOHOME}
                PATH_SUFFIXES lib64 lib
-               PATHS ${OPENIMAGEIOHOME}/lib )
+               PATHS "${OPENIMAGEIOHOME}/lib" )
 find_path ( OPENIMAGEIO_INCLUDES
             NAMES OpenImageIO/imageio.h
             HINTS ${OPENIMAGEIOHOME}

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -3,9 +3,9 @@ set (public_docs osl-languagespec.pdf)
 
 install (FILES ${public_docs} DESTINATION doc COMPONENT documentation)
 
-install ( FILES ${PROJECT_SOURCE_DIR}/../LICENSE
-                ${PROJECT_SOURCE_DIR}/../INSTALL
-                ${PROJECT_SOURCE_DIR}/../CHANGES
-                ${PROJECT_SOURCE_DIR}/../README.md
+install ( FILES "${PROJECT_SOURCE_DIR}/../LICENSE"
+                "${PROJECT_SOURCE_DIR}/../INSTALL"
+                "${PROJECT_SOURCE_DIR}/../CHANGES"
+                "${PROJECT_SOURCE_DIR}/../README.md"
           DESTINATION . )
 

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -2,7 +2,7 @@ set (public_headers accum.h dual.h dual_vec.h
                     export.h genclosure.h Imathx.h matrix22.h optautomata.h oslclosure.h
                     oslcomp.h oslconfig.h oslexec.h oslquery.h )
 message (STATUS "Create oslversion.h from oslversion.h.in")
-configure_file (oslversion.h.in ${CMAKE_BINARY_DIR}/include/oslversion.h @ONLY)
-list (APPEND public_headers ${CMAKE_BINARY_DIR}/include/oslversion.h)
+configure_file (oslversion.h.in "${CMAKE_BINARY_DIR}/include/oslversion.h" @ONLY)
+list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/oslversion.h")
 
 INSTALL ( FILES ${public_headers} DESTINATION include/OSL )

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -32,7 +32,7 @@ if (NOT BUILDSTATIC)
         )
 endif ()
 
-include_directories ( ${CMAKE_SOURCE_DIR}/liboslcomp )
+include_directories ( "${CMAKE_SOURCE_DIR}/liboslcomp" )
 
 FILE ( GLOB exec_headers "*.h" )
 
@@ -52,7 +52,7 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
         MESSAGE (STATUS "LLVM_COMPILE cpp=${llvm_bc_cpp}")
     endif ()
     SET ( ${srclist} ${${srclist}} ${llvm_bc_cpp} )
-    EXEC_PROGRAM ( ${LLVM_DIRECTORY}/bin/llvm-config ARGS --cxxflags OUTPUT_VARIABLE LLVM_COMPILE_FLAGS )
+    EXEC_PROGRAM ( "${LLVM_DIRECTORY}/bin/llvm-config" ARGS --cxxflags OUTPUT_VARIABLE LLVM_COMPILE_FLAGS )
     set (LLVM_COMPILE_FLAGS "${LLVM_COMPILE_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -O3 --combine")
     if (OSL_NAMESPACE)
         LIST (APPEND LLVM_COMPILE_FLAGS "-DOSL_NAMESPACE=${OSL_NAMESPACE}")
@@ -69,7 +69,7 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
     endforeach()
 
     # First try looking in their build (clang++ first, then llvm-g++)
-    FIND_PROGRAM(LLVM_BC_GENERATOR NAMES "clang++" "llvm-g++" PATHS ${LLVM_DIRECTORY}/bin NO_DEFAULT_PATH NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH)
+    FIND_PROGRAM(LLVM_BC_GENERATOR NAMES "clang++" "llvm-g++" PATHS "${LLVM_DIRECTORY}/bin" NO_DEFAULT_PATH NO_CMAKE_SYSTEM_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH)
 
     if(NOT LLVM_BC_GENERATOR)
       # Wasn't in their build, look anywhere
@@ -88,20 +88,20 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
     # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
     ADD_CUSTOM_COMMAND ( OUTPUT ${llvm_bc_cpp}
       COMMAND ${LLVM_BC_GENERATOR}
-      -I${CMAKE_CURRENT_SOURCE_DIR}
-      -I${CMAKE_SOURCE_DIR}/include
-      -I${CMAKE_BINARY_DIR}/include
-      -I${OPENIMAGEIO_INCLUDES}
-      -I${ILMBASE_INCLUDE_DIR}
-      -I${Boost_INCLUDE_DIRS}
+      "-I${CMAKE_CURRENT_SOURCE_DIR}"
+      "-I${CMAKE_SOURCE_DIR}/include"
+      "-I${CMAKE_BINARY_DIR}/include"
+      "-I${OPENIMAGEIO_INCLUDES}"
+      "-I${ILMBASE_INCLUDE_DIR}"
+      "-I${Boost_INCLUDE_DIRS}"
       ${LLVM_COMPILE_FLAGS}
       -O3 -S -emit-llvm -o ${llvm_asm} ${llvm_src}
 
-      COMMAND ${LLVM_DIRECTORY}/bin/llvm-as -f -o ${llvm_bc} ${llvm_asm}
-      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash ${llvm_bc} ${llvm_bc_cpp}
+      COMMAND "${LLVM_DIRECTORY}/bin/llvm-as" -f -o ${llvm_bc} ${llvm_asm}
+      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash" ${llvm_bc} ${llvm_bc_cpp}
       MAIN_DEPENDENCY ${llvm_src}
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 ENDMACRO ( )
 
 if (USE_LLVM_BITCODE)
@@ -126,7 +126,7 @@ TARGET_LINK_LIBRARIES ( oslexec
                         ${PARTIO_LIBRARIES} ${ZLIB_LIBRARIES}
                         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
                         ${LLVM_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES})
-ADD_DEPENDENCIES (oslexec ${CMAKE_CURRENT_SOURCE_DIR}/liboslcexec.map)
+ADD_DEPENDENCIES (oslexec "${CMAKE_CURRENT_SOURCE_DIR}/liboslcexec.map")
 LINK_ILMBASE ( oslexec )
 
 if (BUILDSTATIC)
@@ -142,5 +142,5 @@ target_link_libraries ( closure_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_
 target_link_libraries ( accum_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES} )
 link_ilmbase (closure_test)
 link_ilmbase (accum_test)
-add_test (unit_closure ${CMAKE_BINARY_DIR}/liboslexec/closure_test)
-add_test (unit_accum ${CMAKE_BINARY_DIR}/liboslexec/accum_test)
+add_test (unit_closure "${CMAKE_BINARY_DIR}/liboslexec/closure_test")
+add_test (unit_accum "${CMAKE_BINARY_DIR}/liboslexec/accum_test")

--- a/src/shaders/CMakeLists.txt
+++ b/src/shaders/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/stdosl.h
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/stdosl.h ${CMAKE_CURRENT_BINARY_DIR}
-    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/stdosl.h
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_custom_command (OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/stdosl.h"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/stdosl.h" "${CMAKE_CURRENT_BINARY_DIR}"
+    MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/stdosl.h"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
 macro (osl_compile oslsrc objlist headers)
     # message (STATUS "OSL_COMPILE src=${oslsrc}")
@@ -20,9 +20,9 @@ macro (osl_compile oslsrc objlist headers)
         message (STATUS "cmd: ${CMAKE_CURRENT_BINARY_DIR}/../oslc/oslc ${oslsrc}")
     endif ()
     add_custom_command (OUTPUT ${osofile}
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../oslc/oslc ${oslsrc}
+        COMMAND "${CMAKE_CURRENT_BINARY_DIR}/../oslc/oslc" ${oslsrc}
         MAIN_DEPENDENCY ${oslsrc}
-        DEPENDS ${${headers}} ${oslsrc} ${CMAKE_CURRENT_BINARY_DIR}/stdosl.h ${CMAKE_CURRENT_BINARY_DIR}/../oslc/oslc
+        DEPENDS ${${headers}} ${oslsrc} "${CMAKE_CURRENT_BINARY_DIR}/stdosl.h" "${CMAKE_CURRENT_BINARY_DIR}/../oslc/oslc"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endmacro ()
 


### PR DESCRIPTION
Sprinkle quotes around CMake files where we assemble paths, to protect against weird things when paths might contain spaces.

Related to the analogous OIIO change, https://github.com/OpenImageIO/oiio/pull/740
