### PR TITLE
Query which globals an optimized shader group will need.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,11 @@ API changes, new options, new ShadingSystem features (for renderer writers):
      example, noticing that a material can't possibly call the "transparent"
      closure, and thus concluding that it must be opaque everywhere and thus
      shadow rays need not execute shaders to determine opacity. (#400) (1.6.0)
+   * You can retrieve information about all "globals" (P, N, etc.) that an
+     optimized group needs using new queries "num_globals_needed" and
+     "globals_needed". This could be useful for renderers for which
+     computing those globals is very expensive; examining which are truly
+     needed and only computing those. (#401) (1.6.0)
 
 Performance improvements:
 

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -247,6 +247,9 @@ public:
     ///   int unknown_closures_needed  Nonzero if additional closures may be
     ///                                needed, whose names can't be known
     ///                                without actually running the shader.
+    ///   int num_globals_needed     The number of named globals needed.
+    ///   ptr globals_needed         Retrieves a pointer to the ustring array
+    ///                                containing all globals needed.
     ///   int num_userdata           The number of "user data" variables
     ///                                retrieved by the shader.
     ///   ptr userdata_names         Retrieves a pointer to the array of

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -516,6 +516,21 @@ public:
                                                            &i->m_instsymbols[0] + i->lastparam());
     }
 
+    friend std::pair<Symbol *,Symbol *> sym_range (ShaderInstance *i) {
+        if (i->m_instsymbols.size() == 0)
+            return std::pair<Symbol*,Symbol*> ((Symbol*)NULL, (Symbol*)NULL);
+        else
+            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[0],
+                                               &i->m_instsymbols[i->m_instsymbols.size()]);
+    }
+    friend std::pair<const Symbol *,const Symbol *> sym_range (const ShaderInstance *i) {
+        if (i->m_instsymbols.size() == 0)
+            return std::pair<const Symbol*,const Symbol*> ((const Symbol*)NULL, (const Symbol*)NULL);
+        else
+            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[0],
+                                               &i->m_instsymbols[i->m_instsymbols.size()]);
+    }
+
     int Psym () const { return m_Psym; }
     int Nsym () const { return m_Nsym; }
 
@@ -606,6 +621,9 @@ private:
 ///
 #define FOREACH_PARAM(symboldecl,inst) \
     BOOST_FOREACH (symboldecl, param_range(inst))
+
+#define FOREACH_SYM(symboldecl,inst) \
+    BOOST_FOREACH (symboldecl, sym_range(inst))
 
 
 
@@ -1206,6 +1224,7 @@ private:
     mutable mutex m_mutex;           ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;
+    std::vector<ustring> m_globals_needed;
     std::vector<ustring> m_userdata_names;
     std::vector<TypeDesc> m_userdata_types;
     std::vector<int> m_userdata_offsets;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2726,13 +2726,14 @@ RuntimeOptimizer::run ()
     m_unknown_closures_needed = false;
     m_textures_needed.clear();
     m_closures_needed.clear();
+    m_globals_needed.clear();
     m_userdata_needed.clear();
     for (int layer = 0;  layer < nlayers;  ++layer) {
         set_inst (layer);
         if (inst()->unused())
             continue;  // no need to print or gather stats for unused layers
         // Find interpolated parameters
-        FOREACH_PARAM (const Symbol &s, inst()) {
+        FOREACH_SYM (const Symbol &s, inst()) {
             if ((s.symtype() == SymTypeParam || s.symtype() == SymTypeOutputParam)
                 && ! s.lockgeom()) {
                 UserDataNeeded udn (s.name(), s.typespec().simpletype(), s.has_derivs());
@@ -2744,6 +2745,9 @@ RuntimeOptimizer::run ()
                     m_userdata_needed.erase (found);
                     m_userdata_needed.insert (udn);
                 }
+            }
+            if (s.symtype() == SymTypeGlobal) {
+                m_globals_needed.insert (s.name());
             }
         }
         BOOST_FOREACH (const Opcode &op, inst()->ops()) {

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -352,6 +352,7 @@ private:
     std::vector<ustring> m_local_messages_sent; ///< Messages set in this inst
     std::set<ustring> m_textures_needed;
     std::set<ustring> m_closures_needed;
+    std::set<ustring> m_globals_needed;
     bool m_unknown_textures_needed;
     bool m_unknown_closures_needed;
     std::set<UserDataNeeded> m_userdata_needed;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1147,6 +1147,20 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
         return true;
     }
 
+    if (name == "num_globals_needed" && type == TypeDesc::TypeInt) {
+        if (! group->optimized())
+            optimize_group (*group);
+        *(int *)val = (int)group->m_globals_needed.size();
+        return true;
+    }
+    if (name == "globals_needed" && type.basetype == TypeDesc::PTR) {
+        if (! group->optimized())
+            optimize_group (*group);
+        size_t n = group->m_globals_needed.size();
+        *(ustring **)val = n ? &group->m_globals_needed[0] : NULL;
+        return true;
+    }
+
     if (name == "num_userdata" && type == TypeDesc::TypeInt) {
         if (! group->optimized())
             optimize_group (*group);
@@ -2209,6 +2223,8 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group)
     group.m_unknown_closures_needed = rop.m_unknown_closures_needed;
     BOOST_FOREACH (ustring f, rop.m_closures_needed)
         group.m_closures_needed.push_back (f);
+    BOOST_FOREACH (ustring f, rop.m_globals_needed)
+        group.m_globals_needed.push_back (f);
     size_t num_userdata = rop.m_userdata_needed.size();
     group.m_userdata_names.reserve (num_userdata);
     group.m_userdata_types.reserve (num_userdata);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -557,6 +557,15 @@ test_group_attributes (ShaderGroup *group)
         if (unk)
             std::cout << "    and unknown closures\n";
     }
+    int nglobals = 0;
+    if (shadingsys->getattribute (group, "num_globals_needed", nglobals)) {
+        std::cout << "Need " << nglobals << " globals:\n";
+        ustring *globals = NULL;
+        shadingsys->getattribute (group, "globals_needed",
+                                  TypeDesc::PTR, &globals);
+        for (int i = 0; i < nglobals; ++i)
+            std::cout << "    " << globals[i] << "\n";
+    }
     int nuser = 0;
     if (shadingsys->getattribute (group, "num_userdata", nuser) && nuser) {
         std::cout << "Need " << nuser << " user data items:\n";


### PR DESCRIPTION
New shader group queries: "num_globals_needed", "globals_needed".
Works analogously to asking which textures or userdata are needed by a
(post-optimized) shader group.

Some renderers may find construction of certain globals to be very
expensive, and this allows them to quickly determine exactly which
globals will be needed by the group (_after_ full runtime optimization)
so that the renderer can avoid work for globals that will not be used.
