### PR TITLE
Stop using extremely deprecated TypeDesc defines

### DIFF
--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -963,6 +963,6 @@ OSL::pvt::osllextype (int lex)
     case STRINGTYPE : return TypeDesc::TypeString;
     case VECTORTYPE : return TypeDesc::TypeVector;
     case VOIDTYPE   : return TypeDesc::NONE;
-    default: return PT_UNKNOWN;
+    default: return TypeDesc::UNKNOWN;
     }
 }

--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -353,6 +353,6 @@ OSL::pvt::osolextype (int lex)
     case STRINGTYPE : return TypeDesc::TypeString;
     case VECTORTYPE : return TypeDesc::TypeVector;
     case VOIDTYPE   : return TypeDesc::NONE;
-    default: return PT_UNKNOWN;
+    default: return TypeDesc::UNKNOWN;
     }
 }

--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -189,9 +189,9 @@ oslinfo (const std::string &name, const std::string &path, bool verbose)
                  std::cout << "\t\tUnknown default value\n";
             else std::cout << "nodefault\n";
         }
-        else if (p->type.basetype == PT_STRING)
+        else if (p->type.basetype == TypeDesc::STRING)
             print_default_string_vals (p, verbose);
-        else if (p->type.basetype == PT_INT)
+        else if (p->type.basetype == TypeDesc::INT)
             print_default_int_vals (p, verbose);
         else
             print_default_float_vals (p, verbose);


### PR DESCRIPTION
I want to remove these PT_BLAH definitions from the OIIO headers. They date from literally the first few days of writing OIIO, and have been considered deprecated ever since, a holdover from the thing that preceded TypeDesc.
