### PR TITLE
Support custom LPE symbols from the user

### DIFF
--- a/src/include/OSL/accum.h
+++ b/src/include/OSL/accum.h
@@ -130,6 +130,11 @@ class OSLEXECPUBLIC AccumAutomata
 
         ~AccumAutomata();
 
+        /// Support the given symbol as event tag on lpe expressions
+        void addEventType(ustring symbol) { m_user_events.push_back(symbol); };
+        /// Support the given symbol as scattering tag on lpe expressions
+        void addScatteringType(ustring symbol) { m_user_scatterings.push_back(symbol); };
+
         /// Add a single rule for rendering outputs
         ///
         ///    \param pattern         The light path expression to be mapped to the new rule
@@ -163,6 +168,10 @@ class OSLEXECPUBLIC AccumAutomata
         DfOptimizedAutomata      m_dfoptautomata;
         // List of rules linked as void * from the automata's states
         std::list<AccumRule>     m_accumrules;
+        // Custom symbols to support on expressions as events
+        std::vector<ustring>     m_user_events;
+        // Custom symbols to support on expressions as scattering
+        std::vector<ustring>     m_user_scatterings;
 };
 
 

--- a/src/liboslexec/accum.cpp
+++ b/src/liboslexec/accum.cpp
@@ -82,7 +82,7 @@ AccumRule *
 AccumAutomata::addRule(const char *pattern, int outidx, bool toalpha)
 {
     // First parse the lpexp and see if it fails
-    Parser parser;
+    Parser parser(&m_user_events, &m_user_scatterings);
     LPexp *e = parser.parse(pattern);
     if (parser.error()) {
         std::cerr << "[pathexp] Parse error" << parser.getErrorMsg() << " at char " << parser.getErrorPos() << std::endl;

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -124,7 +124,8 @@ int main()
     const int transpshadow = 6;
     const int reflections  = 7;
     const int nocaustic    = 8;
-    const int naovs        = 9;
+    const int custom       = 9;
+    const int naovs        = 10;
 
     // The actual test cases. Each one is a list of ray hits with some labels.
     // We use 1 char labels for convenience. They will be converted to ustrings
@@ -141,6 +142,7 @@ int main()
                               { { "C_", "RD1", "RD", "L_", NULL },             { beauty, diffuse, diffuse2_3, object_1, nocaustic, END_AOV } },
                               { { "C_", "RS",  "RD", "RG", "L_", NULL },       { END_AOV } },
                               { { "C_", "RS",  "RD", "L_", NULL },             { beauty, specular, reflections, nocaustic, END_AOV } },
+                              { { "C_", "RD",  "RY", "RD", "U_", NULL },       { custom, END_AOV } },
                               { { NULL }, { END_AOV } } };
 
     // Create our fake testing AOV's
@@ -151,6 +153,9 @@ int main()
     // Create the automata and add the rules
     AccumAutomata automata;
 
+    automata.addEventType(ustring("U"));
+    automata.addScatteringType(ustring("Y"));
+
     ASSERT(automata.addRule("C[SG]*D*L",        beauty));
     ASSERT(automata.addRule("C[SG]*D{2,3}L",    diffuse2_3));
     ASSERT(automata.addRule("C[SG]*D*<L.'3'>",  light3));
@@ -160,6 +165,7 @@ int main()
     ASSERT(automata.addRule("CD+<Ts>L",         transpshadow));
     ASSERT(automata.addRule("C<R[^D]>+D*L",     reflections));
     ASSERT(automata.addRule("C([SG]*D){1,2}L",  nocaustic));
+    ASSERT(automata.addRule("CDY+U",            custom));
 
     automata.compile();
 

--- a/src/liboslexec/lpeparse.cpp
+++ b/src/liboslexec/lpeparse.cpp
@@ -37,7 +37,8 @@ OSL_NAMESPACE_ENTER
 
 static ustring udot(".");
 
-Parser::Parser()
+Parser::Parser(const std::vector<ustring> *user_events,
+               const std::vector<ustring> *user_scatterings)
 {
     m_ingroup = false;
     m_error = "";
@@ -69,8 +70,20 @@ Parser::Parser()
     m_basic_labels.insert(Labels::STOP);
 
     m_minus_stop.insert(Labels::STOP);
-}
 
+    if (user_events)
+      for (int i = 0; i < user_events->size(); ++i)
+      {
+          m_label_position[(*user_events)[i]] = 0;
+          m_basic_labels.insert((*user_events)[i]);
+      }
+   if (user_scatterings)
+      for (int i = 0; i < user_scatterings->size(); ++i)
+      {
+          m_label_position[(*user_scatterings)[i]] = 1;
+          m_basic_labels.insert((*user_scatterings)[i]);
+      }
+}
 
 
 LPexp *

--- a/src/liboslexec/lpeparse.h
+++ b/src/liboslexec/lpeparse.h
@@ -61,7 +61,8 @@ class Parser
 {
     public:
 
-        Parser();
+        Parser(const std::vector<ustring> *user_events = NULL,
+               const std::vector<ustring> *user_scatterings = NULL);
 
         /// Parse a string and return the resulting light path expression tree or NULL if failed
         LPexp *parse(const char *text);


### PR DESCRIPTION
This has been requested so light path expressions can use
custom symbols for events and scatterings in addition to the
builtin C, L, D, etc ...
