### PR TITLE
Add a ShadingSystem::Parameter call variety that can set lockgeom=0

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -195,6 +195,16 @@ public:
     ///
     virtual bool Parameter (const char *name, TypeDesc t, const void *val)
         { return true; }
+
+    /// Set a parameter of the next shader, and override the 'lockgeom'
+    /// metadata for that parameter (despite how it may have been set in
+    /// the shader).  If lockgeom is false, it means that this parameter
+    /// should NOT be considered locked against changes by the geometry,
+    /// and therefore the shader should not optimize assuming that the
+    /// instance value (the 'val' specified by this call) is a constant.
+    virtual bool Parameter (const char *name, TypeDesc t, const void *val,
+                            bool lockgeom)
+        { return true; }
 #if 0
     virtual bool Parameter (const char *name, int val) {
         Parameter (name, TypeDesc::IntType, &val);

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -234,6 +234,12 @@ ShaderInstance::parameters (const ParamValueList &params)
                 continue;
 
             so->valuesource (Symbol::InstanceVal);
+            // Lock the param against geometric primitive overrides if the
+            // master thinks it was so locked, AND the Parameter() call
+            // didn't specify lockgeom=false (which would be indicated by
+            // the parameter's interpolation being non-CONSTANT).
+            so->lockgeom (sm->lockgeom() &&
+                          p.interp() == ParamValue::INTERP_CONSTANT);
             void *data = param_storage(i);
             memcpy (data, p.data(), t.simpletype().size());
             if (shadingsys().debug())
@@ -316,6 +322,7 @@ ShaderInstance::copy_code_from_master ()
                 si->data (param_storage(i));
                 si->valuesource (m_instoverrides[i].valuesource());
                 si->connected_down (m_instoverrides[i].connected_down());
+                si->lockgeom (m_instoverrides[i].lockgeom());
             }
         }
     }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -529,16 +529,20 @@ public:
     struct SymOverrideInfo {
         char m_valuesource;
         bool m_connected_down;
+        bool m_lockgeom;
 
         SymOverrideInfo () : m_valuesource(Symbol::DefaultVal),
-                             m_connected_down(false) { }
+                             m_connected_down(false), m_lockgeom(true) { }
         void valuesource (Symbol::ValueSource v) { m_valuesource = v; }
         Symbol::ValueSource valuesource () const { return (Symbol::ValueSource) m_valuesource; }
         const char *valuesourcename () const { return Symbol::valuesourcename(valuesource()); }
         bool connected_down () const { return m_connected_down; }
         void connected_down (bool c) { m_connected_down = c; }
+        bool lockgeom () const { return m_lockgeom; }
+        void lockgeom (bool l) { m_lockgeom = l; }
         friend bool equivalent (const SymOverrideInfo &a, const SymOverrideInfo &b) {
-            return a.valuesource() == b.valuesource();
+            return a.valuesource() == b.valuesource() &&
+                   a.lockgeom() == b.lockgeom();
         }
     };
     typedef std::vector<SymOverrideInfo> SymOverrideInfoVec;
@@ -717,6 +721,8 @@ public:
     virtual bool LoadMemoryCompiledShader (const char *shadername,
                                    const char *buffer);
     virtual bool Parameter (const char *name, TypeDesc t, const void *val);
+    virtual bool Parameter (const char *name, TypeDesc t, const void *val,
+                            bool lockgeom);
     virtual bool Shader (const char *shaderusage,
                          const char *shadername=NULL,
                          const char *layername=NULL);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1083,14 +1083,27 @@ ShadingSystemImpl::printstats () const
 
 
 bool
-ShadingSystemImpl::Parameter (const char *name, TypeDesc t, const void *val)
+ShadingSystemImpl::Parameter (const char *name, TypeDesc t, const void *val,
+                              bool lockgeom)
 {
     // We work very hard not to do extra copies of the data.  First,
     // grow the pending list by one (empty) slot...
     m_pending_params.resize (m_pending_params.size() + 1);
     // ...then initialize it in place
     m_pending_params.back().init (name, t, 1, val);
+    // If we have a possible geometric override (lockgeom=false), set the
+    // param's interpolation to VERTEX rather than the default CONSTANT.
+    if (lockgeom == false)
+        m_pending_params.back().interp (OIIO::ParamValue::INTERP_VERTEX);
     return true;
+}
+
+
+
+bool
+ShadingSystemImpl::Parameter (const char *name, TypeDesc t, const void *val)
+{
+    return Parameter (name, t, val, true);
 }
 
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -81,8 +81,8 @@ inject_params ()
 {
     for (size_t p = 0;  p < params.size();  ++p) {
         const ParamValue &pv (params[p]);
-        shadingsys->Parameter (pv.name().c_str(), pv.type(), pv.data());
-//                               pv.interp() == ParamValue::INTERP_CONSTANT);
+        shadingsys->Parameter (pv.name().c_str(), pv.type(), pv.data(),
+                               pv.interp() == ParamValue::INTERP_CONSTANT);
     }
 }
 


### PR DESCRIPTION
Add a ShadingSystem::Parameter call variety that can set lockgeom=0 on a particular parameter when the instance values are declared, even if they were not so marked in their metadata at the time they were compiled by oslc.

There's an interesting trick involved here: We gather pending parameters for an instance into a ParamValueList, as a temporary holding area until the Shader call.  We use the PV's existing 'interp' field to indicate whether the value has a lockgeom override -- INTERP_CONSTANT as the default, and anything else (we use INTERP_VERTEX) to mean the value may vary across the geom, which is what lockgeom is primarily used for.
