### PR TITLE
Fix for bug introduced with the ShadingSystemImpl PIMPL refactor.

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -656,6 +656,16 @@ public:
     ~ShadingSystemImpl ();
 
     bool attribute (string_view name, TypeDesc type, const void *val);
+    bool attribute (string_view name, int val) {
+        return attribute (name, TypeDesc::INT, &val);
+    }
+    bool attribute (string_view name, float val) {
+        return attribute (name, TypeDesc::FLOAT, &val);
+    }
+    bool attribute (string_view name, string_view val) {
+        const char *s = val.c_str();
+        return attribute (name, TypeDesc::STRING, &s);
+    }
     bool attribute (ShaderGroup *group, string_view name,
                     TypeDesc type, const void *val);
     bool getattribute (string_view name, TypeDesc type, void *val);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -846,7 +846,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     }
 
     if (name == "options" && type == TypeDesc::STRING) {
-        return OIIO::optparser (*(ShadingSystem *)this, *(const char **)val);
+        return OIIO::optparser (*this, *(const char **)val);
     }
 
     lock_guard guard (m_mutex);  // Thread safety


### PR DESCRIPTION
Forgot this spot in SSI::attribute(), where it cast a ShadingSystemImpl*
to a ShadingSystem*, back when one was a subclass of the other. Now they
don't have a parent/child relationship. Yikes!

Because of the way optparser calls the system, I needed to add a couple
new overloaded varieties of attribute() to ShadingSystemImp.
