### PR TITLE
Botched the passing of oslc -D and -U command line args to boost wave.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter
             noise-perlin noise-uperlin noise-simplex noise-usimplex
             pnoise pnoise-cell pnoise-gabor pnoise-perlin pnoise-uperlin
+            oslc-D
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-paramdefault

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -382,7 +382,7 @@ OSLCompilerImpl::compile (const std::string &filename,
         } else if (options[i].c_str()[0] == '-' && options[i].size() > 2) {
             // options meant for the preprocessor
             if (options[i].c_str()[1] == 'D' || options[i].c_str()[1] == 'U')
-                defines.push_back(options[i].substr(2));
+                defines.push_back(options[i]);
             else if (options[i].c_str()[1] == 'I')
                 includepaths.push_back(options[i].substr(2));
 #else

--- a/testsuite/oslc-D/ref/out.txt
+++ b/testsuite/oslc-D/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled test.osl -> test.oso
+Compiled test.osl -> test.oso
+foo is 42
+

--- a/testsuite/oslc-D/run.py
+++ b/testsuite/oslc-D/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python
+
+command = oslc ("-Dfoo=bar test.osl")
+command += testshade ("test")

--- a/testsuite/oslc-D/test.osl
+++ b/testsuite/oslc-D/test.osl
@@ -1,0 +1,13 @@
+// We expect this to be launched with oslc -Dfoo=bar
+
+#ifndef foo
+#define foo 0
+#endif
+
+
+shader test ()
+{
+    int bar = 42;
+    printf ("foo is %d\n", foo );
+}
+


### PR DESCRIPTION
Looks like a stupid cut and paste error on my part, quite a while back,
but I guess nobody used -D much with oslc until we switched SPI's default
to use boost wave rather than /bin/cpp (for which it was always fine).
