### PR TITLE
backfacing() was somehow left out of the docs.

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4788,6 +4788,13 @@ OSL, but is expected to include at a minimum \qkw{camera},
 exception that camera rays should be of class \qkw{camera} and no other.
 \apiend
 
+\apiitem{int {\ce backfacing} ()}
+\indexapi{backfacing()}
+Returns 1 if the surface is being sampled as if ``seen'' from the back
+of the surface (or the ``inside'' of a closed object). Returns 0 if seen
+from the ``front'' or the ``outside'' of a closed object.
+\apiend
+
 \apiitem{int {\ce isconnected} (\emph{type} parameter)}
 \indexapi{isconnected()}
 Returns {\cf 1} if the argument is a shader parameter and is connected

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1206,7 +1206,6 @@ static const char * builtin_func_args [] = {
 
     "area", "fp", "!deriv", NULL,
     "arraylength", "i?[]", NULL,
-    "backfacing", "i", NULL,
     "bump", "xf", "xsf", "xv", "!deriv", NULL,
     "calculatenormal", "vp", "!deriv", NULL,
     "cellnoise", NOISE_ARGS, NULL,

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -557,6 +557,7 @@ closure color cloth(normal N, float s, float t, color diff_warp, color diff_weft
 
 
 // Renderer state
+int backfacing () BUILTIN;
 int raytype (string typename) BUILTIN;
 // the individual 'isFOOray' functions are deprecated
 int iscameraray () { return raytype("camera"); }


### PR DESCRIPTION
Also, move it from the hard-coded table in typecheck.cpp to stdosl.h.
