### PR TITLE
Support for LLVM MCJIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ else ()
     set (USE_BOOST_WAVE OFF CACHE BOOL "Use Boost Wave as preprocessor")
 endif ()
 set (USE_PARTIO ON CACHE BOOL "Use Partio if found")
+set (USE_MCJIT OFF CACHE BOOL "Use LLVM MCJIT (if no, then use old JIT)")
 
 if (LLVM_NAMESPACE)
     add_definitions ("-DLLVM_NAMESPACE=${LLVM_NAMESPACE}")
@@ -171,6 +172,10 @@ endif()
 
 if (USE_BOOST_WAVE)
     add_definitions ("-DUSE_BOOST_WAVE")
+endif ()
+
+if (USE_MCJIT)
+    add_definitions ("-DUSE_MCJIT=1")
 endif ()
 
 if (CMAKE_COMPILER_IS_CLANG AND OSL_USE_LIBCPP)

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ ifneq (${USE_LIBCPP},)
 MY_CMAKE_FLAGS += -DOSL_USE_LIBCPP:BOOL=${USE_LIBCPP}
 endif
 
+ifneq (${USE_MCJIT},)
+MY_CMAKE_FLAGS += -DUSE_MCJIT:BOOL=${USE_MCJIT}
+endif
+
 ifdef DEBUG
 MY_CMAKE_FLAGS += -DCMAKE_BUILD_TYPE:STRING=Debug
 endif
@@ -256,4 +260,5 @@ help:
 	@echo "  make BUILDSTATIC=1 ...      Build static library instead of shared"
 	@echo "  make USE_EXTERNAL_PUGIXML=1 Use the system PugiXML, not the one in OIIO"
 	@echo "  make USE_LIBCPP=1           Use libc++"
+	@echo "  make USE_MCJIT=1            Use LLVM MCJIT (default: use old JIT)"
 	@echo ""

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -175,6 +175,9 @@ find_library ( LLVM_LIBRARY
                PATHS ${LLVM_LIB_DIR})
 message (STATUS "LLVM version  = ${LLVM_VERSION}")
 message (STATUS "LLVM dir      = ${LLVM_DIRECTORY}")
+find_library ( LLVM_MCJIT_LIBRARY
+               NAMES LLVMMCJIT
+               PATHS ${LLVM_LIB_DIR})
 if (VERBOSE)
     message (STATUS "LLVM includes = ${LLVM_INCLUDES}")
     message (STATUS "LLVM library  = ${LLVM_LIBRARY}")

--- a/src/include/llvm_util.h
+++ b/src/include/llvm_util.h
@@ -80,16 +80,16 @@ class OSL_Dummy_JITMemoryManager;
 /// tied to OSL internals at all.
 class OSLEXECPUBLIC LLVM_Util {
 public:
-    LLVM_Util ();
+    LLVM_Util (int debuglevel=0);
     ~LLVM_Util ();
 
     struct PerThreadInfo;
     typedef llvm::IRBuilder<true,llvm::ConstantFolder,
                             llvm::IRBuilderDefaultInserter<true> > IRBuilder;
 
-    /// Set up LLVM -- make sure we have a Context, Module, ExecutionEngine,
-    /// retained JITMemoryManager, etc.
-    static void SetupLLVM ();
+    /// Set debug level
+    void debug (int d) { m_debug = d; }
+    int debug () const { return m_debug; }
 
     /// Return a reference to the current context.
     llvm::LLVMContext &context () const { return *m_llvm_context; }
@@ -109,9 +109,10 @@ public:
     llvm::Module *new_module (const char *id = "default");
 
     /// Create a new module, populated with functions from the buffer
-    /// bitcode[0..size-1].  If err is not NULL, error messages will be
-    /// stored there.
+    /// bitcode[0..size-1].  The name identifies the buffer.  If err is not
+    /// NULL, error messages will be stored there.
     llvm::Module *module_from_bitcode (const char *bitcode, size_t size,
+                                       const std::string &name=std::string(),
                                        std::string *err=NULL);
 
     /// Create a new function (that will later be populated with
@@ -474,6 +475,10 @@ private:
         return (llvm::JITMemoryManager *)m_llvm_jitmm;
     }
 
+    void SetupLLVM ();
+
+
+    int m_debug;
     PerThreadInfo *m_thread;
     llvm::LLVMContext *m_llvm_context;
     llvm::Module *m_llvm_module;

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -103,6 +103,7 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
           "-I${OPENIMAGEIO_INCLUDES}"
           "-I${ILMBASE_INCLUDE_DIR}"
           "-I${Boost_INCLUDE_DIRS}"
+          -DOSL_COMPILING_TO_BITCODE=1
           -O3 -S -emit-llvm -o ${llvm_asm} ${llvm_src}
       COMMAND "${LLVM_DIRECTORY}/bin/llvm-as" -f -o ${llvm_bc} ${llvm_asm}
       COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash" ${llvm_bc} ${llvm_bc_cpp}
@@ -132,7 +133,7 @@ TARGET_LINK_LIBRARIES ( oslexec
                         ${OPENIMAGEIO_LIBRARY} ${PUGIXML_LIBRARIES}
                         ${PARTIO_LIBRARIES} ${ZLIB_LIBRARIES}
                         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
-                        ${LLVM_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES})
+                        ${LLVM_LIBRARY} ${LLVM_MCJIT_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES})
 ADD_DEPENDENCIES (oslexec "${CMAKE_CURRENT_SOURCE_DIR}/liboslcexec.map")
 LINK_ILMBASE ( oslexec )
 

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -55,6 +55,8 @@ public:
 
     virtual ~BackendLLVM ();
 
+    virtual void set_inst (int layer);
+
     /// Create an llvm function for the whole shader group, JIT it,
     /// and store the llvm::Function* handle to it with the ShaderGroup.
     virtual void run ();

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -455,5 +455,41 @@ ShadingContext::free_dict_resources ()
 }
 
 
+#define USTR(cstr) (*((ustring *)&cstr))
+#define TYPEDESC(x) (*(TypeDesc *)&x)
+
+
+OSL_SHADEOP int osl_dict_find_iis (void *sg_, int nodeID, void *query)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    return sg->context->dict_find (nodeID, USTR(query));
+}
+
+
+
+OSL_SHADEOP int osl_dict_find_iss (void *sg_, void *dictionary, void *query)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    return sg->context->dict_find (USTR(dictionary), USTR(query));
+}
+
+
+
+OSL_SHADEOP int osl_dict_next (void *sg_, int nodeID)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    return sg->context->dict_next (nodeID);
+}
+
+
+
+OSL_SHADEOP int osl_dict_value (void *sg_, int nodeID, void *attribname,
+                               long long type, void *data)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    return sg->context->dict_value (nodeID, USTR(attribname), TYPEDESC(type), data);
+}
+
+
 
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -519,5 +519,16 @@ OSL_SHADEOP void osl_luminance_dfdv (void *sg, void *out, void *c)
 
 
 
+#define USTR(cstr) (*((ustring *)&cstr))
+
+OSL_SHADEOP void
+osl_prepend_color_from (void *sg, void *c_, const char *from)
+{
+    ShadingContext *ctx (((ShaderGlobals *)sg)->context);
+    Color3 &c (*(Color3*)c_);
+    c = ctx->shadingsys().to_rgb (USTR(from), c[0], c[1], c[2]);
+}
+
+
 } // namespace pvt
 OSL_NAMESPACE_EXIT


### PR DESCRIPTION
All along, we've been using LLVM's "old" JIT subsystem. It's not really being maintained well these days, and may some day be phased out completely in favor of its replacement "MCJIT."

This patch allows a build-time switch to use either MCJIT or old JIT. Primarily this is to pave the road for future exclusive use of MCJIT if old JIT is removed from LLVM, or if we wish to use some feature of MCJIT that is not backported to old JIT.

Note that this pull request implicitly includes #331 as well; you can review them separately if you wish.

In this patch, we:
- Link against MCJIT libraries from LLVM
- Amend LLVM_Util to have a debug mode.
- Some incidental movement of BackendLLVM methods from llvm_instance.cpp  to backendllvm.cpp.
- Some minor changes to LLVM_Util to support MCJIT.
- Moved some non-essential (and unlikely to inline) functions from llvm_opt.cpp to other cpp files. This helps reduce the dependencies for llvm_ops.cpp, reduce the amount of bitcode to process, and was intended to fix some MCJIT issues (but turned out that they were not relevant in the end).

Currently, this code uses ParseBitcodeFile rather than getLazyBitcodeModule when MCJIT is enabled, since MCJIT appears to have a bug that causes it to not correctly find the symbols in the module when using lazy deserialization. I'm inquiring after this on llvm-dev and hope to get it cleared up at some point, but that doesn't need to hold up this review.
