### PR TITLE
Fix subtle bug with splines and arrays.

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2878,6 +2878,7 @@ LLVMGEN (llvm_gen_spline)
         args.push_back (rop.llvm_load_value (Knot_count));
     else
         args.push_back (rop.ll.constant ((int)Knots.typespec().arraylength()));
+    args.push_back (rop.ll.constant ((int)Knots.typespec().arraylength()));
     rop.ll.call_function (name.c_str(), &args[0], args.size());
 
     if (Result.has_derivs() && !result_derivs)

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -262,18 +262,18 @@ static const char *llvm_helper_function_table[] = {
     "osl_noiseparams_set_bandwidth", "xXf",
     "osl_noiseparams_set_impulses", "xXf",
 
-    "osl_spline_fff", "xXXXXi",
-    "osl_spline_dfdfdf", "xXXXXi",
-    "osl_spline_dfdff", "xXXXXi",
-    "osl_spline_dffdf", "xXXXXi",
-    "osl_spline_vfv", "xXXXXi",
-    "osl_spline_dvdfdv", "xXXXXi",
-    "osl_spline_dvdfv", "xXXXXi",
-    "osl_spline_dvfdv", "xXXXXi",
-    "osl_splineinverse_fff", "xXXXXi",
-    "osl_splineinverse_dfdfdf", "xXXXXi",
-    "osl_splineinverse_dfdff", "xXXXXi",
-    "osl_splineinverse_dffdf", "xXXXXi",
+    "osl_spline_fff", "xXXXXii",
+    "osl_spline_dfdfdf", "xXXXXii",
+    "osl_spline_dfdff", "xXXXXii",
+    "osl_spline_dffdf", "xXXXXii",
+    "osl_spline_vfv", "xXXXXii",
+    "osl_spline_dvdfdv", "xXXXXii",
+    "osl_spline_dvdfv", "xXXXXii",
+    "osl_spline_dvfdv", "xXXXXii",
+    "osl_splineinverse_fff", "xXXXXii",
+    "osl_splineinverse_dfdfdf", "xXXXXii",
+    "osl_splineinverse_dfdff", "xXXXXii",
+    "osl_splineinverse_dffdf", "xXXXXii",
     "osl_setmessage", "xXsLXisi",
     "osl_getmessage", "iXssLXiisi",
     "osl_pointcloud_search", "iXsXfiiXXii*",
@@ -455,7 +455,7 @@ static const char *llvm_helper_function_table[] = {
     "osl_raytype_bit", "iXi",
     "osl_bind_interpolated_param", "iXXLiX",
     "osl_range_check", "iiiXXi",
-    "osl_naninf_check", "xiXiXXiXii",
+    "osl_naninf_check", "xiXiXXiXiiX",
     "osl_uninit_check", "xLXXXiXii",
 
     NULL
@@ -829,9 +829,10 @@ BackendLLVM::llvm_generate_debugnan (const Opcode &op)
                                 ll.constant(op.sourceline()),
                                 ll.constant(sym.name()),
                                 offset,
-                                ncheck
+                                ncheck,
+                                ll.constant(op.opname())
                               };
-        ll.call_function ("osl_naninf_check", args, 9);
+        ll.call_function ("osl_naninf_check", args, 10);
     }
 }
 
@@ -1020,9 +1021,10 @@ BackendLLVM::build_llvm_instance (bool groupentry)
                      ll.constant((int)s.has_derivs()), sg_void_ptr(), 
                      ll.constant(ustring(inst()->shadername())),
                      ll.constant(0), ll.constant(s.name()),
-                     ll.constant(0), ll.constant(ncomps)
+                     ll.constant(0), ll.constant(ncomps),
+                     ll.constant("<none>")
                 };
-                ll.call_function ("osl_naninf_check", args, 9);
+                ll.call_function ("osl_naninf_check", args, 10);
             }
         }
     }

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1744,7 +1744,8 @@ osl_range_check (int indexvalue, int length,
 OSL_SHADEOP void
 osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
                   void *sg, const void *sourcefile, int sourceline,
-                  void *symbolname, int firstcheck, int nchecks)
+                  void *symbolname, int firstcheck, int nchecks,
+                  const void *opname)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     const float *vals = (const float *)vals_;
@@ -1752,11 +1753,12 @@ osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
         for (int c = firstcheck, e = c+nchecks; c < e;  ++c) {
             int i = d*ncomps + c;
             if (! isfinite(vals[i])) {
-                ctx->shadingsys().error ("Detected %g value in %s%s at %s:%d",
+                ctx->shadingsys().error ("Detected %g value in %s%s at %s:%d (op %s)",
                                          vals[i],
                                          d > 0 ? "the derivatives of " : "",
                                          USTR(symbolname).c_str(),
-                                         USTR(sourcefile).c_str(), sourceline);
+                                         USTR(sourcefile).c_str(), sourceline,
+                                         USTR(opname).c_str());
                 return;
             }
         }

--- a/src/liboslexec/opspline.cpp
+++ b/src/liboslexec/opspline.cpp
@@ -117,100 +117,100 @@ const Spline::SplineBasis *Spline::getSplineBasis(const ustring &basis_name)
 #define DVEC(x) (*(Dual2<Vec3> *)x)
 
 OSL_SHADEOP void  osl_spline_fff(void *out, const char *spline_, void *x, 
-                                 float *knots, int knot_count)
+                                 float *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<float, float, float, float, false>
-      (spline, *(float *)out, *(float *)x, knots, knot_count);
+      (spline, *(float *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dfdfdf(void *out, const char *spline_, void *x, 
-                                    float *knots, int knot_count)
+                                    float *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, Dual2<float>, Dual2<float>, float, true>
-      (spline, DFLOAT(out), DFLOAT(x), knots, knot_count);
+      (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dffdf(void *out, const char *spline_, void *x, 
-                                   float *knots, int knot_count)
+                                   float *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, float, Dual2<float>, float, true>
-      (spline, DFLOAT(out), *(float *)x, knots, knot_count);
+      (spline, DFLOAT(out), *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dfdff(void *out, const char *spline_, void *x, 
-                                   float *knots, int knot_count)
+                                   float *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, Dual2<float>, float, float, false>
-      (spline, DFLOAT(out), DFLOAT(x), knots, knot_count);
+      (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_vfv(void *out, const char *spline_, void *x, 
-                                 Vec3 *knots, int knot_count)
+                                 Vec3 *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Vec3, float, Vec3, Vec3, false>
-      (spline, *(Vec3 *)out, *(float *)x, knots, knot_count);
+      (spline, *(Vec3 *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dvdfv(void *out, const char *spline_, void *x, 
-                                   Vec3 *knots, int knot_count)
+                                   Vec3 *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Vec3, float, Vec3, Vec3, false>
-      (spline, *(Vec3 *)out, *(float *)x, knots, knot_count);
+      (spline, *(Vec3 *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dvfdv(void *out, const char *spline_, void *x, 
-                                    Vec3 *knots, int knot_count)
+                                    Vec3 *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<Vec3>, float, Dual2<Vec3>, Vec3, true>
-      (spline, DVEC(out), *(float *)x, knots, knot_count);
+      (spline, DVEC(out), *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void  osl_spline_dvdfdv(void *out, const char *spline_, void *x, 
-                                    Vec3 *knots, int knot_count)
+                                    Vec3 *knots, int knot_count, int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<Vec3>, Dual2<float>, Dual2<Vec3>, Vec3, true>
-      (spline, DVEC(out), DFLOAT(x), knots, knot_count);
+      (spline, DVEC(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
 
 
 OSL_SHADEOP void osl_splineinverse_fff(void *out, const char *spline_, void *x, 
-                                       float *knots, int knot_count)
+                                       float *knots, int knot_count, int knot_arraylen)
 {
     // Version with no derivs
     const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
-    Spline::spline_inverse<float> (spline, *(float *)out, *(float *)x, knots, knot_count);
+    Spline::spline_inverse<float> (spline, *(float *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void osl_splineinverse_dfdff(void *out, const char *spline_, void *x, 
-                                         float *knots, int knot_count)
+                                         float *knots, int knot_count, int knot_arraylen)
 {
     // x has derivs, so return derivs as well
     const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
-    Spline::spline_inverse<Dual2<float> > (spline, DFLOAT(out), DFLOAT(x), knots, knot_count);
+    Spline::spline_inverse<Dual2<float> > (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void osl_splineinverse_dfdfdf(void *out, const char *spline_, void *x, 
-                                          float *knots, int knot_count)
+                                          float *knots, int knot_count, int knot_arraylen)
 {
     // Ignore knot derivatives
-    osl_splineinverse_dfdff (out, spline_, x, knots, knot_count);
+    osl_splineinverse_dfdff (out, spline_, x, knots, knot_count, knot_arraylen);
 }
 
 OSL_SHADEOP void osl_splineinverse_dffdf(void *out, const char *spline_, void *x, 
-                                         float *knots, int knot_count)
+                                         float *knots, int knot_count, int knot_arraylen)
 {
     // Ignore knot derivs
     float outtmp = 0;
-    osl_splineinverse_fff (&outtmp, spline_, x, knots, knot_count);
+    osl_splineinverse_fff (&outtmp, spline_, x, knots, knot_count, knot_arraylen);
     DFLOAT(out) = outtmp;
 }
 

--- a/testsuite/debugnan/ref/out.txt
+++ b/testsuite/debugnan/ref/out.txt
@@ -1,4 +1,4 @@
 Compiled test.osl -> test.oso
-ERROR: Detected nan value in Cout at test.osl:5
+ERROR: Detected nan value in Cout at test.osl:5 (op texture)
 
 Output Cout to Cout.tif

--- a/testsuite/spline/test.osl
+++ b/testsuite/spline/test.osl
@@ -1,4 +1,6 @@
-shader test(output color Cspline = 0, output color DxCspline = 0, output float Fspline = 0, output float DxFspline = 0, output float NumKnots = 0)
+shader test (output color Cspline = 0, output color DxCspline = 0,
+             output float Fspline = 0, output float DxFspline = 0,
+             output float NumKnots = 0)
 {
    string bases[5] = { "catmull-rom", "bezier", "bspline", "hermite", "linear" };
    color  colors[5] = { color(1,0,0),
@@ -52,4 +54,21 @@ shader test(output color Cspline = 0, output color DxCspline = 0, output float F
 
    NumKnots   = spline("linear", u, 4, fltknots);
    
+    {
+        // Regression test for a bug involving splines on arrays, where
+        // the number of knots is less than the length of the whole array,
+        // and the knots have derivatives -- prior to fixing the bug, the
+        // derivatives were accessed with the wrong offset (assuming that
+        // array length == num_knots).  Bug fixed 19-Dec-2013.
+        color knots[16];
+        for (int i = 0; i < 4; ++i)
+            knots[i] = color (i/3, i/3, i/3);
+        for (int i = 4; i < arraylength(knots); ++i)
+            knots[i] = color(u*1.0e9, u*1.0e9, u*1.0e9);
+        color c = spline ("linear", u, 4, knots);
+        if (! (c[0] < 2.0 && c[1] < 2.0 && c[2] < 2.0 &&
+               Dx(c[0]) < 2.0 && Dx(c[1]) < 2.0 && Dx(c[2]) < 2.0 &&
+               Dy(c[0]) < 2.0 && Dy(c[1]) < 2.0 && Dy(c[2]) < 2.0))
+            printf ("Hey, found a bad value!\n");
+    }
 }


### PR DESCRIPTION
It took a special set of circumstances: the variety of spline that takes
an array of knot values, but where the user passes how many knots to use
and it's less than the full length of the array, AND the knot array has
derivatives.  When accessing the derivatives, it was offsetting to find
them based on the number of knots being used, but it should have been
the array length generating the offset (the positions of the derivs
don't change just because you aren't using all the array elements to
store the knot values). So it was reading bogus, potentially
uninitialized values.

The solution involved needing to pass both the num_knots and the
knot_arraylen to the various spline routines.

Along the way, for debugging help, I also modified nan/inf checking to
print the op name as well as the source file and line.

I added a regression test as part of testsuite/spline.
