### PR TITLE
Split ShaderGlobals definition into separate shaderglobals.h

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (public_headers accum.h dual.h dual_vec.h
                     export.h genclosure.h Imathx.h matrix22.h optautomata.h oslclosure.h
-                    oslcomp.h oslconfig.h oslexec.h oslquery.h )
+                    oslcomp.h oslconfig.h oslexec.h oslquery.h
+                    shaderglobals.h)
 message (STATUS "Create oslversion.h from oslversion.h.in")
 configure_file (oslversion.h.in "${CMAKE_BINARY_DIR}/include/oslversion.h" @ONLY)
 list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/oslversion.h")

--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "oslconfig.h"
+#include "shaderglobals.h"
 
 #include <OpenImageIO/refcnt.h>
 #include <OpenImageIO/ustring.h>
@@ -42,8 +43,6 @@ class ShaderGroup;
 typedef shared_ptr<ShaderGroup> ShaderGroupRef;
 typedef ShaderGroup ShadingAttribState;       // DEPRECATED name
 typedef ShaderGroupRef ShadingAttribStateRef; // DEPRECATED name
-struct ShaderGlobals;
-struct ClosureColor;
 struct ClosureParam;
 struct PerThreadInfo;
 class ShadingContext;
@@ -375,46 +374,6 @@ private:
     // Make delete private and unimplemented in order to prevent apps
     // from calling it.  Instead, they should call ShadingSystem::destroy().
     void operator delete (void *todel) { }
-};
-
-
-
-/// This struct represents the global variables accessible from a shader, note
-/// that not all fields will be valid in all contexts.
-///
-/// All points, vectors and normals are given in "common" space.
-struct ShaderGlobals {
-    Vec3 P, dPdx, dPdy;              /**< Position */
-    Vec3 dPdz;                       /**< z zeriv for volume shading */
-    Vec3 I, dIdx, dIdy;              /**< Incident ray */
-    Vec3 N;                          /**< Shading normal */
-    Vec3 Ng;                         /**< True geometric normal */
-    float u, dudx, dudy;             /**< Surface parameter u */
-    float v, dvdx, dvdy;             /**< Surface parameter v */
-    Vec3 dPdu, dPdv;                 /**< Tangents on the surface */
-    float time;                      /**< Time for each sample */
-    float dtime;                     /**< Time interval for each sample */
-    Vec3 dPdtime;                    /**< Velocity */
-    Vec3 Ps, dPsdx, dPsdy;           /**< Point being lit (valid only in light
-                                          attenuation shaders */
-    void* renderstate;               /**< Opaque pointer to renderer state (can
-                                          be used to retrieve renderer specific
-                                          details like userdata) */
-    void* tracedata;                 /**< Opaque pointer to renderer state
-                                          resuling from a trace() call. */
-    void* objdata;                   /**< Opaque pointer to object data */
-    ShadingContext* context;         /**< ShadingContext (this will be set by
-                                          OSL itself) */
-    TransformationPtr object2common; /**< Object->common xform */
-    TransformationPtr shader2common; /**< Shader->common xform */
-    ClosureColor *Ci;                /**< Output closure (should be initialized
-                                          to NULL) */
-    float surfacearea;               /**< Total area of the object (defined by
-                                          light shaders for energy normalization) */
-    int raytype;                     /**< Bit field of ray type flags */
-    int flipHandedness;              /**< flips the result of calculatenormal() */
-    int backfacing;                  /**< True if we want are shading the
-                                          backside of the surface */
 };
 
 

--- a/src/include/shaderglobals.h
+++ b/src/include/shaderglobals.h
@@ -1,0 +1,85 @@
+/*
+Copyright (c) 2009-2013 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+
+OSL_NAMESPACE_ENTER
+
+struct ClosureColor;
+class ShadingContext;
+
+
+
+/// Opaque pointer to whatever the renderer uses to represent a
+/// (potentially motion-blurred) coordinate transformation.
+typedef const void * TransformationPtr;
+
+
+
+
+/// This struct represents the global variables accessible from a shader, note
+/// that not all fields will be valid in all contexts.
+///
+/// All points, vectors and normals are given in "common" space.
+struct ShaderGlobals {
+    Vec3 P, dPdx, dPdy;              /**< Position */
+    Vec3 dPdz;                       /**< z zeriv for volume shading */
+    Vec3 I, dIdx, dIdy;              /**< Incident ray */
+    Vec3 N;                          /**< Shading normal */
+    Vec3 Ng;                         /**< True geometric normal */
+    float u, dudx, dudy;             /**< Surface parameter u */
+    float v, dvdx, dvdy;             /**< Surface parameter v */
+    Vec3 dPdu, dPdv;                 /**< Tangents on the surface */
+    float time;                      /**< Time for each sample */
+    float dtime;                     /**< Time interval for each sample */
+    Vec3 dPdtime;                    /**< Velocity */
+    Vec3 Ps, dPsdx, dPsdy;           /**< Point being lit (valid only in light
+                                          attenuation shaders */
+    void* renderstate;               /**< Opaque pointer to renderer state (can
+                                          be used to retrieve renderer specific
+                                          details like userdata) */
+    void* tracedata;                 /**< Opaque pointer to renderer state
+                                          resuling from a trace() call. */
+    void* objdata;                   /**< Opaque pointer to object data */
+    ShadingContext* context;         /**< ShadingContext (this will be set by
+                                          OSL itself) */
+    TransformationPtr object2common; /**< Object->common xform */
+    TransformationPtr shader2common; /**< Shader->common xform */
+    ClosureColor *Ci;                /**< Output closure (should be initialized
+                                          to NULL) */
+    float surfacearea;               /**< Total area of the object (defined by
+                                          light shaders for energy normalization) */
+    int raytype;                     /**< Bit field of ray type flags */
+    int flipHandedness;              /**< flips the result of calculatenormal() */
+    int backfacing;                  /**< True if we want are shading the
+                                          backside of the surface */
+};
+
+
+OSL_NAMESPACE_EXIT


### PR DESCRIPTION
I was working on something else that needed to know the layout of ShaderGlobals, and wanted a lighter-weight method than including all of oslexec.h.
