### PR TITLE
Fix broken testshade_dso

### DIFF
--- a/src/include/OSL/export.h
+++ b/src/include/OSL/export.h
@@ -77,7 +77,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   #endif
   #define OSL_LLVM_EXPORT __declspec(dllexport)
 #else
-  #if __GNUC__ >= 4
+  #if (10000*__GNUC__ + 100*__GNUC_MINOR__ + __GNUC_PATCHLEVEL__) > 40102
     #define OSL_DLL_IMPORT __attribute__ ((visibility ("default")))
     #define OSL_DLL_EXPORT __attribute__ ((visibility ("default")))
     #define OSL_DLL_LOCAL  __attribute__ ((visibility ("hidden")))

--- a/src/liboslexec/liboslexec.map
+++ b/src/liboslexec/liboslexec.map
@@ -1,4 +1,4 @@
 {
-    global: *OSL*; osl_*;
+    global: *OSL*; osl_*; test_shade;
     local: *;
 };


### PR DESCRIPTION
In one of the previous changes to hide symbols, we inadvertently broke
testshade_dso on Linux (at least for the LLVM_STATIC case). It can be
fixed by adding the test_shade symbol to the list of things that aren't
hidden. While I'm in there, make the export.h test a bit more exact,
per the way we do it in OIIO.
