### PR TITLE
testshade: consolidate --iparam, --fparam, --vparam, --sparam ==> --param

### DIFF
--- a/testsuite/gettextureinfo/run.py
+++ b/testsuite/gettextureinfo/run.py
@@ -5,4 +5,4 @@ command = testshade("-g 1 1 test")
 
 # Construct a test specifically for odd data and pixel windows
 command += oiiotool("--pattern checker 100x50+10+20 3 --fullsize 300x200+0+0 -o win.exr")
-command += testshade("-g 1 1 --sparam filename win.exr --iparam date 0 test")
+command += testshade("-g 1 1 --param filename win.exr --param date 0 test")

--- a/testsuite/initops/run.py
+++ b/testsuite/initops/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python 
 
-command = testshade("-g 3 3 --fparam a 10 test")
+command = testshade("-g 3 3 --param a 10.0 test")

--- a/testsuite/noise-cell/run.py
+++ b/testsuite/noise-cell/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename cell -fparam offset 0 -fparam scale 1 testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename cell -param offset 0.0 -param scale 1.0 testnoise")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/noise-gabor/run.py
+++ b/testsuite/noise-gabor/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename gabor testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename gabor testnoise")
 outputs = [ "out.txt", "out.tif" ]
 # expect a few LSB failures
 failthresh = 0.004

--- a/testsuite/noise-perlin/run.py
+++ b/testsuite/noise-perlin/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename perlin testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename perlin testnoise")
 outputs = [ "out.txt", "out.tif" ]
 # expect some LSB failures on this test
 failthresh = 0.004

--- a/testsuite/noise-simplex/run.py
+++ b/testsuite/noise-simplex/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename simplex testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename simplex testnoise")
 outputs = [ "out.txt", "out.tif" ]
 # expect some LSB failures on this test
 failthresh = 0.004

--- a/testsuite/noise-uperlin/run.py
+++ b/testsuite/noise-uperlin/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename uperlin -fparam offset 0 -fparam scale 1 testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename uperlin -param offset 0.0 -param scale 1.0 testnoise")
 outputs = [ "out.txt", "out.tif" ]
 # expect some LSB failures on this test
 failthresh = 0.004

--- a/testsuite/noise-usimplex/run.py
+++ b/testsuite/noise-usimplex/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testnoise.osl")
-command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename usimplex -fparam offset 0 -fparam scale 1 testnoise")
+command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename usimplex -param offset 0.0 -param scale 1.0 testnoise")
 outputs = [ "out.txt", "out.tif" ]
 # expect some LSB failures on this test
 failthresh = 0.004

--- a/testsuite/pnoise-cell/run.py
+++ b/testsuite/pnoise-cell/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testpnoise.osl")
-command += testshade("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename cell -fparam offset 0 -fparam scale 1 testpnoise")
+command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename cell -param offset 0.0 -param scale 1.0 testpnoise")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/pnoise-gabor/run.py
+++ b/testsuite/pnoise-gabor/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testpnoise.osl")
-command += testshade("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename gabor testpnoise")
+command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename gabor testpnoise")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/pnoise-perlin/run.py
+++ b/testsuite/pnoise-perlin/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testpnoise.osl")
-command += testshade("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename perlin testpnoise")
+command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename perlin testpnoise")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/pnoise-uperlin/run.py
+++ b/testsuite/pnoise-uperlin/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python 
 
 command = oslc("../common/shaders/testpnoise.osl")
-command += testshade("-g 512 512 -od uint8 -o Cout out.tif -sparam noisename uperlin -fparam offset 0 -fparam scale 1 testpnoise")
+command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename uperlin -param offset 0.0 -param scale 1.0 testpnoise")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/pointcloud-fold/run.py
+++ b/testsuite/pointcloud-fold/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python 
 
-command += testshade("-fparam radius 1000 rdcloud")
+command += testshade("-param radius 1000.0 rdcloud")

--- a/testsuite/pointcloud/run.py
+++ b/testsuite/pointcloud/run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python 
 
 command += testshade("-g 16 16 -od uint8 -o Cout out0.tif wrcloud")
-command += testshade("-g 256 256 -fparam radius 0.01 -od uint8 -o Cout out1.tif rdcloud")
-command += testshade("-g 256 256 -fparam radius 0.1 -od uint8 -o Cout out2.tif rdcloud")
+command += testshade("-g 256 256 -param radius 0.01 -od uint8 -o Cout out1.tif rdcloud")
+command += testshade("-g 256 256 -param radius 0.1 -od uint8 -o Cout out2.tif rdcloud")
 outputs = [ "out0.tif", "out1.tif", "out2.tif" ]

--- a/testsuite/texture-swirl/run.py
+++ b/testsuite/texture-swirl/run.py
@@ -1,4 +1,4 @@
 #!/usr/bin/python 
 
-command += testshade("-g 512 512 --center --fparam swirl 2 -od uint8 -o Cout out.tif swirl")
+command += testshade("-g 512 512 --center --param swirl 2.0 -od uint8 -o Cout out.tif swirl")
 outputs = [ "out.txt", "out.tif" ]


### PR DESCRIPTION
--param takes two arguments: name and value.  For aggregates (like colors or matrices), the value is a comma-separated list (no spaces, or it won't recognize it as one argument).

The type is deduced from the appearance of the argument:
    1.3,0.5,0.5 is a vector
    2 is an int
    2.0 is a float (to pass an 'integer' as a float, use the decimal point)
    blah is a string (doesn't fit any other patterns)

When ambiguous -- for example, if you really want a string "14", you can use an optional type override like this:

```
--param:type=string ...
```

So, as an illustrative example:

OLD:

```
testshade --iparam I 14 --vparam V 1 2 3 --fparam F 3 --sparam Foo foo  --sparam Zero 0 ...
```

NEW:

```
testshade --param I 14 --param V 1,2,3 --fparam F 3.0 --param Foo foo  --param:type=string Zero 0 ...
```

The new code allows passing of matrix values, which the old did not account for.

Also, the new code can allow explicit disambiguation of triple types:

```
  testshade --param:type=point 0,0,0 --param:type=color 0.2,0.3,0.5 ...
```

There's also an optional parameter that lets you specify the lockgeom status of a parameter.  Just let that slide for now, you'll see shortly how I'm using that (in another patch).

N.B. This depends upon the following OIIO patch: https://github.com/OpenImageIO/oiio/pull/752
