### PR TITLE
testrender/testshade fix -- delete group refs before shading system.

### DIFF
--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -656,6 +656,7 @@ int main (int argc, const char *argv[]) {
     }
 
     // We're done with the shading system now, destroy it
+    shaders.clear ();  // Must release the group refs first
     ShadingSystem::destroy (shadingsys);
 
     return EXIT_SUCCESS;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -684,6 +684,7 @@ test_shade (int argc, const char *argv[])
     }
 
     // We're done with the shading system now, destroy it
+    shadergroup.reset ();  // Must release this before destroying shadingsys
     ShadingSystem::destroy (shadingsys);
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Suggested by Anders Lindqvist.
