### PR TITLE
testshade/testrender : have get_attribute fall back on get_userdata,

### DIFF
--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -380,6 +380,10 @@ void globals_from_hit(ShaderGlobals& sg, const Ray& r, const Dual2<float>& t, in
         sg.Ng = -sg.Ng;
     }
     sg.flipHandedness = flip;
+
+    // In our SimpleRenderer, the "renderstate" itself just a pointer to
+    // the ShaderGlobals.
+    sg.renderstate = &sg;
 }
 
 Vec3 eval_background(const Dual2<Vec3>& dir, ShadingContext* ctx) {

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -74,6 +74,7 @@ OSL_NAMESPACE_ENTER
 static ustring u_camera("camera"), u_screen("screen");
 static ustring u_NDC("NDC"), u_raster("raster");
 static ustring u_perspective("perspective");
+static ustring u_s("s"), u_t("t");
 static TypeDesc TypeFloatArray2 (TypeDesc::FLOAT, 2);
 static TypeDesc TypeFloatArray4 (TypeDesc::FLOAT, 4);
 static TypeDesc TypeIntArray2 (TypeDesc::INT, 2);
@@ -323,6 +324,11 @@ SimpleRenderer::get_array_attribute (void *renderstate, bool derivatives, ustrin
         return true;
     }
 
+    // If no named attribute was found, allow userdata to bind to the
+    // attribute request.
+    if (object.empty() && index == -1)
+        return get_userdata (derivatives, name, type, renderstate, val);
+
     return false;
 }
 
@@ -339,8 +345,36 @@ SimpleRenderer::get_attribute (void *renderstate, bool derivatives, ustring obje
 
 
 bool
-SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type, void *renderstate, void *val)
+SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
+                              void *renderstate, void *val)
 {
+    // Just to illustrate how this works, respect s and t userdata, filled
+    // in with the uv coordinates.  In a real renderer, it would probably
+    // look up something specific to the primitive, rather than have hard-
+    // coded names.
+
+    // In our SimpleRenderer, the "renderstate" itself just a pointer to
+    // the ShaderGlobals. That wouldn't necessarily be the case with all
+    // renderer implementations, so watch out.
+    ShaderGlobals *sg = reinterpret_cast<ShaderGlobals *>(renderstate);
+
+    if (name == u_s && type == TypeDesc::TypeFloat) {
+        ((float *)val)[0] = sg->u;
+        if (derivatives) {
+            ((float *)val)[1] = sg->dudx;
+            ((float *)val)[2] = sg->dudy;
+        }
+        return true;
+    }
+    if (name == u_t && type == TypeDesc::TypeFloat) {
+        ((float *)val)[0] = sg->v;
+        if (derivatives) {
+            ((float *)val)[1] = sg->dvdx;
+            ((float *)val)[2] = sg->dvdy;
+        }
+        return true;
+    }
+
     return false;
 }
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -350,6 +350,10 @@ setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
     // Just zero the whole thing out to start
     memset(&sg, 0, sizeof(ShaderGlobals));
 
+    // In our SimpleRenderer, the "renderstate" itself just a pointer to
+    // the ShaderGlobals.
+    sg.renderstate = &sg;
+
     // Set "shader" space to be Mshad.  In a real renderer, this may be
     // different for each shader group.
     sg.shader2common = OSL::TransformationPtr (&Mshad);


### PR DESCRIPTION
testshade/testrender : have get_attribute fall back on get_userdata,
and have get_userdata bind "s" and "t" (to u & v).

This lets us simulate and test (in testshade & testrender) retrieval of
userdata, and also illustrates more clearly how we assume that get_attribute
will allow binding to userdata, if present.
