### PR TITLE
Adjust test to handle printf("%f", float_array).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             oslc-err-struct-array-init
             oslc-variadic-macro
             pointcloud pointcloud-fold
+            printf-whole-array
             raytype reparam
             render-background render-bumptest
             render-cornell render-furnace-diffuse

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -308,7 +308,7 @@ LLVMGEN (llvm_gen_printf)
                     s += ourformat;
 
                     llvm::Value* loaded = rop.llvm_load_value (sym, 0, arrind, c);
-                    if (sym.typespec().is_floatbased()) {
+                    if (simpletype.basetype == TypeDesc::FLOAT) {
                         // C varargs convention upconverts float->double.
                         loaded = rop.ll.op_float_to_double(loaded);
                     }

--- a/testsuite/printf-whole-array/ref/out.txt
+++ b/testsuite/printf-whole-array/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled test.osl -> test.oso
+iarray = 1 2 3 4 5
+sarray = a b c d e
+farray = 1.000000 2.000000 3.000000 4.000000 5.000000
+

--- a/testsuite/printf-whole-array/run.py
+++ b/testsuite/printf-whole-array/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = testshade("test")

--- a/testsuite/printf-whole-array/test.osl
+++ b/testsuite/printf-whole-array/test.osl
@@ -1,0 +1,11 @@
+shader test (
+    int iarray[5] = {1,2,3,4,5},
+    string sarray[5] = {"a", "b", "c", "d", "e"},
+    float farray[5] = {1,2,3,4,5}
+    )
+{
+    printf ("iarray = %i\n", iarray);
+    printf ("sarray = %s\n", sarray);
+    printf ("farray = %f\n", farray);
+}
+


### PR DESCRIPTION
TypeSpec::is_floatbased() specifically excludes arrays.
