### PR TITLE
ShadingSystem: Add group-specific attribute()

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -164,6 +164,28 @@ public:
         return attribute (name, TypeDesc::STRING, &s);
     }
 
+
+    /// Set an attribute for a specific shader group.  Return true if the
+    /// name and type were recognized and the attrib was set. Documented
+    /// attributes are as follows:
+    /// None. This is a placeholder for future functionality.
+    bool attribute (ShaderGroup *group, string_view name,
+                    TypeDesc type, const void *val);
+    bool attribute (ShaderGroup *group, string_view name, int val) {
+        return attribute (group, name, TypeDesc::INT, &val);
+    }
+    bool attribute (ShaderGroup *group, string_view name, float val) {
+        return attribute (group, name, TypeDesc::FLOAT, &val);
+    }
+    bool attribute (ShaderGroup *group, string_view name, double val) {
+        float f = (float) val;
+        return attribute (group, name, TypeDesc::FLOAT, &f);
+    }
+    bool attribute (ShaderGroup *group, string_view name, string_view val) {
+        const char *s = val.c_str();
+        return attribute (group, name, TypeDesc::STRING, &s);
+    }
+
     /// Get the named attribute, store it in value.
     ///
     bool getattribute (string_view name, TypeDesc type, void *val);

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -649,6 +649,8 @@ public:
     ~ShadingSystemImpl ();
 
     bool attribute (string_view name, TypeDesc type, const void *val);
+    bool attribute (ShaderGroup *group, string_view name,
+                    TypeDesc type, const void *val);
     bool getattribute (string_view name, TypeDesc type, void *val);
     bool getattribute (ShaderGroup *group, string_view name,
                        TypeDesc type, void *val);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -109,6 +109,15 @@ ShadingSystem::attribute (string_view name, TypeDesc type, const void *val)
 
 
 bool
+ShadingSystem::attribute (ShaderGroup *group, string_view name,
+                          TypeDesc type, const void *val)
+{
+    return m_impl->attribute (group, name, type, val);
+}
+
+
+
+bool
 ShadingSystem::getattribute (string_view name, TypeDesc type, void *val)
 {
     return m_impl->getattribute (name, type, val);
@@ -1033,6 +1042,16 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     return false;
 #undef ATTR_DECODE
 #undef ATTR_DECODE_STRING
+}
+
+
+
+bool
+ShadingSystemImpl::attribute (ShaderGroup *group, string_view name,
+                              TypeDesc type, const void *val)
+{
+    // No current group attributes to set
+    return false;
 }
 
 


### PR DESCRIPTION
I don't have a use for this at the moment, but I anticipate some (and it's symmetric to the group-specific getattribute I already added), so I want to get the function added to the API before the next major version branch.
