### PR TITLE
Make sure isconnected() works with struct variables.

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1574,9 +1574,9 @@ ASTfunction_call::codegen (Symbol *dest)
         for (int i = 0;  a;  a = a->nextptr(), form = form->nextptr(), ++i) {
             ASTvariable_declaration *f = (ASTvariable_declaration *) form;
             const TypeSpec &ftype (f->sym()->typespec());
-            // If the formal parameter is a struct, we also need to alias
-            // each of the fields
             if (ftype.is_structure() || ftype.is_structure_array()) {
+                // If the formal parameter is a struct, we also need to
+                // alias each of the fields
                 if (a->nodetype() == variable_ref_node) {
                     // Passed a variable that is a struct ; make the struct
                     // fields of the formal param alias to the struct fields
@@ -1603,9 +1603,8 @@ ASTfunction_call::codegen (Symbol *dest)
                 } else {
                     ASSERT (0 && "unhandled structure designation");
                 }
-            } else {
-                f->sym()->alias (argdest[i]);
             }
+            f->sym()->alias (argdest[i]);
         }
 
         // Return statements inside the middle of a function (not the

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2080,6 +2080,19 @@ RuntimeOptimizer::resolve_isconnected ()
         if (op.opname() == u_isconnected) {
             inst()->make_symbol_room (1);
             SymbolPtr s = inst()->argsymbol (op.firstarg() + 1);
+            while (const StructSpec *structspec = s->typespec().structspec()) {
+                // How to deal with structures -- just change the reference
+                // to the first field in the struct.
+                // FIXME -- if we ever allow separate layer connection of
+                // individual struct members, this will need something more
+                // sophisticated.
+                ASSERT (structspec && structspec->numfields() >= 1);
+                std::string fieldname = (s->name().string() + "." +
+                                         structspec->field(0).name.string());
+                int fieldsymid = inst()->findparam (ustring(fieldname));
+                ASSERT (fieldsymid >= 0);
+                s = inst()->symbol(fieldsymid);
+            }
             if (s->connected())
                 turn_into_assign_one (op, "resolve isconnected() [1]");
             else

--- a/testsuite/isconnected/mystruct.h
+++ b/testsuite/isconnected/mystruct.h
@@ -1,0 +1,4 @@
+struct MyStruct {
+    float x;
+    float y;
+};

--- a/testsuite/isconnected/ref/out.txt
+++ b/testsuite/isconnected/ref/out.txt
@@ -1,6 +1,11 @@
 Compiled test.osl -> test.oso
 Compiled upstream.osl -> upstream.oso
 Connect upstream.out to downstream.a
+Connect upstream.struct1 to downstream.mystruct1
 a is connected
 b is not connected
+mystruct1 is connected
+mystruct1.x is connected
+mystruct2 is not connected
+mystruct2.x is not connected
 

--- a/testsuite/isconnected/run.py
+++ b/testsuite/isconnected/run.py
@@ -1,3 +1,5 @@
 #!/usr/bin/python 
 
-command = testshade("-g 1 1 --layer upstream upstream --layer downstream test --connect upstream out downstream a")
+command = testshade("-g 1 1 --layer upstream upstream --layer downstream test " +
+                    "--connect upstream out downstream a " +
+                    "--connect upstream struct1 downstream mystruct1")

--- a/testsuite/isconnected/test.osl
+++ b/testsuite/isconnected/test.osl
@@ -1,11 +1,24 @@
+#include "mystruct.h"
+
 void status (float variable, string name)
 {
     printf ("%s %s connected\n", name, isconnected(variable) ? "is" : "is not");
 }
 
 
-shader test (float a = 0, float b = 0)
+void status (MyStruct variable, string name)
+{
+    printf ("%s %s connected\n", name, isconnected(variable) ? "is" : "is not");
+    status (variable.x, concat(name, ".x"));
+}
+
+
+shader test (float a = 0, float b = 0,
+             MyStruct mystruct1 = {0,0},
+             MyStruct mystruct2 = {0,0})
 {
     status (a, "a");
     status (b, "b");
+    status (mystruct1, "mystruct1");
+    status (mystruct2, "mystruct2");
 }

--- a/testsuite/isconnected/upstream.osl
+++ b/testsuite/isconnected/upstream.osl
@@ -1,4 +1,8 @@
-shader upstream (output float out = 0)
+#include "mystruct.h"
+
+shader upstream (output float out = 0, output MyStruct struct1 = {0,0})
 {
     out = 1;
+    struct1.x = 3;
+    struct1.y = 4;
 }


### PR DESCRIPTION
(1) At runtime, when resolving isconnected(), for a struct, recurse into the first
    field of the struct (recursively, if that, too, is a struct) and figure out
    whether that is connected.

(2) At oslc time, to make sure this happens properly as we descend into functions,
    we have to be sure to correctly alias the formal params to actual params
    for structs as well as non-structs.
