### PR TITLE
Fix some typos, trailing spaces and wrong copy-paste in comments

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -137,10 +137,10 @@ ASTNode::warning (const char *format, ...)
 
 
 void
-ASTNode::print (std::ostream &out, int indentlevel) const 
+ASTNode::print (std::ostream &out, int indentlevel) const
 {
     indent (out, indentlevel);
-    out << "(" << nodetypename() << " : " 
+    out << "(" << nodetypename() << " : "
         << "    (type: " << typespec().string() << ") "
         << (opname() ? opname() : "") << "\n";
     printchildren (out, indentlevel);
@@ -151,7 +151,7 @@ ASTNode::print (std::ostream &out, int indentlevel) const
 
 
 void
-ASTNode::printchildren (std::ostream &out, int indentlevel) const 
+ASTNode::printchildren (std::ostream &out, int indentlevel) const
 {
     for (size_t i = 0;  i < m_children.size();  ++i) {
         if (! child(i))
@@ -192,7 +192,7 @@ void
 ASTshader_declaration::print (std::ostream &out, int indentlevel) const
 {
     indent (out, indentlevel);
-    out << "(" << nodetypename() << " " << shadertypename() 
+    out << "(" << nodetypename() << " " << shadertypename()
               << " \"" << m_shadername << "\"\n";
     printchildren (out, indentlevel);
     indent (out, indentlevel);
@@ -294,7 +294,7 @@ ASTfunction_declaration::print (std::ostream &out, int indentlevel) const
     indent (out, indentlevel);
     out << nodetypename() << " " << m_sym->mangled();
     if (m_sym->scope())
-        out << " (" << m_sym->name() 
+        out << " (" << m_sym->name()
                   << " in scope " << m_sym->scope() << ")";
     out << "\n";
     printchildren (out, indentlevel);
@@ -308,7 +308,7 @@ ASTvariable_declaration::ASTvariable_declaration (OSLCompilerImpl *comp,
                                                   bool isparam, bool ismeta,
                                                   bool isoutput, bool initlist)
     : ASTNode (variable_declaration_node, comp, 0, init, NULL /* meta */),
-      m_name(name), m_sym(NULL), 
+      m_name(name), m_sym(NULL),
       m_isparam(isparam), m_isoutput(isoutput), m_ismetadata(ismeta),
       m_initlist(initlist)
 {
@@ -370,12 +370,12 @@ void
 ASTvariable_declaration::print (std::ostream &out, int indentlevel) const
 {
     indent (out, indentlevel);
-    out << "(" << nodetypename() << " " 
-              << m_sym->typespec().string() << " " 
+    out << "(" << nodetypename() << " "
+              << m_sym->typespec().string() << " "
               << m_sym->mangled();
 #if 0
     if (m_sym->scope())
-        out << " (" << m_sym->name() 
+        out << " (" << m_sym->name()
                   << " in scope " << m_sym->scope() << ")";
 #endif
     out << "\n";
@@ -410,7 +410,7 @@ ASTvariable_ref::print (std::ostream &out, int indentlevel) const
 {
     indent (out, indentlevel);
     out << "(" << nodetypename() << " (type: "
-        << (m_sym ? m_sym->typespec().string() : "unknown") << ") " 
+        << (m_sym ? m_sym->typespec().string() : "unknown") << ") "
         << (m_sym ? m_sym->mangled() : m_name.string()) << ")\n";
     DASSERT (nchildren() == 0);
 }
@@ -919,11 +919,11 @@ ASTfunction_call::opname () const
 
 
 void
-ASTfunction_call::print (std::ostream &out, int indentlevel) const 
+ASTfunction_call::print (std::ostream &out, int indentlevel) const
 {
     ASTNode::print (out, indentlevel);
 #if 0
-    if (is_user_function()) { 
+    if (is_user_function()) {
         out << "\n";
         user_function()->print (out, indentlevel+1);
         out << "\n";

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -68,16 +68,16 @@ public:
         conditional_statement_node,
         loop_statement_node, loopmod_statement_node, return_statement_node,
         binary_expression_node, unary_expression_node,
-        assign_expression_node, ternary_expression_node, 
+        assign_expression_node, ternary_expression_node,
         typecast_expression_node, type_constructor_node,
         function_call_node,
         literal_node,
         _last_node
     };
 
-    enum Operator { Nothing=0, Decr, Incr, 
+    enum Operator { Nothing=0, Decr, Incr,
                     Assign, Mul, Div, Add, Sub, Mod,
-                    Equal, NotEqual, Greater, Less, GreaterEqual, LessEqual, 
+                    Equal, NotEqual, Greater, Less, GreaterEqual, LessEqual,
                     BitAnd, BitOr, Xor, Compl,
                     And, Or, Not, ShiftLeft, ShiftRight };
 
@@ -123,7 +123,7 @@ public:
     /// type" may be passed down, conveying any requirements or
     /// coercion.  The default (base class) implementation just type
     /// checks all the child nodes and makes this node's type be the
-    /// expected if it is unknown, but doens't change it if it's not
+    /// expected if it is unknown, but doesn't change it if it's not
     /// unknown.
     virtual TypeSpec typecheck (TypeSpec expected = TypeSpec());
 
@@ -156,7 +156,7 @@ public:
     }
 
     /// Append a new node (specified by a reference-counted pointer)
-    /// onto the end of the sequence that *this belongs to.  Return an
+    /// onto the end of the sequence that *this belongs to.  Return a
     /// reference-counted pointer to *this.
     ref append (ref &x) { append (x.get()); return this; }
 
@@ -206,8 +206,8 @@ protected:
             n->print (out, indentlevel);
     }
 
-    /// A is the head of a list of nodes, traverse the list and call
-    /// the print() method for each node in the list.
+    /// A is the head of a list of nodes, traverse the list and compute
+    /// the length of the list.
     static size_t listlength (const ref &A) {
         size_t len = 0;
         for (const ASTNode *n = A.get();  n;  n = n->nextptr())
@@ -244,7 +244,7 @@ protected:
             return ref();
         }
     }
-        
+
     /// Return the number of child nodes.
     ///
     size_t nchildren () const { return m_children.size(); }
@@ -286,7 +286,7 @@ protected:
 
     /// Emit a single IR opcode -- append one op to the list of
     /// intermediate code, returning the label (address) of the new op.
-    int emitcode (const char *opname, Symbol *arg0=NULL, 
+    int emitcode (const char *opname, Symbol *arg0=NULL,
                   Symbol *arg1=NULL, Symbol *arg2=NULL, Symbol *arg3=NULL);
 
     /// Emit a single IR opcode -- append one op to the list of
@@ -323,7 +323,7 @@ class ASTshader_declaration : public ASTNode
 {
 public:
     ASTshader_declaration (OSLCompilerImpl *comp, int stype, ustring name,
-                           ASTNode *form, ASTNode *stmts, ASTNode *meta) 
+                           ASTNode *form, ASTNode *stmts, ASTNode *meta)
         : ASTNode (shader_declaration_node, comp, stype, meta, form, stmts),
           m_shadername(name)
     { }
@@ -402,7 +402,7 @@ public:
     bool is_output () const { return m_isoutput; }
 
     /// For shader params, generate the string that gives the
-    /// intialization of literal values and place it in 'out'.
+    /// initialization of literal values and place it in 'out'.
     /// Return whether the full initialization is comprised only of
     /// literals (and no init ops are needed).
     bool param_default_literals (const Symbol *sym, std::string &out);
@@ -423,7 +423,7 @@ private:
     void codegen_initlist (ref init, TypeSpec type, Symbol *sym);
 
     // Helper for param_default_literals: generate the string that gives
-    // the intialization of the literal value (and/or the default, if
+    // the initialization of the literal value (and/or the default, if
     // init==NULL) and append it to 'out'.  Return whether the full
     // initialization is comprised only of literals (no init ops needed).
     bool param_one_default_literal (const Symbol *sym, ASTNode *init,
@@ -565,7 +565,7 @@ class ASTconditional_statement : public ASTNode
 public:
     ASTconditional_statement (OSLCompilerImpl *comp, ASTNode *cond,
                               ASTNode *truestmt, ASTNode *falsestmt=NULL)
-        : ASTNode (conditional_statement_node, comp, 0, 
+        : ASTNode (conditional_statement_node, comp, 0,
                    cond, truestmt, falsestmt)
     { }
 
@@ -832,7 +832,7 @@ private:
                                  bool equivreturn);
 
     /// Handle all the special cases for built-ins.  This includes
-    /// irregular patterns of which args are read vs written, special 
+    /// irregular patterns of which args are read vs written, special
     /// checks for printf- and texture-like, etc.
     void typecheck_builtin_specialcase ();
 

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ************************************************************/
 
 
-/* Option 'noyywrap' indicates that when EOF is hit, yyin does not 
+/* Option 'noyywrap' indicates that when EOF is hit, yyin does not
  * automatically reset to another file.
  */
 %option noyywrap
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %option prefix="osl"
 
 
- /* Define regular expression macros 
+ /* Define regular expression macros
   ************************************************/
 
  /* white space, not counting newline */
@@ -59,7 +59,7 @@ DIGIT           [0-9]
  /* Integer literal */
 INTEGER         {DIGIT}+
  /* floating point literal (E, FLT1, FLT2, FLT3 are just helpers)
-  * NB: we don't allow leading +/- due to ambiguity between 
+  * NB: we don't allow leading +/- due to ambiguity between
   * whether "a-0.5" is really "a -0.5" or "a - 0.5".  Resolve this
   * in the grammar.
   */
@@ -290,7 +290,7 @@ preprocess (const char *yytext)
                 // error output match the standard cpp.
                 if (filename.find (oslcompiler->cwd()) == 0) {
                     filename.erase (0, oslcompiler->cwd().size());
-                    if (filename.size() && 
+                    if (filename.size() &&
                         (filename[0] == '/' || filename[0] == '\\'))
                         filename.erase (0, 1);
                 }

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -145,7 +145,7 @@ Symbol::print_vals (std::ostream &out, int maxvals) const
             out << (j ? " " : "") << ((int *)data())[j];
     } else if (t.basetype == TypeDesc::STRING) {
         for (int j = 0;  j < n;  ++j)
-            out << (j ? " " : "") << "\"" 
+            out << (j ? " " : "") << "\""
                 << Strutil::escape_chars(((ustring *)data())[j].string())
                 << "\"";
     }
@@ -162,8 +162,8 @@ Symbol::print (std::ostream &out, int maxvals) const
     out << Symbol::symtype_shortname(symtype())
         << " " << typespec().string() << " " << name();
     if (everused())
-        out << " (used " << firstuse() << ' ' << lastuse() 
-            << " read " << firstread() << ' ' << lastread() 
+        out << " (used " << firstuse() << ' ' << lastuse()
+            << " read " << firstread() << ' ' << lastread()
             << " write " << firstwrite() << ' ' << lastwrite();
     else
         out << " (unused";
@@ -236,7 +236,7 @@ SymbolTable::find_exact (ustring mangled_name) const
 
 
 
-Symbol * 
+Symbol *
 SymbolTable::clash (ustring name) const
 {
     Symbol *s = find (name);
@@ -329,12 +329,12 @@ SymbolTable::print ()
                 continue;
             std::cout << "    " << structid << ": struct " << s->mangled();
             if (s->scope())
-                std::cout << " (" << s->name() 
+                std::cout << " (" << s->name()
                           << " in scope " << s->scope() << ")";
             std::cout << " :\n";
             for (size_t i = 0;  i < s->numfields();  ++i) {
                 const StructSpec::FieldSpec & f (s->field(i));
-                std::cout << "\t" << f.name << " : " 
+                std::cout << "\t" << f.name << " : "
                           << f.type.string() << "\n";
             }
             ++structid;
@@ -354,7 +354,7 @@ SymbolTable::print ()
             std::cout << s->typespec().string();
         }
         if (s->scope())
-            std::cout << " (" << s->name() << " in scope " 
+            std::cout << " (" << s->name() << " in scope "
                       << s->scope() << ")";
         if (s->is_function()) {
             const FunctionSymbol *f = (const FunctionSymbol *) s;

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -198,7 +198,7 @@ private:
 /// are unique), there's a hash_map of symbols.  There's also a stack
 /// of such maps representing the current scope hierarchy, so a symbol
 /// search proceeds from innermost scope (top of stack) to outermost
-/// (bottom of stack).  
+/// (bottom of stack).
 ///
 class SymbolTable {
 public:
@@ -230,7 +230,7 @@ public:
     /// return it, otherwise return NULL.
     Symbol * clash (ustring name) const;
 
-    /// Insert the symbol into the current inner scope.  
+    /// Insert the symbol into the current inner scope.
     ///
     void insert (Symbol *sym);
 

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -213,7 +213,7 @@ ASTvariable_declaration::typecheck_struct_initializers (ref init)
 }
 
 
- 
+
 TypeSpec
 ASTvariable_ref::typecheck (TypeSpec expected)
 {
@@ -222,7 +222,7 @@ ASTvariable_ref::typecheck (TypeSpec expected)
 }
 
 
- 
+
 TypeSpec
 ASTpreincdec::typecheck (TypeSpec expected)
 {
@@ -233,7 +233,7 @@ ASTpreincdec::typecheck (TypeSpec expected)
 }
 
 
- 
+
 TypeSpec
 ASTpostincdec::typecheck (TypeSpec expected)
 {
@@ -246,7 +246,7 @@ ASTpostincdec::typecheck (TypeSpec expected)
 }
 
 
- 
+
 TypeSpec
 ASTindex::typecheck (TypeSpec expected)
 {
@@ -297,7 +297,7 @@ ASTindex::typecheck (TypeSpec expected)
     // Make sure the indices (children 1+) are integers
     for (size_t c = 1;  c < nchildren();  ++c)
         if (! child(c)->typespec().is_int())
-            error ("%s index must be an integer, not a %s", 
+            error ("%s index must be an integer, not a %s",
                    indextype, type_c_str(index()->typespec()));
 
     // If the thing we're indexing is an lvalue, so is the indexed element
@@ -462,7 +462,7 @@ ASTreturn_statement::typecheck (TypeSpec expected)
         }
         myfunc->encountered_return ();
     } else {
-        // We're not part of any user function, so this 'return' must 
+        // We're not part of any user function, so this 'return' must
         // be from the main shader body.  That's fine (it's equivalent
         // to calling exit()), but it can't return a value.
         if (expr())
@@ -608,10 +608,10 @@ ASTbinary_expression::typecheck (TypeSpec expected)
 
     case Equal :
     case NotEqual :
-        // Any equivalent types can be compared with == and !=, also a 
+        // Any equivalent types can be compared with == and !=, also a
         // float or int can be compared to any other numeric type.
         // Result is always an int.
-        if (equivalent (l, r) || 
+        if (equivalent (l, r) ||
               (l.is_numeric() && r.is_int_or_float()) ||
               (l.is_int_or_float() && r.is_numeric()))
             return m_typespec = TypeDesc::TypeInt;
@@ -748,7 +748,7 @@ ASTtype_constructor::typecheck (TypeSpec expected)
     }
 
     // If we made it this far, no match could be found.
-    std::string err = Strutil::format ("Cannot construct %s (", 
+    std::string err = Strutil::format ("Cannot construct %s (",
                                        type_c_str(typespec()));
     for (ref a = args();  a;  a = a->next()) {
         err += a->typespec().string();
@@ -800,7 +800,7 @@ ASTNode::check_arglist (const char *funcname, ASTNode::ref arg,
         int advance;
         TypeSpec formaltype = m_compiler->type_from_code (formals, &advance);
         formals += advance;
-        // std::cerr << "\targ is " << argtype.string() 
+        // std::cerr << "\targ is " << argtype.string()
         //           << ", formal is " << formaltype.string() << "\n";
         if (argtype == formaltype)
             continue;   // ok, move on to next arg
@@ -815,7 +815,7 @@ ASTNode::check_arglist (const char *funcname, ASTNode::ref arg,
         // anything that gets this far we don't consider a match
         return false;
     }
-    if (*formals && *formals != '*' && *formals != '.') 
+    if (*formals && *formals != '*' && *formals != '.')
         return false;  // Non-*, non-... formals expected, no more actuals
 
     return true;  // Is this safe?
@@ -1219,7 +1219,7 @@ static const char * builtin_func_args [] = {
     "Dy", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "Dz", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "displace", "xf", "xsf", "xv", "!deriv", NULL,
-    "environment", "fsv.", "fsvvv.","csv.", "csvvv.", 
+    "environment", "fsv.", "fsvvv.","csv.", "csvvv.",
                "vsv.", "vsvvv.", "!tex", "!rw", "!deriv", NULL,
     "error", "xs*", "!printf", NULL,
     "exit", "x", NULL,
@@ -1249,9 +1249,9 @@ static const char * builtin_func_args [] = {
     "splineinverse", "fsff[]", "fsfif[]", NULL,
     "split", "iss[]si", "iss[]s", "iss[]", "!rw", NULL,
     "surfacearea", "f", NULL,
-    "texture", "fsff.", "fsffffff.","csff.", "csffffff.", 
+    "texture", "fsff.", "fsffffff.","csff.", "csffffff.",
                "vsff.", "vsffffff.", "!tex", "!rw", "!deriv", NULL,
-    "texture3d", "fsp.", "fspvvv.","csp.", "cspvvv.", 
+    "texture3d", "fsp.", "fspvvv.","csp.", "cspvvv.",
                "vsp.", "vspvvv.", "!tex", "!rw", "!deriv", NULL,
     "trace", "ipv.", "!deriv", NULL,
     "warning", "xs*", "!printf", NULL,   // FIXME -- further checking
@@ -1381,7 +1381,7 @@ OSLCompilerImpl::typelist_from_code (const char *code) const
             ret += "...";
         } else if (*code == '?') {
             ret += "<any>";
-        } else {            
+        } else {
             TypeSpec t = type_from_code (code, &advance);
             ret += type_c_str(t);
         }


### PR DESCRIPTION
Since I am studying the code and found some typos, here is my modest contribution.
whitespace-mode and are useful for Emacs. :-)
also (setq show-trailing-whitespace t)
