### PR TITLE
Refactor ShadingAttribState (now just use ShaderGroup / ShaderGroupRef).

### DIFF
--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -67,19 +67,18 @@ ShadingContext::~ShadingContext ()
 
 
 bool
-ShadingContext::execute (ShaderUse use, ShadingAttribState &sas,
+ShadingContext::execute (ShaderUse use, ShaderGroup &sgroup,
                          ShaderGlobals &ssg, bool run)
 {
     DASSERT (use == ShadUseSurface);  // FIXME
     m_curuse = use;
-    m_attribs = &sas;
+    m_attribs = &sgroup;
 
     // Optimize if we haven't already
-    ShaderGroup &sgroup (sas.shadergroup (use));
     if (sgroup.nlayers()) {
         sgroup.start_running ();
         if (! sgroup.optimized()) {
-            shadingsys().optimize_group (sas, sgroup);
+            shadingsys().optimize_group (sgroup);
             if (shadingsys().m_greedyjit && shadingsys().m_groups_to_compile_count) {
                 // If we are greedily JITing, optimize/JIT everything now
                 shadingsys().optimize_all_groups ();
@@ -129,7 +128,7 @@ ShadingContext::execute (ShaderUse use, ShadingAttribState &sas,
 Symbol *
 ShadingContext::symbol (ShaderUse use, ustring name)
 {
-    ShaderGroup &sgroup (attribs()->shadergroup (use));
+    ShaderGroup &sgroup (*attribs());
     int nlayers = sgroup.nlayers ();
     if (sgroup.llvm_compiled_version()) {
         for (int layer = nlayers-1;  layer >= 0;  --layer) {
@@ -146,7 +145,7 @@ ShadingContext::symbol (ShaderUse use, ustring name)
 void *
 ShadingContext::symbol_data (Symbol &sym)
 {
-    ShaderGroup &sgroup (attribs()->shadergroup ((ShaderUse)m_curuse));
+    ShaderGroup &sgroup (*attribs());
     if (! sgroup.llvm_compiled_version())
         return NULL;   // can't retrieve symbol if we didn't JIT and runit
 

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -563,17 +563,24 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
 }
 
 
+}; // namespace pvt
 
-ShaderGroup::ShaderGroup ()
-  : m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0), m_optimized(0), m_does_nothing(false)
+
+
+ShaderGroup::ShaderGroup (const char *name)
+  : m_name(name),
+    m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
+    m_optimized(0), m_does_nothing(false)
 {
     m_executions = 0;
 }
 
 
 
-ShaderGroup::ShaderGroup (const ShaderGroup &g)
-  : m_layers(g.m_layers), m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0), m_optimized(0), m_does_nothing(false)
+ShaderGroup::ShaderGroup (const ShaderGroup &g, const char *name)
+  : m_name(name), m_layers(g.m_layers),
+    m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
+    m_optimized(0), m_does_nothing(false)
 {
     m_executions = 0;
 }
@@ -597,5 +604,4 @@ ShaderGroup::~ShaderGroup ()
 }
 
 
-}; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1108,17 +1108,17 @@ ShadingSystemImpl::Parameter (const char *name, TypeDesc t, const void *val)
 
 
 
-bool
+ShaderGroupRef
 ShadingSystemImpl::ShaderGroupBegin (const char *groupname)
 {
     if (m_in_group) {
         error ("Nested ShaderGroupBegin() calls");
-        return false;
+        return ShaderGroupRef();
     }
     m_in_group = true;
     m_group_use = ShadUseUnknown;
-    m_group_name = ustring (groupname);
-    return true;
+    m_curgroup.reset (new ShaderGroup(groupname));
+    return m_curgroup;
 }
 
 
@@ -1133,11 +1133,9 @@ ShadingSystemImpl::ShaderGroupEnd (void)
 
     // Mark the layers that can be run lazily
     if (m_group_use != ShadUseUnknown) {
-        ShaderGroup &sgroup (m_curattrib->shadergroup (m_group_use));
-        sgroup.name (m_group_name);
-        size_t nlayers = sgroup.nlayers ();
+        size_t nlayers = m_curgroup->nlayers ();
         for (size_t layer = 0;  layer < nlayers;  ++layer) {
-            ShaderInstance *inst = sgroup[layer];
+            ShaderInstance *inst = (*m_curgroup)[layer];
             if (! inst)
                 continue;
             if (m_lazylayers) {
@@ -1164,12 +1162,18 @@ ShadingSystemImpl::ShaderGroupEnd (void)
             }
         }
 
-        merge_instances (m_curattrib->shadergroup (m_group_use));
+        merge_instances (*m_curgroup);
+    }
+
+    {
+        // Record the group for later greedy JITing
+        spin_lock lock (m_groups_to_compile_mutex);
+        m_groups_to_compile.push_back (m_curgroup);
+        ++m_groups_to_compile_count;
     }
 
     m_in_group = false;
     m_group_use = ShadUseUnknown;
-    m_group_name.clear ();
 
     return true;
 }
@@ -1182,8 +1186,8 @@ ShadingSystemImpl::Shader (const char *shaderusage,
                            const char *layername)
 {
     // Make sure we have a current attrib state
-    if (! m_curattrib)
-        m_curattrib.reset (new ShadingAttribState);
+    if (! m_curgroup)
+        m_curgroup.reset (new ShaderGroup (""));
 
     ShaderMaster::ref master = loadshader (shadername);
     if (! master) {
@@ -1197,21 +1201,13 @@ ShadingSystemImpl::Shader (const char *shaderusage,
         return false;
     }
 
-    // If somebody is already hanging onto the shader state, clone it before
-    // we modify it.
-    if (! m_curattrib.unique ()) {
-        ShadingAttribStateRef newstate (new ShadingAttribState (*m_curattrib));
-        m_curattrib = newstate;
-    }
-
     ShaderInstanceRef instance (new ShaderInstance (master, layername));
     instance->parameters (m_pending_params);
     m_pending_params.clear ();
 
-    ShaderGroup &shadergroup (m_curattrib->shadergroup (use));
     if (! m_in_group || m_group_use == ShadUseUnknown) {
         // A singleton, or the first in a group
-        shadergroup.clear ();
+        m_curgroup->clear ();
         m_stat_groups += 1;
     }
     if (m_in_group) {
@@ -1224,8 +1220,7 @@ ShadingSystemImpl::Shader (const char *shaderusage,
         }
     }
 
-    shadergroup.append (instance);
-    m_curattrib->changed_shaders ();
+    m_curgroup->append (instance);
     m_stat_groupinstances += 1;
 
     // FIXME -- check for duplicate layer name within the group?
@@ -1317,26 +1312,17 @@ ShadingSystemImpl::ConnectShaders (const char *srclayer, const char *srcparam,
 
 
 
-ShadingAttribStateRef
+ShaderGroupRef
 ShadingSystemImpl::state ()
 {
     {
         // Record the state for later greedy JITing
         spin_lock lock (m_groups_to_compile_mutex);
-        m_groups_to_compile.push_back (m_curattrib);
+        m_groups_to_compile.push_back (m_curgroup);
         ++m_groups_to_compile_count;
     }
-    return m_curattrib;
+    return m_curgroup;
 }
-
-
-
-void
-ShadingSystemImpl::clear_state ()
-{
-    m_curattrib.reset (new ShadingAttribState);
-}
-
 
 
 
@@ -1380,10 +1366,10 @@ ShadingSystemImpl::release_context (ShadingContext *ctx)
 
 
 bool
-ShadingSystemImpl::execute (ShadingContext &ctx, ShadingAttribState &sas,
+ShadingSystemImpl::execute (ShadingContext &ctx, ShaderGroup &group,
                             ShaderGlobals &ssg, bool run)
 {
-    return ctx.execute (ShadUseSurface, sas, ssg, run);
+    return ctx.execute (ShadUseSurface, group, ssg, run);
 }
 
 
@@ -1410,7 +1396,7 @@ ShadingSystemImpl::find_named_layer_in_group (ustring layername,
     inst = NULL;
     if (m_group_use >= ShadUseUnknown)
         return -1;
-    ShaderGroup &group (m_curattrib->shadergroup (m_group_use));
+    ShaderGroup &group (*m_curgroup);
     for (int i = 0;  i < group.nlayers();  ++i) {
         if (group[i]->layername() == layername) {
             inst = group[i];
@@ -1554,8 +1540,7 @@ ShadingSystemImpl::group_post_jit_cleanup (ShaderGroup &group)
 
 
 void
-ShadingSystemImpl::optimize_group (ShadingAttribState &attribstate, 
-                                   ShaderGroup &group)
+ShadingSystemImpl::optimize_group (ShaderGroup &group)
 {
     OIIO::Timer timer;
     lock_guard lock (group.m_mutex);
@@ -1597,7 +1582,6 @@ ShadingSystemImpl::optimize_group (ShadingAttribState &attribstate,
 
     release_context (ctx);
 
-    attribstate.changed_shaders ();
     group.m_optimized = true;
     spin_lock stat_lock (m_stat_mutex);
     m_stat_optimization_time += timer();
@@ -1653,18 +1637,17 @@ ShadingSystemImpl::optimize_all_groups (int nthreads)
 
     // And here's the single thread case
     while (m_groups_to_compile_count) {
-        ShadingAttribStateRef sas;
+        ShaderGroupRef group;
         {
             spin_lock lock (m_groups_to_compile_mutex);
             if (m_groups_to_compile.size() == 0)
                 return;  // Nothing left to compile
-            sas = m_groups_to_compile.back ();
+            group = m_groups_to_compile.back ();
             m_groups_to_compile.pop_back ();
         }
         --m_groups_to_compile_count;
-        if (! sas.unique()) {   // don't compile if nobody recorded it but us
-            ShaderGroup &sgroup (sas->shadergroup (ShadUseSurface));
-                optimize_group (*sas, sgroup);
+        if (! group.unique()) {   // don't compile if nobody recorded it but us
+            optimize_group (*group);
         }
     }
 }

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -77,7 +77,7 @@ Scene scene;
 int backgroundShaderID = -1;
 int backgroundResolution = 0;
 Background background;
-std::vector<ShadingAttribStateRef> shaders;
+std::vector<ShaderGroupRef> shaders;
 std::string scenefile, imagefile;
 
 int get_filenames(int argc, const char *argv[])
@@ -298,7 +298,7 @@ void parse_scene() {
                 backgroundResolution = strtoint(res_attr.value());
             backgroundShaderID = int(shaders.size()) - 1;
         } else if (strcmp(node.name(), "ShaderGroup") == 0) {
-            shadingsys->ShaderGroupBegin();
+            ShaderGroupRef group = shadingsys->ShaderGroupBegin();
             ParamStorage<1024> store; // scratch space to hold parameters until they are read by Shader()
             for (pugi::xml_node gnode = node.first_child(); gnode; gnode = gnode.next_sibling()) {
                 if (strcmp(gnode.name(), "Parameter") == 0) {
@@ -339,7 +339,7 @@ void parse_scene() {
                 }
             }
             shadingsys->ShaderGroupEnd();
-            shaders.push_back(shadingsys->state());
+            shaders.push_back (group);
         } else {
             // unknown element?
         }


### PR DESCRIPTION
This is a de-cluttering refactor I've wanted to do for a long time, but was always low priority. Decided to bang it out while my US-based coworkers were eating turkey and giving me an unusual degree of peace and quiet. The bottom line is that it removes the pointless "ShadingAttribState" wrapper around what was effectively just a ShaderGroup.

In the early days, we imagined ShadingAttribState would hold several shader groups (displacement, surface, volume, etc.) and a bunch of other related state.  But in fact, no extra state materialized, and in practice there was no point having the attrib state hold more than one group.

This patch refactors and simplifies to get rid of the pointless additional abstraction layers:
- No ShadingAttribState, its usage is replaced by ShaderGroup.  It holds just one group, no extra state.
- Modify ShaderGroupBegin() to return the ShaderGroupRef.
- Deprecated: (1) the use of ShadingSystem::state(), not necessary with SGB returning the group ref; (2) the idiom of using a bare Shader() call to imply that it forms a group of one layer only, instead, assume a surrounding ShaderGroupBegin() and ShaderGroupEnd(); (3) ShadingSystem::clear_attribs, which was never nontrivially implemented.
- Improve comments in oslexec.h.
