### PR TITLE
Major refactor of runtime optimization and code generation in oslexec.

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -1,0 +1,611 @@
+/*
+Copyright (c) 2009-2013 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+#ifndef BACKENDLLVM_H
+#define BACKENDLLVM_H
+
+#include <vector>
+#include <map>
+
+#include "oslexec_pvt.h"
+using namespace OSL;
+using namespace OSL::pvt;
+
+#include "llvm_headers.h"
+#include "runtimeoptimize.h"
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {   // OSL::pvt
+
+
+/// OSOProcessor that generates LLVM IR and JITs it to give machine
+/// code to implement a shader group.
+class BackendLLVM : public OSOProcessorBase {
+public:
+    BackendLLVM (ShadingSystemImpl &shadingsys, ShaderGroup &group,
+                ShadingContext *context);
+
+    virtual ~BackendLLVM ();
+
+    /// Create an llvm function for the whole shader group, JIT it,
+    /// and store the llvm::Function* handle to it with the ShaderGroup.
+    virtual void run ();
+
+
+    /// What LLVM debug level are we at?
+    int llvm_debug() const;
+
+    /// Set up a bunch of static things we'll need for the whole group.
+    ///
+    void initialize_llvm_group ();
+
+    int layer_remap (int origlayer) const { return m_layer_remap[origlayer]; }
+
+    /// Create an llvm function for the current shader instance.
+    /// This will end up being the group entry if 'groupentry' is true.
+    llvm::Function* build_llvm_instance (bool groupentry);
+
+    /// Build up LLVM IR code for the given range [begin,end) or
+    /// opcodes, putting them (initially) into basic block bb (or the
+    /// current basic block if bb==NULL).
+    bool build_llvm_code (int beginop, int endop, llvm::BasicBlock *bb=NULL);
+
+    typedef std::map<std::string, llvm::AllocaInst*> AllocationMap;
+
+    void llvm_assign_initial_value (const Symbol& sym);
+    llvm::LLVMContext &llvm_context () const { return *m_llvm_context; }
+    llvm::Module *llvm_module () const { return m_llvm_module; }
+    AllocationMap &named_values () { return m_named_values; }
+    llvm::IRBuilder<> &builder () { return *m_builder; }
+
+    /// Return an llvm::Value* corresponding to the address of the given
+    /// symbol element, with derivative (0=value, 1=dx, 2=dy) and array
+    /// index (NULL if it's not an array).
+    llvm::Value *llvm_get_pointer (const Symbol& sym, int deriv=0,
+                                   llvm::Value *arrayindex=NULL);
+
+    /// Return the llvm::Value* corresponding to the given element
+    /// value, with derivative (0=value, 1=dx, 2=dy), array index (NULL
+    /// if it's not an array), and component (x=0 or scalar, y=1, z=2).
+    /// If deriv >0 and the symbol doesn't have derivatives, return 0
+    /// for the derivative.  If the component >0 and it's a scalar,
+    /// return the scalar -- this allows automatic casting to triples.
+    /// Finally, auto-cast int<->float if requested (no conversion is
+    /// performed if cast is the default of UNKNOWN).
+    llvm::Value *llvm_load_value (const Symbol& sym, int deriv,
+                                  llvm::Value *arrayindex, int component,
+                                  TypeDesc cast=TypeDesc::UNKNOWN);
+
+
+    /// Given an llvm::Value* of a pointer (and the type of the data
+    /// that it points to), Return the llvm::Value* corresponding to the
+    /// given element value, with derivative (0=value, 1=dx, 2=dy),
+    /// array index (NULL if it's not an array), and component (x=0 or
+    /// scalar, y=1, z=2).  If deriv >0 and the symbol doesn't have
+    /// derivatives, return 0 for the derivative.  If the component >0
+    /// and it's a scalar, return the scalar -- this allows automatic
+    /// casting to triples.  Finally, auto-cast int<->float if requested
+    /// (no conversion is performed if cast is the default of UNKNOWN).
+    llvm::Value *llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
+                              int deriv, llvm::Value *arrayindex,
+                              int component, TypeDesc cast=TypeDesc::UNKNOWN);
+
+    /// Just like llvm_load_value, but when both the symbol and the
+    /// array index are known to be constants.  This can even handle
+    /// pulling constant-indexed elements out of constant arrays.  Use
+    /// arrayindex==-1 to indicate that it's not an array dereference.
+    llvm::Value *llvm_load_constant_value (const Symbol& sym,
+                                           int arrayindex, int component,
+                                           TypeDesc cast=TypeDesc::UNKNOWN);
+
+    /// llvm_load_value with non-constant component designation.  Does
+    /// not work with arrays or do type casts!
+    llvm::Value *llvm_load_component_value (const Symbol& sym, int deriv,
+                                            llvm::Value *component);
+
+    /// Non-array version of llvm_load_value, with default deriv &
+    /// component.
+    llvm::Value *llvm_load_value (const Symbol& sym, int deriv = 0,
+                                  int component = 0,
+                                  TypeDesc cast=TypeDesc::UNKNOWN) {
+        return llvm_load_value (sym, deriv, NULL, component, cast);
+    }
+
+    /// Legacy version
+    ///
+    llvm::Value *loadLLVMValue (const Symbol& sym, int component=0,
+                                int deriv=0, TypeDesc cast=TypeDesc::UNKNOWN) {
+        return llvm_load_value (sym, deriv, NULL, component, cast);
+    }
+
+    /// Return an llvm::Value* that is either a scalar and derivs is
+    /// false, or a pointer to sym's values (if sym is an aggreate or
+    /// derivs == true).  Furthermore, if deriv == true and sym doesn't
+    /// have derivs, coerce it into a variable with zero derivs.
+    llvm::Value *llvm_load_arg (const Symbol& sym, bool derivs);
+
+    /// Just like llvm_load_arg(sym,deriv), except use use sym's derivs
+    /// as-is, no coercion.
+    llvm::Value *llvm_load_arg (const Symbol& sym) {
+        return llvm_load_arg (sym, sym.has_derivs());
+    }
+
+    /// Store new_val into the given symbol, given the derivative
+    /// (0=value, 1=dx, 2=dy), array index (NULL if it's not an array),
+    /// and component (x=0 or scalar, y=1, z=2).  If deriv>0 and the
+    /// symbol doesn't have a deriv, it's a nop.  If the component >0
+    /// and it's a scalar, set the scalar.  Returns true if ok, false
+    /// upon failure.
+    bool llvm_store_value (llvm::Value *new_val, const Symbol& sym, int deriv,
+                           llvm::Value *arrayindex, int component);
+
+    /// Store new_val into the memory pointed to by dst_ptr, given the
+    /// derivative (0=value, 1=dx, 2=dy), array index (NULL if it's not
+    /// an array), and component (x=0 or scalar, y=1, z=2).  If deriv>0
+    /// and the symbol doesn't have a deriv, it's a nop.  If the
+    /// component >0 and it's a scalar, set the scalar.  Returns true if
+    /// ok, false upon failure.
+    bool llvm_store_value (llvm::Value* new_val, llvm::Value* dst_ptr,
+                           const TypeSpec &type, int deriv,
+                           llvm::Value* arrayindex, int component);
+
+    /// Non-array version of llvm_store_value, with default deriv &
+    /// component.
+    bool llvm_store_value (llvm::Value *new_val, const Symbol& sym,
+                           int deriv=0, int component=0) {
+        return llvm_store_value (new_val, sym, deriv, NULL, component);
+    }
+
+    /// llvm_store_value with non-constant component designation.  Does
+    /// not work with arrays or do type casts!
+    bool llvm_store_component_value (llvm::Value *new_val, const Symbol& sym,
+                                     int deriv, llvm::Value *component);
+
+    /// Legacy version
+    ///
+    bool storeLLVMValue (llvm::Value* new_val, const Symbol& sym,
+                         int component=0, int deriv=0) {
+        return llvm_store_value (new_val, sym, deriv, component);
+    }
+
+    /// Generate an alloca instruction to allocate space for the given
+    /// type, with derivs if derivs==true, and return the AllocaInst of
+    /// its pointer.
+    llvm::AllocaInst *llvm_alloca (const TypeSpec &type, bool derivs,
+                                   const std::string &name="");
+
+    /// Given the OSL symbol, return the llvm::Value* corresponding to the
+    /// start of that symbol (first element, first component, and just the
+    /// plain value if it has derivatives).
+    llvm::Value *getOrAllocateLLVMSymbol (const Symbol& sym);
+
+    llvm::Value *getLLVMSymbolBase (const Symbol &sym);
+
+    /// Generate the LLVM IR code to convert fval from a float to
+    /// an integer and return the new value.
+    llvm::Value *llvm_float_to_int (llvm::Value *fval);
+
+    /// Generate the LLVM IR code to convert ival from an int to a float
+    /// and return the new value.
+    llvm::Value *llvm_int_to_float (llvm::Value *ival);
+
+    /// Generate IR code for simple a/b, but considering OSL's semantics
+    /// that x/0 = 0, not inf.
+    llvm::Value *llvm_make_safe_div (TypeDesc type,
+                                     llvm::Value *a, llvm::Value *b);
+
+    /// Generate IR code for simple a mod b, but considering OSL's
+    /// semantics that x mod 0 = 0, not inf.
+    llvm::Value *llvm_make_safe_mod (TypeDesc type,
+                                     llvm::Value *a, llvm::Value *b);
+
+    /// Test whether val is nonzero, return the llvm::Value* that's the
+    /// result of a CreateICmpNE or CreateFCmpUNE (depending on the
+    /// type).  If test_derivs is true, it it also tests whether the
+    /// derivs are zero.
+    llvm::Value *llvm_test_nonzero (Symbol &val, bool test_derivs = false);
+
+    /// Implementaiton of Simple assignment.  If arrayindex >= 0, in
+    /// designates a particular array index to assign.
+    bool llvm_assign_impl (Symbol &Result, Symbol &Src, int arrayindex = -1);
+
+
+    /// This will return a llvm::Type that is the same as a C union of
+    /// the given types[].
+    llvm::Type *llvm_type_union(const std::vector<llvm::Type *> &types);
+
+    /// This will return a llvm::Type that is the same as a C struct
+    /// comprised fields of the given types[], in order.
+    llvm::Type *llvm_type_struct(const std::vector<llvm::Type *> &types,
+                                 const std::string &name="");
+
+    /// Convert the name of a global (and its derivative index) into the
+    /// field number of the ShaderGlobals struct.
+    int ShaderGlobalNameToIndex (ustring name);
+
+    /// Return the LLVM type handle for the ShaderGlobals struct.
+    ///
+    llvm::Type *llvm_type_sg ();
+
+    /// Return the LLVM type handle for a pointer to a
+    /// ShaderGlobals struct.
+    llvm::Type *llvm_type_sg_ptr ();
+
+    /// Return the ShaderGlobals pointer.
+    ///
+    llvm::Value *sg_ptr () const { return m_llvm_shaderglobals_ptr; }
+
+    llvm::Type *llvm_type_closure_component ();
+    llvm::Type *llvm_type_closure_component_ptr ();
+    llvm::Type *llvm_type_closure_component_attr ();
+    llvm::Type *llvm_type_closure_component_attr_ptr ();
+
+    /// Return the ShaderGlobals pointer cast as a void*.
+    ///
+    llvm::Value *sg_void_ptr () {
+        return llvm_void_ptr (m_llvm_shaderglobals_ptr);
+    }
+
+    llvm::Value *llvm_ptr_cast (llvm::Value* val, llvm::Type *type) {
+        return builder().CreatePointerCast(val,type);
+    }
+
+    llvm::Value *llvm_ptr_cast (llvm::Value* val, const TypeSpec &type) {
+        return llvm_ptr_cast (val, llvm::PointerType::get (llvm_type(type), 0));
+    }
+
+    llvm::Value *llvm_void_ptr (llvm::Value* val) {
+        return builder().CreatePointerCast(val,llvm_type_void_ptr());
+    }
+
+    llvm::Value *llvm_void_ptr (const Symbol &sym, int deriv=0) {
+        return llvm_void_ptr (llvm_get_pointer(sym, deriv));
+    }
+
+    llvm::Value *llvm_void_ptr_null () {
+        return llvm::ConstantPointerNull::get (llvm_type_void_ptr());
+    }
+
+    /// Return the LLVM type handle for a structure of the common group
+    /// data that holds all the shader params.
+    llvm::Type *llvm_type_groupdata ();
+
+    /// Return the LLVM type handle for a pointer to the common group
+    /// data that holds all the shader params.
+    llvm::Type *llvm_type_groupdata_ptr ();
+
+    /// Return the ShaderGlobals pointer.
+    ///
+    llvm::Value *groupdata_ptr () const { return m_llvm_groupdata_ptr; }
+
+    /// Return the group data pointer cast as a void*.
+    ///
+    llvm::Value *groupdata_void_ptr () {
+        return llvm_void_ptr (m_llvm_groupdata_ptr);
+    }
+
+    /// Return a ref to where the "layer_run" flag is stored for the
+    /// named layer.
+    llvm::Value *layer_run_ptr (int layer);
+
+    /// Return an llvm::Value holding the given floating point constant.
+    ///
+    llvm::Value *llvm_constant (float f);
+
+    /// Return an llvm::Value holding the given integer constant.
+    ///
+    llvm::Value *llvm_constant (int i);
+
+    /// Return an llvm::Value holding the given size_t constant.
+    ///
+    llvm::Value *llvm_constant (size_t i);
+
+    /// Return an llvm::Value holding the given bool constant.
+    /// Change the name so it doesn't get mixed up with int.
+    llvm::Value *llvm_constant_bool (bool b);
+
+    /// Return a constant void pointer to the given address
+    ///
+    llvm::Value *llvm_constant_ptr (void *p, llvm::PointerType *type)
+    {
+        return builder().CreateIntToPtr (llvm_constant (size_t (p)), type, "const pointer");
+    }
+
+    /// Return an llvm::Value holding the given string constant.
+    ///
+    llvm::Value *llvm_constant (ustring s);
+    llvm::Value *llvm_constant (const char *s) {
+        return llvm_constant(ustring(s));
+    }
+    /// Return an llvm::Value holding the given pointer constant.
+    ///
+    llvm::Value *llvm_constant_ptr (void *p);
+
+    /// Return an llvm::Value for a long long that is a packed
+    /// representation of a TypeDesc.
+    llvm::Value *llvm_constant (const TypeDesc &type);
+
+    /// Generate LLVM code to zero out the variable (including derivs)
+    ///
+    void llvm_assign_zero (const Symbol &sym);
+
+    /// Generate LLVM code to zero out the derivatives of sym.
+    ///
+    void llvm_zero_derivs (const Symbol &sym);
+
+    /// Generate LLVM code to zero out the derivatives of an array
+    /// only for the first count elements of it.
+    ///
+    void llvm_zero_derivs (const Symbol &sym, llvm::Value *count);
+
+    /// Generate a pointer that is (ptrtype)((char *)ptr + offset).
+    /// If ptrtype is NULL, just return a void*.
+    llvm::Value *llvm_offset_ptr (llvm::Value *ptr, int offset,
+                                  llvm::Type *ptrtype=NULL);
+
+    /// Generate code for a call to the function pointer, with the given
+    /// arg list.  Return an llvm::Value* corresponding to the return
+    /// value of the function, if any.
+    llvm::Value *llvm_call_function (llvm::Value *func,
+                                     llvm::Value **args, int nargs);
+    /// Generate code for a call to the named function with the given arg
+    /// list.  Return an llvm::Value* corresponding to the return value of
+    /// the function, if any.
+    llvm::Value *llvm_call_function (const char *name,
+                                     llvm::Value **args, int nargs);
+
+    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0) {
+        return llvm_call_function (name, &arg0, 1);
+    }
+    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
+                                     llvm::Value *arg1) {
+        llvm::Value *args[2] = { arg0, arg1 };
+        return llvm_call_function (name, args, 2);
+    }
+    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
+                                     llvm::Value *arg1, llvm::Value *arg2) {
+        llvm::Value *args[3] = { arg0, arg1, arg2 };
+        return llvm_call_function (name, args, 3);
+    }
+    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
+                                     llvm::Value *arg1, llvm::Value *arg2,
+                                     llvm::Value *arg3) {
+        llvm::Value *args[4] = { arg0, arg1, arg2, arg3 };
+        return llvm_call_function (name, args, 4);
+    }
+
+    void llvm_gen_debug_printf (const std::string &message);
+
+    /// Generate code to call the given layer.  If 'unconditional' is
+    /// true, call it without even testing if the layer has already been
+    /// called.
+    void llvm_call_layer (int layer, bool unconditional = false);
+
+    /// Execute the upstream connection (if any, and if not yet run) that
+    /// establishes the value of symbol sym, which has index 'symindex'
+    /// within the current layer rop.inst().  If already_run is not NULL,
+    /// it points to a vector of layer indices that are known to have been 
+    /// run -- those can be skipped without dynamically checking their
+    /// execution status.
+    void llvm_run_connected_layers (Symbol &sym, int symindex, int opnum = -1,
+                                    std::set<int> *already_run = NULL);
+
+    /// Generate code for a call to the named function with the given
+    /// arg list as symbols -- float & ints will be passed by value,
+    /// triples and matrices will be passed by address.  If deriv_ptrs
+    /// is true, pass pointers even for floats if they have derivs.
+    /// Return an llvm::Value* corresponding to the return value of the
+    /// function, if any.
+    llvm::Value *llvm_call_function (const char *name,  const Symbol **args,
+                                     int nargs, bool deriv_ptrs=false);
+    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
+                                     bool deriv_ptrs=false);
+    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
+                                     const Symbol &B, bool deriv_ptrs=false);
+    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
+                                     const Symbol &B, const Symbol &C,
+                                     bool deriv_ptrs=false);
+
+    /// Generate code for a memset.
+    ///
+    void llvm_memset (llvm::Value *ptr, int val, int len, int align=1);
+
+    /// Generate code for variable size memset
+    ///
+    void llvm_memset (llvm::Value *ptr, int val, llvm::Value *len, int align=1);
+
+    /// Generate code for a memcpy.
+    ///
+    void llvm_memcpy (llvm::Value *dst, llvm::Value *src,
+                      int len, int align=1);
+
+    /// Generate the appropriate llvm type definition for an OSL TypeSpec
+    /// (this is the actual type, for example when we allocate it).
+    llvm::Type *llvm_type (const TypeSpec &typespec);
+
+    /// Generate the parameter-passing llvm type definition for an OSL
+    /// TypeSpec.
+    llvm::Type *llvm_pass_type (const TypeSpec &typespec);
+
+    llvm::Type *llvm_type_float() { return m_llvm_type_float; }
+    llvm::Type *llvm_type_triple() { return m_llvm_type_triple; }
+    llvm::Type *llvm_type_matrix() { return m_llvm_type_matrix; }
+    llvm::Type *llvm_type_int() { return m_llvm_type_int; }
+    llvm::Type *llvm_type_addrint() { return m_llvm_type_addrint; }
+    llvm::Type *llvm_type_bool() { return m_llvm_type_bool; }
+    llvm::Type *llvm_type_longlong() { return m_llvm_type_longlong; }
+    llvm::Type *llvm_type_void() { return m_llvm_type_void; }
+    llvm::Type *llvm_type_typedesc() { return llvm_type_longlong(); }
+    llvm::PointerType *llvm_type_prepare_closure_func() { return m_llvm_type_prepare_closure_func; }
+    llvm::PointerType *llvm_type_setup_closure_func() { return m_llvm_type_setup_closure_func; }
+    llvm::PointerType *llvm_type_int_ptr() { return m_llvm_type_int_ptr; }
+    llvm::PointerType *llvm_type_void_ptr() { return m_llvm_type_char_ptr; }
+    llvm::PointerType *llvm_type_string() { return m_llvm_type_char_ptr; }
+    llvm::PointerType *llvm_type_ustring_ptr() { return m_llvm_type_ustring_ptr; }
+    llvm::PointerType *llvm_type_float_ptr() { return m_llvm_type_float_ptr; }
+    llvm::PointerType *llvm_type_triple_ptr() { return m_llvm_type_triple_ptr; }
+    llvm::PointerType *llvm_type_matrix_ptr() { return m_llvm_type_matrix_ptr; }
+
+    /// Shorthand to create a new LLVM basic block and return its handle.
+    ///
+    llvm::BasicBlock *llvm_new_basic_block (const std::string &name) {
+        return llvm::BasicBlock::Create (llvm_context(), name, m_layer_func);
+    }
+
+    /// Save the basic block pointers when entering a loop.
+    ///
+    void llvm_push_loop (llvm::BasicBlock *step, llvm::BasicBlock *after) {
+        m_loop_step_block.push_back (step);
+        m_loop_after_block.push_back (after);
+    }
+
+    /// Pop basic block pointers when exiting a loop.
+    ///
+    void llvm_pop_loop () {
+        ASSERT (! m_loop_step_block.empty() && ! m_loop_after_block.empty());
+        m_loop_step_block.pop_back ();
+        m_loop_after_block.pop_back ();
+    }
+
+    /// Return the basic block of the current loop's 'step' instructions.
+    llvm::BasicBlock *llvm_loop_step_block () const {
+        ASSERT (! m_loop_step_block.empty());
+        return m_loop_step_block.back();
+    }
+
+    /// Return the basic block of the current loop's exit point.
+    llvm::BasicBlock *llvm_loop_after_block () const {
+        ASSERT (! m_loop_after_block.empty());
+        return m_loop_after_block.back();
+    }
+
+    /// Save the return block pointer when entering a function.
+    ///
+    void llvm_push_function (llvm::BasicBlock *after) {
+        m_return_block.push_back (after);
+    }
+
+    /// Pop basic return destination when exiting a function.
+    ///
+    void llvm_pop_function () {
+        ASSERT (! m_return_block.empty());
+        m_return_block.pop_back ();
+    }
+
+    /// Return the basic block of the current loop's 'step' instructions.
+    ///
+    llvm::BasicBlock *llvm_return_block () const {
+        ASSERT (! m_return_block.empty());
+        return m_return_block.back();
+    }
+
+    /// Return the basic block of the exit for the whole instance.
+    ///
+    bool llvm_has_exit_instance_block () const {
+        return m_exit_instance_block;
+    }
+
+    /// Return the basic block of the exit for the whole instance.
+    ///
+    llvm::BasicBlock *llvm_exit_instance_block () {
+        if (! m_exit_instance_block) {
+            std::string name = Strutil::format ("%s_%d_exit_", inst()->layername(), inst()->id());
+            m_exit_instance_block = llvm_new_basic_block (name);
+        }
+        return m_exit_instance_block;
+    }
+
+    /// Check for inf/nan in all written-to arguments of the op
+    void llvm_generate_debugnan (const Opcode &op);
+    /// Check for uninitialized values in all read-from arguments to the op
+    void llvm_generate_debug_uninit (const Opcode &op);
+
+    llvm::Function *layer_func () const { return m_layer_func; }
+
+    void llvm_setup_optimization_passes ();
+
+private:
+    PerThreadInfo *m_thread;
+    std::vector<int> m_layer_remap;     ///< Remapping of layer ordering
+    std::set<int> m_layers_already_run; ///< List of layers run
+    int m_num_used_layers;              ///< Number of layers actually used
+
+    double m_stat_total_llvm_time;        ///<   total time spent on LLVM
+    double m_stat_llvm_setup_time;        ///<     llvm setup time
+    double m_stat_llvm_irgen_time;        ///<     llvm IR generation time
+    double m_stat_llvm_opt_time;          ///<     llvm IR optimization time
+    double m_stat_llvm_jit_time;          ///<     llvm JIT time
+
+    // LLVM stuff
+    llvm::LLVMContext *m_llvm_context;
+    llvm::Module *m_llvm_module;
+    llvm::ExecutionEngine *m_llvm_exec;
+    AllocationMap m_named_values;
+    std::map<const Symbol*,int> m_param_order_map;
+    llvm::IRBuilder<> *m_builder;
+    llvm::Value *m_llvm_shaderglobals_ptr;
+    llvm::Value *m_llvm_groupdata_ptr;
+    llvm::Function *m_layer_func;     ///< Current layer func we're building
+    std::vector<llvm::BasicBlock *> m_loop_after_block; // stack for break
+    std::vector<llvm::BasicBlock *> m_loop_step_block;  // stack for continue
+    std::vector<llvm::BasicBlock *> m_return_block;     // stack for func call
+    llvm::BasicBlock * m_exit_instance_block;  // exit point for the instance
+    llvm::Type *m_llvm_type_float;
+    llvm::Type *m_llvm_type_int;
+    llvm::Type *m_llvm_type_addrint;
+    llvm::Type *m_llvm_type_bool;
+    llvm::Type *m_llvm_type_longlong;
+    llvm::Type *m_llvm_type_void;
+    llvm::Type *m_llvm_type_triple;
+    llvm::Type *m_llvm_type_matrix;
+    llvm::PointerType *m_llvm_type_ustring_ptr;
+    llvm::PointerType *m_llvm_type_char_ptr;
+    llvm::PointerType *m_llvm_type_int_ptr;
+    llvm::PointerType *m_llvm_type_float_ptr;
+    llvm::PointerType *m_llvm_type_triple_ptr;
+    llvm::PointerType *m_llvm_type_matrix_ptr;
+    llvm::Type *m_llvm_type_sg;  // LLVM type of ShaderGlobals struct
+    llvm::Type *m_llvm_type_groupdata;  // LLVM type of group data
+    llvm::Type *m_llvm_type_closure_component; // LLVM type for ClosureComponent
+    llvm::Type *m_llvm_type_closure_component_attr; // LLVM type for ClosureMeta::Attr
+    llvm::PointerType *m_llvm_type_prepare_closure_func;
+    llvm::PointerType *m_llvm_type_setup_closure_func;
+    llvm::PassManager *m_llvm_passes;
+    llvm::FunctionPassManager *m_llvm_func_passes;
+    int m_llvm_local_mem;             // Amount of memory we use for locals
+
+    friend class ShadingSystemImpl;
+};
+
+
+}; // namespace pvt
+OSL_NAMESPACE_EXIT
+
+#endif /* BACKENDLLVM_H */

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "oslexec_pvt.h"
 #include "genclosure.h"
-#include "runtimeoptimize.h"
+#include "backendllvm.h"
 
 using namespace OSL;
 using namespace OSL::pvt;
@@ -87,7 +87,7 @@ static ustring u_index ("index");
 
 /// Macro that defines the arguments to LLVM IR generating routines
 ///
-#define LLVMGEN_ARGS     RuntimeOptimizer &rop, int opnum
+#define LLVMGEN_ARGS     BackendLLVM &rop, int opnum
 
 /// Macro that defines the full declaration of an LLVM generator.
 /// 
@@ -99,7 +99,7 @@ LLVMGEN (llvm_gen_generic);
 
 
 void
-RuntimeOptimizer::llvm_gen_debug_printf (const std::string &message)
+BackendLLVM::llvm_gen_debug_printf (const std::string &message)
 {
     ustring s = ustring::format ("(%s %s) %s", inst()->shadername().c_str(),
                                  inst()->layername().c_str(), message.c_str());
@@ -112,7 +112,7 @@ RuntimeOptimizer::llvm_gen_debug_printf (const std::string &message)
 
 
 void
-RuntimeOptimizer::llvm_call_layer (int layer, bool unconditional)
+BackendLLVM::llvm_call_layer (int layer, bool unconditional)
 {
     // Make code that looks like:
     //     if (! groupdata->run[parentlayer]) {
@@ -157,7 +157,7 @@ RuntimeOptimizer::llvm_call_layer (int layer, bool unconditional)
 
 
 void
-RuntimeOptimizer::llvm_run_connected_layers (Symbol &sym, int symindex,
+BackendLLVM::llvm_run_connected_layers (Symbol &sym, int symindex,
                                              int opnum,
                                              std::set<int> *already_run)
 {
@@ -1928,7 +1928,7 @@ LLVMGEN (llvm_gen_loopmod_op)
 
 
 static llvm::Value *
-llvm_gen_texture_options (RuntimeOptimizer &rop, int opnum,
+llvm_gen_texture_options (BackendLLVM &rop, int opnum,
                           int first_optional_arg, bool tex3d, int nchans,
                           llvm::Value* &alpha, llvm::Value* &dalphadx,
                           llvm::Value* &dalphady)
@@ -2289,7 +2289,7 @@ LLVMGEN (llvm_gen_environment)
 
 
 static llvm::Value *
-llvm_gen_trace_options (RuntimeOptimizer &rop, int opnum,
+llvm_gen_trace_options (BackendLLVM &rop, int opnum,
                         int first_optional_arg)
 {
     // Reserve space for the TraceOpt, with alignment
@@ -2389,7 +2389,7 @@ arg_typecode (Symbol *sym, bool derivs)
 
 
 static llvm::Value *
-llvm_gen_noise_options (RuntimeOptimizer &rop, int opnum,
+llvm_gen_noise_options (BackendLLVM &rop, int opnum,
                         int first_optional_arg)
 {
     // Reserve space for the NoiseParams, with alignment
@@ -2917,7 +2917,7 @@ LLVMGEN (llvm_gen_spline)
 
 
 static void
-llvm_gen_keyword_fill(RuntimeOptimizer &rop, Opcode &op, const ClosureRegistry::ClosureEntry *clentry, ustring clname, llvm::Value *attr_p, int argsoffset)
+llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::ClosureEntry *clentry, ustring clname, llvm::Value *attr_p, int argsoffset)
 {
     DASSERT(((op.nargs() - argsoffset) % 2) == 0);
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "llvm_headers.h"
 
 #include "oslexec_pvt.h"
-#include "runtimeoptimize.h"
+#include "backendllvm.h"
 
 using namespace OSL;
 using namespace OSL::pvt;
@@ -40,7 +40,7 @@ namespace pvt {
 
 
 llvm::Type *
-RuntimeOptimizer::llvm_type_union(const std::vector<llvm::Type *> &types)
+BackendLLVM::llvm_type_union(const std::vector<llvm::Type *> &types)
 {
 #if OSL_LLVM_VERSION >= 32
     llvm::DataLayout target(llvm_module());
@@ -77,7 +77,7 @@ RuntimeOptimizer::llvm_type_union(const std::vector<llvm::Type *> &types)
 
 
 llvm::Type *
-RuntimeOptimizer::llvm_type_struct (const std::vector<llvm::Type *> &types,
+BackendLLVM::llvm_type_struct (const std::vector<llvm::Type *> &types,
                                     const std::string &name)
 {
     return llvm::StructType::create(llvm_context(), types, name);
@@ -86,7 +86,7 @@ RuntimeOptimizer::llvm_type_struct (const std::vector<llvm::Type *> &types,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant (float f)
+BackendLLVM::llvm_constant (float f)
 {
     return llvm::ConstantFP::get (llvm_context(), llvm::APFloat(f));
 }
@@ -94,7 +94,7 @@ RuntimeOptimizer::llvm_constant (float f)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant (int i)
+BackendLLVM::llvm_constant (int i)
 {
     return llvm::ConstantInt::get (llvm_context(), llvm::APInt(32,i));
 }
@@ -102,7 +102,7 @@ RuntimeOptimizer::llvm_constant (int i)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant (size_t i)
+BackendLLVM::llvm_constant (size_t i)
 {
     int bits = sizeof(size_t)*8;
     return llvm::ConstantInt::get (llvm_context(), llvm::APInt(bits,i));
@@ -111,7 +111,7 @@ RuntimeOptimizer::llvm_constant (size_t i)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant_bool (bool i)
+BackendLLVM::llvm_constant_bool (bool i)
 {
     return llvm::ConstantInt::get (llvm_context(), llvm::APInt(1,i));
 }
@@ -119,7 +119,7 @@ RuntimeOptimizer::llvm_constant_bool (bool i)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant (ustring s)
+BackendLLVM::llvm_constant (ustring s)
 {
     // Create a const size_t with the ustring contents
     size_t bits = sizeof(size_t)*8;
@@ -132,7 +132,7 @@ RuntimeOptimizer::llvm_constant (ustring s)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant_ptr (void *p)
+BackendLLVM::llvm_constant_ptr (void *p)
 {
     // Create a const size_t with the address
     size_t bits = sizeof(size_t)*8;
@@ -145,7 +145,7 @@ RuntimeOptimizer::llvm_constant_ptr (void *p)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_constant (const TypeDesc &type)
+BackendLLVM::llvm_constant (const TypeDesc &type)
 {
     long long *i = (long long *)&type;
     return llvm::ConstantInt::get (llvm_context(), llvm::APInt(64,*i));
@@ -154,7 +154,7 @@ RuntimeOptimizer::llvm_constant (const TypeDesc &type)
 
 
 llvm::Type *
-RuntimeOptimizer::llvm_type (const TypeSpec &typespec)
+BackendLLVM::llvm_type (const TypeSpec &typespec)
 {
     if (typespec.is_closure_based())
         return llvm_type_void_ptr();
@@ -186,7 +186,7 @@ RuntimeOptimizer::llvm_type (const TypeSpec &typespec)
 
 
 llvm::Type *
-RuntimeOptimizer::llvm_pass_type (const TypeSpec &typespec)
+BackendLLVM::llvm_pass_type (const TypeSpec &typespec)
 {
     if (typespec.is_closure_based())
         return llvm_type_void_ptr();
@@ -221,7 +221,7 @@ RuntimeOptimizer::llvm_pass_type (const TypeSpec &typespec)
 
 
 void
-RuntimeOptimizer::llvm_assign_zero (const Symbol &sym)
+BackendLLVM::llvm_assign_zero (const Symbol &sym)
 {
     // Just memset the whole thing to zero, let LLVM sort it out.
     // This even works for closures.
@@ -239,7 +239,7 @@ RuntimeOptimizer::llvm_assign_zero (const Symbol &sym)
 
 
 void
-RuntimeOptimizer::llvm_zero_derivs (const Symbol &sym)
+BackendLLVM::llvm_zero_derivs (const Symbol &sym)
 {
     if (sym.typespec().is_closure_based())
         return; // Closures don't have derivs
@@ -256,7 +256,7 @@ RuntimeOptimizer::llvm_zero_derivs (const Symbol &sym)
 
 
 void
-RuntimeOptimizer::llvm_zero_derivs (const Symbol &sym, llvm::Value *count)
+BackendLLVM::llvm_zero_derivs (const Symbol &sym, llvm::Value *count)
 {
     if (sym.typespec().is_closure_based())
         return; // Closures don't have derivs
@@ -274,7 +274,7 @@ RuntimeOptimizer::llvm_zero_derivs (const Symbol &sym, llvm::Value *count)
 
 
 int
-RuntimeOptimizer::ShaderGlobalNameToIndex (ustring name)
+BackendLLVM::ShaderGlobalNameToIndex (ustring name)
 {
     // N.B. The order of names in this table MUST exactly match the
     // ShaderGlobals struct in oslexec.h, as well as the llvm 'sg' type
@@ -300,7 +300,7 @@ RuntimeOptimizer::ShaderGlobalNameToIndex (ustring name)
 
 
 llvm::Value *
-RuntimeOptimizer::getLLVMSymbolBase (const Symbol &sym)
+BackendLLVM::getLLVMSymbolBase (const Symbol &sym)
 {
     Symbol* dealiased = sym.dealias();
 
@@ -337,7 +337,7 @@ RuntimeOptimizer::getLLVMSymbolBase (const Symbol &sym)
 
 
 llvm::AllocaInst *
-RuntimeOptimizer::llvm_alloca (const TypeSpec &type, bool derivs,
+BackendLLVM::llvm_alloca (const TypeSpec &type, bool derivs,
                                const std::string &name)
 {
     TypeSpec elemtype = type.elementtype();
@@ -353,7 +353,7 @@ RuntimeOptimizer::llvm_alloca (const TypeSpec &type, bool derivs,
 
 
 llvm::Value *
-RuntimeOptimizer::getOrAllocateLLVMSymbol (const Symbol& sym)
+BackendLLVM::getOrAllocateLLVMSymbol (const Symbol& sym)
 {
     DASSERT ((sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp ||
               sym.symtype() == SymTypeConst)
@@ -374,7 +374,7 @@ RuntimeOptimizer::getOrAllocateLLVMSymbol (const Symbol& sym)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_get_pointer (const Symbol& sym, int deriv,
+BackendLLVM::llvm_get_pointer (const Symbol& sym, int deriv,
                                     llvm::Value *arrayindex)
 {
     bool has_derivs = sym.has_derivs();
@@ -415,7 +415,7 @@ RuntimeOptimizer::llvm_get_pointer (const Symbol& sym, int deriv,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_load_value (const Symbol& sym, int deriv,
+BackendLLVM::llvm_load_value (const Symbol& sym, int deriv,
                                    llvm::Value *arrayindex, int component,
                                    TypeDesc cast)
 {
@@ -460,7 +460,7 @@ RuntimeOptimizer::llvm_load_value (const Symbol& sym, int deriv,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
+BackendLLVM::llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
                                    int deriv, llvm::Value *arrayindex,
                                    int component, TypeDesc cast)
 {
@@ -501,7 +501,7 @@ RuntimeOptimizer::llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_load_constant_value (const Symbol& sym, 
+BackendLLVM::llvm_load_constant_value (const Symbol& sym, 
                                             int arrayindex, int component,
                                             TypeDesc cast)
 {
@@ -545,7 +545,7 @@ RuntimeOptimizer::llvm_load_constant_value (const Symbol& sym,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_load_component_value (const Symbol& sym, int deriv,
+BackendLLVM::llvm_load_component_value (const Symbol& sym, int deriv,
                                              llvm::Value *component)
 {
     bool has_derivs = sym.has_derivs();
@@ -576,7 +576,7 @@ RuntimeOptimizer::llvm_load_component_value (const Symbol& sym, int deriv,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_load_arg (const Symbol& sym, bool derivs)
+BackendLLVM::llvm_load_arg (const Symbol& sym, bool derivs)
 {
     ASSERT (sym.typespec().is_floatbased());
     if (sym.typespec().is_int() ||
@@ -610,7 +610,7 @@ RuntimeOptimizer::llvm_load_arg (const Symbol& sym, bool derivs)
 
 
 bool
-RuntimeOptimizer::llvm_store_value (llvm::Value* new_val, const Symbol& sym,
+BackendLLVM::llvm_store_value (llvm::Value* new_val, const Symbol& sym,
                                     int deriv, llvm::Value* arrayindex,
                                     int component)
 {
@@ -627,7 +627,7 @@ RuntimeOptimizer::llvm_store_value (llvm::Value* new_val, const Symbol& sym,
 
 
 bool
-RuntimeOptimizer::llvm_store_value (llvm::Value* new_val, llvm::Value* dst_ptr,
+BackendLLVM::llvm_store_value (llvm::Value* new_val, llvm::Value* dst_ptr,
                                     const TypeSpec &type,
                                     int deriv, llvm::Value* arrayindex,
                                     int component)
@@ -659,7 +659,7 @@ RuntimeOptimizer::llvm_store_value (llvm::Value* new_val, llvm::Value* dst_ptr,
 
 
 bool
-RuntimeOptimizer::llvm_store_component_value (llvm::Value* new_val,
+BackendLLVM::llvm_store_component_value (llvm::Value* new_val,
                                               const Symbol& sym, int deriv,
                                               llvm::Value* component)
 {
@@ -689,7 +689,7 @@ RuntimeOptimizer::llvm_store_component_value (llvm::Value* new_val,
 
 
 llvm::Value *
-RuntimeOptimizer::layer_run_ptr (int layer)
+BackendLLVM::layer_run_ptr (int layer)
 {
     llvm::Value *layer_run = builder().CreateConstGEP2_32 (groupdata_ptr(), 0, 0);
     return builder().CreateConstGEP2_32 (layer_run, 0, layer);
@@ -698,7 +698,7 @@ RuntimeOptimizer::layer_run_ptr (int layer)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (llvm::Value *func,
+BackendLLVM::llvm_call_function (llvm::Value *func,
                                       llvm::Value **args, int nargs)
 {
     ASSERT (func);
@@ -717,7 +717,7 @@ RuntimeOptimizer::llvm_call_function (llvm::Value *func,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (const char *name,
+BackendLLVM::llvm_call_function (const char *name,
                                       llvm::Value **args, int nargs)
 {
     llvm::Function *func = llvm_module()->getFunction (name);
@@ -729,7 +729,7 @@ RuntimeOptimizer::llvm_call_function (const char *name,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (const char *name, 
+BackendLLVM::llvm_call_function (const char *name, 
                                       const Symbol **symargs, int nargs,
                                       bool deriv_ptrs)
 {
@@ -753,7 +753,7 @@ RuntimeOptimizer::llvm_call_function (const char *name,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
+BackendLLVM::llvm_call_function (const char *name, const Symbol &A,
                                       bool deriv_ptrs)
 {
     const Symbol *args[1];
@@ -764,7 +764,7 @@ RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
+BackendLLVM::llvm_call_function (const char *name, const Symbol &A,
                                       const Symbol &B, bool deriv_ptrs)
 {
     const Symbol *args[2];
@@ -776,7 +776,7 @@ RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
+BackendLLVM::llvm_call_function (const char *name, const Symbol &A,
                                       const Symbol &B, const Symbol &C,
                                       bool deriv_ptrs)
 {
@@ -790,7 +790,7 @@ RuntimeOptimizer::llvm_call_function (const char *name, const Symbol &A,
 
 
 void
-RuntimeOptimizer::llvm_memset (llvm::Value *ptr, int val,
+BackendLLVM::llvm_memset (llvm::Value *ptr, int val,
                                int len, int align)
 {
     llvm_memset(ptr, val, llvm_constant(len), align);
@@ -799,7 +799,7 @@ RuntimeOptimizer::llvm_memset (llvm::Value *ptr, int val,
 
 
 void
-RuntimeOptimizer::llvm_memset (llvm::Value *ptr, int val,
+BackendLLVM::llvm_memset (llvm::Value *ptr, int val,
                                llvm::Value *len, int align)
 {
     // memset with i32 len
@@ -828,7 +828,7 @@ RuntimeOptimizer::llvm_memset (llvm::Value *ptr, int val,
 
 
 void
-RuntimeOptimizer::llvm_memcpy (llvm::Value *dst, llvm::Value *src,
+BackendLLVM::llvm_memcpy (llvm::Value *dst, llvm::Value *src,
                                int len, int align)
 {
     // i32 len
@@ -854,7 +854,7 @@ RuntimeOptimizer::llvm_memcpy (llvm::Value *dst, llvm::Value *src,
 /// Convert a float llvm value to an integer.
 ///
 llvm::Value *
-RuntimeOptimizer::llvm_float_to_int (llvm::Value* fval)
+BackendLLVM::llvm_float_to_int (llvm::Value* fval)
 {
     return builder().CreateFPToSI(fval, llvm_type_int());
 }
@@ -864,7 +864,7 @@ RuntimeOptimizer::llvm_float_to_int (llvm::Value* fval)
 /// Convert an integer llvm value to a float.
 ///
 llvm::Value *
-RuntimeOptimizer::llvm_int_to_float (llvm::Value* ival)
+BackendLLVM::llvm_int_to_float (llvm::Value* ival)
 {
     return builder().CreateSIToFP(ival, llvm_type_float());
 }
@@ -872,7 +872,7 @@ RuntimeOptimizer::llvm_int_to_float (llvm::Value* ival)
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_make_safe_div (TypeDesc type,
+BackendLLVM::llvm_make_safe_div (TypeDesc type,
                                       llvm::Value *a, llvm::Value *b)
 {
     if (type.basetype == TypeDesc::FLOAT) {
@@ -891,7 +891,7 @@ RuntimeOptimizer::llvm_make_safe_div (TypeDesc type,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_make_safe_mod (TypeDesc type,
+BackendLLVM::llvm_make_safe_mod (TypeDesc type,
                                       llvm::Value *a, llvm::Value *b)
 {
     if (type.basetype == TypeDesc::FLOAT) {
@@ -910,7 +910,7 @@ RuntimeOptimizer::llvm_make_safe_mod (TypeDesc type,
 
 
 llvm::Value *
-RuntimeOptimizer::llvm_test_nonzero (Symbol &val, bool test_derivs)
+BackendLLVM::llvm_test_nonzero (Symbol &val, bool test_derivs)
 {
     const TypeSpec &ts (val.typespec());
     ASSERT (! ts.is_array() && ! ts.is_closure() && ! ts.is_string());
@@ -947,7 +947,7 @@ RuntimeOptimizer::llvm_test_nonzero (Symbol &val, bool test_derivs)
 
 
 bool
-RuntimeOptimizer::llvm_assign_impl (Symbol &Result, Symbol &Src,
+BackendLLVM::llvm_assign_impl (Symbol &Result, Symbol &Src,
                                     int arrayindex)
 {
     ASSERT (! Result.typespec().is_structure());

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -83,12 +83,28 @@ void erase_if (Container &c, const Predicate &p)
 
 
 
-RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
+OSOProcessorBase::OSOProcessorBase (ShadingSystemImpl &shadingsys,
                                     ShaderGroup &group, ShadingContext *ctx)
     : m_shadingsys(shadingsys),
-      m_thread(shadingsys.get_perthread_info()),
+      m_group(group),
       m_context(ctx),
       m_debug(shadingsys.debug()),
+      m_inst(NULL)
+{
+    set_debug ();
+}
+
+
+
+OSOProcessorBase::~OSOProcessorBase ()
+{
+}
+
+
+
+RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
+                                    ShaderGroup &group, ShadingContext *ctx)
+    : OSOProcessorBase(shadingsys, group, ctx),
       m_optimize(shadingsys.optimize()),
       m_opt_simplify_param(shadingsys.m_opt_simplify_param),
       m_opt_constant_fold(shadingsys.m_opt_constant_fold),
@@ -100,29 +116,29 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_opt_assign(shadingsys.m_opt_assign),
       m_opt_mix(shadingsys.m_opt_mix),
       m_opt_middleman(shadingsys.m_opt_middleman),
-      m_group(group),
-      m_inst(NULL), m_pass(0),
+      m_pass(0),
       m_next_newconst(0), m_next_newtemp(0),
-      m_stat_opt_locking_time(0), m_stat_specialization_time(0),
-      m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
-      m_stat_llvm_irgen_time(0), m_stat_llvm_opt_time(0),
-      m_stat_llvm_jit_time(0),
-      m_llvm_context(NULL), m_llvm_module(NULL),
-      m_llvm_exec(NULL), m_builder(NULL),
-      m_llvm_passes(NULL), m_llvm_func_passes(NULL)
+      m_stat_opt_locking_time(0), m_stat_specialization_time(0)
 {
-    set_debug ();
     memset (&m_shaderglobals, 0, sizeof(ShaderGlobals));
-    m_shaderglobals.context = m_context;
+    m_shaderglobals.context = shadingcontext();
 }
 
 
 
 RuntimeOptimizer::~RuntimeOptimizer ()
 {
-    delete m_builder;
-    delete m_llvm_passes;
-    delete m_llvm_func_passes;
+}
+
+
+
+void
+OSOProcessorBase::set_inst (int newlayer)
+{
+    m_layer = newlayer;
+    m_inst = group()[m_layer];
+    ASSERT (m_inst != NULL);
+    set_debug ();
 }
 
 
@@ -130,10 +146,7 @@ RuntimeOptimizer::~RuntimeOptimizer ()
 void
 RuntimeOptimizer::set_inst (int newlayer)
 {
-    m_layer = newlayer;
-    m_inst = m_group[m_layer];
-    ASSERT (m_inst != NULL);
-    set_debug ();
+    OSOProcessorBase::set_inst (newlayer);
     m_all_consts.clear ();
     m_symbol_aliases.clear ();
     m_block_aliases.clear ();
@@ -143,14 +156,36 @@ RuntimeOptimizer::set_inst (int newlayer)
 
 
 void
-RuntimeOptimizer::set_debug ()
+OSOProcessorBase::set_debug ()
 {
     // start with the shading system's idea of debugging level
     m_debug = shadingsys().debug();
 
-    if (shadingsys().m_debug_groupname &&
-        shadingsys().m_debug_groupname != m_group.name()) {
+    // Force debugging off if a specific group was selected for debug
+    // and we're not it.
+    if (shadingsys().debug_groupname() &&
+        shadingsys().debug_groupname() != group().name()) {
         m_debug = 0;
+    }
+    // Force debugging off if a specific instance was selected for debug
+    // and we're not currently examining it.
+    if (inst() && shadingsys().debug_layername() &&
+        shadingsys().debug_layername() != inst()->layername()) {
+        m_debug = 0;
+    }
+}
+
+
+
+void
+RuntimeOptimizer::set_debug ()
+{
+    OSOProcessorBase::set_debug ();
+
+    // If a specific group is isolated for debugging and  the
+    // 'optimize_dondebug' flag is on, fully optimize all other groups.
+    if (shadingsys().debug_groupname() &&
+        shadingsys().debug_groupname() != group().name()) {
         if (shadingsys().m_optimize_nondebug) {
             // Debugging trick: if user said to only debug one group, turn
             // on full optimization for all others!  This prevents
@@ -169,27 +204,6 @@ RuntimeOptimizer::set_debug ()
             m_opt_middleman = true;
         }
     }
-    // if user said to only debug one layer, turn off debug if not it
-    if (inst() && shadingsys().m_debug_layername &&
-        shadingsys().m_debug_layername != inst()->layername()) {
-        m_debug = 0;
-    }
-}
-
-
-
-int
-RuntimeOptimizer::llvm_debug() const
-{
-    if (shadingsys().m_llvm_debug == 0)
-        return 0;
-    if (shadingsys().m_debug_groupname &&
-        shadingsys().m_debug_groupname != m_group.name())
-        return 0;
-    if (inst() && shadingsys().m_debug_layername &&
-        shadingsys().m_debug_layername != inst()->layername())
-        return 0;
-    return shadingsys().m_llvm_debug;
 }
 
 
@@ -668,7 +682,7 @@ RuntimeOptimizer::add_useparam (SymbolPtrVec &allsyms)
 
 
 bool
-RuntimeOptimizer::is_zero (const Symbol &A)
+OSOProcessorBase::is_zero (const Symbol &A)
 {
     if (! A.is_constant())
         return false;
@@ -682,7 +696,7 @@ RuntimeOptimizer::is_zero (const Symbol &A)
 
 
 bool
-RuntimeOptimizer::is_one (const Symbol &A)
+OSOProcessorBase::is_one (const Symbol &A)
 {
     if (! A.is_constant())
         return false;
@@ -789,7 +803,7 @@ RuntimeOptimizer::simplify_params ()
                     // srcsym is the earlier group's output param, which
                     // is connected as the input to the param we're
                     // examining.
-                    ShaderInstance *uplayer = m_group[c.srclayer];
+                    ShaderInstance *uplayer = group()[c.srclayer];
                     Symbol *srcsym = uplayer->symbol(c.src.param);
                     if (!srcsym->lockgeom())
                         continue; // Not if it can be overridden by geometry
@@ -875,13 +889,8 @@ RuntimeOptimizer::find_params_holding_globals ()
 
 
 
-/// Set up m_in_conditional[] to be true for all ops that are inside of
-/// conditionals, false for all unconditionally-executed ops, m_in_loop[]
-/// to be true for all ops that are inside a loop, and m_first_return
-/// to be the op number of the first return/exit statement (or code.size()
-/// if there is no return/exit statement).
 void
-RuntimeOptimizer::find_conditionals ()
+OSOProcessorBase::find_conditionals ()
 {
     OpcodeVec &code (inst()->ops());
 
@@ -908,13 +917,8 @@ RuntimeOptimizer::find_conditionals ()
 
 
 
-/// Identify basic blocks by assigning a basic block ID for each
-/// instruction.  Within any basic bock, there are no jumps in or out.
-/// Also note which instructions are inside conditional states.
-/// If do_llvm is true, also construct the m_bb_map that maps opcodes
-/// beginning BB's to llvm::BasicBlock records.
 void
-RuntimeOptimizer::find_basic_blocks (bool do_llvm)
+OSOProcessorBase::find_basic_blocks ()
 {
     OpcodeVec &code (inst()->ops());
 
@@ -932,7 +936,7 @@ RuntimeOptimizer::find_basic_blocks (bool do_llvm)
     }
 
     // Main code starts a basic block
-    block_begin[inst()->m_maincodebegin] = true;
+    block_begin[inst()->maincodebegin()] = true;
 
     for (size_t opnum = 0;  opnum < code.size();  ++opnum) {
         Opcode &op (code[opnum]);
@@ -1051,7 +1055,7 @@ RuntimeOptimizer::is_simple_assign (Opcode &op)
     // Simple only if arg0 is the only write, and is write only.
     if (op.argwrite_bits() != 1 || op.argread(0))
         return false;
-    const OpDescriptor *opd = m_shadingsys.op_descriptor (op.opname());
+    const OpDescriptor *opd = shadingsys().op_descriptor (op.opname());
     if (!opd || !opd->simple_assign)
         return false;   // reject all other known non-simple assignments
     // Make sure the result isn't also read
@@ -1081,15 +1085,6 @@ RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
 
 
 bool
-RuntimeOptimizer::is_renderer_output (ustring name) const
-{
-    const std::vector<ustring> &aovs (shadingsys().m_renderer_outputs);
-    return std::find (aovs.begin(), aovs.end(), name) != aovs.end();
-}
-
-
-
-bool
 RuntimeOptimizer::unread_after (const Symbol *A, int opnum)
 {
     // Try to figure out if this symbol is completely unused after this
@@ -1106,7 +1101,7 @@ RuntimeOptimizer::unread_after (const Symbol *A, int opnum)
             return false;   // Asked not do do this optimization
         if (A->connected_down())
             return false;   // Connected to something downstream
-        if (is_renderer_output (A->name()))
+        if (shadingsys().is_renderer_output (A->name()))
             return false;   // This is a renderer output -- don't cull it
     }
 
@@ -1389,7 +1384,7 @@ public:
                 return false;   // Asked not to do this optimization
             if (sym.connected_down())
                 return false;   // Connected to something downstream
-            if (m_rop.is_renderer_output (sym.name()))
+            if (m_rop.shadingsys().is_renderer_output (sym.name()))
                 return false;   // This is a renderer output
             return (sym.lastuse() < sym.initend());
         }
@@ -1623,9 +1618,9 @@ RuntimeOptimizer::mark_outgoing_connections ()
     inst()->outgoing_connections (false);
     FOREACH_PARAM (Symbol &s, inst())
         s.connected_down (false);
-    for (int lay = m_layer+1;  lay < m_group.nlayers();  ++lay) {
-        BOOST_FOREACH (Connection &c, m_group[lay]->m_connections)
-            if (c.srclayer == m_layer) {
+    for (int lay = layer()+1;  lay < group().nlayers();  ++lay) {
+        BOOST_FOREACH (Connection &c, group()[lay]->m_connections)
+            if (c.srclayer == layer()) {
                 inst()->symbol(c.src.param)->connected_down (true);
                 inst()->outgoing_connections (true);
             }
@@ -1898,7 +1893,7 @@ RuntimeOptimizer::optimize_instance ()
             // For various ops that we know how to effectively
             // constant-fold, dispatch to the appropriate routine.
             if (optimize() >= 2 && m_opt_constant_fold) {
-                const OpDescriptor *opd = m_shadingsys.op_descriptor (op.opname());
+                const OpDescriptor *opd = shadingsys().op_descriptor (op.opname());
                 if (opd && opd->folder) {
                     size_t old_num_ops = inst()->ops().size();
                     changed += (*opd->folder) (*this, opnum);
@@ -2453,9 +2448,9 @@ RuntimeOptimizer::collapse_syms ()
     // that aren't needed downstream can be removed.
     FOREACH_PARAM (Symbol &s, inst())
         s.connected_down (false);
-    for (int lay = m_layer+1;  lay < m_group.nlayers();  ++lay) {
-        BOOST_FOREACH (Connection &c, m_group[lay]->m_connections)
-            if (c.srclayer == m_layer)
+    for (int lay = layer()+1;  lay < group().nlayers();  ++lay) {
+        BOOST_FOREACH (Connection &c, group()[lay]->m_connections)
+            if (c.srclayer == layer())
                 inst()->symbol(c.src.param)->connected_down (true);
     }
 
@@ -2487,9 +2482,9 @@ RuntimeOptimizer::collapse_syms ()
         c.dst.param = symbol_remap[c.dst.param];
 
     // Fix downstream connections that reference us
-    for (int lay = m_layer+1;  lay < m_group.nlayers();  ++lay) {
-        BOOST_FOREACH (Connection &c, m_group[lay]->m_connections)
-            if (c.srclayer == m_layer)
+    for (int lay = layer()+1;  lay < group().nlayers();  ++lay) {
+        BOOST_FOREACH (Connection &c, group()[lay]->m_connections)
+            if (c.srclayer == layer())
                 c.src.param = symbol_remap[c.src.param];
     }
 
@@ -2591,19 +2586,19 @@ RuntimeOptimizer::collapse_ops ()
 
 
 void
-RuntimeOptimizer::optimize_group ()
+RuntimeOptimizer::run ()
 {
     Timer rop_timer;
-    int nlayers = (int) m_group.nlayers ();
+    int nlayers = (int) group().nlayers ();
     if (debug())
-        m_shadingsys.info ("About to optimize shader group %s (%d layers):",
-                           m_group.name().c_str(), nlayers);
+        shadingsys().info ("About to optimize shader group %s (%d layers):",
+                           group().name().c_str(), nlayers);
 
     m_params_holding_globals.resize (nlayers);
 
     // If no closures were provided, register the builtin ones
-    if (m_shadingsys.m_closure_registry.empty())
-        m_shadingsys.register_builtin_closures();
+    if (shadingsys().m_closure_registry.empty())
+        shadingsys().register_builtin_closures();
 
     // Optimize each layer, from first to last
     size_t old_nsyms = 0, old_nops = 0;
@@ -2611,7 +2606,7 @@ RuntimeOptimizer::optimize_group ()
         set_inst (layer);
         if (inst()->unused())
             continue;
-        m_inst->copy_code_from_master ();
+        inst()->copy_code_from_master ();
         if (debug() && optimize() >= 1) {
             std::cout.flush ();
             std::cout << "Before optimizing layer " << layer << " " 
@@ -2654,7 +2649,7 @@ RuntimeOptimizer::optimize_group ()
         // upstream connections as also needing derivatives.
         BOOST_FOREACH (Connection &c, inst()->m_connections) {
             if (inst()->symbol(c.dst.param)->has_derivs()) {
-                Symbol *source = m_group[c.srclayer]->symbol(c.src.param);
+                Symbol *source = group()[c.srclayer]->symbol(c.src.param);
                 if (! source->typespec().is_closure_based() &&
                     source->typespec().elementtype().is_floatbased()) {
                     source->has_derivs (true);
@@ -2696,294 +2691,24 @@ RuntimeOptimizer::optimize_group ()
     }
 
     m_stat_specialization_time = rop_timer();
-
-    Timer timer;
-    build_llvm_group ();
-    m_stat_total_llvm_time = timer();
-
-    // Once we're generated the IR, we really don't need the ops and args,
-    // and we only need the syms that include the params.
-    off_t symmem = 0;
-    size_t connectionmem = 0;
-    for (int layer = 0;  layer < nlayers;  ++layer) {
-        set_inst (layer);
-        // We no longer needs ops and args -- create empty vectors and
-        // swap with the ones in the instance.
-        OpcodeVec noops;
-        std::swap (inst()->ops(), noops);
-        std::vector<int> noargs;
-        std::swap (inst()->args(), noargs);
-
-        if (inst()->unused()) {
-            // If we'll never use the layer, we don't need the syms at all
-            SymbolVec nosyms;
-            std::swap (inst()->symbols(), nosyms);
-            symmem += vectorbytes(nosyms);
-            // also don't need the connection info any more
-            connectionmem += (off_t) inst()->clear_connections ();
-        }
-    }
     {
         // adjust memory stats
         ShadingSystemImpl &ss (shadingsys());
         spin_lock lock (ss.m_stat_mutex);
-        ss.m_stat_mem_inst_syms -= symmem;
-        ss.m_stat_mem_inst_connections -= connectionmem;
-        ss.m_stat_mem_inst -= symmem + connectionmem;
-        ss.m_stat_memory -= symmem + connectionmem;
         ss.m_stat_preopt_syms += old_nsyms;
         ss.m_stat_preopt_ops += old_nops;
         ss.m_stat_postopt_syms += new_nsyms;
         ss.m_stat_postopt_ops += new_nops;
-        ss.m_stat_max_llvm_local_mem = std::max (ss.m_stat_max_llvm_local_mem,
-                                                  m_llvm_local_mem);
     }
-
-    if (m_shadingsys.m_compile_report) {
-        if (m_group.name()) {
-            m_shadingsys.info ("Optimized shader group %s:", m_group.name().c_str());
-            m_shadingsys.info ("    New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
-              new_nsyms, old_nsyms,
+    if (shadingsys().m_compile_report) {
+        shadingsys().info ("Optimized shader group %s:",
+                           group().name() ? group().name().c_str() : "");
+        shadingsys().info (" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+              m_stat_specialization_time, new_nsyms, old_nsyms,
               100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
               new_nops, old_nops,
               100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
-        } else {
-            m_shadingsys.info ("Optimized shader group: New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
-              new_nsyms, old_nsyms,
-              100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
-              new_nops, old_nops,
-              100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
-        }
-        m_shadingsys.info ("    (%1.2fs = %1.2f spc, %1.2f lllock, %1.2f llset, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
-                           m_stat_total_llvm_time+m_stat_specialization_time,
-                           m_stat_specialization_time, 
-                           m_stat_opt_locking_time, m_stat_llvm_setup_time,
-                           m_stat_llvm_irgen_time, m_stat_llvm_opt_time,
-                           m_stat_llvm_jit_time,
-                           m_llvm_local_mem/1024);
     }
-}
-
-
-
-void
-ShadingSystemImpl::optimize_group (ShadingAttribState &attribstate, 
-                                   ShaderGroup &group)
-{
-    Timer timer;
-    lock_guard lock (group.m_mutex);
-    if (group.optimized()) {
-        // The group was somehow optimized by another thread between the
-        // time we checked group.optimized() and now that we have the lock.
-        // Nothing to do but record how long we waited for the lock.
-        spin_lock stat_lock (m_stat_mutex);
-        double t = timer();
-        m_stat_optimization_time += t;
-        m_stat_opt_locking_time += t;
-        return;
-    }
-
-    if (m_only_groupname && m_only_groupname != group.name()) {
-        // For debugging purposes, we are requested to compile only one
-        // shader group, and this is not it.  Mark it as does_nothing,
-        // and also as optimized so nobody locks on it again, and record
-        // how long we waited for the lock.
-        group.does_nothing (true);
-        group.m_optimized = true;
-        spin_lock stat_lock (m_stat_mutex);
-        double t = timer();
-        m_stat_optimization_time += t;
-        m_stat_opt_locking_time += t;
-        return;
-    }
-
-    double locking_time = timer();
-
-    ShadingContext *ctx = get_context ();
-    RuntimeOptimizer rop (*this, group, ctx);
-    rop.optimize_group ();
-    release_context (ctx);
-
-    attribstate.changed_shaders ();
-    group.m_optimized = true;
-    spin_lock stat_lock (m_stat_mutex);
-    m_stat_optimization_time += timer();
-    m_stat_opt_locking_time += locking_time + rop.m_stat_opt_locking_time;
-    m_stat_specialization_time += rop.m_stat_specialization_time;
-    m_stat_total_llvm_time += rop.m_stat_total_llvm_time;
-    m_stat_llvm_setup_time += rop.m_stat_llvm_setup_time;
-    m_stat_llvm_irgen_time += rop.m_stat_llvm_irgen_time;
-    m_stat_llvm_opt_time += rop.m_stat_llvm_opt_time;
-    m_stat_llvm_jit_time += rop.m_stat_llvm_jit_time;
-    m_stat_groups_compiled += 1;
-    m_stat_instances_compiled += group.nlayers();
-}
-
-
-
-static void optimize_all_groups_wrapper (ShadingSystemImpl *ss)
-{
-    ss->optimize_all_groups (1);
-}
-
-
-
-void
-ShadingSystemImpl::optimize_all_groups (int nthreads)
-{
-    if (! m_greedyjit) {
-        // No greedy JIT, just free any groups we've recorded
-        spin_lock lock (m_groups_to_compile_mutex);
-        m_groups_to_compile.clear ();
-        m_groups_to_compile_count = 0;
-        return;
-    }
-
-    // Spawn a bunch of threads to do this in parallel -- just call this
-    // routine again (with threads=1) for each thread.
-    if (nthreads < 1)  // threads <= 0 means use all hardware available
-        nthreads = std::min ((int)boost::thread::hardware_concurrency(),
-                             (int)m_groups_to_compile_count);
-    if (nthreads > 1) {
-        if (m_threads_currently_compiling)
-            return;   // never mind, somebody else spawned the JIT threads
-        boost::thread_group threads;
-        m_threads_currently_compiling += nthreads;
-        for (int t = 0;  t < nthreads;  ++t)
-            threads.add_thread (new boost::thread (optimize_all_groups_wrapper, this));
-        threads.join_all ();
-        m_threads_currently_compiling -= nthreads;
-        return;
-    }
-
-    // And here's the single thread case
-    while (m_groups_to_compile_count) {
-        ShadingAttribStateRef sas;
-        {
-            spin_lock lock (m_groups_to_compile_mutex);
-            if (m_groups_to_compile.size() == 0)
-                return;  // Nothing left to compile
-            sas = m_groups_to_compile.back ();
-            m_groups_to_compile.pop_back ();
-        }
-        --m_groups_to_compile_count;
-        if (! sas.unique()) {   // don't compile if nobody recorded it but us
-            ShaderGroup &sgroup (sas->shadergroup (ShadUseSurface));
-                optimize_group (*sas, sgroup);
-        }
-    }
-}
-
-
-
-int
-ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
-{
-    // Look through the shader group for pairs of nodes/layers that
-    // actually do exactly the same thing, and eliminate one of the
-    // rundantant shaders, carefully rewiring all its outgoing
-    // connections to later layers to refer to the one we keep.
-    //
-    // It turns out that in practice, it's not uncommon to have
-    // duplicate nodes.  For example, some materials are "layered" --
-    // like a character skin shader that has separate sub-networks for
-    // skin, oil, wetness, and so on -- and those different sub-nets
-    // often reference the same texture maps or noise functions by
-    // repetition.  Yes, ideally, the redundancies would be eliminated
-    // before they were fed to the renderer, but in practice that's hard
-    // and for many scenes we get substantial savings of time (mostly
-    // because of reduced texture calls) and instance memory by finding
-    // these redundancies automatically.  The amount of savings is quite
-    // scene dependent, as well as probably very dependent on the
-    // general shading and lookdev approach of the studio.  But it was
-    // very helpful for us in many cases.
-    //
-    // The basic loop below looks very inefficient, O(n^2) in number of
-    // instances in the group. But it's really not -- a few seconds (sum
-    // of all threads) for even our very complex scenes. This is because
-    // most potential pairs have a very fast rejection case if they are
-    // not using the same master.  Since there's no appreciable cost to
-    // the brute force approach, it seems silly to have a complex scheme
-    // to try to reduce the number of pairings.
-
-    if (! m_opt_merge_instances)
-        return 0;
-
-    Timer timer;                // Time we spend looking for and doing merges
-    int merges = 0;             // number of merges we do
-    size_t connectionmem = 0;   // Connection memory we free
-    int nlayers = group.nlayers();
-
-    // Loop over all layers...
-    for (int a = 0;  a < nlayers;  ++a) {
-        if (group[a]->unused())    // Don't merge a layer that's not used
-            continue;
-        // Check all later layers...
-        for (int b = a+1;  b < nlayers;  ++b) {
-            if (group[b]->unused())    // Don't merge a layer that's not used
-                continue;
-
-            // Now we have two used layers, a and b, to examine.
-            // See if they are mergeable (identical).  All the heavy
-            // lifting is done by ShaderInstance::mergeable().
-            if (! group[a]->mergeable (*group[b], group))
-                continue;
-
-            // The two nodes a and b are mergeable, so merge them.
-            ShaderInstance *A = group[a];
-            ShaderInstance *B = group[b];
-            ++merges;
-
-            // We'll keep A, get rid of B.  For all layers later than B,
-            // check its incoming connections and replace all references
-            // to B with references to A.
-            for (int j = b+1;  j < nlayers;  ++j) {
-                ShaderInstance *inst = group[j];
-                if (inst->unused())  // don't bother if it's unused
-                    continue;
-                for (int c = 0, ce = inst->nconnections();  c < ce;  ++c) {
-                    Connection &con = inst->connection(c);
-                    if (con.srclayer == b) {
-                        con.srclayer = a;
-                        if (B->symbols().size()) {
-                            ASSERT (A->symbol(con.src.param)->name() ==
-                                    B->symbol(con.src.param)->name());
-                        }
-                    }
-                }
-            }
-
-            // Mark parameters of B as no longer connected
-            for (int p = B->firstparam();  p < B->lastparam();  ++p) {
-                if (B->symbols().size())
-                    B->symbol(p)->connected_down(false);
-                if (B->m_instoverrides.size())
-                    B->instoverride(p)->connected_down(false);
-            }
-            // B won't be used, so mark it as having no outgoing
-            // connections and clear its incoming connections (which are
-            // no longer used).
-            B->outgoing_connections (false);
-            B->run_lazily (true);
-            connectionmem += B->clear_connections ();
-            ASSERT (B->unused());
-        }
-    }
-
-    {
-        // Adjust stats
-        spin_lock lock (m_stat_mutex);
-        m_stat_mem_inst_connections -= connectionmem;
-        m_stat_mem_inst -= connectionmem;
-        m_stat_memory -= connectionmem;
-        if (post_opt)
-            m_stat_merged_inst_opt += merges;
-        else
-            m_stat_merged_inst += merges;
-        m_stat_inst_merge_time += timer();
-    }
-
-    return merges;
 }
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -26,14 +26,16 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#pragma once
+#ifndef RUNTIMEOPTIMIZE_H
+#define RUNTIMEOPTIMIZE_H
+
 #include <vector>
 #include <map>
 
 #include "oslexec_pvt.h"
 using namespace OSL;
 using namespace OSL::pvt;
-
-#include "llvm_headers.h"
 
 
 OSL_NAMESPACE_ENTER
@@ -42,15 +44,19 @@ namespace pvt {   // OSL::pvt
 
 
 
-/// Container for state that needs to be passed around
-class RuntimeOptimizer {
+/// OSOProcessor that does runtime optimization on shaders.
+class RuntimeOptimizer : public OSOProcessorBase {
 public:
     RuntimeOptimizer (ShadingSystemImpl &shadingsys, ShaderGroup &group,
                       ShadingContext *context);
 
-    ~RuntimeOptimizer ();
+    virtual ~RuntimeOptimizer ();
 
-    void optimize_group ();
+    virtual void run ();
+
+    virtual void set_inst (int layer);
+
+    virtual void set_debug ();
 
     /// Optimize one layer of a group, given what we know about its
     /// instance variables and connections.
@@ -59,49 +65,6 @@ public:
     /// Post-optimization cleanup of a layer: add 'useparam' instructions,
     /// track variable lifetimes, coalesce temporaries.
     void post_optimize_instance ();
-
-    /// Set which instance we are currently optimizing.
-    ///
-    void set_inst (int layer);
-
-    /// Re-check what debugging level we ought to be at.
-    void set_debug ();
-
-    /// Return the layer number of the currently-optimizing instance
-    /// within the group.
-    int layer () const { return m_layer; }
-
-    /// Return a pointer to the currently-optimizing instance within the
-    /// group.
-    ShaderInstance *inst () const { return m_inst; }
-
-    /// Return a reference to a particular indexed op in the current inst
-    Opcode &op (int opnum) { return inst()->ops()[opnum]; }
-
-    /// Return a pointer to a particular indexed symbol in the current inst
-    Symbol *symbol (int symnum) { return inst()->symbol(symnum); }
-
-    /// Return a reference to the shader group being optimized.
-    ///
-    ShaderGroup &group () const { return m_group; }
-
-    ShadingSystemImpl &shadingsys () const { return m_shadingsys; }
-
-    TextureSystem *texturesys () const { return shadingsys().texturesys(); }
-
-    RendererServices *renderer () const { return shadingsys().renderer(); }
-
-    /// Retrieve the dummy shading context.
-    ShadingContext *shadingcontext () const { return m_context; }
-
-    /// Retrieve the dummy shader globals
-    ShaderGlobals *shaderglobals () { return &m_shaderglobals; }
-
-    /// What debug level are we at?
-    int debug() const { return m_debug; }
-
-    /// What LLVM debug level are we at?
-    int llvm_debug() const;
 
     /// What's our current optimization level?
     int optimize() const { return m_optimize; }
@@ -156,20 +119,9 @@ public:
     /// of instructions that were altered.
     int turn_into_nop (int begin, int end, const char *why=NULL);
 
-    void find_conditionals ();
-
     void simplify_params ();
 
     void find_params_holding_globals ();
-
-    /// Will the op executed for-sure unconditionally every time the
-    /// shader is run?  (Not inside a loop or conditional or after a
-    /// possible early exit from the shader.)
-    bool op_is_unconditionally_executed (int opnum) const {
-        return !m_in_conditional[opnum] && opnum < m_first_return;
-    }
-
-    void find_basic_blocks (bool do_llvm = false);
 
     bool coerce_assigned_constant (Opcode &op);
 
@@ -215,11 +167,6 @@ public:
     void global_alias (int symindex, int alias) {
         m_symbol_aliases[symindex] = alias;
     }
-
-    /// Is the symbol a constant whose value is 0?
-    static bool is_zero (const Symbol &A);
-    /// Is the symbol a constant whose value is 1?
-    static bool is_one (const Symbol &A);
 
     /// Is the given symbol stale?  A "stale" symbol is one that, within
     /// the current basic block, has been assigned in a simple manner
@@ -357,515 +304,6 @@ public:
     /// 
     int peephole2 (int opnum);
 
-    /// Helper: return the symbol index of the symbol that is the argnum-th
-    /// argument to the given op.
-    int oparg (const Opcode &op, int argnum) const {
-        return inst()->arg (op.firstarg()+argnum);
-    }
-
-    /// Helper: return the ptr to the symbol that is the argnum-th
-    /// argument to the given op.
-    Symbol *opargsym (const Opcode &op, int argnum) {
-        return (argnum < op.nargs()) ?
-                    inst()->argsymbol (op.firstarg()+argnum) : NULL;
-    }
-
-    /// Is the named symbol among the renderer outputs?
-    bool is_renderer_output (ustring name) const;
-
-    /// Create an llvm function for the whole shader group, JIT it,
-    /// and store the llvm::Function* handle to it with the ShaderGroup.
-    void build_llvm_group ();
-
-    int layer_remap (int origlayer) const { return m_layer_remap[origlayer]; }
-
-    /// Set up a bunch of static things we'll need for the whole group.
-    ///
-    void initialize_llvm_group ();
-
-    /// Create an llvm function for the current shader instance.
-    /// This will end up being the group entry if 'groupentry' is true.
-    llvm::Function* build_llvm_instance (bool groupentry);
-
-    /// Build up LLVM IR code for the given range [begin,end) or
-    /// opcodes, putting them (initially) into basic block bb (or the
-    /// current basic block if bb==NULL).
-    bool build_llvm_code (int beginop, int endop, llvm::BasicBlock *bb=NULL);
-
-    typedef std::map<std::string, llvm::AllocaInst*> AllocationMap;
-
-    void llvm_assign_initial_value (const Symbol& sym);
-    llvm::LLVMContext &llvm_context () const { return *m_llvm_context; }
-    llvm::Module *llvm_module () const { return m_llvm_module; }
-    AllocationMap &named_values () { return m_named_values; }
-    llvm::IRBuilder<> &builder () { return *m_builder; }
-
-    /// Return an llvm::Value* corresponding to the address of the given
-    /// symbol element, with derivative (0=value, 1=dx, 2=dy) and array
-    /// index (NULL if it's not an array).
-    llvm::Value *llvm_get_pointer (const Symbol& sym, int deriv=0,
-                                   llvm::Value *arrayindex=NULL);
-
-    /// Return the llvm::Value* corresponding to the given element
-    /// value, with derivative (0=value, 1=dx, 2=dy), array index (NULL
-    /// if it's not an array), and component (x=0 or scalar, y=1, z=2).
-    /// If deriv >0 and the symbol doesn't have derivatives, return 0
-    /// for the derivative.  If the component >0 and it's a scalar,
-    /// return the scalar -- this allows automatic casting to triples.
-    /// Finally, auto-cast int<->float if requested (no conversion is
-    /// performed if cast is the default of UNKNOWN).
-    llvm::Value *llvm_load_value (const Symbol& sym, int deriv,
-                                  llvm::Value *arrayindex, int component,
-                                  TypeDesc cast=TypeDesc::UNKNOWN);
-
-
-    /// Given an llvm::Value* of a pointer (and the type of the data
-    /// that it points to), Return the llvm::Value* corresponding to the
-    /// given element value, with derivative (0=value, 1=dx, 2=dy),
-    /// array index (NULL if it's not an array), and component (x=0 or
-    /// scalar, y=1, z=2).  If deriv >0 and the symbol doesn't have
-    /// derivatives, return 0 for the derivative.  If the component >0
-    /// and it's a scalar, return the scalar -- this allows automatic
-    /// casting to triples.  Finally, auto-cast int<->float if requested
-    /// (no conversion is performed if cast is the default of UNKNOWN).
-    llvm::Value *llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
-                              int deriv, llvm::Value *arrayindex,
-                              int component, TypeDesc cast=TypeDesc::UNKNOWN);
-
-    /// Just like llvm_load_value, but when both the symbol and the
-    /// array index are known to be constants.  This can even handle
-    /// pulling constant-indexed elements out of constant arrays.  Use
-    /// arrayindex==-1 to indicate that it's not an array dereference.
-    llvm::Value *llvm_load_constant_value (const Symbol& sym,
-                                           int arrayindex, int component,
-                                           TypeDesc cast=TypeDesc::UNKNOWN);
-
-    /// llvm_load_value with non-constant component designation.  Does
-    /// not work with arrays or do type casts!
-    llvm::Value *llvm_load_component_value (const Symbol& sym, int deriv,
-                                            llvm::Value *component);
-
-    /// Non-array version of llvm_load_value, with default deriv &
-    /// component.
-    llvm::Value *llvm_load_value (const Symbol& sym, int deriv = 0,
-                                  int component = 0,
-                                  TypeDesc cast=TypeDesc::UNKNOWN) {
-        return llvm_load_value (sym, deriv, NULL, component, cast);
-    }
-
-    /// Legacy version
-    ///
-    llvm::Value *loadLLVMValue (const Symbol& sym, int component=0,
-                                int deriv=0, TypeDesc cast=TypeDesc::UNKNOWN) {
-        return llvm_load_value (sym, deriv, NULL, component, cast);
-    }
-
-    /// Return an llvm::Value* that is either a scalar and derivs is
-    /// false, or a pointer to sym's values (if sym is an aggreate or
-    /// derivs == true).  Furthermore, if deriv == true and sym doesn't
-    /// have derivs, coerce it into a variable with zero derivs.
-    llvm::Value *llvm_load_arg (const Symbol& sym, bool derivs);
-
-    /// Just like llvm_load_arg(sym,deriv), except use use sym's derivs
-    /// as-is, no coercion.
-    llvm::Value *llvm_load_arg (const Symbol& sym) {
-        return llvm_load_arg (sym, sym.has_derivs());
-    }
-
-    /// Store new_val into the given symbol, given the derivative
-    /// (0=value, 1=dx, 2=dy), array index (NULL if it's not an array),
-    /// and component (x=0 or scalar, y=1, z=2).  If deriv>0 and the
-    /// symbol doesn't have a deriv, it's a nop.  If the component >0
-    /// and it's a scalar, set the scalar.  Returns true if ok, false
-    /// upon failure.
-    bool llvm_store_value (llvm::Value *new_val, const Symbol& sym, int deriv,
-                           llvm::Value *arrayindex, int component);
-
-    /// Store new_val into the memory pointed to by dst_ptr, given the
-    /// derivative (0=value, 1=dx, 2=dy), array index (NULL if it's not
-    /// an array), and component (x=0 or scalar, y=1, z=2).  If deriv>0
-    /// and the symbol doesn't have a deriv, it's a nop.  If the
-    /// component >0 and it's a scalar, set the scalar.  Returns true if
-    /// ok, false upon failure.
-    bool llvm_store_value (llvm::Value* new_val, llvm::Value* dst_ptr,
-                           const TypeSpec &type, int deriv,
-                           llvm::Value* arrayindex, int component);
-
-    /// Non-array version of llvm_store_value, with default deriv &
-    /// component.
-    bool llvm_store_value (llvm::Value *new_val, const Symbol& sym,
-                           int deriv=0, int component=0) {
-        return llvm_store_value (new_val, sym, deriv, NULL, component);
-    }
-
-    /// llvm_store_value with non-constant component designation.  Does
-    /// not work with arrays or do type casts!
-    bool llvm_store_component_value (llvm::Value *new_val, const Symbol& sym,
-                                     int deriv, llvm::Value *component);
-
-    /// Legacy version
-    ///
-    bool storeLLVMValue (llvm::Value* new_val, const Symbol& sym,
-                         int component=0, int deriv=0) {
-        return llvm_store_value (new_val, sym, deriv, component);
-    }
-
-    /// Generate an alloca instruction to allocate space for the given
-    /// type, with derivs if derivs==true, and return the AllocaInst of
-    /// its pointer.
-    llvm::AllocaInst *llvm_alloca (const TypeSpec &type, bool derivs,
-                                   const std::string &name="");
-
-    /// Given the OSL symbol, return the llvm::Value* corresponding to the
-    /// start of that symbol (first element, first component, and just the
-    /// plain value if it has derivatives).
-    llvm::Value *getOrAllocateLLVMSymbol (const Symbol& sym);
-
-    llvm::Value *getLLVMSymbolBase (const Symbol &sym);
-
-    /// Generate the LLVM IR code to convert fval from a float to
-    /// an integer and return the new value.
-    llvm::Value *llvm_float_to_int (llvm::Value *fval);
-
-    /// Generate the LLVM IR code to convert ival from an int to a float
-    /// and return the new value.
-    llvm::Value *llvm_int_to_float (llvm::Value *ival);
-
-    /// Generate IR code for simple a/b, but considering OSL's semantics
-    /// that x/0 = 0, not inf.
-    llvm::Value *llvm_make_safe_div (TypeDesc type,
-                                     llvm::Value *a, llvm::Value *b);
-
-    /// Generate IR code for simple a mod b, but considering OSL's
-    /// semantics that x mod 0 = 0, not inf.
-    llvm::Value *llvm_make_safe_mod (TypeDesc type,
-                                     llvm::Value *a, llvm::Value *b);
-
-    /// Test whether val is nonzero, return the llvm::Value* that's the
-    /// result of a CreateICmpNE or CreateFCmpUNE (depending on the
-    /// type).  If test_derivs is true, it it also tests whether the
-    /// derivs are zero.
-    llvm::Value *llvm_test_nonzero (Symbol &val, bool test_derivs = false);
-
-    /// Implementaiton of Simple assignment.  If arrayindex >= 0, in
-    /// designates a particular array index to assign.
-    bool llvm_assign_impl (Symbol &Result, Symbol &Src, int arrayindex = -1);
-
-
-    /// This will return a llvm::Type that is the same as a C union of
-    /// the given types[].
-    llvm::Type *llvm_type_union(const std::vector<llvm::Type *> &types);
-
-    /// This will return a llvm::Type that is the same as a C struct
-    /// comprised fields of the given types[], in order.
-    llvm::Type *llvm_type_struct(const std::vector<llvm::Type *> &types,
-                                 const std::string &name="");
-
-    /// Convert the name of a global (and its derivative index) into the
-    /// field number of the ShaderGlobals struct.
-    int ShaderGlobalNameToIndex (ustring name);
-
-    /// Return the LLVM type handle for the ShaderGlobals struct.
-    ///
-    llvm::Type *llvm_type_sg ();
-
-    /// Return the LLVM type handle for a pointer to a
-    /// ShaderGlobals struct.
-    llvm::Type *llvm_type_sg_ptr ();
-
-    /// Return the ShaderGlobals pointer.
-    ///
-    llvm::Value *sg_ptr () const { return m_llvm_shaderglobals_ptr; }
-
-    llvm::Type *llvm_type_closure_component ();
-    llvm::Type *llvm_type_closure_component_ptr ();
-    llvm::Type *llvm_type_closure_component_attr ();
-    llvm::Type *llvm_type_closure_component_attr_ptr ();
-
-    /// Return the ShaderGlobals pointer cast as a void*.
-    ///
-    llvm::Value *sg_void_ptr () {
-        return llvm_void_ptr (m_llvm_shaderglobals_ptr);
-    }
-
-    llvm::Value *llvm_ptr_cast (llvm::Value* val, llvm::Type *type) {
-        return builder().CreatePointerCast(val,type);
-    }
-
-    llvm::Value *llvm_ptr_cast (llvm::Value* val, const TypeSpec &type) {
-        return llvm_ptr_cast (val, llvm::PointerType::get (llvm_type(type), 0));
-    }
-
-    llvm::Value *llvm_void_ptr (llvm::Value* val) {
-        return builder().CreatePointerCast(val,llvm_type_void_ptr());
-    }
-
-    llvm::Value *llvm_void_ptr (const Symbol &sym, int deriv=0) {
-        return llvm_void_ptr (llvm_get_pointer(sym, deriv));
-    }
-
-    llvm::Value *llvm_void_ptr_null () {
-        return llvm::ConstantPointerNull::get (llvm_type_void_ptr());
-    }
-
-    /// Return the LLVM type handle for a structure of the common group
-    /// data that holds all the shader params.
-    llvm::Type *llvm_type_groupdata ();
-
-    /// Return the LLVM type handle for a pointer to the common group
-    /// data that holds all the shader params.
-    llvm::Type *llvm_type_groupdata_ptr ();
-
-    /// Return the ShaderGlobals pointer.
-    ///
-    llvm::Value *groupdata_ptr () const { return m_llvm_groupdata_ptr; }
-
-    /// Return the group data pointer cast as a void*.
-    ///
-    llvm::Value *groupdata_void_ptr () {
-        return llvm_void_ptr (m_llvm_groupdata_ptr);
-    }
-
-    /// Return a ref to where the "layer_run" flag is stored for the
-    /// named layer.
-    llvm::Value *layer_run_ptr (int layer);
-
-    /// Return an llvm::Value holding the given floating point constant.
-    ///
-    llvm::Value *llvm_constant (float f);
-
-    /// Return an llvm::Value holding the given integer constant.
-    ///
-    llvm::Value *llvm_constant (int i);
-
-    /// Return an llvm::Value holding the given size_t constant.
-    ///
-    llvm::Value *llvm_constant (size_t i);
-
-    /// Return an llvm::Value holding the given bool constant.
-    /// Change the name so it doesn't get mixed up with int.
-    llvm::Value *llvm_constant_bool (bool b);
-
-    /// Return a constant void pointer to the given address
-    ///
-    llvm::Value *llvm_constant_ptr (void *p, llvm::PointerType *type)
-    {
-        return builder().CreateIntToPtr (llvm_constant (size_t (p)), type, "const pointer");
-    }
-
-    /// Return an llvm::Value holding the given string constant.
-    ///
-    llvm::Value *llvm_constant (ustring s);
-    llvm::Value *llvm_constant (const char *s) {
-        return llvm_constant(ustring(s));
-    }
-    /// Return an llvm::Value holding the given pointer constant.
-    ///
-    llvm::Value *llvm_constant_ptr (void *p);
-
-    /// Return an llvm::Value for a long long that is a packed
-    /// representation of a TypeDesc.
-    llvm::Value *llvm_constant (const TypeDesc &type);
-
-    /// Generate LLVM code to zero out the variable (including derivs)
-    ///
-    void llvm_assign_zero (const Symbol &sym);
-
-    /// Generate LLVM code to zero out the derivatives of sym.
-    ///
-    void llvm_zero_derivs (const Symbol &sym);
-
-    /// Generate LLVM code to zero out the derivatives of an array
-    /// only for the first count elements of it.
-    ///
-    void llvm_zero_derivs (const Symbol &sym, llvm::Value *count);
-
-    /// Generate a pointer that is (ptrtype)((char *)ptr + offset).
-    /// If ptrtype is NULL, just return a void*.
-    llvm::Value *llvm_offset_ptr (llvm::Value *ptr, int offset,
-                                  llvm::Type *ptrtype=NULL);
-
-    /// Generate code for a call to the function pointer, with the given
-    /// arg list.  Return an llvm::Value* corresponding to the return
-    /// value of the function, if any.
-    llvm::Value *llvm_call_function (llvm::Value *func,
-                                     llvm::Value **args, int nargs);
-    /// Generate code for a call to the named function with the given arg
-    /// list.  Return an llvm::Value* corresponding to the return value of
-    /// the function, if any.
-    llvm::Value *llvm_call_function (const char *name,
-                                     llvm::Value **args, int nargs);
-
-    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0) {
-        return llvm_call_function (name, &arg0, 1);
-    }
-    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
-                                     llvm::Value *arg1) {
-        llvm::Value *args[2] = { arg0, arg1 };
-        return llvm_call_function (name, args, 2);
-    }
-    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
-                                     llvm::Value *arg1, llvm::Value *arg2) {
-        llvm::Value *args[3] = { arg0, arg1, arg2 };
-        return llvm_call_function (name, args, 3);
-    }
-    llvm::Value *llvm_call_function (const char *name, llvm::Value *arg0,
-                                     llvm::Value *arg1, llvm::Value *arg2,
-                                     llvm::Value *arg3) {
-        llvm::Value *args[4] = { arg0, arg1, arg2, arg3 };
-        return llvm_call_function (name, args, 4);
-    }
-
-    void llvm_gen_debug_printf (const std::string &message);
-
-    /// Generate code to call the given layer.  If 'unconditional' is
-    /// true, call it without even testing if the layer has already been
-    /// called.
-    void llvm_call_layer (int layer, bool unconditional = false);
-
-    /// Execute the upstream connection (if any, and if not yet run) that
-    /// establishes the value of symbol sym, which has index 'symindex'
-    /// within the current layer rop.inst().  If already_run is not NULL,
-    /// it points to a vector of layer indices that are known to have been 
-    /// run -- those can be skipped without dynamically checking their
-    /// execution status.
-    void llvm_run_connected_layers (Symbol &sym, int symindex, int opnum = -1,
-                                    std::set<int> *already_run = NULL);
-
-    /// Generate code for a call to the named function with the given
-    /// arg list as symbols -- float & ints will be passed by value,
-    /// triples and matrices will be passed by address.  If deriv_ptrs
-    /// is true, pass pointers even for floats if they have derivs.
-    /// Return an llvm::Value* corresponding to the return value of the
-    /// function, if any.
-    llvm::Value *llvm_call_function (const char *name,  const Symbol **args,
-                                     int nargs, bool deriv_ptrs=false);
-    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
-                                     bool deriv_ptrs=false);
-    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
-                                     const Symbol &B, bool deriv_ptrs=false);
-    llvm::Value *llvm_call_function (const char *name, const Symbol &A,
-                                     const Symbol &B, const Symbol &C,
-                                     bool deriv_ptrs=false);
-
-    /// Generate code for a memset.
-    ///
-    void llvm_memset (llvm::Value *ptr, int val, int len, int align=1);
-
-    /// Generate code for variable size memset
-    ///
-    void llvm_memset (llvm::Value *ptr, int val, llvm::Value *len, int align=1);
-
-    /// Generate code for a memcpy.
-    ///
-    void llvm_memcpy (llvm::Value *dst, llvm::Value *src,
-                      int len, int align=1);
-
-    /// Generate the appropriate llvm type definition for an OSL TypeSpec
-    /// (this is the actual type, for example when we allocate it).
-    llvm::Type *llvm_type (const TypeSpec &typespec);
-
-    /// Generate the parameter-passing llvm type definition for an OSL
-    /// TypeSpec.
-    llvm::Type *llvm_pass_type (const TypeSpec &typespec);
-
-    llvm::Type *llvm_type_float() { return m_llvm_type_float; }
-    llvm::Type *llvm_type_triple() { return m_llvm_type_triple; }
-    llvm::Type *llvm_type_matrix() { return m_llvm_type_matrix; }
-    llvm::Type *llvm_type_int() { return m_llvm_type_int; }
-    llvm::Type *llvm_type_addrint() { return m_llvm_type_addrint; }
-    llvm::Type *llvm_type_bool() { return m_llvm_type_bool; }
-    llvm::Type *llvm_type_longlong() { return m_llvm_type_longlong; }
-    llvm::Type *llvm_type_void() { return m_llvm_type_void; }
-    llvm::Type *llvm_type_typedesc() { return llvm_type_longlong(); }
-    llvm::PointerType *llvm_type_prepare_closure_func() { return m_llvm_type_prepare_closure_func; }
-    llvm::PointerType *llvm_type_setup_closure_func() { return m_llvm_type_setup_closure_func; }
-    llvm::PointerType *llvm_type_int_ptr() { return m_llvm_type_int_ptr; }
-    llvm::PointerType *llvm_type_void_ptr() { return m_llvm_type_char_ptr; }
-    llvm::PointerType *llvm_type_string() { return m_llvm_type_char_ptr; }
-    llvm::PointerType *llvm_type_ustring_ptr() { return m_llvm_type_ustring_ptr; }
-    llvm::PointerType *llvm_type_float_ptr() { return m_llvm_type_float_ptr; }
-    llvm::PointerType *llvm_type_triple_ptr() { return m_llvm_type_triple_ptr; }
-    llvm::PointerType *llvm_type_matrix_ptr() { return m_llvm_type_matrix_ptr; }
-
-    /// Shorthand to create a new LLVM basic block and return its handle.
-    ///
-    llvm::BasicBlock *llvm_new_basic_block (const std::string &name) {
-        return llvm::BasicBlock::Create (llvm_context(), name, m_layer_func);
-    }
-
-    /// Save the basic block pointers when entering a loop.
-    ///
-    void llvm_push_loop (llvm::BasicBlock *step, llvm::BasicBlock *after) {
-        m_loop_step_block.push_back (step);
-        m_loop_after_block.push_back (after);
-    }
-
-    /// Pop basic block pointers when exiting a loop.
-    ///
-    void llvm_pop_loop () {
-        ASSERT (! m_loop_step_block.empty() && ! m_loop_after_block.empty());
-        m_loop_step_block.pop_back ();
-        m_loop_after_block.pop_back ();
-    }
-
-    /// Return the basic block of the current loop's 'step' instructions.
-    llvm::BasicBlock *llvm_loop_step_block () const {
-        ASSERT (! m_loop_step_block.empty());
-        return m_loop_step_block.back();
-    }
-
-    /// Return the basic block of the current loop's exit point.
-    llvm::BasicBlock *llvm_loop_after_block () const {
-        ASSERT (! m_loop_after_block.empty());
-        return m_loop_after_block.back();
-    }
-
-    /// Save the return block pointer when entering a function.
-    ///
-    void llvm_push_function (llvm::BasicBlock *after) {
-        m_return_block.push_back (after);
-    }
-
-    /// Pop basic return destination when exiting a function.
-    ///
-    void llvm_pop_function () {
-        ASSERT (! m_return_block.empty());
-        m_return_block.pop_back ();
-    }
-
-    /// Return the basic block of the current loop's 'step' instructions.
-    ///
-    llvm::BasicBlock *llvm_return_block () const {
-        ASSERT (! m_return_block.empty());
-        return m_return_block.back();
-    }
-
-    /// Return the basic block of the exit for the whole instance.
-    ///
-    bool llvm_has_exit_instance_block () const {
-        return m_exit_instance_block;
-    }
-
-    /// Return the basic block of the exit for the whole instance.
-    ///
-    llvm::BasicBlock *llvm_exit_instance_block () {
-        if (! m_exit_instance_block) {
-            std::string name = Strutil::format ("%s_%d_exit_", inst()->layername(), inst()->id());
-            m_exit_instance_block = llvm_new_basic_block (name);
-        }
-        return m_exit_instance_block;
-    }
-
-    /// Check for inf/nan in all written-to arguments of the op
-    void llvm_generate_debugnan (const Opcode &op);
-    /// Check for uninitialized values in all read-from arguments to the op
-    void llvm_generate_debug_uninit (const Opcode &op);
-
-    llvm::Function *layer_func () const { return m_layer_func; }
-
-    void llvm_setup_optimization_passes ();
-
     bool opt_elide_unconnected_outputs () const {
         return m_opt_elide_unconnected_outputs;
     }
@@ -876,17 +314,14 @@ public:
     /// Which optimization pass are we on?
     int optimization_pass () const { return m_pass; }
 
-    ShaderGlobals &dummy_shaderglobals () { return m_shaderglobals; }
+    /// Retrieve ptr to the dummy shader globals
+    ShaderGlobals *shaderglobals () { return &m_shaderglobals; }
 
     // Maximum number of new constant symbols that a constant-folding
     // function is able to add.
     static const int max_new_consts_per_fold = 10;
 
 private:
-    ShadingSystemImpl &m_shadingsys;
-    PerThreadInfo *m_thread;
-    ShadingContext *m_context;        ///< Shading context
-    int m_debug;                      ///< Current debug level
     int m_optimize;                   ///< Current optimization level
     bool m_opt_simplify_param;            ///< Turn instance params into const?
     bool m_opt_constant_fold;             ///< Allow constant folding?
@@ -901,14 +336,11 @@ private:
     ShaderGlobals m_shaderglobals;        ///< Dummy ShaderGlobals
 
     // Keep track of some things for the whole shader group:
-    ShaderGroup &m_group;             ///< Group we're optimizing
     typedef boost::unordered_map<ustring,ustring,ustringHash> ustringmap_t;
     std::vector<ustringmap_t> m_params_holding_globals;
                    ///< Which params of each layer really just hold globals
 
     // All below is just for the one inst we're optimizing at the moment:
-    ShaderInstance *m_inst;           ///< Instance we're optimizing
-    int m_layer;                      ///< Layer we're optimizing
     int m_pass;                       ///< Optimization pass we're on now
     std::vector<int> m_all_consts;    ///< All const symbol indices for inst
     int m_next_newconst;              ///< Unique ID for next new const we add
@@ -919,58 +351,8 @@ private:
     std::map<int,int> m_stale_syms;     ///< Stale symbols for this block
     int m_local_unknown_message_sent;   ///< Non-const setmessage in this inst
     std::vector<ustring> m_local_messages_sent; ///< Messages set in this inst
-    std::vector<int> m_bblockids;       ///< Basic block IDs for each op
-    std::vector<char> m_in_conditional; ///< Whether each op is in a cond
-    std::vector<char> m_in_loop;        ///< Whether each op is in a loop
-    int m_first_return;                 ///< Op number of first return or exit
-    std::vector<int> m_layer_remap;     ///< Remapping of layer ordering
-    std::set<int> m_layers_already_run; ///< List of layers run
-    int m_num_used_layers;              ///< Number of layers actually used
     double m_stat_opt_locking_time;       ///<   locking time
     double m_stat_specialization_time;    ///<   specialization time
-    double m_stat_total_llvm_time;        ///<   total time spent on LLVM
-    double m_stat_llvm_setup_time;        ///<     llvm setup time
-    double m_stat_llvm_irgen_time;        ///<     llvm IR generation time
-    double m_stat_llvm_opt_time;          ///<     llvm IR optimization time
-    double m_stat_llvm_jit_time;          ///<     llvm JIT time
-
-    // LLVM stuff
-    llvm::LLVMContext *m_llvm_context;
-    llvm::Module *m_llvm_module;
-    llvm::ExecutionEngine *m_llvm_exec;
-    AllocationMap m_named_values;
-    std::map<const Symbol*,int> m_param_order_map;
-    llvm::IRBuilder<> *m_builder;
-    llvm::Value *m_llvm_shaderglobals_ptr;
-    llvm::Value *m_llvm_groupdata_ptr;
-    llvm::Function *m_layer_func;     ///< Current layer func we're building
-    std::vector<llvm::BasicBlock *> m_loop_after_block; // stack for break
-    std::vector<llvm::BasicBlock *> m_loop_step_block;  // stack for continue
-    std::vector<llvm::BasicBlock *> m_return_block;     // stack for func call
-    llvm::BasicBlock * m_exit_instance_block;  // exit point for the instance
-    llvm::Type *m_llvm_type_float;
-    llvm::Type *m_llvm_type_int;
-    llvm::Type *m_llvm_type_addrint;
-    llvm::Type *m_llvm_type_bool;
-    llvm::Type *m_llvm_type_longlong;
-    llvm::Type *m_llvm_type_void;
-    llvm::Type *m_llvm_type_triple;
-    llvm::Type *m_llvm_type_matrix;
-    llvm::PointerType *m_llvm_type_ustring_ptr;
-    llvm::PointerType *m_llvm_type_char_ptr;
-    llvm::PointerType *m_llvm_type_int_ptr;
-    llvm::PointerType *m_llvm_type_float_ptr;
-    llvm::PointerType *m_llvm_type_triple_ptr;
-    llvm::PointerType *m_llvm_type_matrix_ptr;
-    llvm::Type *m_llvm_type_sg;  // LLVM type of ShaderGlobals struct
-    llvm::Type *m_llvm_type_groupdata;  // LLVM type of group data
-    llvm::Type *m_llvm_type_closure_component; // LLVM type for ClosureComponent
-    llvm::Type *m_llvm_type_closure_component_attr; // LLVM type for ClosureMeta::Attr
-    llvm::PointerType *m_llvm_type_prepare_closure_func;
-    llvm::PointerType *m_llvm_type_setup_closure_func;
-    llvm::PassManager *m_llvm_passes;
-    llvm::FunctionPassManager *m_llvm_func_passes;
-    int m_llvm_local_mem;             // Amount of memory we use for locals
 
     // Persistant data shared between layers
     bool m_unknown_message_sent;      ///< Somebody did a non-const setmessage
@@ -978,7 +360,6 @@ private:
 
     friend class ShadingSystemImpl;
 };
-
 
 
 
@@ -994,3 +375,6 @@ private:
 
 }; // namespace pvt
 OSL_NAMESPACE_EXIT
+
+#endif /* RUNTIMEOPTIMIZE_H */
+


### PR DESCRIPTION
Previously, the monstrous RuntimeOptimizer class handled all the runtime
optimization as well as LLVM IR generation and JIT.  It was unmanageably
huge, and did not afford easy ways to test other "back ends" (for example,
JITing for alternate hardware platforms.

This patch splits up the class into modular pieces:
- RuntimeOptimizer is strictly about the runtime oso -> oso code
  transformations.  It doesn't know or care about LLVM.
- BackendLLVM takes oso and generates LLVM IR and JITs it.
- OSOProcessorBase provides an abstraction layer for the caller and
  serves as a base class for the other two that factors out
  commonalities that will be needed for any similar oso-walking
  code-generating process.  Alternate back ends (for example, PTX, GLSL,
  etc.) will presumably just be additional subclasses.

In the process, lots of code has shuffled from file to file, methods
have moved from one class to another, and some things have been renamed.
This is going to make the diffs very hard to follow, it will look like a
complete rewrite of these classes.  But actually, the code and
algorithms have not really changed.

This is just a first step toward making liboslexec support multiple back
ends.  Much more coming, but this is preliminary work as I perform some
other experiments.
