### PR TITLE
OSLQuery: make default value array length match the type

### DIFF
--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -191,7 +191,11 @@ symbol
                         typespec.make_array ($3);
                     OSOReader::osoreader->symbol ((SymType)$1, typespec, $4);
                 }
-            initial_values_opt hints_opt ENDOFLINE
+            initial_values_opt hints_opt
+                {
+                    OSOReader::osoreader->parameter_done ();
+                }
+            ENDOFLINE
         | ENDOFLINE
         ;
 

--- a/src/liboslexec/osoreader.h
+++ b/src/liboslexec/osoreader.h
@@ -88,6 +88,10 @@ public:
     ///
     virtual void symdefault (const char *def) { }
 
+    /// Called when we're done with all information related to a parameter
+    /// symbol.
+    virtual void parameter_done () { }
+
     /// Return true for parsers whose only purpose is to read the header up
     /// to params, to stop parsing as soon as we start encountering temps in
     /// the symbol table.

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -114,6 +114,7 @@ public:
     virtual void symdefault (int def);
     virtual void symdefault (float def);
     virtual void symdefault (const char *def);
+    virtual void parameter_done ();
     virtual void hint (const char *hintstring);
     virtual void codemarker (const char *name);
     virtual bool parse_code_section () { return false; }
@@ -190,6 +191,27 @@ OSOReaderQuery::symdefault (const char *def)
         p.sdefault.push_back (std::string(def));
         p.validdefault = true;
     }
+}
+
+
+
+void
+OSOReaderQuery::parameter_done ()
+{
+    m_reading_param = false;
+
+    // Make sure all value defaults have the right number of elements in
+    // case they were only partially initialized.
+    OSLQuery::Parameter &p (m_query.m_params.back());
+    int nvalues = p.type.numelements() * p.type.aggregate;
+    if (p.type.basetype == TypeDesc::INT)
+        p.idefault.resize (nvalues, 0);
+    else if (p.type.basetype == TypeDesc::FLOAT)
+        p.fdefault.resize (nvalues, 0);
+    else if (p.type.basetype == TypeDesc::STRING)
+        p.sdefault.resize (nvalues, std::string());
+    if (p.spacename.size())
+        p.spacename.resize (p.type.numelements(), std::string());
 }
 
 


### PR DESCRIPTION
OSLQuery: make default value array length match correct number of
elements for array parameters, even if the shader source didn't fully
initialize the array.  The mismatch between the std::vector size and the
size implied by the type of the paramter was confusing for client apps.
This also made odd looking oslinfo output in these cases.

To implement this cleanly, I needed to add a OSOReader::parameter_done()
callback, called at just the right point in parsing.
