### PR TITLE
Fix IlmBase 2.1 build breakages

### DIFF
--- a/src/cmake/modules/FindIlmBase.cmake
+++ b/src/cmake/modules/FindIlmBase.cmake
@@ -104,16 +104,19 @@ if (ILMBASE_CACHED_STATE AND
   endforeach ()
 endif ()
 
+
 # Generic search paths
 set (IlmBase_generic_include_paths
   ${ILMBASE_CUSTOM_INCLUDE_DIR}
   /usr/include
+  /usr/include/${CMAKE_LIBRARY_ARCHITECTURE}
   /usr/local/include
   /sw/include
   /opt/local/include)
 set (IlmBase_generic_library_paths
   ${ILMBASE_CUSTOM_LIB_DIR}
   /usr/lib
+  /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
   /usr/local/lib
   /sw/lib
   /opt/local/lib)
@@ -143,7 +146,6 @@ PREFIX_FIND_INCLUDE_DIR (IlmBase
   OpenEXR/IlmBaseConfig.h IlmBase_include_paths)
 
 if (ILMBASE_INCLUDE_DIR)
-
   # Get the version from config file, if not already set.
   if (NOT ILMBASE_VERSION)
     FILE(STRINGS "${ILMBASE_INCLUDE_DIR}/OpenEXR/IlmBaseConfig.h" ILMBASE_BUILD_SPECIFICATION
@@ -169,11 +171,12 @@ if (ILMBASE_CUSTOM)
   endif()
   set (IlmBase_Libraries ${ILMBASE_CUSTOM_LIBRARIES})
   separate_arguments(IlmBase_Libraries)
-elseif (${ILMBASE_VERSION} VERSION_LESS "2.1")
-  set (IlmBase_Libraries Half Iex Imath IlmThread)
 else ()
-  string(REGEX REPLACE "([0-9]+)[.]([0-9]+).*" "\\1_\\2" _ilmbase_libs_ver ${ILMBASE_VERSION})
-  set (IlmBase_Libraries Half Iex-${_ilmbase_libs_ver} Imath-${_ilmbase_libs_ver} IlmThread-${_ilmbase_libs_ver})
+#elseif (${ILMBASE_VERSION} VERSION_LESS "2.1")
+  set (IlmBase_Libraries Half Iex Imath IlmThread)
+#else ()
+#  string(REGEX REPLACE "([0-9]+)[.]([0-9]+).*" "\\1_\\2" _ilmbase_libs_ver ${ILMBASE_VERSION})
+#  set (IlmBase_Libraries Half Iex-${_ilmbase_libs_ver} Imath-${_ilmbase_libs_ver} IlmThread-${_ilmbase_libs_ver})
 endif ()
 
 
@@ -184,7 +187,6 @@ foreach (ilmbase_lib ${IlmBase_Libraries})
   PREFIX_FIND_LIB (IlmBase ${ilmbase_lib}
     IlmBase_library_paths IlmBase_libvars IlmBase_cachevars)
 endforeach ()
-
 # Create the list of variables that might need to be cleared
 set (ILMBASE_CACHED_VARS
   ILMBASE_INCLUDE_DIR ${IlmBase_cachevars}


### PR DESCRIPTION
(other minor changes are due to syncing with the analogous file in OIIO)

The analogous OIIO review is here:  https://github.com/OpenImageIO/oiio/pull/842
