### PR TITLE
De-virtualize OSLCompiler and ShadingSystem classes!

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,14 +52,17 @@ ShadingSystem API changes and new options (for renderer writers):
   previously took a std::string& or a const char*. (1.5.7)
 * New ShadingSystem::getattribute variety that takes a ShaderGroup* as a
   first argument, allows queries for various information pertaining to a
-  particular group. (1.5.7)
+  particular group. (#362) (1.5.8)
 * ShadingSystem::getattribute(group,...) allows queries that retrieve
   all the names and types of userdata the compiled group may need
   ("num_userdata", "userdata_names", "userdata_types"), as well as the
   names of all textures it might access and whether it's possible that
   it will try to acccess textures whose names are not known without
   executing the shader ("num_textures_needed", "textures_needed",
-  "unknown_textures_needed"). (1.5.7)
+  "unknown_textures_needed"). (#362) (1.5.8)
+* De-virtualized OSLCompiler and ShadingSystem classes -- it is now safe to
+  construct them in the usual way, the create() and destroy() functions for
+  them are optional/deprecated. (#363) (1.5.8)
 
 Performance improvements:
 * Dramatically speed up LLVM optimization & JIT of small shaders --
@@ -118,6 +121,10 @@ Under the hood:
   contiguous in a log, rather than possibly line-by-line interspersed
   with the output of another shader invocation running concurrently in a
   different thread (1.5.5).
+* By de-virtualizing OSLCompiler and ShadingSystem classes, we make it
+  much easier in the future to change both these classes (at least, adding
+  new methods) and changing the Impl internals, without breaking link
+  compatibility within release branches. (#363) (1.5.8)
 
 Build & test system improvements and developer goodies:
 * Make OSL work with LLVM 3.4 (1.5.4)

--- a/src/include/OSL/oslcomp.h
+++ b/src/include/OSL/oslcomp.h
@@ -33,22 +33,32 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 OSL_NAMESPACE_ENTER
 
 
+namespace pvt {
+    class OSLCompilerImpl;
+}
+
+
+
 class OSLCOMPPUBLIC OSLCompiler {
 public:
+    /// DEPRECATED -- it's ok to directly construct an OSLCompiler now.
     static OSLCompiler *create ();
 
-    OSLCompiler (void) { }
-    virtual ~OSLCompiler (void) { }
+    OSLCompiler ();
+    ~OSLCompiler ();
 
     /// Compile the given file, using the list of command-line options.
     /// Return true if ok, false if the compile failed.
-    virtual bool compile (const std::string &filename,
-                          const std::vector<std::string> &options,
-                          const std::string &stdoslpath = "") = 0;
+    bool compile (string_view filename,
+                  const std::vector<string_view> &options,
+                  string_view stdoslpath = string_view());
 
     /// Return the name of our compiled output (must be called after
     /// compile()).
-    virtual std::string output_filename () const = 0;
+    string_view output_filename () const;
+
+private:
+    pvt::OSLCompilerImpl *m_impl;
 };
 
 

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -64,7 +64,39 @@ OSL_NAMESPACE_ENTER
 OSLCompiler *
 OSLCompiler::create ()
 {
-    return new pvt::OSLCompilerImpl;
+    return new OSLCompiler;
+}
+
+
+
+OSLCompiler::OSLCompiler ()
+    : m_impl(new pvt::OSLCompilerImpl)
+{
+}
+
+
+
+OSLCompiler::~OSLCompiler ()
+{
+    delete m_impl;
+}
+
+
+
+bool
+OSLCompiler::compile (string_view filename,
+                      const std::vector<string_view> &options,
+                      string_view stdoslpath)
+{
+    return m_impl->compile (filename, options, stdoslpath);
+}
+
+
+
+string_view
+OSLCompiler::output_filename () const
+{
+    return m_impl->output_filename();
 }
 
 
@@ -301,9 +333,9 @@ preprocess (const std::string &filename,
 
 
 bool
-OSLCompilerImpl::compile (const std::string &filename,
-                          const std::vector<std::string> &options,
-                          const std::string &stdoslpath)
+OSLCompilerImpl::compile (string_view filename,
+                          const std::vector<string_view> &options,
+                          string_view stdoslpath)
 {
     if (! OIIO::Filesystem::exists (filename)) {
         error (ustring(), 0, "Input file \"%s\" not found", filename.c_str());

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -59,16 +59,16 @@ typedef std::map<const Symbol *, SymPtrSet> SymDependencyMap;
 
 
 
-class OSLCompilerImpl : public OSL::OSLCompiler {
+class OSLCompilerImpl {
 public:
     OSLCompilerImpl ();
-    virtual ~OSLCompilerImpl ();
+    ~OSLCompilerImpl ();
 
     /// Fully compile a shader located in 'filename', with the command-line
     /// options ("-I" and the like) in the options vector.
-    virtual bool compile (const std::string &filename,
-                          const std::vector<std::string> &options,
-                          const std::string &stdoslpath = "");
+    bool compile (string_view filename,
+                  const std::vector<string_view> &options,
+                  string_view stdoslpath);
 
     /// The name of the file we're currently parsing
     ///
@@ -220,7 +220,7 @@ public:
     void add_struct_fields (StructSpec *structspec, ustring basename,
                             SymType symtype, int arraylen, ASTNode *node=NULL);
 
-    std::string output_filename () const { return m_output_filename; }
+    string_view output_filename () const { return m_output_filename; }
 
     /// Push the designated function on the stack, to keep track of
     /// nesting and so recursed methods can query which is the current

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -617,7 +617,7 @@ public:
         SetupClosureFunc          setup;
     };
 
-    void register_closure (const char *name, int id, const ClosureParam *params,
+    void register_closure (string_view name, int id, const ClosureParam *params,
                            PrepareClosureFunc prepare, SetupClosureFunc setup);
 
     const ClosureEntry *get_entry (ustring name) const;
@@ -640,34 +640,34 @@ private:
 
 
 
-class ShadingSystemImpl : public ShadingSystem
+class ShadingSystemImpl
 {
 public:
     ShadingSystemImpl (RendererServices *renderer=NULL,
                        TextureSystem *texturesystem=NULL,
                        ErrorHandler *err=NULL);
-    virtual ~ShadingSystemImpl ();
+    ~ShadingSystemImpl ();
 
-    virtual bool attribute (string_view name, TypeDesc type, const void *val);
-    virtual bool getattribute (string_view name, TypeDesc type, void *val);
-    virtual bool getattribute (ShaderGroup *group, string_view name,
-                               TypeDesc type, void *val);
-    virtual bool LoadMemoryCompiledShader (string_view shadername,
-                                           string_view buffer);
-    virtual bool Parameter (string_view name, TypeDesc t, const void *val);
-    virtual bool Parameter (string_view name, TypeDesc t, const void *val,
-                            bool lockgeom);
-    virtual bool Shader (string_view shaderusage,
-                         string_view shadername = string_view(),
-                         string_view layername = string_view());
-    virtual ShaderGroupRef ShaderGroupBegin (string_view groupname = string_view());
-    virtual bool ShaderGroupEnd (void);
-    virtual bool ConnectShaders (string_view srclayer, string_view srcparam,
-                                 string_view dstlayer, string_view dstparam);
-    virtual ShaderGroupRef state ();
-    virtual bool ReParameter (ShaderGroup &group,
-                              string_view layername, string_view paramname,
-                              TypeDesc type, const void *val);
+    bool attribute (string_view name, TypeDesc type, const void *val);
+    bool getattribute (string_view name, TypeDesc type, void *val);
+    bool getattribute (ShaderGroup *group, string_view name,
+                       TypeDesc type, void *val);
+    bool LoadMemoryCompiledShader (string_view shadername,
+                                   string_view buffer);
+    bool Parameter (string_view name, TypeDesc t, const void *val);
+    bool Parameter (string_view name, TypeDesc t, const void *val,
+                    bool lockgeom);
+    bool Shader (string_view shaderusage,
+                 string_view shadername = string_view(),
+                 string_view layername = string_view());
+    ShaderGroupRef ShaderGroupBegin (string_view groupname = string_view());
+    bool ShaderGroupEnd (void);
+    bool ConnectShaders (string_view srclayer, string_view srcparam,
+                         string_view dstlayer, string_view dstparam);
+    ShaderGroupRef state ();
+    bool ReParameter (ShaderGroup &group,
+                      string_view layername, string_view paramname,
+                      TypeDesc type, const void *val);
 
     // Internal error, warning, info, and message reporting routines that
     // take printf-like arguments.  Based on Tinyformat.
@@ -687,27 +687,27 @@ public:
     void info (const std::string &message) const;
     void message (const std::string &message) const;
 
-    virtual std::string getstats (int level=1) const;
+    std::string getstats (int level=1) const;
 
     ErrorHandler &errhandler () const { return *m_err; }
 
     ShaderMaster::ref loadshader (string_view name);
 
-    virtual PerThreadInfo * create_thread_info();
+    PerThreadInfo * create_thread_info();
 
-    virtual void destroy_thread_info (PerThreadInfo *threadinfo);
+    void destroy_thread_info (PerThreadInfo *threadinfo);
 
-    virtual ShadingContext *get_context (PerThreadInfo *threadinfo = NULL);
+    ShadingContext *get_context (PerThreadInfo *threadinfo = NULL);
 
-    virtual void release_context (ShadingContext *ctx);
+    void release_context (ShadingContext *ctx);
 
-    virtual bool execute (ShadingContext &ctx, ShaderGroup &group,
-                          ShaderGlobals &ssg, bool run=true);
+    bool execute (ShadingContext &ctx, ShaderGroup &group,
+                  ShaderGlobals &ssg, bool run=true);
 
-    virtual const void* get_symbol (ShadingContext &ctx, ustring name,
-                                    TypeDesc &type);
+    const void* get_symbol (ShadingContext &ctx, ustring name,
+                            TypeDesc &type);
 
-    void operator delete (void *todel) { ::delete ((char *)todel); }
+//    void operator delete (void *todel) { ::delete ((char *)todel); }
 
     /// Is the shading system in debug mode, and if so, how verbose?
     ///
@@ -758,10 +758,10 @@ public:
     float *alloc_float_constants (size_t n) { return m_float_pool.alloc (n); }
     ustring *alloc_string_constants (size_t n) { return m_string_pool.alloc (n); }
 
-    virtual void register_closure(const char *name, int id, const ClosureParam *params,
-                                  PrepareClosureFunc prepare, SetupClosureFunc setup);
-    virtual bool query_closure(const char **name, int *id,
-                               const ClosureParam **params);
+    void register_closure (string_view name, int id, const ClosureParam *params,
+                           PrepareClosureFunc prepare, SetupClosureFunc setup);
+    bool query_closure (const char **name, int *id,
+                        const ClosureParam **params);
     const ClosureRegistry::ClosureEntry *find_closure(ustring name) const {
         return m_closure_registry.get_entry(name);
     }
@@ -790,9 +790,9 @@ public:
     /// Set the current color space.
     bool set_colorspace (ustring colorspace);
 
-    virtual int raytype_bit (ustring name);
+    int raytype_bit (ustring name);
 
-    virtual void optimize_all_groups (int nthreads=0);
+    void optimize_all_groups (int nthreads=0);
 
     typedef boost::unordered_map<ustring,OpDescriptor,ustringHash> OpDescriptorMap;
 

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -67,7 +67,7 @@ usage ()
 int
 main (int argc, const char *argv[])
 {
-    std::vector <std::string> args;
+    std::vector<string_view> args;
     bool quiet = false;
     if (argc <= 1) {
         usage ();
@@ -99,12 +99,12 @@ main (int argc, const char *argv[])
             args.push_back (argv[a]);
         }
         else {
-            boost::scoped_ptr<OSLCompiler> compiler (OSLCompiler::create ());
-            bool ok = compiler->compile (argv[a], args);
+            OSLCompiler compiler;
+            bool ok = compiler.compile (argv[a], args);
             if (ok) {
                 if (!quiet)
                     std::cout << "Compiled " << argv[a] << " -> " 
-                              << compiler->output_filename() << "\n";
+                              << compiler.output_filename() << "\n";
             } else {
                 std::cout << "FAILED " << argv[a] << "\n";
                 return EXIT_FAILURE;


### PR DESCRIPTION
There are two ways to expose just an abstract class API from a library,
while completely hiding all internals of the class (and in particular,
data internals).
1. Subclassing: Make the Foo public API be an abstract class, with only
   pure virtual methods, and no data. Internal to the library, subclass the
   parent as 'class FooImpl : public Foo', fully elaborating the
   methods. This implementation class is hidden from the client app, so
   you'll need create() and destroy() methods.
2. PIMPL idiom: Make the Foo public API a simple concrete class with no
   virtual methods, but containing a private FooImpl *m_impl (where FooImpl
   is a forward-declared class, so not exposed). The ctr/dtr of the exposed
   class will internally create/destroy a FooImpl, and all the methods of
   Foo::method() simply call m_impl->method().  This means that the FooImpl
   also now no longer needs any virtual methods.

The cost of these are roughly the same -- #1 needs to look up methods in
the vtbl every time, whereas #2 needs to make an extra wrapping function
call every time (though in theory, a good optimizing compiler with LTO
should be able to make this essentially free).

If it's important for the client app to be able to completely substitute
their own custom implementation while following the same API (i.e.,
somebody needs to subclass Foo to specialize it), then #1 is the only
way to go. An example of this is RendererServices -- the whole point of
RS is to allow a renderer implementation to subclass it in order to
provide all the renderer-specific bits of functionality.

However, if the library is providing the one and only possible
implementation, i.e., no subclassing is ever desired/necessary, and the
whole exercise is simply to hide the implementation details behind an
abstrat API, then #2 has a distinct advantage: because there are no
virtual methods, Foo can have new (non-virtual!) public methods added,
and FooImpl can change arbitrarily, without breaking backward
compatibility in linkage with apps! In other words, #2 allows
substantially more change to internals, and adding publicly exposed
features, without violating promises that are usually made about
compatibility for "release branches" of a product. (Whereas, the #1
approach dare not change anything about the API, for fear of altering
the layout of the vtbl.)

So, therefore, this patch "de-virtualizes" the main two public
interfaces for OSL, OSLCompiler and ShadingSystem, switching their API
abstraction strategy from approach #1 to approach #2, and thus serves as
powerful insurance as we move forward, allowing much more freedom in the
range of changes we make may to internals within release branches
without breaking compatibility.

Along the way, I also took a few remaining places in these two APIs
where we passed std::string around and replaced them with string_view.
