### PR TITLE
OSL format() speedup

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -234,7 +234,7 @@ LLVMGEN (llvm_gen_printf)
 
     // For some ops, we push the shader globals pointer
     if (op.opname() == op_printf || op.opname() == op_error ||
-            op.opname() == op_warning)
+            op.opname() == op_warning || op.opname() == op_format)
         call_args.push_back (rop.sg_void_ptr());
 
     // We're going to need to adjust the format string as we go, but I'd

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -231,7 +231,7 @@ static const char *llvm_helper_function_table[] = {
     "osl_allocate_closure_component", "CXiii",
     "osl_allocate_weighted_closure_component", "CXiiiX",
     "osl_closure_to_string", "sXC",
-    "osl_format", "ss*",
+    "osl_format", "sXs*",
     "osl_printf", "xXs*",
     "osl_error", "xXs*",
     "osl_warning", "xXs*",

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1281,6 +1281,9 @@ public:
     /// attribname is "", return the value of the node itself.
     int dict_value (int nodeID, ustring attribname, TypeDesc type, void *data);
 
+    ustring lastformat () const { return m_lastformat; }
+    void lastformat (ustring f) { m_lastformat = f;}
+
     /// Various setup of the context done by execute().  Return true if
     /// the function should be executed, otherwise false.
     bool prepare_execution (ShaderUse use, ShaderGroup &sas);
@@ -1336,6 +1339,7 @@ private:
     PerThreadInfo *m_threadinfo;        ///< Ptr to our thread's info
     ShaderGroup *m_attribs;             ///< Ptr to shading attrib state
     std::vector<char> m_heap;           ///< Heap memory
+    ustring m_lastformat;               ///< ustring of last format()
     typedef boost::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;
     RegexMap m_regex_map;               ///< Compiled regex's
     MessageList m_messages;             ///< Message blackboard


### PR DESCRIPTION
ustring construction is relatively slow (by design, it's assumed to be infrequent). If we happen to be constructing strings in the shader using many calls to format() which are usually making the same strings over and over, we can actually speed up by having the ShadingContext remember the last ustring created by format, and if it matches the string we just made, we can return the ustring directly without having to construct it again.

In my contrived tests that emphasize ustring creation bottleneck (see https://github.com/OpenImageIO/oiio/pull/846 for explanation), I'm seeing an additional 10% speedup with this patch on the OSL side. On several production asset frames I've tried, I'm getting essentially the same speed as before. So while in theory an "incoherent" construction of strings would be doing slightly more work by performing this check before ustring construction, in practice I'm not seeing any slowdown on actual scenes. So I suspect that scenes either have infrequent ustring construction and are not affected, or have VERY frequent but extremely coherent ustring construction and are sped up. Frequent but incoherent seems harder to find in the wild.
