### PR TITLE
Fix potential debug printing crash if group name is NULL

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1190,7 +1190,7 @@ BackendLLVM::run ()
     if (shadingsys().m_max_local_mem_KB &&
         m_llvm_local_mem/1024 > shadingsys().m_max_local_mem_KB) {
         shadingcontext()->error ("Shader group \"%s\" needs too much local storage: %d KB",
-                            group().name().c_str(), m_llvm_local_mem/1024);
+                                 group().name(), m_llvm_local_mem/1024);
     }
 
     // Optimize the LLVM IR unless it's just a ret void group (1 layer,
@@ -1242,8 +1242,7 @@ BackendLLVM::run ()
     m_stat_total_llvm_time = timer();
 
     if (shadingsys().m_compile_report) {
-        shadingcontext()->info ("JITed shader group %s:",
-                           group().name() ? group().name().c_str() : "");
+        shadingcontext()->info ("JITed shader group %s:", group().name());
         shadingcontext()->info ("    (%1.2fs = %1.2f setup, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
                            m_stat_total_llvm_time, 
                            m_stat_llvm_setup_time,

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1076,7 +1076,8 @@ RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
         if (i != m_stale_syms.end()) {
             Opcode &uselessop (inst()->ops()[i->second]);
             turn_into_nop (uselessop,
-                           debug() > 1 ? Strutil::format("remove stale value assignment to %s, reassigned on op %d", opargsym(uselessop,0)->name().c_str(), opnum).c_str() : "");
+                           debug() > 1 ? Strutil::format("remove stale value assignment to %s, reassigned on op %d",
+                                                         opargsym(uselessop,0)->name(), opnum).c_str() : "");
         }
     }
     m_stale_syms[sym] = opnum;
@@ -2605,7 +2606,7 @@ RuntimeOptimizer::run ()
     int nlayers = (int) group().nlayers ();
     if (debug())
         shadingcontext()->info ("About to optimize shader group %s (%d layers):",
-                           group().name().c_str(), nlayers);
+                           group().name(), nlayers);
 
     m_params_holding_globals.resize (nlayers);
 
@@ -2710,8 +2711,7 @@ RuntimeOptimizer::run ()
         ss.m_stat_postopt_ops += new_nops;
     }
     if (shadingsys().m_compile_report) {
-        shadingcontext()->info ("Optimized shader group %s:",
-                           group().name() ? group().name().c_str() : "");
+        shadingcontext()->info ("Optimized shader group %s:", group().name());
         shadingcontext()->info (" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
               m_stat_specialization_time, new_nsyms, old_nsyms,
               100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),


### PR DESCRIPTION
actually by simplifying some prints to use the ustring directly,
which is also less verbose.
