### PR TITLE
OpenEXR includes cleanup

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -37,7 +37,6 @@ endif ()
 find_package (IlmBase REQUIRED)
 
 include_directories ("${ILMBASE_INCLUDE_DIR}")
-include_directories ("${ILMBASE_INCLUDE_DIR}/OpenEXR")
 
 macro (LINK_ILMBASE target)
     target_link_libraries (${target} ${ILMBASE_LIBRARIES})

--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -142,11 +142,7 @@ list (APPEND IlmBase_library_paths ${IlmBase_generic_library_paths})
 PREFIX_FIND_INCLUDE_DIR (IlmBase
   OpenEXR/IlmBaseConfig.h IlmBase_include_paths)
 
-# If the headers were found, add its parent to the list of lib directories
 if (ILMBASE_INCLUDE_DIR)
-  get_filename_component (tmp_extra_dir "${ILMBASE_INCLUDE_DIR}/../" ABSOLUTE)
-  list (APPEND IlmBase_library_paths ${tmp_extra_dir})
-  unset (tmp_extra_dir)
 
   # Get the version from config file, if not already set.
   if (NOT ILMBASE_VERSION)


### PR DESCRIPTION
Make sure we include all OpenEXR related headers with `<OpenEXR/foo.h>` and remove the addition of the OpenEXR sub-folder from system search paths.

This is the companion to this OIIO pull request: https://github.com/OpenImageIO/oiio/pull/758
