### PR TITLE
Defensive programming to be sure getcwd exists!

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -3,6 +3,8 @@
 OSL_NAMESPACE ?= 'OSL_Arnold'
 OPENIMAGEIO_NAMESPACE ?= 'OpenImageIO_Arnold'
 
+MY_CMAKE_FLAGS += "-DEXTRA_CPP_DEFINITIONS=\"-DOSL_SPI=1\""
+
 ifeq (${platform}, macosx)
     MY_CMAKE_FLAGS += \
         -DBUILD_WITH_INSTALL_RPATH=1 \

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -30,6 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/strutil.h>
 
 #include "oslexec_pvt.h"
 #include "../liboslcomp/oslcomp_pvt.h"
@@ -463,6 +465,49 @@ static const char *llvm_helper_function_table[] = {
 
 
 
+#ifdef OSL_SPI
+static void
+check_cwd (ShadingSystemImpl &shadingsys)
+{
+    std::string err;
+    char pathname[1024] = { "" };
+    if (! getcwd (pathname, sizeof(pathname)-1)) {
+        int e = errno;
+        err += Strutil::format ("Failed getcwd(), errno is %d: %s\n",
+                                errno, pathname);
+        if (e == EACCES || e == ENOENT) {
+            err += "Read/search permission problem or dir does not exist.\n";
+            const char *pwdenv = getenv ("PWD");
+            if (! pwdenv) {
+                err += "$PWD is not even found in the environment.\n";
+            } else {
+                err += Strutil::format ("$PWD is \"%s\"\n", pwdenv);
+                err += Strutil::format ("That %s.\n",
+                          OIIO::Filesystem::exists(pwdenv) ? "exists" : "does NOT exist");
+                err += Strutil::format ("That %s a directory.\n",
+                          OIIO::Filesystem::is_directory(pwdenv) ? "is" : "is NOT");
+                std::vector<std::string> pieces;
+                Strutil::split (pwdenv, pieces, "/");
+                std::string p;
+                for (size_t i = 0;  i < pieces.size();  ++i) {
+                    if (! pieces[i].size())
+                        continue;
+                    p += "/";
+                    p += pieces[i];
+                    err += Strutil::format ("  %s : %s and is%s a directory.\n", p,
+                        OIIO::Filesystem::exists(p) ? "exists" : "does NOT exist",
+                        OIIO::Filesystem::is_directory(p) ? "" : " NOT");
+                }
+            }
+        }
+    }
+    if (err.size())
+        shadingsys.error (err);
+}
+#endif
+
+
+
 BackendLLVM::BackendLLVM (ShadingSystemImpl &shadingsys,
                           ShaderGroup &group, ShadingContext *ctx)
     : OSOProcessorBase (shadingsys, group, ctx),
@@ -473,6 +518,12 @@ BackendLLVM::BackendLLVM (ShadingSystemImpl &shadingsys,
     // set_debug ();
     // memset (&m_shaderglobals, 0, sizeof(ShaderGlobals));
     // m_shaderglobals.context = m_context;
+
+#ifdef OSL_SPI
+    // Temporary (I hope) check to diagnose an intermittent failure of
+    // getcwd inside LLVM. Oy.
+    check_cwd (shadingsys);
+#endif
 }
 
 


### PR DESCRIPTION
In rare circumstances, we're hitting an assertion inside LLVM that can
only happen if a call to getcwd() fails. This stupid bit of code is to
try to catch it in the act and figure out exactly what's going
wrong. Should not bother anybody not at SPI.
