### PR TITLE
oslc bug fix for initializing array elements inside a param that's a struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-paramdefault
+            oslc-err-struct-array-init
             oslc-variadic-macro
             pointcloud pointcloud-fold
             raytype reparam

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -872,7 +872,8 @@ ASTvariable_declaration::codegen_initlist (ref init, TypeSpec type,
 Symbol *
 ASTvariable_declaration::codegen_struct_initializers (ref init)
 {
-    if (! init->next() && init->typespec() == m_typespec) {
+    if (! init->next() && init->typespec() == m_typespec &&
+            init->nodetype() != compound_initializer_node) {
         // Special case: just one initializer, it's a whole struct of
         // the right type.
         Symbol *initsym = init->codegen (m_sym);

--- a/testsuite/oslc-err-struct-array-init/ref/out.txt
+++ b/testsuite/oslc-err-struct-array-init/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+Out is 1 2 3 4
+

--- a/testsuite/oslc-err-struct-array-init/run.py
+++ b/testsuite/oslc-err-struct-array-init/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = testshade("test")

--- a/testsuite/oslc-err-struct-array-init/test.osl
+++ b/testsuite/oslc-err-struct-array-init/test.osl
@@ -1,0 +1,14 @@
+
+struct mystruct{
+    float f[4];
+};
+
+
+
+shader test (output mystruct Out  = { {1.0, 2.0, 3.0, 4.0} } )
+{
+    printf ("Out is %g %g %g %g\n", Out.f[0], Out.f[1], Out.f[2], Out.f[3]);
+}
+
+
+


### PR DESCRIPTION
Went the wrong way down an 'if', needed one more test to make sure this corner
case got directed to the right place where it should be handled.

I've also added a regression test that covers it.
