### PR TITLE
Change some pass-by-value to pass-by-ref, very slight but measurable speedup

### DIFF
--- a/src/include/OSL/dual_vec.h
+++ b/src/include/OSL/dual_vec.h
@@ -189,7 +189,7 @@ robust_multVecMatrix (const Matrix44 &M, const Dual2<Vec3> &in, Dual2<Vec3> &out
 /// Multiply a matrix times a direction with derivatives to obtain
 /// a transformed direction with derivatives.
 inline void
-multDirMatrix (const Matrix44 &M, Dual2<Vec3> &in, Dual2<Vec3> &out)
+multDirMatrix (const Matrix44 &M, const Dual2<Vec3> &in, Dual2<Vec3> &out)
 {
     M.multDirMatrix (in.val(), out.val());
     M.multDirMatrix (in.dx(), out.dx());

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -680,45 +680,45 @@ OSL_SHADEOP void osl_smoothstep_dfdfdfdf(void *result, void* e0_, void* e1_, voi
 // point = M * point
 OSL_SHADEOP void osl_transform_vmv(void *result, void* M_, void* v_)
 {
-   Vec3 v = VEC(v_);
-   Matrix44 M = MAT(M_);
+   const Vec3 &v = VEC(v_);
+   const Matrix44 &M = MAT(M_);
    robust_multVecMatrix (M, v, VEC(result));
 }
 
 OSL_SHADEOP void osl_transform_dvmdv(void *result, void* M_, void* v_)
 {
-   Dual2<Vec3> v = DVEC(v_);
-   Matrix44    M = MAT(M_);
+   const Dual2<Vec3> &v = DVEC(v_);
+   const Matrix44    &M = MAT(M_);
    robust_multVecMatrix (M, v, DVEC(result));
 }
 
 // vector = M * vector
 OSL_SHADEOP void osl_transformv_vmv(void *result, void* M_, void* v_)
 {
-   Vec3 v = VEC(v_);
-   Matrix44 M = MAT(M_);
+   const Vec3 &v = VEC(v_);
+   const Matrix44 &M = MAT(M_);
    M.multDirMatrix (v, VEC(result));
 }
 
 OSL_SHADEOP void osl_transformv_dvmdv(void *result, void* M_, void* v_)
 {
-   Dual2<Vec3> v = DVEC(v_);
-   Matrix44    M = MAT(M_);
+   const Dual2<Vec3> &v = DVEC(v_);
+   const Matrix44    &M = MAT(M_);
    multDirMatrix (M, v, DVEC(result));
 }
 
 // normal = M * normal
 OSL_SHADEOP void osl_transformn_vmv(void *result, void* M_, void* v_)
 {
-   Vec3 v = VEC(v_);
-   Matrix44 M = MAT(M_);
+   const Vec3 &v = VEC(v_);
+   const Matrix44 &M = MAT(M_);
    M.inverse().transpose().multDirMatrix (v, VEC(result));
 }
 
 OSL_SHADEOP void osl_transformn_dvmdv(void *result, void* M_, void* v_)
 {
-   Dual2<Vec3> v = DVEC(v_);
-   Matrix44    M = MAT(M_);
+   const Dual2<Vec3> &v = DVEC(v_);
+   const Matrix44    &M = MAT(M_);
    multDirMatrix (M.inverse().transpose(), v, DVEC(result));
 }
 


### PR DESCRIPTION
I noticed that some functions we call when transforming vectors by matrices were written with pass-by-value rather than using const&. Changing resulted in a measurable (though small) speedup in benchmarks.
