### PR TITLE
Revise getattribute userdata retrieval

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -206,13 +206,13 @@ public:
     ///                                without actually running the shader.
     ///   int num_userdata           The number of "user data" variables
     ///                                retrieved by the shader.
-    ///   ustring userdata_names[]   The names of the user data that may be
-    ///                                retrieved. The array should be at
-    ///                                least as long as num_userdata.
-    ///   TypeDesc userdata_types[]  The types of the user data (in the same
-    ///                                 order as userdata_names). They are
-    ///                                 retrieved by asking for uint64's,
-    ///                                 which are the same size as TypeDesc.
+    ///   ptr userdata_names         Retrieves a pointer to the array of
+    ///                                ustring holding the userdata names.
+    ///   ptr userdata_types         Retrieves a pointer to the array of
+    ///                                 TypeDesc describing the userdata.
+    ///   ptr userdata_offsets       Retrieves a pointer to the array of
+    ///                                 int describing the userdata offsets
+    ///                                 within the heap.
     bool getattribute (ShaderGroup *group, string_view name,
                        TypeDesc type, void *val);
     // Shortcuts for common types

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1162,7 +1162,9 @@ private:
     mutex m_mutex;                   ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     bool m_unknown_textures_needed;
-    std::vector<NameAndTypeDesc> m_userdata_needed;
+    std::vector<ustring> m_userdata_names;
+    std::vector<TypeDesc> m_userdata_types;
+    std::vector<int> m_userdata_offsets;
     atomic_ll m_executions;          ///< Number of times the group executed
     friend class OSL::pvt::ShadingSystemImpl;
 };

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -498,31 +498,33 @@ test_group_attributes (ShaderGroup *group)
     int nt = 0;
     if (shadingsys->getattribute (group, "num_textures_needed", nt)) {
         std::cout << "Need " << nt << " textures:\n";
-        std::vector<ustring> tex (nt);
-        if (nt) {
-            shadingsys->getattribute (group, "textures_needed",
-                                      TypeDesc(TypeDesc::STRING,nt), &tex[0]);
-            BOOST_FOREACH (OIIO::ustring t, tex)
-                std::cout << "    " << t << "\n";
-        }
+        ustring *tex = NULL;
+        shadingsys->getattribute (group, "textures_needed",
+                                  TypeDesc::PTR, &tex);
+        for (int i = 0; i < nt; ++i)
+            std::cout << "    " << tex[i] << "\n";
         int unk = 0;
         shadingsys->getattribute (group, "unknown_textures_needed", unk);
         if (unk)
             std::cout << "    and unknown textures\n";
     }
     int nuser = 0;
-    if (shadingsys->getattribute (group, "num_userdata", nuser)) {
+    if (shadingsys->getattribute (group, "num_userdata", nuser) && nuser) {
         std::cout << "Need " << nuser << " user data items:\n";
-        std::vector<ustring> user (nuser);
-        std::vector<TypeDesc> types (nuser);
-        if (nuser) {
-            shadingsys->getattribute (group, "userdata_names",
-                                      TypeDesc(TypeDesc::STRING,nuser), &user[0]);
-            shadingsys->getattribute (group, "userdata_types",
-                                      TypeDesc(TypeDesc::UINT64,nuser), &types[0]);
-            for (int i = 0; i < nuser; ++i)
-                std::cout << "    " << user[i] << ' ' << types[i] << "\n";
-        }
+        ustring *userdata_names = NULL;
+        TypeDesc *userdata_types = NULL;
+        int *userdata_offsets = NULL;
+        shadingsys->getattribute (group, "userdata_names",
+                                  TypeDesc::PTR, &userdata_names);
+        shadingsys->getattribute (group, "userdata_types",
+                                  TypeDesc::PTR, &userdata_types);
+        shadingsys->getattribute (group, "userdata_offsets",
+                                  TypeDesc::PTR, &userdata_offsets);
+        DASSERT (userdata_names && userdata_types && userdata_offsets);
+        for (int i = 0; i < nuser; ++i)
+            std::cout << "    " << userdata_names[i] << ' '
+                      << userdata_types[i] << "  offset="
+                      << userdata_offsets[i] << "\n";
     }
 }
 


### PR DESCRIPTION
After further thought (and use), I want to revise the way some of the
getattribute thingies I just added are queried -- instead of retrieving (copying)
a whole array, just retrieve a pointer to where the data lives in the group.

Instead of copying the whole array to user space (especially awkwardly
for the userdata_types, since there is no way for TypeDesc to specify
a TypeDesc type!), I changed it so that they are actually retrieving
a pointer.  So it looks like this:

```
ustring *names = NULL;
shadingsys->getattribute (group, "userdata_names",
                          TypeDesc::PTR, &names);
// now names[0] is the first name, names[1] the second, etc.
```

This is safer and simpler, and doesn't require coping or allocation, since
the names and types already exist in the group as a contiguous array.

Also, I added one more tag, "userdata_offsets". Suffice it to say that
in a future checking, it will all be clear how and why it's used.
