### PR TITLE
Constant folding of compassign and mxassign

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -467,7 +467,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (luminance,   luminance,           none,          true);
     OP (matrix,      matrix,              matrix,        true);
     OP (max,         minmax,              max,           true);
-    OP (mxcompassign, mxcompassign,       none,          false);
+    OP (mxcompassign, mxcompassign,       mxcompassign,  false);
     OP (mxcompref,   mxcompref,           none,          true);
     OP (min,         minmax,              min,           true);
     OP (mix,         mix,                 mix,           true);


### PR DESCRIPTION
Triple component set for cases where the previous value is known (in
addition to the index and assigned value are constant).  Turn A[I]=C
into A=N, where N=A but with N[I]=C.  Same for matrix component assigns.

A practical example of this would be the following code:

```
color C = 0;
C[1] = 0.5;
```

Now it will turn this directly into a constant (0, 0.5, 0) instead of assigning
to C and then assigning one component of C separately.
