### PR TITLE
RendererServices - remove horrible lock every time we did a texture call

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -57,7 +57,7 @@ typedef void (*SetupClosureFunc)(RendererServices *, int id, void *data);
 /// renderer may provide callback to the ShadingSystem.
 class OSLEXECPUBLIC RendererServices {
 public:
-    RendererServices () { }
+    RendererServices (TextureSystem *texsys=NULL);
     virtual ~RendererServices () { }
 
     /// Get the 4x4 matrix that transforms by the specified

--- a/testsuite/gettextureinfo/ref/out-alt.txt
+++ b/testsuite/gettextureinfo/ref/out-alt.txt
@@ -1,0 +1,28 @@
+Compiled test.osl -> test.oso
+Executing...
+../common/textures/grid.tx resolution: 1024 1024 (1)
+../common/textures/grid.tx channels: 4 (1)
+../common/textures/grid.tx texturetype: Plain Texture (1)
+../common/textures/grid.tx textureformat: Plain Texture (1)
+../common/textures/grid.tx datawindow: 0 0 1023 1023
+../common/textures/grid.tx displaywindow: 0 0 1023 1023
+../common/textures/grid.tx datetime: 2009:09:12  0:53:24 (1)
+../common/textures/grid.tx foobar: not found (0)
+ERROR: [RendererServices::get_texture_info] Invalid image file "badfile"
+badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+
+Executing...
+win.exr resolution: 100 50 (1)
+win.exr channels: 3 (1)
+win.exr texturetype: Plain Texture (1)
+win.exr textureformat: Plain Texture (1)
+win.exr datawindow: 10 20 109 69
+win.exr displaywindow: 0 0 299 199
+win.exr foobar: not found (0)
+ERROR: [RendererServices::get_texture_info] Invalid image file "badfile"
+badfile data: not found (0)
+win.exr exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+


### PR DESCRIPTION
This didn't affect SPI's renderer, because these methods were overloaded
in the derived class we use for our internal RS.  But if somebody else was
integrating OSL into a renderer and used the default (base class) texture
functions, they'd run into a serious threading performance issue because
of the lock.  This fixes it by allocating a TextureSystem when the RS is
constructed, then just calls through the pointer without any locks for
individual texture function calls.
