### PR TITLE
Make sure all #include guards contain "OSL" to avoid symbol pollution.

### DIFF
--- a/src/include/Imathx.h
+++ b/src/include/Imathx.h
@@ -37,9 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #pragma once
-#ifndef OSL_IMATHX_H
-#define OSL_IMATHX_H
-
 
 #include <OpenEXR/ImathVec.h>
 #include <OpenEXR/ImathMatrix.h>
@@ -96,5 +93,3 @@ T determinant (const Imathx::Matrix22<T> &m)
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* ifndef(OSL_IMATHX_H) */

--- a/src/include/accum.h
+++ b/src/include/accum.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_ACCUM_H
-#define OSL_ACCUM_H
 
 #include "oslconfig.h"
 #include "optautomata.h"
@@ -246,5 +244,3 @@ class OSLEXECPUBLIC Accumulator
 
 
 OSL_NAMESPACE_EXIT
-
-#endif // OSL_ACCUM_H

--- a/src/include/dual.h
+++ b/src/include/dual.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_DUAL_H
-#define OSL_DUAL_H
 
 #include "oslversion.h"
 OSL_NAMESPACE_ENTER
@@ -788,5 +786,3 @@ inline Dual2<T> smoothstep (const Dual2<T> &e0, const Dual2<T> &e1, const Dual2<
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_DUAL_H */

--- a/src/include/dual_vec.h
+++ b/src/include/dual_vec.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_DUAL_VEC_H
-#define OSL_DUAL_VEC_H
 
 #include "oslconfig.h"
 #include "dual.h"
@@ -360,5 +358,3 @@ distance (const Dual2<Vec3> &a, const Dual2<Vec3> &b)
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_DUAL_VEC_H */

--- a/src/include/export.h
+++ b/src/include/export.h
@@ -28,8 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #pragma once
-#ifndef OSL_EXPORT_H
-#define OSL_EXPORT_H
 
 /// \file
 /// OSLPUBLIC and OSLEXPORT macros that are necessary for proper symbol
@@ -110,5 +108,3 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #  define OSLQUERYPUBLIC OSL_DLL_IMPORT
 #endif
-
-#endif // OSL_EXPORT_H

--- a/src/include/genclosure.h
+++ b/src/include/genclosure.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_GENCLOSURE_H
-#define OSL_GENCLOSURE_H
 
 #include <OpenImageIO/ustring.h>
 #include "oslconfig.h"
@@ -86,5 +84,3 @@ struct ClosureParam {
 #define CLOSURE_FINISH_PARAM(st) { TypeDesc(), sizeof(st), NULL, 0 }
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_OSLCLOSURE_H */

--- a/src/include/matrix22.h
+++ b/src/include/matrix22.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #pragma once
-#ifndef OSL_MATRIX22_H
-#define OSL_MATRIX22_H
 
 
 #include <OpenEXR/ImathMatrix.h>
@@ -906,5 +904,3 @@ operator << (std::ostream &s, const Matrix22<T> &m)
 }
 
 } // namespace Imathx
-
-#endif /* ifndef(OSL_MATRIX22_H) */

--- a/src/include/optautomata.h
+++ b/src/include/optautomata.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_OPTAUTOMATA_H
-#define OSL_OPTAUTOMATA_H
 
 #include <OpenImageIO/ustring.h>
 
@@ -96,5 +94,3 @@ class DfOptimizedAutomata
 };
 
 OSL_NAMESPACE_EXIT
-
-#endif // OSL_OPTAUTOMATA_H

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_PVT_H
-#define OSL_PVT_H
 
 #include "oslconfig.h"
 
@@ -865,5 +863,3 @@ typedef std::vector<Opcode> OpcodeVec;
 
 }; // namespace OSL::pvt
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_PVT_H */

--- a/src/include/oslclosure.h
+++ b/src/include/oslclosure.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLCLOSURE_H
-#define OSLCLOSURE_H
 
 #include <cstring>
 #include <OpenImageIO/ustring.h>
@@ -166,5 +164,3 @@ struct OSLEXECPUBLIC ClosureAdd : public ClosureColor
 };
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLCLOSURE_H */

--- a/src/include/oslcomp.h
+++ b/src/include/oslcomp.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLCOMP_H
-#define OSLCOMP_H
 
 #include "oslconfig.h"
 
@@ -56,5 +54,3 @@ public:
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLCOMP_H */

--- a/src/include/oslconfig.h
+++ b/src/include/oslconfig.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLCONFIG_H
-#define OSLCONFIG_H
 
 /////////////////////////////////////////////////////////////////////////
 /// \file
@@ -118,5 +116,3 @@ using OIIO::ustringHash;
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLCONFIG_H */

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLEXEC_H
-#define OSLEXEC_H
 
 
 #include "oslconfig.h"
@@ -657,5 +655,3 @@ public:
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLEXEC_H */

--- a/src/include/oslquery.h
+++ b/src/include/oslquery.h
@@ -38,8 +38,6 @@ Sony Pictures Imageworks terms, above.
 
 
 #pragma once
-#ifndef OSLQUERY_H
-#define OSLQUERY_H
 
 #include <string>
 #include <vector>
@@ -137,5 +135,3 @@ private:
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLQUERY_H */

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_AST_H
-#define OSL_AST_H
 
 #include <boost/intrusive_ptr.hpp>
 #include "OpenImageIO/refcnt.h"
@@ -951,5 +949,3 @@ private:
 }; // namespace pvt
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_AST_H */

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLCOMP_PVT_H
-#define OSLCOMP_PVT_H
 
 #include <vector>
 #include <stack>
@@ -393,6 +391,3 @@ extern OSLCompilerImpl *oslcompiler;
 }; // namespace pvt
 
 OSL_NAMESPACE_EXIT
-
-
-#endif /* OSLCOMP_PVT_H */

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_SYMTAB_H
-#define OSL_SYMTAB_H
 
 #include <vector>
 #include <stack>
@@ -292,5 +290,3 @@ private:
 }; // namespace pvt
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_SYMTAB_H */

--- a/src/liboslexec/automata.h
+++ b/src/liboslexec/automata.h
@@ -26,8 +26,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef OSL_AUTOMATA_H
-#define OSL_AUTOMATA_H
+#pragma once
 
 #include <set>
 #include <map>
@@ -337,5 +336,3 @@ class StateSetRecord {
 void ndfautoToDfauto(const NdfAutomata &ndfautomata, DfAutomata &dfautomata);
 
 OSL_NAMESPACE_EXIT
-
-#endif // OSL_AUTOMATA_H

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_BACKENDLLVM_H
-#define OSL_BACKENDLLVM_H
 
 #include <vector>
 #include <map>
@@ -607,5 +605,3 @@ private:
 
 }; // namespace pvt
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_BACKENDLLVM_H */

--- a/src/liboslexec/constantpool.h
+++ b/src/liboslexec/constantpool.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_CONSTANTPOOL_H
-#define OSL_CONSTANTPOOL_H
 
 #include <vector>
 #include <list>
@@ -99,5 +97,3 @@ private:
 
 }; // namespace OSL::pvt
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_CONSTANTPOOL_H */

--- a/src/liboslexec/llvm_headers.h
+++ b/src/liboslexec/llvm_headers.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_LLVM_HEADERS_H
-#define OSL_LLVM_HEADERS_H
 
 #ifdef LLVM_NAMESPACE
 namespace llvm = LLVM_NAMESPACE;
@@ -95,6 +93,3 @@ namespace llvm = LLVM_NAMESPACE;
 # include <llvm/Target/TargetData.h>
 
 #endif
-
-
-#endif /* OSL_LLVM_HEADERS_H */

--- a/src/liboslexec/lpeparse.h
+++ b/src/liboslexec/lpeparse.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_LEPARSE_H
-#define OSL_LEPARSE_H
 
 #include "lpexp.h"
 
@@ -148,5 +146,3 @@ class Parser
 
 
 OSL_NAMESPACE_EXIT
-
-#endif // OSL_LEPARSE_H

--- a/src/liboslexec/lpexp.h
+++ b/src/liboslexec/lpexp.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_REGEXP_H
-#define OSL_REGEXP_H
 
 #include "automata.h"
 
@@ -209,5 +207,3 @@ class Rule
 } // namespace regexp
 
 OSL_NAMESPACE_EXIT
-
-#endif // OSL_REGEXP_H

--- a/src/liboslexec/noiseimpl.h
+++ b/src/liboslexec/noiseimpl.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_NOISEIMPL_H
-#define OSL_NOISEIMPL_H
 
 #include <limits>
 
@@ -1482,5 +1480,3 @@ Dual2<Vec3> pgabor3 (const Dual2<float> &x, float xperiod,
 }; // namespace pvt
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_NOISEIMPL_H */

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSLEXEC_PVT_H
-#define OSLEXEC_PVT_H
 
 #include <string>
 #include <vector>
@@ -1524,5 +1522,3 @@ protected:
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSLEXEC_PVT_H */

--- a/src/liboslexec/osoreader.h
+++ b/src/liboslexec/osoreader.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_OSOREADER_H
-#define OSL_OSOREADER_H
 
 #include "osl_pvt.h"
 
@@ -152,5 +150,3 @@ private:
 
 }; // namespace pvt
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_OSOREADER_H */

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_RUNTIMEOPTIMIZE_H
-#define OSL_RUNTIMEOPTIMIZE_H
 
 #include <vector>
 #include <map>
@@ -375,6 +373,3 @@ private:
 
 }; // namespace pvt
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_RUNTIMEOPTIMIZE_H */
-

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_SPLINEIMPL_H
-#define OSL_SPLINEIMPL_H
 
 // avoid naming conflict with MSVC macro
 #ifdef BTYPE
@@ -242,4 +240,3 @@ void spline_inverse (const SplineBasis *spline,
 }; // namespace pvt
 OSL_NAMESPACE_EXIT
 
-#endif // OSL_SPLINEIMPL_H

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_SIMPLEREND_H
-#define OSL_SIMPLEREND_H
 
 #include <map>
 
@@ -71,5 +69,3 @@ private:
 };
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_SIMPLEREND_H */

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #pragma once
-#ifndef OSL_SIMPLEREND_H
-#define OSL_SIMPLEREND_H
 
 #include <map>
 
@@ -85,5 +83,3 @@ private:
 
 
 OSL_NAMESPACE_EXIT
-
-#endif /* OSL_SIMPLEREND_H */


### PR DESCRIPTION
Also add #pragma once in the headers that didn't already contain it.

Fixes #304
