### PR TITLE
Use string_ref for most public API input parameters

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -106,6 +106,7 @@ using OIIO::ErrorHandler;
 using OIIO::TypeDesc;
 using OIIO::ustring;
 using OIIO::ustringHash;
+using OIIO::string_view;
 
 // Sort out smart pointers
 #ifdef OSL_USING_CPLUSPLUS11

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -140,49 +140,46 @@ public:
     ///                              designated as the debug shaders.
     ///    string only_groupname  Compile only this one group (skip all others)
     ///
-    virtual bool attribute (const std::string &name, TypeDesc type,
+    virtual bool attribute (string_view name, TypeDesc type,
                             const void *val) = 0;
     // Shortcuts for common types
-    bool attribute (const std::string &name, int val) {
+    bool attribute (string_view name, int val) {
         return attribute (name, TypeDesc::INT, &val);
     }
-    bool attribute (const std::string &name, float val) {
+    bool attribute (string_view name, float val) {
         return attribute (name, TypeDesc::FLOAT, &val);
     }
-    bool attribute (const std::string &name, double val) {
+    bool attribute (string_view name, double val) {
         float f = (float) val;
         return attribute (name, TypeDesc::FLOAT, &f);
     }
-    bool attribute (const std::string &name, const char *val) {
-        return attribute (name, TypeDesc::STRING, &val);
-    }
-    bool attribute (const std::string &name, const std::string &val) {
+    bool attribute (string_view name, string_view val) {
         const char *s = val.c_str();
         return attribute (name, TypeDesc::STRING, &s);
     }
 
     /// Get the named attribute, store it in value.
     ///
-    virtual bool getattribute (const std::string &name, TypeDesc type,
+    virtual bool getattribute (string_view name, TypeDesc type,
                                void *val) = 0;
     // Shortcuts for common types
-    bool getattribute (const std::string &name, int &val) {
+    bool getattribute (string_view name, int &val) {
         return getattribute (name, TypeDesc::INT, &val);
     }
-    bool getattribute (const std::string &name, float &val) {
+    bool getattribute (string_view name, float &val) {
         return getattribute (name, TypeDesc::FLOAT, &val);
     }
-    bool getattribute (const std::string &name, double &val) {
+    bool getattribute (string_view name, double &val) {
         float f;
         bool ok = getattribute (name, TypeDesc::FLOAT, &f);
         if (ok)
             val = f;
         return ok;
     }
-    bool getattribute (const std::string &name, char **val) {
+    bool getattribute (string_view name, char **val) {
         return getattribute (name, TypeDesc::STRING, val);
     }
-    bool getattribute (const std::string &name, std::string &val) {
+    bool getattribute (string_view name, std::string &val) {
         const char *s = NULL;
         bool ok = getattribute (name, TypeDesc::STRING, &s);
         if (ok)
@@ -192,8 +189,8 @@ public:
 
     /// Load compiled shader (oso) from a memory buffer, overriding
     /// shader lookups in the shader search path
-    virtual bool LoadMemoryCompiledShader (const char *shadername,
-                                           const char *buffer)=0;
+    virtual bool LoadMemoryCompiledShader (string_view shadername,
+                                           string_view buffer)=0;
 
     // The basic sequence for declaring a shader group looks like this:
     // ShadingSystem *ss = ...;
@@ -215,7 +212,7 @@ public:
 
     /// Signal the start of a new shader group.  The return value is a
     /// reference-counted opaque handle to the ShaderGroup.
-    virtual ShaderGroupRef ShaderGroupBegin (const char *groupname=NULL) = 0;
+    virtual ShaderGroupRef ShaderGroupBegin (string_view groupname = string_view()) = 0;
 
     /// Signal the end of a new shader group.
     ///
@@ -223,7 +220,7 @@ public:
 
     /// Set a parameter of the next shader.
     ///
-    virtual bool Parameter (const char *name, TypeDesc t, const void *val)
+    virtual bool Parameter (string_view name, TypeDesc t, const void *val)
         { return true; }
 
     /// Set a parameter of the next shader, and override the 'lockgeom'
@@ -232,35 +229,21 @@ public:
     /// should NOT be considered locked against changes by the geometry,
     /// and therefore the shader should not optimize assuming that the
     /// instance value (the 'val' specified by this call) is a constant.
-    virtual bool Parameter (const char *name, TypeDesc t, const void *val,
+    virtual bool Parameter (string_view name, TypeDesc t, const void *val,
                             bool lockgeom)
         { return true; }
-#if 0
-    virtual bool Parameter (const char *name, int val) {
-        Parameter (name, TypeDesc::IntType, &val);
-    }
-    virtual bool Parameter (const char *name, float val) {
-        Parameter (name, TypeDesc::FloatType, &val);
-    }
-    virtual bool Parameter (const char *name, double val) {}
-    virtual bool Parameter (const char *name, const char *val) {}
-    virtual bool Parameter (const char *name, const std::string &val) {}
-    virtual bool Parameter (const char *name, TypeDesc t, const int *val) {}
-    virtual bool Parameter (const char *name, TypeDesc t, const float *val) {}
-    virtual bool Parameter (const char *name, TypeDesc t, const char **val) {}
-#endif
 
     /// Create a new shader instance, either replacing the one for the
     /// specified usage (if not within a group) or appending to the
     /// current group (if a group has been started).
-    virtual bool Shader (const char *shaderusage,
-                         const char *shadername=NULL,
-                         const char *layername=NULL) = 0;
+    virtual bool Shader (string_view shaderusage,
+                         string_view shadername = string_view(),
+                         string_view layername = string_view()) = 0;
 
     /// Connect two shaders within the current group
     ///
-    virtual bool ConnectShaders (const char *srclayer, const char *srcparam,
-                                 const char *dstlayer, const char *dstparam)=0;
+    virtual bool ConnectShaders (string_view srclayer, string_view srcparam,
+                                 string_view dstlayer, string_view dstparam)=0;
 
     /// Return a reference-counted (but opaque) reference to the current
     /// shading attribute state maintained by the ShadingSystem.
@@ -275,7 +258,7 @@ public:
     /// geometric primitive).  This call gives you a way of changing the
     /// instance value, even if it's not a geometric override.
     virtual bool ReParameter (ShaderGroup &group,
-                              const char *layername, const char *paramname,
+                              string_view layername, string_view paramname,
                               TypeDesc type, const void *val)
         { return false; }
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -55,7 +55,7 @@ const char *shadertypename (ShaderType s);
 
 /// Convert a ShaderType to a human-readable name ("surface", etc.)
 ///
-ShaderType shadertype_from_name (const char *name);
+ShaderType shadertype_from_name (string_view name);
 
 
 
@@ -73,7 +73,7 @@ const char *shaderusename (ShaderUse s);
 
 /// Convert a ShaderUse to a human-readable name ("surface", etc.)
 ///
-ShaderUse shaderuse_from_name (const char *name);
+ShaderUse shaderuse_from_name (string_view name);
 
 
 

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -51,7 +51,7 @@ using OIIO::ParamValueList;
 
 
 ShaderInstance::ShaderInstance (ShaderMaster::ref master,
-                                const char *layername) 
+                                string_view layername)
     : m_master(master),
       //DON'T COPY  m_instsymbols(m_master->m_symbols),
       //DON'T COPY  m_instops(m_master->m_ops), m_instargs(m_master->m_args),
@@ -570,7 +570,7 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
 
 
 
-ShaderGroup::ShaderGroup (const char *name)
+ShaderGroup::ShaderGroup (string_view name)
   : m_name(name),
     m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
     m_optimized(0), m_does_nothing(false)
@@ -580,7 +580,7 @@ ShaderGroup::ShaderGroup (const char *name)
 
 
 
-ShaderGroup::ShaderGroup (const ShaderGroup &g, const char *name)
+ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
   : m_name(name), m_layers(g.m_layers),
     m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
     m_optimized(0), m_does_nothing(false)

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -517,9 +517,9 @@ OSOReaderToMaster::instruction_end ()
 
 
 ShaderMaster::ref
-ShadingSystemImpl::loadshader (const char *cname)
+ShadingSystemImpl::loadshader (string_view cname)
 {
-    if (! cname || ! cname[0]) {
+    if (! cname.size()) {
         error ("Attempt to load shader with empty name \"\".");
         return NULL;
     }
@@ -566,14 +566,14 @@ ShadingSystemImpl::loadshader (const char *cname)
 
 
 bool
-ShadingSystemImpl::LoadMemoryCompiledShader (const char *shadername,
-                                             const char *buffer)
+ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
+                                             string_view buffer)
 {
-    if (! shadername || ! shadername[0]) {
+    if (! shadername.size()) {
         error ("Attempt to load shader with empty name \"\".");
         return false;
     }
-    if (! buffer || ! buffer[0]) {
+    if (! buffer.size()) {
         error ("Attempt to load shader \"%s\" with empty OSO data.", shadername);
         return false;
     }

--- a/src/liboslexec/oslexec.cpp
+++ b/src/liboslexec/oslexec.cpp
@@ -61,17 +61,17 @@ shadertypename (ShaderType s)
 
 
 ShaderType
-shadertype_from_name (const char *name)
+shadertype_from_name (string_view name)
 {
-    if (! strcmp (name, "shader") || ! strcmp (name, "generic"))
+    if (name == "shader" || name == "generic")
         return ShadTypeGeneric;
-    if (! strcmp (name, "surface"))
+    if (name == "surface")
         return ShadTypeSurface;
-    if (! strcmp (name, "displacement"))
+    if (name == "displacement")
         return ShadTypeDisplacement;
-    if (! strcmp (name, "volume"))
+    if (name == "volume")
         return ShadTypeVolume;
-    if (! strcmp (name, "light"))
+    if (name == "light")
         return ShadTypeLight;
     return ShadTypeUnknown;
 }
@@ -91,11 +91,11 @@ shaderusename (ShaderUse s)
 
 
 ShaderUse
-shaderuse_from_name (const char *name)
+shaderuse_from_name (string_view name)
 {
-    if (! strcmp (name, "surface"))
+    if (name == "surface")
         return ShadUseSurface;
-    if (! strcmp (name, "displacement"))
+    if (name == "displacement")
         return ShadUseDisplacement;
     return ShadUseLast;
 }


### PR DESCRIPTION
The string_ref class was was put in OIIO a while back (and harmlessly backported to OIIO 1.3 as well, to accommodate anybody building OSL 1.4 against OIIO 1.3).

Here I'm just using it for some public OSL API functions, where we had dubiously used std::string before.

In general, string_ref solves several problems:
1. Avoids redundant std::string construction (including allocation/deletion) when the API takes a std::string& but the calling function only has a char\* (including when passing a string literal).
2. It's "safer" since it includes a length internally (the callee knows exactly how many characters are being passed)..
3. Can be more efficient if the callee needs to know the length (especially if this might happen multiple times).
4. Presents a single uniform interface that can take a char*, a std::string, or a ustring as an argument, all very efficiently.

C++17 is shaping up to feature a similar class (unfortunately renamed at a late date from string_ref to string_view -- some day we'll deal with this) and so this kind of passing of character sequences to yield safer, more efficient code is going to be the norm across the whole C++ culture as we move forward.
