### PR TITLE
Remove remnants of hash() from the OSL spec and type checking.

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3482,6 +3482,7 @@ The old {\cf cellnoise(...coords...)} function is equivalent to
 {\cf noise("cell",...coords...)}.
 \apiend
 
+\begin{comment}   % couldn't find a use for this
 \apiitem{\emph{type} {\ce hash} (float u) \\
 \emph{type} {\ce hash} (float u, float v) \\
 \emph{type} {\ce hash} (point p) \\
@@ -3503,6 +3504,7 @@ The return \emph{type} may be any of \float, \color, \point, \vector, or
 (e.g., \point), each component is an uncorrelated \float\ {\cf hash}
 function.
 \apiend
+\end{comment}
 
 \apiitem{\emph{type} {\ce spline} (string basis, float x, \emph{type} $\mathtt{y}_0$, \emph{type} $\mathtt{y}_1$, ... \emph{type} $\mathtt{y}_{n-1}$)\\
 \emph{type} {\ce spline} (string basis, float x, \emph{type} y[]) \\

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1228,7 +1228,6 @@ static const char * builtin_func_args [] = {
     "getattribute", "is?", "is?[]", "iss?", "iss?[]",  "isi?", "isi?[]", "issi?", "issi?[]", "!rw", NULL,  // FIXME -- further checking?
     "getmessage", "is?", "is?[]", "iss?", "iss?[]", "!rw", NULL,
     "gettextureinfo", "iss?", "iss?[]", "!rw", NULL,  // FIXME -- further checking?
-    "hash", NOISE_ARGS, NULL,
     "isconnected", "i?", NULL,
     "noise", GNOISE_ARGS, NOISE_ARGS, "!deriv", NULL,
     "pnoise", PGNOISE_ARGS, PNOISE_ARGS, "!deriv", NULL,
@@ -1238,7 +1237,6 @@ static const char * builtin_func_args [] = {
     "printf", "xs*", "!printf", NULL,
     "psnoise", PNOISE_ARGS, NULL,
     "random", "f", "c", "p", "v", "n", NULL,
-//    "raylevel", "i", NULL,
     "regex_match", "iss", "isi[]s", NULL,
     "regex_search", "iss", "isi[]s", NULL,
     "setmessage", "xs?", "xs?[]", NULL,


### PR DESCRIPTION
It was never implemented, and we can't think of a good use for it.

We can always bring it back later if there's a good reason.
