### PR TITLE
Work towards allowing queries of interesting post-optimization information

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,16 @@ ShadingSystem API changes and new options (for renderer writers):
   RS's TextureSystem. (1.5.6)
 * Use OIIO's new string_view for many public API input parameters that
   previously took a std::string& or a const char*. (1.5.7)
+* New ShadingSystem::getattribute variety that takes a ShaderGroup* as a
+  first argument, allows queries for various information pertaining to a
+  particular group. (1.5.7)
+* ShadingSystem::getattribute(group,...) allows queries that retrieve
+  all the names and types of userdata the compiled group may need
+  ("num_userdata", "userdata_names", "userdata_types"), as well as the
+  names of all textures it might access and whether it's possible that
+  it will try to acccess textures whose names are not known without
+  executing the shader ("num_textures_needed", "textures_needed",
+  "unknown_textures_needed"). (1.5.7)
 
 Performance improvements:
 * Dramatically speed up LLVM optimization & JIT of small shaders --

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -187,6 +187,54 @@ public:
         return ok;
     }
 
+    /// Get the named attribute about a particular shader group, store it
+    /// in value.  Attributes that are currently documented include:
+    ///   int num_textures_needed    The number of texture names that are
+    ///                                known to be potentially needed by the
+    ///                                group (after optimization).
+    ///   ustring textures_needed[]  The names of the textures known to be
+    ///                                needed. Must be of length at least as
+    ///                                long as num_textures_needed.
+    ///   int unknown_textures_needed  Nonzero if additional textures may be
+    ///                                needed, whose names can't be known
+    ///                                without actually running the shader.
+    ///   int num_userdata           The number of "user data" variables
+    ///                                retrieved by the shader.
+    ///   ustring userdata_names[]   The names of the user data that may be
+    ///                                retrieved. The array should be at
+    ///                                least as long as num_userdata.
+    ///   TypeDesc userdata_types[]  The types of the user data (in the same
+    ///                                 order as userdata_names). They are
+    ///                                 retrieved by asking for uint64's,
+    ///                                 which are the same size as TypeDesc.
+    virtual bool getattribute (ShaderGroup *group, string_view name,
+                               TypeDesc type, void *val) = 0;
+    // Shortcuts for common types
+    bool getattribute (ShaderGroup *group, string_view name, int &val) {
+        return getattribute (group, name, TypeDesc::INT, &val);
+    }
+    bool getattribute (ShaderGroup *group, string_view name, float &val) {
+        return getattribute (group, name, TypeDesc::FLOAT, &val);
+    }
+    bool getattribute (ShaderGroup *group, string_view name, double &val) {
+        float f;
+        bool ok = getattribute (group, name, TypeDesc::FLOAT, &f);
+        if (ok)
+            val = f;
+        return ok;
+    }
+    bool getattribute (ShaderGroup *group, string_view name, char **val) {
+        return getattribute (group, name, TypeDesc::STRING, val);
+    }
+    bool getattribute (ShaderGroup *group, string_view name, std::string &val) {
+        const char *s = NULL;
+        bool ok = getattribute (group, name, TypeDesc::STRING, &s);
+        if (ok)
+            val = s;
+        return ok;
+    }
+
+
     /// Load compiled shader (oso) from a memory buffer, overriding
     /// shader lookups in the shader search path
     virtual bool LoadMemoryCompiledShader (string_view shadername,

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -571,9 +571,10 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
 
 
 ShaderGroup::ShaderGroup (string_view name)
-  : m_name(name),
-    m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
-    m_optimized(0), m_does_nothing(false)
+  : m_optimized(0), m_does_nothing(false),
+    m_llvm_groupdata_size(0),
+    m_llvm_compiled_version(NULL),
+    m_name(name)
 {
     m_executions = 0;
 }
@@ -581,9 +582,11 @@ ShaderGroup::ShaderGroup (string_view name)
 
 
 ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
-  : m_name(name), m_layers(g.m_layers),
-    m_llvm_compiled_version(NULL), m_llvm_groupdata_size(0),
-    m_optimized(0), m_does_nothing(false)
+  : m_optimized(0), m_does_nothing(false),
+    m_llvm_groupdata_size(0),
+    m_llvm_compiled_version(NULL),
+    m_layers(g.m_layers),
+    m_name(name)
 {
     m_executions = 0;
 }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -350,6 +350,13 @@ private:
     std::map<int,int> m_stale_syms;     ///< Stale symbols for this block
     int m_local_unknown_message_sent;   ///< Non-const setmessage in this inst
     std::vector<ustring> m_local_messages_sent; ///< Messages set in this inst
+    std::set<ustring> m_textures_needed;
+    bool m_unknown_textures_needed;
+#if OPENIMAGEIO_VERSION < 10406
+    std::set<NameAndTypeDesc,NameAndTypeDesc_less> m_userdata_needed;
+#else
+    std::set<NameAndTypeDesc> m_userdata_needed;
+#endif
     double m_stat_opt_locking_time;       ///<   locking time
     double m_stat_specialization_time;    ///<   specialization time
 


### PR DESCRIPTION
Extend the ShadingSystem API to allow a form of getattribute() that
takes the pointer to a specific ShadingGroup. Some possible queries are
about post-optimized state, in which case asking for them will trigger
optimization on that group if it has not yet been performed.

We start out with two sets of interesting group attribute queries (and,
of course, the infrastructure and code by which we record them):
1. Make it possible to extract the names of all textures that it can
   determine might be accessed by the group (after all instance value
   binding, constant folding, and optimization has been taken into
   account), as well as knowing whether additional textures may be
   accessed, whose names cannot be determined without actually executing
   the shader. (This may be helpful to renderer implementations that simply
   are not able to accommodate textures that can't be bound prior to
   start of shader execution.)
2. Make it possible to extract the names and types of all "user data"
   that might be queried (that is, shader parameters that may, after
   optimization, still be expected to take on per-point interpolated
   values, supplied by the geometry). (N.B. This is leading toward another
   really interesting feature/optimization, which will be part of a later
   checkin.)

See testshade.cpp, test_group_attributes(), for examples of these
queries in action.
