### PR TITLE
Buffer error output so a shader invocation's output is contiguous in logs

### DIFF
--- a/src/include/oslexec.h
+++ b/src/include/oslexec.h
@@ -91,6 +91,9 @@ public:
     ///                              every shader compiled (0).
     ///    int max_warnings_per_thread  Number of warning calls that should be
     ///                              processed per thread (100).
+    ///    int buffer_printf      Buffer printf output from shaders and
+    ///                              output atomically, to prevent threads
+    ///                              from interleaving lines. (1)
     /// 2. Attributes that should be set by applications/renderers that
     /// incorporate OSL:
     ///    string commonspace     Name of "common" coord system ("world")
@@ -548,7 +551,8 @@ public:
     /// and the data has been put in *data.  Return false if the texture
     /// doesn't exist, doesn't have the requested data, if the data
     /// doesn't match the type requested. or some other failure.
-    virtual bool get_texture_info (ustring filename, int subimage,
+    virtual bool get_texture_info (ShaderGlobals *sg,
+                                   ustring filename, int subimage,
                                    ustring dataname, TypeDesc datatype,
                                    void *data);
 

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -180,7 +180,7 @@ BackendLLVM::getLLVMSymbolBase (const Symbol &sym)
     std::string mangled_name = dealiased->mangled();
     AllocationMap::iterator map_iter = named_values().find (mangled_name);
     if (map_iter == named_values().end()) {
-        shadingsys().error ("Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
+        shadingcontext()->error ("Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
                             mangled_name.c_str(), dealiased->name().c_str());
         return 0;
     }

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -77,7 +77,8 @@ namespace pugi = OIIO::pugi;
 //
 class Dictionary {
 public:
-    Dictionary (ShadingSystemImpl &ss) : m_shadingsys(ss) {
+    Dictionary (ShadingContext *ctx) : m_context(ctx)
+    {
         // Create placeholder element 0 == 'not found'
         m_nodes.push_back (Node(0, pugi::xml_node()));
     }
@@ -141,7 +142,7 @@ private:
     typedef boost::unordered_map <Query, QueryResult, QueryHash> QueryMap;
     typedef boost::unordered_map<ustring, int, ustringHash> DocMap;
 
-    ShadingSystemImpl &m_shadingsys;  // back-pointer to shading sys
+    ShadingContext *m_context;  // back-pointer to shading context
 
     // List of XML documents we've read in.
     std::vector<pugi::xml_document *> m_documents;
@@ -187,9 +188,9 @@ Dictionary::get_document_index (ustring dictionaryname)
                                              dictionaryname.length());
         }
         if (! parse_result) {
-            m_shadingsys.error ("XML parsed with errors: %s, at offset %d",
-                                parse_result.description(),
-                                parse_result.offset);
+            m_context->error ("XML parsed with errors: %s, at offset %d",
+                              parse_result.description(),
+                              parse_result.offset);
             m_document_map[dictionaryname] = -1;
             return -1;
         }
@@ -226,8 +227,8 @@ Dictionary::dict_find (ustring dictionaryname, ustring query)
         matches = doc->select_nodes (query.c_str());
     }
     catch (const pugi::xpath_exception& e) {
-        m_shadingsys.error ("Invalid dict_find query '%s': %s",
-                            query.c_str(), e.what());
+        m_context->error ("Invalid dict_find query '%s': %s",
+                          query.c_str(), e.what());
         return 0;
     }
 
@@ -273,8 +274,8 @@ Dictionary::dict_find (int nodeID, ustring query)
         matches = node.node.select_nodes (query.c_str());
     }
     catch (const pugi::xpath_exception& e) {
-        m_shadingsys.error ("Invalid dict_find query '%s': %s",
-                            query.c_str(), e.what());
+        m_context->error ("Invalid dict_find query '%s': %s",
+                          query.c_str(), e.what());
         return 0;
     }
 
@@ -408,7 +409,7 @@ int
 ShadingContext::dict_find (ustring dictionaryname, ustring query)
 {
     if (! m_dictionary) {
-        m_dictionary = new Dictionary (shadingsys());
+        m_dictionary = new Dictionary (this);
     }
     return m_dictionary->dict_find (dictionaryname, query);
 }
@@ -419,7 +420,7 @@ int
 ShadingContext::dict_find (int nodeID, ustring query)
 {
     if (! m_dictionary) {
-        m_dictionary = new Dictionary (shadingsys());
+        m_dictionary = new Dictionary (this);
     }
     return m_dictionary->dict_find (nodeID, query);
 }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -227,7 +227,7 @@ LLVMGEN (llvm_gen_printf)
 
     std::vector<llvm::Value*> call_args;
     if (!format_sym.is_constant()) {
-        rop.shadingsys().warning ("%s must currently have constant format\n",
+        rop.shadingcontext()->warning ("%s must currently have constant format\n",
                                   op.opname().c_str());
         return false;
     }
@@ -264,7 +264,7 @@ LLVMGEN (llvm_gen_printf)
                 ++format;
             char formatchar = *format++;  // Also eat the format char
             if (arg >= op.nargs()) {
-                rop.shadingsys().error ("Mismatch between format string and arguments (%s:%d)",
+                rop.shadingcontext()->error ("Mismatch between format string and arguments (%s:%d)",
                                         op.sourcefile().c_str(), op.sourceline());
                 return false;
             }
@@ -910,7 +910,7 @@ LLVMGEN (llvm_gen_unary_op)
             result = rop.ll.op_not (src_val);
         } else {
             // Don't know how to handle this.
-            rop.shadingsys().error ("Don't know how to handle op '%s', eliding the store\n", opname.c_str());
+            rop.shadingcontext()->error ("Don't know how to handle op '%s', eliding the store\n", opname.c_str());
         }
 
         // Store the result
@@ -928,7 +928,7 @@ LLVMGEN (llvm_gen_unary_op)
 
         if (dst_derivs) {
             // mul results in <a * b, a * b_dx + b * a_dx, a * b_dy + b * a_dy>
-            rop.shadingsys().info ("punting on derivatives for now\n");
+            rop.shadingcontext()->info ("punting on derivatives for now\n");
             // FIXME!!
         }
     }
@@ -2063,7 +2063,7 @@ llvm_gen_texture_options (BackendLLVM &rop, int opnum,
                                     opt, rop.ll.constant(nchans), val);
 
         } else {
-            rop.shadingsys().error ("Unknown texture%s optional argument: \"%s\", <%s> (%s:%d)",
+            rop.shadingcontext()->error ("Unknown texture%s optional argument: \"%s\", <%s> (%s:%d)",
                                     tex3d ? "3d" : "",
                                     name.c_str(), valtype.c_str(),
                                     op.sourcefile().c_str(), op.sourceline());
@@ -2296,7 +2296,7 @@ llvm_gen_trace_options (BackendLLVM &rop, int opnum,
         } else if (name == ktraceset && valtype == TypeDesc::STRING) {
             rop.ll.call_function ("osl_trace_set_traceset", opt, val);
         } else {
-            rop.shadingsys().error ("Unknown trace() optional argument: \"%s\", <%s> (%s:%d)",
+            rop.shadingcontext()->error ("Unknown trace() optional argument: \"%s\", <%s> (%s:%d)",
                                     name.c_str(), valtype.c_str(),
                                     op.sourcefile().c_str(), op.sourceline());
         }
@@ -2406,7 +2406,7 @@ llvm_gen_noise_options (BackendLLVM &rop, int opnum,
                                     rop.llvm_load_value (Val, 0, NULL, 0,
                                                          TypeDesc::TypeFloat));
         } else {
-            rop.shadingsys().error ("Unknown %s optional argument: \"%s\", <%s> (%s:%d)",
+            rop.shadingcontext()->error ("Unknown %s optional argument: \"%s\", <%s> (%s:%d)",
                                     op.opname().c_str(),
                                     name.c_str(), valtype.c_str(),
                                     op.sourcefile().c_str(), op.sourceline());
@@ -2503,7 +2503,7 @@ LLVMGEN (llvm_gen_noise)
         derivs = true;
         name = periodic ? Strings::gaborpnoise : Strings::gabornoise;
     } else {
-        rop.shadingsys().error ("%snoise type \"%s\" is unknown, called from (%s:%d)",
+        rop.shadingcontext()->error ("%snoise type \"%s\" is unknown, called from (%s:%d)",
                                 (periodic ? "periodic " : ""), name.c_str(),
                                 op.sourcefile().c_str(), op.sourceline());
         return false;
@@ -2915,7 +2915,7 @@ llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::Closu
                 legal = true;
         }
         if (!legal) {
-            rop.shadingsys().warning("Unsupported closure keyword arg \"%s\" for %s (%s:%d)", key->c_str(), clname.c_str(), op.sourcefile().c_str(), op.sourceline());
+            rop.shadingcontext()->warning("Unsupported closure keyword arg \"%s\" for %s (%s:%d)", key->c_str(), clname.c_str(), op.sourcefile().c_str(), op.sourceline());
             continue;
         }
 
@@ -2947,7 +2947,7 @@ LLVMGEN (llvm_gen_closure)
 
     const ClosureRegistry::ClosureEntry * clentry = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-        rop.shadingsys().error ("Closure '%s' is not supported by the current renderer, called from (%s:%d)",
+        rop.shadingcontext()->error ("Closure '%s' is not supported by the current renderer, called from (%s:%d)",
                                 closure_name.c_str(), op.sourcefile().c_str(), op.sourceline());
         return false;
     }
@@ -3014,7 +3014,7 @@ LLVMGEN (llvm_gen_closure)
             rop.ll.op_memcpy (dst, src, (int)p.type.size(),
                              4 /* use 4 byte alignment for now */);
         } else {
-            rop.shadingsys().error ("Incompatible formal argument %d to '%s' closure. Prototypes don't match renderer registry.",
+            rop.shadingcontext()->error ("Incompatible formal argument %d to '%s' closure. Prototypes don't match renderer registry.",
                                     carg + 1, closure_name.c_str());
         }
     }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -963,7 +963,8 @@ BackendLLVM::build_llvm_code (int beginop, int endop, llvm::BasicBlock *bb)
                    op.opname() == op_end) {
             // Skip this op, it does nothing...
         } else {
-            shadingsys().error ("LLVMOSL: Unsupported op %s in layer %s\n", op.opname().c_str(), inst()->layername().c_str());
+            shadingcontext()->error ("LLVMOSL: Unsupported op %s in layer %s\n",
+                                     op.opname(), inst()->layername());
             return false;
         }
 
@@ -1218,13 +1219,13 @@ BackendLLVM::run ()
     ll.module (ll.module_from_bitcode (osl_llvm_compiled_ops_block,
                                        osl_llvm_compiled_ops_size, &err));
     if (err.length())
-        shadingsys().error ("ParseBitcodeFile returned '%s'\n", err.c_str());
+        shadingcontext()->error ("ParseBitcodeFile returned '%s'\n", err.c_str());
     ASSERT (ll.module());
 #endif
 
     // Create the ExecutionEngine
     if (! ll.make_jit_execengine (&err)) {
-        shadingsys().error ("Failed to create engine: %s\n", err.c_str());
+        shadingcontext()->error ("Failed to create engine: %s\n", err.c_str());
         ASSERT (0);
         return;
     }
@@ -1266,7 +1267,7 @@ BackendLLVM::run ()
 
     if (shadingsys().m_max_local_mem_KB &&
         m_llvm_local_mem/1024 > shadingsys().m_max_local_mem_KB) {
-        shadingsys().error ("Shader group \"%s\" needs too much local storage: %d KB",
+        shadingcontext()->error ("Shader group \"%s\" needs too much local storage: %d KB",
                             group().name().c_str(), m_llvm_local_mem/1024);
     }
 
@@ -1319,9 +1320,9 @@ BackendLLVM::run ()
     m_stat_total_llvm_time = timer();
 
     if (shadingsys().m_compile_report) {
-        shadingsys().info ("JITed shader group %s:",
+        shadingcontext()->info ("JITed shader group %s:",
                            group().name() ? group().name().c_str() : "");
-        shadingsys().info ("    (%1.2fs = %1.2f setup, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
+        shadingcontext()->info ("    (%1.2fs = %1.2f setup, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
                            m_stat_total_llvm_time, 
                            m_stat_llvm_setup_time,
                            m_stat_llvm_irgen_time, m_stat_llvm_opt_time,

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -730,7 +730,7 @@ osl_get_matrix (ShaderGlobals *sg, Matrix44 *r, const char *from)
         r->makeIdentity();
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->shadingsys().error ("Unknown transformation \"%s\"", from);
+            ctx->error ("Unknown transformation \"%s\"", from);
     }
     return ok;
 }
@@ -757,7 +757,7 @@ osl_get_inverse_matrix (ShaderGlobals *sg, Matrix44 *r, const char *to)
         r->makeIdentity ();
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->shadingsys().error ("Unknown transformation \"%s\"", to);
+            ctx->error ("Unknown transformation \"%s\"", to);
     }
     return ok;
 }
@@ -772,7 +772,7 @@ osl_prepend_matrix_from (void *sg, void *r, const char *from)
     else {
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->shadingsys().error ("Unknown transformation \"%s\"", from);
+            ctx->error ("Unknown transformation \"%s\"", from);
     }
     return ok;
 }
@@ -1474,7 +1474,7 @@ OSL_SHADEOP int osl_get_textureinfo(void *sg_,    void *fin_,
     const ustring &filename  = USTR(fin_);
     const ustring &dataname  = USTR(dnam_);
 
-    return sg->renderer->get_texture_info (filename, 0 /*FIXME-ptex*/,
+    return sg->renderer->get_texture_info (sg, filename, 0 /*FIXME-ptex*/,
                                            dataname, typedesc, data);
 }
 
@@ -1721,7 +1721,7 @@ osl_range_check (int indexvalue, int length,
 {
     if (indexvalue < 0 || indexvalue >= length) {
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
-        ctx->shadingsys().error ("Index [%d] out of range [0..%d]: %s:%d",
+        ctx->error ("Index [%d] out of range [0..%d]: %s:%d",
                                  indexvalue, length-1,
                                  USTR(sourcefile).c_str(), sourceline);
         if (indexvalue >= length)
@@ -1753,7 +1753,7 @@ osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
         for (int c = firstcheck, e = c+nchecks; c < e;  ++c) {
             int i = d*ncomps + c;
             if (! isfinite(vals[i])) {
-                ctx->shadingsys().error ("Detected %g value in %s%s at %s:%d (op %s)",
+                ctx->error ("Detected %g value in %s%s at %s:%d (op %s)",
                                          vals[i],
                                          d > 0 ? "the derivatives of " : "",
                                          USTR(symbolname).c_str(),
@@ -1809,7 +1809,7 @@ osl_uninit_check (long long typedesc_, void *vals_,
             }
     }
     if (uninit) {
-        ctx->shadingsys().error ("Detected possible use of uninitialized value in %s at %s:%d",
+        ctx->error ("Detected possible use of uninitialized value in %s at %s:%d",
                                  USTR(symbolname).c_str(),
                                  USTR(sourcefile).c_str(), sourceline);
     }

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -27,6 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "oslexec_pvt.h"
+#include "shaderglobals.h"
 
 
 /////////////////////////////////////////////////////////////////////////
@@ -73,7 +74,7 @@ osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val
         if (m->name == name) {
             // message already exists?
             if (m->has_data())
-                sg->context->shadingsys().error(
+                sg->context->error(
                    "message \"%s\" already exists (created here: %s:%d)"
                    " cannot set again from %s:%d",
                    name.c_str(),
@@ -82,7 +83,7 @@ osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val
                    sourcefile.c_str(),
                    sourceline);
             else // NOTE: this cannot be triggered when strict_messages=false because we won't record "failed" getmessage calls
-               sg->context->shadingsys().error(
+               sg->context->error(
                    "message \"%s\" was queried before being set (queried here: %s:%d)"
                    " setting it now (%s:%d) would lead to inconsistent results",
                    name.c_str(),
@@ -127,7 +128,7 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
         if (m->name == name) {
             if (m->type != type) {
                 // found message, but types don't match
-                sg->context->shadingsys().error(
+                sg->context->error(
                     "type mismatch for message \"%s\" (%s as %s here: %s:%d)"
                     " cannot fetch as %s from %s:%d",
                     name.c_str(),
@@ -146,7 +147,7 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
             }
             if (m->layeridx > layeridx) {
                 // found message, but was set by a layer deeper than the one querying the message
-                sg->context->shadingsys().error(
+                sg->context->error(
                     "message \"%s\" was set by layer #%d (%s:%d)"
                     " but is being queried by layer #%d (%s:%d)"
                     " - messages may only be transfered from nodes "

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -645,7 +645,7 @@ struct GenericNoise {
             GaborNoise gnoise;
             gnoise (name, result, s, sg, opt);
         } else {
-            ((ShadingContext *)sg->context)->shadingsys().error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
         }
     }
 
@@ -673,7 +673,7 @@ struct GenericNoise {
             GaborNoise gnoise;
             gnoise (name, result, s, t, sg, opt);
         } else {
-            ((ShadingContext *)sg->context)->shadingsys().error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
         }
     }
 };
@@ -707,7 +707,7 @@ struct GenericPNoise {
             GaborPNoise gnoise;
             gnoise (name, result, s, sp, sg, opt);
         } else {
-            ((ShadingContext *)sg->context)->shadingsys().error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
         }
     }
 
@@ -730,7 +730,7 @@ struct GenericPNoise {
             GaborPNoise gnoise;
             gnoise (name, result, s, t, sp, tp, sg, opt);
         } else {
-            ((ShadingContext *)sg->context)->shadingsys().error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
         }
     }
 };

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -108,7 +108,7 @@ osl_printf (ShaderGlobals *sg, const char* format_str, ...)
 #endif
     std::string s = Strutil::vformat (format_str, args);
     va_end (args);
-    sg->context->shadingsys().message (s);
+    sg->context->message ("%s", s);
 }
 
 
@@ -119,7 +119,7 @@ osl_error (ShaderGlobals *sg, const char* format_str, ...)
     va_start (args, format_str);
     std::string s = Strutil::vformat (format_str, args);
     va_end (args);
-    sg->context->shadingsys().error (s);
+    sg->context->error ("%s", s);
 }
 
 
@@ -131,7 +131,7 @@ osl_warning (ShaderGlobals *sg, const char* format_str, ...)
         va_start (args, format_str);
         std::string s = Strutil::vformat (format_str, args);
         va_end (args);
-        sg->context->shadingsys().warning (s);
+        sg->context->warning ("%s", s);
     }
 }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -882,7 +882,8 @@ private:
     std::vector<ustring> m_renderer_outputs; ///< Names of renderer outputs
     ustring m_colorspace;                 ///< What RGB colors mean
     int m_max_local_mem_KB;               ///< Local storage can a shader use
-    bool m_compile_report;
+    bool m_compile_report;                ///< Print compilation report?
+    bool m_buffer_printf;                 ///< Buffer/batch printf output?
 
     // Derived/cached calculations from options:
     Color3 m_Red, m_Green, m_Blue;        ///< Color primaries (xyY)
@@ -1279,6 +1280,24 @@ public:
         }
     }
 
+    // Record an error (or warning, printf, etc.)
+    void record_error (ErrorHandler::ErrCode code, const std::string &text) const;
+    // Process all the recorded errors, warnings, printfs
+    void process_errors () const;
+
+    TINYFORMAT_WRAP_FORMAT (void, error, const,
+                            std::ostringstream msg;, msg,
+                            record_error(ErrorHandler::EH_ERROR, msg.str());)
+    TINYFORMAT_WRAP_FORMAT (void, warning, const,
+                            std::ostringstream msg;, msg,
+                            record_error(ErrorHandler::EH_WARNING, msg.str());)
+    TINYFORMAT_WRAP_FORMAT (void, info, const,
+                            std::ostringstream msg;, msg,
+                            record_error(ErrorHandler::EH_INFO, msg.str());)
+    TINYFORMAT_WRAP_FORMAT (void, message, const,
+                            std::ostringstream msg;, msg,
+                            record_error(ErrorHandler::EH_MESSAGE, msg.str());)
+
 private:
 
     void free_dict_resources ();
@@ -1310,6 +1329,10 @@ private:
     static const int FAILED_ATTRIBS = 16;
     GetAttribQuery m_failed_attribs[FAILED_ATTRIBS];
     int m_next_failed_attrib;
+
+    // Buffering of error messages and printfs
+    typedef std::pair<ErrorHandler::ErrCode, std::string> ErrorItem;
+    mutable std::vector<ErrorItem> m_buffered_errors;
 };
 
 

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -193,13 +193,13 @@ RendererServices::pointcloud_search (ShaderGlobals *sg,
         return 0;
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
-        sg->context->shadingsys().error ("pointcloud_search: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_search: could not open \"%s\"", filename.c_str());
         return 0;
     }
     spin_lock lock (pc->m_mutex);
     Partio::ParticlesDataMutable *cloud = pc->m_partio_cloud;
     if (cloud == NULL) { // The file failed to load
-        sg->context->shadingsys().error ("pointcloud_search: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_search: could not open \"%s\"", filename.c_str());
         return 0;
     }
 
@@ -290,20 +290,20 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
 
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
-        sg->context->shadingsys().error ("pointcloud_get: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_get: could not open \"%s\"", filename.c_str());
         return 0;
     }
     spin_lock lock (pc->m_mutex);
     Partio::ParticlesDataMutable *cloud = pc->m_partio_cloud;
     if (cloud == NULL) { // The file failed to load
-        sg->context->shadingsys().error ("pointcloud_get: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_get: could not open \"%s\"", filename.c_str());
         return 0;
     }
 
     // lookup the ParticleAttribute pointer needed for a query
     Partio::ParticleAttribute *attr = pc->m_attributes[attr_name].get();
     if (! attr) {
-        sg->context->shadingsys().error ("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name.c_str(), filename.c_str());
+        sg->context->error ("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name.c_str(), filename.c_str());
         return 0;
     }
 
@@ -327,7 +327,7 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
 
     // Finally check for some equivalent types like float3 and vector
     if (!compatiblePartioType(attr, attr_partio_type)) {
-        sg->context->shadingsys().error ("Type of attribute \"%s\" : %s[%d] not compatible with OSL's %s in \"%s\" pointcloud",
+        sg->context->error ("Type of attribute \"%s\" : %s[%d] not compatible with OSL's %s in \"%s\" pointcloud",
                     attr_name.c_str(), partioTypeString(attr), attr->count,
                     element_type.c_str(), filename.c_str());
         return 0;

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -120,9 +120,7 @@ RendererServices::texture (ustring filename, TextureOpt &options,
     {
         std::string err = texturesys()->geterror();
         if (err.size()) {
-            std::cerr << "[RendererServices::texture] " << err.c_str();
-            if (err[err.size()-1] != '\n')
-                std::cerr << "\n";
+            sg->context->error ("[RendererServices::texture] %s", err);
         }
     }
     return status;
@@ -142,9 +140,7 @@ RendererServices::texture3d (ustring filename, TextureOpt &options,
     {
         std::string err = texturesys()->geterror();
         if (err.size()) {
-            std::cerr << "[RendererServices::texture3d] " << err.c_str();
-            if (err[err.size()-1] != '\n')
-                std::cerr << "\n";
+            sg->context->error ("[RendererServices::texture3d] %s", err);
         }
     }
     return status;
@@ -161,9 +157,7 @@ RendererServices::environment (ustring filename, TextureOpt &options,
     if (!status) {
         std::string err = texturesys()->geterror();
         if (err.size()) {
-            std::cerr << "[RendererServices::environment] " << err.c_str();
-            if (err[err.size()-1] != '\n')
-                std::cerr << "\n";
+            sg->context->error ("[RendererServices::environment] %s", err);
         }
     }
     return status;
@@ -172,7 +166,8 @@ RendererServices::environment (ustring filename, TextureOpt &options,
 
     
 bool
-RendererServices::get_texture_info (ustring filename, int subimage,
+RendererServices::get_texture_info (ShaderGlobals *sg,
+                                    ustring filename, int subimage,
                                     ustring dataname,
                                     TypeDesc datatype, void *data)
 {
@@ -181,9 +176,7 @@ RendererServices::get_texture_info (ustring filename, int subimage,
     if (!status) {
         std::string err = texturesys()->geterror();
         if (err.size()) {
-            std::cerr << "[RendererServices::get_texture_info] " << err.c_str();
-            if (err[err.size()-1] != '\n')
-                std::cerr << "\n";
+            sg->context->error ("[RendererServices::get_texture_info] %s", err);
         }
     }
     return status;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2604,7 +2604,7 @@ RuntimeOptimizer::run ()
     Timer rop_timer;
     int nlayers = (int) group().nlayers ();
     if (debug())
-        shadingsys().info ("About to optimize shader group %s (%d layers):",
+        shadingcontext()->info ("About to optimize shader group %s (%d layers):",
                            group().name().c_str(), nlayers);
 
     m_params_holding_globals.resize (nlayers);
@@ -2710,9 +2710,9 @@ RuntimeOptimizer::run ()
         ss.m_stat_postopt_ops += new_nops;
     }
     if (shadingsys().m_compile_report) {
-        shadingsys().info ("Optimized shader group %s:",
+        shadingcontext()->info ("Optimized shader group %s:",
                            group().name() ? group().name().c_str() : "");
-        shadingsys().info (" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+        shadingcontext()->info (" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
               m_stat_specialization_time, new_nsyms, old_nsyms,
               100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
               new_nops, old_nops,

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -4,4 +4,4 @@ ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10
 Output Cout to Cout.tif
 ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10
 ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11
-[RendererServices::texture] ImageInput::create() called with no filename
+ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/gettextureinfo/ref/out.txt
+++ b/testsuite/gettextureinfo/ref/out.txt
@@ -8,7 +8,7 @@ Executing...
 ../common/textures/grid.tx displaywindow: 0 0 1023 1023
 ../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
 ../common/textures/grid.tx foobar: not found (0)
-[RendererServices::get_texture_info] Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+ERROR: [RendererServices::get_texture_info] Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
 
 Invalid image file "badfile"
 badfile data: not found (0)
@@ -23,7 +23,7 @@ win.exr textureformat: Plain Texture (1)
 win.exr datawindow: 10 20 109 69
 win.exr displaywindow: 0 0 299 199
 win.exr foobar: not found (0)
-[RendererServices::get_texture_info] Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+ERROR: [RendererServices::get_texture_info] Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
 
 Invalid image file "badfile"
 badfile data: not found (0)


### PR DESCRIPTION
The aim of this patch is to buffer a shader's printf, warning, and error
outputs and then send them to the error manager in a single atomic chunk
rather than individually, so that each individual shader invocation will
have all of its console output appear contiguous in a log, rather than
haphazardly interleaved with the individual lines of other shader
invocations running concurrently in different threads.

The buffer lives in the ShadingContext, and any accumulated output is sent
to the renderer all at once (and protected by a mutex) when the shader
execution is finished.  Also, for good measure, we flush again when the
app gives the context back to the ShadingSystem (in case that now, or in the
future, there's a code path that involves a ShadingContext that encounters
errors but never calls execute).

Most of the individual line changes in this patch are tracking down all the
places that ShadingSystem->{error,warning,message,info} were called, and
instead calling equivalent routines in the ShadingContext instead, so it will
be buffered.  (We had to add those functions to the context, and we do so
leveraging the wonderful Tinyformat package.)

One minor API gotcha is that, embarrassingly,
RendererServices::get_texture_info had direct output to std::err! We
wanted to change that to a context->error() call, but unfortunately that
function (unlike most other RS calls) didn't accept a ShaderGlobals*, so
I had to change the API signature of that function to add it. This is a
non-back-compatible API change, but it's clearly fixing an oversight.

I made a ShadingSystem option "buffer_printf", which controls this. It
default to being on, and I think that's what most people will want, but
you can turn it off if for some reason you really, really want every
shader's printf or error output to be passed to the error manager
immediately without waiting until the shader invocation has completed
(with the obvious effect of, as before, possibly being interleaved with
output of other concurrent shader invocations).
