### PR TITLE
Gracefully handle the USE_MCJIT=0 case for old LLVM without MCJIT libs

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -175,12 +175,19 @@ find_library ( LLVM_LIBRARY
                PATHS ${LLVM_LIB_DIR})
 message (STATUS "LLVM version  = ${LLVM_VERSION}")
 message (STATUS "LLVM dir      = ${LLVM_DIRECTORY}")
-find_library ( LLVM_MCJIT_LIBRARY
-               NAMES LLVMMCJIT
-               PATHS ${LLVM_LIB_DIR})
+
+if (USE_MCJIT)
+    find_library ( LLVM_MCJIT_LIBRARY
+                   NAMES LLVMMCJIT
+                   PATHS ${LLVM_LIB_DIR})
+else ()
+    set (LLVM_MCJIT_LIBRARY "")
+endif ()
+
 if (VERBOSE)
     message (STATUS "LLVM includes = ${LLVM_INCLUDES}")
     message (STATUS "LLVM library  = ${LLVM_LIBRARY}")
+    message (STATUS "LLVM MCJIT library  = ${LLVM_MCJIT_LIBRARY}")
     message (STATUS "LLVM lib dir  = ${LLVM_LIB_DIR}")
 endif ()
 


### PR DESCRIPTION
Addresses a problem reported by Mark Hall -- when building against LLVM old enough to not have MCJIT, it fails by not finding the MCJIT libraries, even when USE_MCJIT is not turned on. Solution is to not do those lookups if USE_MCJIT is off.
