### PR TITLE
Add a method to RendererServices that returns a pointer to the TextureSystem used by the RS

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -286,6 +286,9 @@ public:
                              TypeDesc type, void *val, bool derivatives) {
         return false;
     }
+
+    /// Return a pointer to the texture system (if available).
+    virtual TextureSystem *texturesys () const;
 };
 
 

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -45,7 +45,7 @@ OSL_NAMESPACE_ENTER
 
 
 namespace {
-static TextureSystem *texturesys = NULL;
+static TextureSystem *texturesys_ = NULL;
 static spin_mutex texturesys_mutex;
 }
 
@@ -56,16 +56,24 @@ RendererServices::RendererServices (TextureSystem *texsys)
     // Ensure thread safety while checking if we already have a
     // TextureSystem.
     OIIO::spin_lock lock (texturesys_mutex);
-    if (! texturesys) {
+    if (! texturesys_) {
         if (texsys) {// caller provided a texture system
-            texturesys = texsys;
+            texturesys_ = texsys;
         } else { // Need to create a new texture system
-            texturesys = TextureSystem::create (true /* shared */);
+            texturesys_ = TextureSystem::create (true /* shared */);
             // Make some good guesses about default options
-            texturesys->attribute ("automip",  1);
-            texturesys->attribute ("autotile", 64);
+            texturesys_->attribute ("automip",  1);
+            texturesys_->attribute ("autotile", 64);
         }
     }
+}
+
+
+
+TextureSystem *
+RendererServices::texturesys () const
+{
+    return texturesys_;
 }
 
 
@@ -122,10 +130,10 @@ RendererServices::texture (ustring filename, TextureOpt &options,
                            float s, float t, float dsdx, float dtdx,
                            float dsdy, float dtdy, float *result)
 {
-    bool status = texturesys->texture (filename, options, s, t,
-                                       dsdx, dtdx, dsdy, dtdy, result);
+    bool status =  texturesys()->texture (filename, options, s, t,
+                                          dsdx, dtdx, dsdy, dtdy, result);
     if (!status) {
-        std::string err = texturesys->geterror();
+        std::string err = texturesys()->geterror();
         if (err.size()) {
             sg->context->error ("[RendererServices::texture] %s", err);
         }
@@ -141,10 +149,10 @@ RendererServices::texture3d (ustring filename, TextureOpt &options,
                              const Vec3 &dPdx, const Vec3 &dPdy,
                              const Vec3 &dPdz, float *result)
 {
-    bool status = texturesys->texture3d (filename, options, P, dPdx, dPdy, dPdz,
+    bool status = texturesys()->texture3d (filename, options, P, dPdx, dPdy, dPdz,
                                             result);
     if (!status) {
-        std::string err = texturesys->geterror();
+        std::string err = texturesys()->geterror();
         if (err.size()) {
             sg->context->error ("[RendererServices::texture3d] %s", err);
         }
@@ -159,9 +167,9 @@ RendererServices::environment (ustring filename, TextureOpt &options,
                                ShaderGlobals *sg, const Vec3 &R,
                                const Vec3 &dRdx, const Vec3 &dRdy, float *result)
 {
-    bool status = texturesys->environment (filename, options, R, dRdx, dRdy, result);
+    bool status = texturesys()->environment (filename, options, R, dRdx, dRdy, result);
     if (!status) {
-        std::string err = texturesys->geterror();
+        std::string err = texturesys()->geterror();
         if (err.size()) {
             sg->context->error ("[RendererServices::environment] %s", err);
         }
@@ -177,10 +185,10 @@ RendererServices::get_texture_info (ShaderGlobals *sg,
                                     ustring dataname,
                                     TypeDesc datatype, void *data)
 {
-    bool status = texturesys->get_texture_info (filename, subimage, dataname,
-                                                datatype, data);
+    bool status = texturesys()->get_texture_info (filename, subimage, dataname,
+                                                   datatype, data);
     if (!status) {
-        std::string err = texturesys->geterror();
+        std::string err = texturesys()->geterror();
         if (err.size()) {
             sg->context->error ("[RendererServices::get_texture_info] %s", err);
         }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -331,7 +331,12 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     }
 #endif
 
-    // If client didn't supply a texture system, create a new one
+    // If client didn't supply a texture system, use the one already held
+    // by the renderer (if it returns one).
+    if (! m_texturesys)
+        m_texturesys = renderer->texturesys();
+
+    // If we still don't have a texture system, create a new one
     if (! m_texturesys) {
         m_texturesys = TextureSystem::create (true /* shared */);
         ASSERT (m_texturesys);


### PR DESCRIPTION
When creating the ShadingSystem, if the RS has a TS, then use it rather than creating a new TS, and have a public method that you can use to retrieve it.

This is a consequence of the last patch. Basically, it makes it easier to coordinate between a ShadingSystem & RendererServices that share the same TextureSystem. It's not good enough to let them each have a separate TS, even if those TS's share the same underlying IC, because the two TS's may capture different error messages from different calls, oops. You really do want the very same one in general.
