### PR TITLE
Fix thread contention issue in testshade.

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -80,6 +80,7 @@ static std::string reparam_layer;
 static ErrorHandler errhandler;
 static int iters = 1;
 static std::string raytype = "camera";
+static int raytype_bit = 0;
 static std::string extraoptions;
 static SimpleRenderer rend;  // RendererServices
 static OSL::Matrix44 Mshad;  // "shader" space to "common" space matrix
@@ -301,6 +302,7 @@ getargs (int argc, const char *argv[])
 
     if (debug || verbose)
         errhandler.verbosity (ErrorHandler::VERBOSE);
+    raytype_bit = shadingsys->raytype_bit (ustring (raytype));
 }
 
 
@@ -363,7 +365,7 @@ setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
     sg.object2common = OSL::TransformationPtr (&Mobj);
 
     // Just make it look like all shades are the result of 'raytype' rays.
-    sg.raytype = shadingsys->raytype_bit (ustring(raytype));
+    sg.raytype = raytype_bit;
 
     // Set up u,v to vary across the "patch", and also their derivatives.
     // Note that since u & x, and v & y are aligned, we only need to set


### PR DESCRIPTION
We were doing incredibly stupid in testshade -- setup_shaderglobals was
setting sg.renderstate was asking for
shadingsys->raytype_bit(ustring(raytype)) for EVERY shadde, instead of
finding out which bit it was once and using that int all the time.

Most egregiously, the construction of a ustring was creating thread
contention (it was the SAME ustring every time, which is the worst case
for the locking in the ustring table -- at least if they were different
character sequences, the ustring internals are unlikely to have them
vying for the same lock!).

The net result was that for small shaders especially, the
setup_shaderglobals thread contention could dominated runtime when more
than a few threads were running. This made testshade very unreliable for
benchmarking the actual execution time of short shaders when many
threads were used. Ick!

The fix is very simple, just ask for the bit once globally, and use that
result when setting up the SG's for the individual shades.
