### PR TITLE
OSL statistics output includes version and major options.

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1171,11 +1171,33 @@ ShadingSystemImpl::getstats (int level) const
     if (level <= 0)
         return "";
     std::ostringstream out;
-    out << "OSL ShadingSystem statistics (" << (void*)this << ")\n";
+    out << "OSL ShadingSystem statistics (" << (void*)this;
+    out << ") ver " << OSL_LIBRARY_VERSION_STRING << "\n";
     if (m_stat_shaders_requested == 0) {
         out << "  No shaders requested\n";
         return out.str();
     }
+
+    std::string opt;
+#define BOOLOPT(name) if (m_##name) opt += #name " "
+#define INTOPT(name) opt += Strutil::format(#name "=%d ", m_##name)
+    INTOPT (optimize);
+    INTOPT (llvm_optimize);
+    INTOPT (debug);
+    INTOPT (llvm_debug);
+    BOOLOPT (lazylayers);
+    BOOLOPT (lazyglobals);
+    BOOLOPT (clearmemory);
+    BOOLOPT (debugnan);
+    BOOLOPT (debug_uninit);
+    BOOLOPT (lockgeom_default);
+    BOOLOPT (range_checking);
+    BOOLOPT (greedyjit);
+    BOOLOPT (countlayerexecs);
+#undef BOOLOPT
+#undef INTOPT
+    out << "  Options:  " << Strutil::wordwrap(opt, 75, 12) << "\n";
+
     out << "  Shaders:\n";
     out << "    Requested: " << m_stat_shaders_requested << "\n";
     out << "    Loaded:    " << m_stat_shaders_loaded << "\n";


### PR DESCRIPTION
This is so that when viewing a log containing OSL ShadingSystem
statistics, we can be sure which version of the library it was, and how
the most important options were set.

Example output looks like this:

```
OSL ShadingSystem statistics (0x7ff65c005a00) ver 1.5.7dev
  Options:  optimize=2 llvm_optimize=0 debug=1 llvm_debug=0 lazylayers
            lockgeom_default range_checking
  Shaders:
    Requested: 1
...
```
