### PR TITLE
oslinfo --param lets you print info on just one parameter.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,9 @@ Release 1.6 -- in development (compared to 1.5)
 Language, standard libary, and compiler changes (for shader writers):
 API changes, new options, new ShadingSystem features (for renderer writers):
 Performance improvements:
-Bug fixes:
+Bug fixes and other improvements:
+* oslinfo --param lets you ask for information on just one parameter of
+  a shader. #397 (1.6.0)
 Under the hood:
 Build & test system improvements and developer goodies:
 Documentation:


### PR DESCRIPTION
Also switch oslinfo to use ArgParse.

Example output:

```
$ oslinfo test
shader "test"
float s  0
float t  0
float foo  1
float bar  13
output color outputColor  [ 0 1 0 ]

$ oslinfo --param foo test
shader "test"
float foo  1
```
