### PR TITLE
Optimization: Be less conservative in implementation of unread_after().

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1161,7 +1161,7 @@ RuntimeOptimizer::unread_after (const Symbol *A, int opnum)
 
     // For all else, check if it's either never read at all in this
     // layer or it's only read earlier and we're not part of a loop
-    return !A->everread() || (A->lastread() < opnum && !m_in_loop[opnum]);
+    return !A->everread() || (A->lastread() <= opnum && !m_in_loop[opnum]);
 }
 
 


### PR DESCRIPTION
It was really implemented as if it were "unread AT OR after". It's used to determine whether it's safe to elide assignments to variables that aren't subsequently use. But sometimes the assignment is a function where the variable assigned to is also one of the arguments. For example,

    x = func(x,y)

x is read on that op, but not AFTER. But because of how the unread_after also discounted elision if used on that op, it was less aggressive than it could have been in eliminating statements like this.

I'm seeing around a 1/2 - 1% speedup on production frames because of this, with a similar decrease in post-optimized symbols and instructions. Not dramatic, but every little bit counts.
