### PR TITLE
Add faster, lower precision variants of the standard math routines

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -29,6 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "oslversion.h"
+#include "fastmath.h"
+#include <OpenImageIO/fmath.h>
 OSL_NAMESPACE_ENTER
 
 
@@ -335,9 +337,15 @@ template<class T>
 inline Dual2<T> cos (const Dual2<T> &a)
 {
     T sina, cosa;
-    sina = std::sin (a.val());
-    cosa = std::cos (a.val());
+    OIIO::sincos(a.val(), &sina, &cosa);
     return Dual2<T> (cosa, -sina * a.dx(), -sina * a.dy());
+}
+
+inline Dual2<float> fast_cos(const Dual2<float> &a)
+{
+    float sina, cosa;
+    fast_sincosf(a.val(), &sina, &cosa);
+    return Dual2<float> (cosa, -sina * a.dx(), -sina * a.dy());
 }
 
 // f(x) = sin(x),  f'(x) = cos(x)
@@ -345,106 +353,144 @@ template<class T>
 inline Dual2<T> sin (const Dual2<T> &a)
 {
     T sina, cosa;
-    sina = std::sin (a.val());
-    cosa = std::cos (a.val());
+    OIIO::sincos(a.val(), &sina, &cosa);
     return Dual2<T> (sina, cosa * a.dx(), cosa * a.dy());
+}
+
+inline Dual2<float> fast_sin(const Dual2<float> &a)
+{
+    float sina, cosa;
+    fast_sincosf(a.val(), &sina, &cosa);
+    return Dual2<float> (sina, cosa * a.dx(), cosa * a.dy());
 }
 
 // f(x) = tan(x), f'(x) = sec^2(x)
 template<class T>
 inline Dual2<T> tan (const Dual2<T> &a)
 {
-   T tana, cosa, sec2a;
-   tana  = std::tan (a.val());
-   cosa  = std::cos (a.val());
-   sec2a = T(1)/(cosa*cosa);
-   return Dual2<T> (tana, sec2a * a.dx(), sec2a * a.dy());
+    T tana  = std::tan (a.val());
+    T cosa  = std::cos (a.val());
+    T sec2a = T(1)/(cosa*cosa);
+    return Dual2<T> (tana, sec2a * a.dx(), sec2a * a.dy());
+}
+
+inline Dual2<float> fast_tan(const Dual2<float> &a)
+{
+    float tana  = fast_tanf(a.val());
+    float cosa  = fast_cosf(a.val());
+    float sec2a = 1 / (cosa * cosa);
+    return Dual2<float> (tana, sec2a * a.dx(), sec2a * a.dy());
 }
 
 // f(x) = cosh(x), f'(x) = sinh(x)
 template<class T>
 inline Dual2<T> cosh (const Dual2<T> &a)
 {
-   T cosha, sinha;
-   cosha = std::cosh(a.val());
-   sinha = std::sinh(a.val());
-   return Dual2<T> (cosha, sinha * a.dx(), sinha * a.dy());
+    T cosha = std::cosh(a.val());
+    T sinha = std::sinh(a.val());
+    return Dual2<T> (cosha, sinha * a.dx(), sinha * a.dy());
 }
+
+inline Dual2<float> fast_cosh(const Dual2<float> &a)
+{
+    float cosha = fast_coshf(a.val());
+    float sinha = fast_sinhf(a.val());
+    return Dual2<float> (cosha, sinha * a.dx(), sinha * a.dy());
+}
+
 
 // f(x) = sinh(x), f'(x) = cosh(x)
 template<class T>
 inline Dual2<T> sinh (const Dual2<T> &a)
 {
-   T cosha, sinha;
-   cosha = std::cosh(a.val());
-   sinha = std::sinh(a.val());
-   return Dual2<T> (sinha, cosha * a.dx(), cosha * a.dy());
+    T cosha = std::cosh(a.val());
+    T sinha = std::sinh(a.val());
+    return Dual2<T> (sinha, cosha * a.dx(), cosha * a.dy());
+}
+
+inline Dual2<float> fast_sinh(const Dual2<float> &a)
+{
+    float cosha = fast_coshf(a.val());
+    float sinha = fast_sinhf(a.val());
+    return Dual2<float> (sinha, cosha * a.dx(), cosha * a.dy());
 }
 
 // f(x) = tanh(x), f'(x) = sech^2(x)
 template<class T>
 inline Dual2<T> tanh (const Dual2<T> &a)
 {
-   T cosha, tanha, sech2a;
-   tanha = std::tanh(a.val());
-   cosha = std::cosh(a.val());
-   sech2a = T(1)/(cosha*cosha);
-   return Dual2<T> (tanha, sech2a * a.dx(), sech2a * a.dy());
+    T tanha = std::tanh(a.val());
+    T cosha = std::cosh(a.val());
+    T sech2a = T(1)/(cosha*cosha);
+    return Dual2<T> (tanha, sech2a * a.dx(), sech2a * a.dy());
+}
+
+inline Dual2<float> fast_tanh(const Dual2<float> &a)
+{
+    float tanha = fast_tanhf(a.val());
+    float cosha = fast_coshf(a.val());
+    float sech2a = 1 / (cosha * cosha);
+    return Dual2<float> (tanha, sech2a * a.dx(), sech2a * a.dy());
 }
 
 // f(x) = acos(x), f'(x) = -1/(sqrt(1 - x^2))
 template<class T>
-inline Dual2<T> acos (const Dual2<T> &a)
+inline Dual2<T> safe_acos (const Dual2<T> &a)
 {
-   if (a.val() >= T(1)) 
-      return Dual2<T> (T(0), T(0), T(0));
-   if (a.val() <= T(-1)) 
-      return Dual2<T> (T(M_PI), T(0), T(0));
+    if (a.val() >= T(1))
+        return Dual2<T> (T(0), T(0), T(0));
+    if (a.val() <= T(-1))
+        return Dual2<T> (T(M_PI), T(0), T(0));
+    T arccosa = std::acos (a.val());
+    T denom   = -T(1) / std::sqrt (T(1) - a.val()*a.val());
+    return Dual2<T> (arccosa, denom * a.dx(), denom * a.dy());
+}
 
-   T arccosa, denom;
-   arccosa = std::acos (a.val());
-   denom   = -T(1) / std::sqrt (T(1) - a.val()*a.val());
-
-   return Dual2<T> (arccosa, denom * a.dx(), denom * a.dy());
+inline Dual2<float> fast_acos(const Dual2<float> &a)
+{
+    float arccosa = fast_acosf(a.val());
+    float denom   = fabsf(a.val()) < 1.0f ? -1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
+    return Dual2<float> (arccosa, denom * a.dx(), denom * a.dy());
 }
 
 // f(x) = asin(x), f'(x) = 1/(sqrt(1 - x^2))
 template<class T>
-inline Dual2<T> asin (const Dual2<T> &a)
+inline Dual2<T> safe_asin (const Dual2<T> &a)
 {
-   if (a.val() >= T(1)) 
-      return Dual2<T> (T(M_PI/2), T(0), T(0));
-   if (a.val() <= T(-1)) 
-      return Dual2<T> (T(-M_PI/2), T(0), T(0));
+    if (a.val() >= T(1))
+        return Dual2<T> (T(M_PI/2), T(0), T(0));
+    if (a.val() <= T(-1))
+        return Dual2<T> (T(-M_PI/2), T(0), T(0));
 
-   T arcsina, denom;
-   arcsina = std::asin (a.val());
-   denom   = T(1) / std::sqrt (T(1) - a.val()*a.val());
-
-   return Dual2<T> (arcsina, denom * a.dx(), denom * a.dy());
+    T arcsina = std::asin (a.val());
+    T denom   = T(1) / std::sqrt (T(1) - a.val()*a.val());
+    return Dual2<T> (arcsina, denom * a.dx(), denom * a.dy());
 }
+
+inline Dual2<float> fast_asin(const Dual2<float> &a)
+{
+    float arcsina = fast_asinf(a.val());
+    float denom   = fabsf(a.val()) < 1.0f ? 1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
+    return Dual2<float> (arcsina, denom * a.dx(), denom * a.dy());
+}
+
 
 // f(x) = atan(x), f'(x) = 1/(1 + x^2)
 template<class T>
 inline Dual2<T> atan (const Dual2<T> &a)
 {
-   T arctana, denom;
-   arctana = std::atan (a.val());
-   denom   = T(1) / (T(1) + a.val()*a.val());
-
-   return Dual2<T> (arctana, denom * a.dx(), denom * a.dy());
+    T arctana = std::atan (a.val());
+    T denom   = T(1) / (T(1) + a.val()*a.val());
+    return Dual2<T> (arctana, denom * a.dx(), denom * a.dy());
 }
 
+inline Dual2<float> fast_atan(const Dual2<float> &a)
+{
+    float arctana = fast_atanf(a.val());
+    float denom   = 1.0f / (1.0f + a.val() * a.val());
+    return Dual2<float> (arctana, denom * a.dx(), denom * a.dy());
 
-/// Make a simple way to extract the value of a dual<T> and a regular T with
-/// uniform syntax.
-template<class T>
-inline T value (const Dual2<T> &f) { return f.val(); }
-
-template<class T>
-inline T value (const T &f) { return f; }
-
-
+}
 
 // f(x,x) = atan2(y,x); f'(x) =  y x' / (x^2 + y^2),
 //                      f'(y) = -x y' / (x^2 + y^2)
@@ -453,14 +499,18 @@ inline T value (const T &f) { return f; }
 template<class T>
 inline Dual2<T> atan2 (const Dual2<T> &y, const Dual2<T> &x)
 {
-   if (y.val() == T(0) && x.val() == T(0))
-      return Dual2<T> (T(0), T(0), T(0));
+    T atan2xy = std::atan2 (y.val(), x.val());
+    T denom = (x.val() == T(0) && y.val() == T(0)) ? T(0) : T(1) / (x.val()*x.val() + y.val()*y.val());
+    return Dual2<T> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
+                               (y.val()*x.dy() - x.val()*y.dy())*denom );
+}
 
-   T atan2xy;
-   atan2xy = std::atan2 (y.val(), x.val());
-   T denom = T(1) / (x.val()*x.val() + y.val()*y.val());
-   return Dual2<T> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
-                              (y.val()*x.dy() - x.val()*y.dy())*denom );
+inline Dual2<float> fast_atan2(const Dual2<float> &y, const Dual2<float> &x)
+{
+    float atan2xy = fast_atan2f(y.val(), x.val());
+    float denom = (x.val() == 0 && y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
+    return Dual2<float> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
+                                   (y.val()*x.dy() - x.val()*y.dy())*denom );
 }
 
 
@@ -471,239 +521,193 @@ inline Dual2<T> atan2 (const Dual2<T> &y, const Dual2<T> &x)
 //   (from http://en.wikipedia.org/wiki/Automatic_differentiation)
 // so, pow(u,v) = < u^v, vu^(v-1) u' + log(u)u^v v' >
 template<class T>
-inline Dual2<T> pow (const Dual2<T> &u, const Dual2<T> &v)
-{
-    if (v.val() == T(0))
-        return Dual2<T> ( T(1) );    // u^0 == 1
-    if (u.val() == T(0))
-        return Dual2<T> ( T(0) );    // 0^v == 0
-    if (u.val() < T(0)) {
-        if (truncf(v.val()) != v.val())
-            return T(0);  // return 0 rather than imaginary
-        // The function is not continuous in v, so assume v's derivs zero.
-        // This gets rid of the log(u), which makes life easier.
-        T powuvm1 = std::pow (u.val(), v.val()-T(1)); // u^(v-1)
-        T powuv   = powuvm1 * u.val();  // u^v
-        return Dual2<T> ( powuv, v.val()*powuvm1 * u.dx(),
-                          v.val()*powuvm1 * u.dy() );
-    }
-    // Full case of pow(u,v) well-defined
-    T powuvm1 = std::pow (u.val(), v.val()-T(1)); // u^(v-1)
-    T powuv   = powuvm1 * u.val();  // u^v
-    T logu    = std::log (u.val());
-    return Dual2<T> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
-                      v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
-}
-
-
-
-/// A version of pow that is robust to overflow and domain errors.
-///
-inline float
-safe_pow (float x, float y)
-{
-    // Quick return for x==0, including returning 0 (rather than Inf) when
-    // y is negative.
-    if (x == 0.0f)
-        return y == 0.0f ? 1.0f : 0.0f;
-    // Return 0 rather than NaNs for domain errors where x<0 and y not int
-    if (x < 0.0f && floorf(y) != y)
-        return 0.0f;
-    // Ask for standard pow()
-    float r = std::pow (x, y);
-    // Clamp to avoid Inf values.  We purposely clamp at considerably
-    // less than FLOAT_MAX (but still bigger than anyone is likely to
-    // need) so that subsequent additions or multiplications are less
-    // likely to overflow and end up with an Inf right afterwards.
-    const float big = 1e30;
-    if (r < -big)
-        return -big;
-    if (r > big)
-        return big;
-    return r;
-}
-
-
-
-template<class T>
 inline Dual2<T> safe_pow (const Dual2<T> &u, const Dual2<T> &v)
 {
-    if (v.val() == T(0))
-        return Dual2<T> ( T(1) );    // u^0 == 1
-    if (u.val() == T(0))
-        return Dual2<T> ( T(0) );    // 0^v == 0
-    if (u.val() < T(0)) {
-        if (truncf(v.val()) != v.val())
-            return T(0);  // return 0 rather than imaginary
-        // The function is not continuous in v, so assume v's derivs zero.
-        // This gets rid of the log(u), which makes life easier.
-        T powuvm1 = safe_pow (u.val(), v.val()-T(1));  // u^(v-1)
-        T powuv   = powuvm1 * u.val();   // u^v
-        return Dual2<T> ( powuv, v.val()*powuvm1 * u.dx(),
-                          v.val()*powuvm1 * u.dy() );
-    }
-    // Full case of pow(u,v) well-defined 
-    T powuvm1 = safe_pow (u.val(), v.val()-T(1));  // u^(v-1)
-    T powuv   = powuvm1 * u.val();   // u^v
-    T logu    = std::log (u.val());
+    // NOTE: this function won't return exactly the same as pow(x,y) because we
+    // use the identity u^v=u * u^(v-1) which does not hold in all cases for our
+    // "safe" variant (nor does it hold in general in floating point arithmetic).
+    T powuvm1 = safe_pow(u.val(), v.val() - T(1));
+    T powuv   = powuvm1 * u.val();
+    T logu    = u.val() > 0 ? safe_log(u.val()) : T(0);
     return Dual2<T> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
-                      v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
+                             v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
 }
 
+inline Dual2<float> fast_safe_pow(const Dual2<float> &u, const Dual2<float> &v)
+{
+    // NOTE: same issue as above (fast_safe_pow does even more clamping)
+    float powuvm1 = fast_safe_powf(u.val(), v.val() - 1.0f);
+    float powuv   = powuvm1 * u.val();
+    float logu    = u.val() > 0 ? fast_logf(u.val()) : 0.0f;
+    return Dual2<float> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
+                                 v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
+
+}
 
 // f(x) = log(a), f'(x) = 1/x
 // (log base e)
 template<class T>
-inline Dual2<T> log (const Dual2<T> &a)
+inline Dual2<T> safe_log (const Dual2<T> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0))
-      return Dual2<T> (T(-std::numeric_limits<T>::max()), T(0), T(0));
-
-   T loga, inv_a;
-   loga  = std::log (a.val());
-   inv_a = T(1)/a.val();
-
-   return Dual2<T> (loga, inv_a * a.dx(), inv_a * a.dy());
+    T loga = safe_log(a.val());
+    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / a.val();
+    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
 }
 
-// f(x) = log(a)/log(b)  -- leverage Dual2<T>log() and Dua2<T>operator/()
-// (log base e)
-template<class T>
-inline Dual2<T> log (const Dual2<T> &a, const Dual2<T> &b)
+inline Dual2<float> fast_log(const Dual2<float> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0) || b.val() <= T(0) || b.val() == T(1)) {
-      if (b.val() == T(1))
-         return Dual2<T> (T(std::numeric_limits<T>::max()), T(0), T(0));
-      else
-         return Dual2<T> (T(-std::numeric_limits<T>::max()), T(0), T(0));
-   }
-
-   Dual2<T> loga, logb;
-   loga  = log (a);
-   logb  = log (b);
-
-   return loga/logb;
+    float loga = fast_logf(a.val());
+    float inva = a.val() < std::numeric_limits<float>::min() ? 0.0f : 1.0f / a.val();
+    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
 }
 
 // f(x) = log2(x), f'(x) = 1/(x*log2)
 // (log base 2)
 template<class T>
-inline Dual2<T> log2 (const Dual2<T> &a)
+inline Dual2<T> safe_log2 (const Dual2<T> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0))
-      return Dual2<T> (T(-std::numeric_limits<T>::max()), T(0), T(0));
+    T loga = safe_log2(a.val());
+    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN2));
+    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
+}
 
-   T log2, log2a, inv_a_log2;
-
-   log2       = std::log (T(2));
-   log2a      = std::log (a.val()) / log2;
-   inv_a_log2 = T(1)/(a.val() * log2);
-
-   return Dual2<T> (log2a, inv_a_log2 * a.dx(), inv_a_log2 * a.dy());
+inline Dual2<float> fast_log2(const Dual2<float> &a)
+{
+    float loga = fast_log2f(a.val());
+    float aln2 = a.val() * float(M_LN2);
+    float inva = aln2 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln2;
+    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
 }
 
 // f(x) = log10(x), f'(x) = 1/(x*log10)
 // (log base 10)
 template<class T>
-inline Dual2<T> log10 (const Dual2<T> &a)
+inline Dual2<T> safe_log10 (const Dual2<T> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0))
-      return Dual2<T> (T(-std::numeric_limits<T>::max()), T(0), T(0));
+    T loga = safe_log10(a.val());
+    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN10));
+    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
+}
 
-   T log10, log10a, inv_a_log10;
-   log10       = std::log (T(10));
-   log10a      = std::log10 (a.val());
-   inv_a_log10 = T(1)/(a.val() * log10);
-
-   return Dual2<T> (log10a, inv_a_log10 * a.dx(), inv_a_log10 * a.dy());
+inline Dual2<float> fast_log10(const Dual2<float> &a)
+{
+    float loga  = fast_log10f(a.val());
+    float aln10 = a.val() * float(M_LN10);
+    float inva  = aln10 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln10;
+    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
 }
 
 // f(x) = e^x, f'(x) = e^x
 template<class T>
 inline Dual2<T> exp (const Dual2<T> &a)
 {
-   T expa;
-   expa  = std::exp (a.val());
+    T expa = std::exp(a.val());
+    return Dual2<T> (expa, expa * a.dx(), expa * a.dy());
+}
 
-   return Dual2<T> (expa, expa * a.dx(), expa * a.dy());
+inline Dual2<float> fast_exp(const Dual2<float> &a)
+{
+    float expa = fast_expf(a.val());
+    return Dual2<float> (expa, expa * a.dx(), expa * a.dy());
 }
 
 // f(x) = 2^x, f'(x) = (2^x)*log(2)
 template<class T>
 inline Dual2<T> exp2 (const Dual2<T> &a)
 {
-   T exp2a, ln2;
-   exp2a  = std::pow (T(2), a.val());
-   ln2    = std::log (T(2));
-
-   return Dual2<T> (exp2a, exp2a*ln2*a.dx(), exp2a*ln2*a.dy());
+    // FIXME: std::exp2 is only available in C++11
+    T exp2a = exp2f(float(a.val()));
+    return Dual2<T> (exp2a, exp2a*T(M_LN2)*a.dx(), exp2a*T(M_LN2)*a.dy());
 }
+
+inline Dual2<float> fast_exp2(const Dual2<float> &a)
+{
+    float exp2a = fast_exp2f(float(a.val()));
+    return Dual2<float> (exp2a, exp2a*float(M_LN2)*a.dx(), exp2a*float(M_LN2)*a.dy());
+}
+
 
 // f(x) = e^x - 1, f'(x) = e^x
 template<class T>
 inline Dual2<T> expm1 (const Dual2<T> &a)
 {
-   float expm1a, expa;
-   expm1a = expm1f (a.val());
-   expa   = std::exp (a.val());
+    // FIXME: std::expm1 is only available in C++11
+    T expm1a = expm1f(float(a.val())); // float version!
+    T expa   = std::exp  (a.val());
+    return Dual2<T> (expm1a, expa * a.dx(), expa * a.dy());
+}
 
-   return Dual2<T> (expm1a, expa * a.dx(), expa * a.dy());
+inline Dual2<float> fast_expm1(const Dual2<float> &a)
+{
+    float expm1a = fast_expm1f(a.val());
+    float expa   = fast_expf  (a.val());
+    return Dual2<float> (expm1a, expa * a.dx(), expa * a.dy());
 }
 
 // f(x) = erf(x), f'(x) = (2e^(-x^2))/sqrt(pi)
 template<class T>
 inline Dual2<T> erf (const Dual2<T> &a)
 {
-   T erfa, derfadx;
-   erfa    = erff (a.val()); // float version!
-   derfadx = T(2)*std::exp(-a.val()*a.val())/std::sqrt(T(M_PI));
+    // FIXME: std::erf is only defined in C++11
+    T erfa = erff (float(a.val())); // float version!
+    T two_over_sqrt_pi = T(1.128379167095512573896158903);
+    T derfadx = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
+    return Dual2<T> (erfa, derfadx * a.dx(), derfadx * a.dy());
+}
 
-   return Dual2<T> (erfa, derfadx * a.dx(), derfadx * a.dy());
+inline Dual2<float> fast_erf(const Dual2<float> &a)
+{
+    float erfa = fast_erff (float(a.val())); // float version!
+    float two_over_sqrt_pi = 1.128379167095512573896158903f;
+    float derfadx = fast_expf(-a.val() * a.val()) * two_over_sqrt_pi;
+    return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
 }
 
 // f(x) = erfc(x), f'(x) = -(2e^(-x^2))/sqrt(pi)
 template<class T>
 inline Dual2<T> erfc (const Dual2<T> &a)
 {
-   T erfca, derfcadx;
-   erfca    = erfcf (a.val()); // float version!
-   derfcadx = -T(2)*std::exp(-a.val()*a.val())/std::sqrt(T(M_PI));
-
-   return Dual2<T> (erfca, derfcadx * a.dx(), derfcadx * a.dy());
+    // FIXME: std::erfc is only defined in C++11
+    T erfca = T(1) - erfcf (float(a.val())); // float version!
+    T two_over_sqrt_pi = -T(1.128379167095512573896158903);
+    T derfcadx = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
+    return Dual2<T> (erfca, derfcadx * a.dx(), derfcadx * a.dy());
 }
+
+inline Dual2<float> fast_erfc(const Dual2<float> &a)
+{
+    float erfa = fast_erfcf (float(a.val())); // float version!
+    float two_over_sqrt_pi = -1.128379167095512573896158903f;
+    float derfadx = fast_expf(-a.val() * a.val()) * two_over_sqrt_pi;
+    return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
+}
+
 
 // f(x) = sqrt(x), f'(x) = 1/(2*sqrt(x))
 template<class T>
 inline Dual2<T> sqrt (const Dual2<T> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0))
-      return Dual2<T> (T(0), T(0), T(0));
+    if (a.val() <= T(0))
+        return Dual2<T> (T(0), T(0), T(0));
 
-   T sqrta, inv_2sqrta;
-   sqrta      = std::sqrt(a.val());
-   inv_2sqrta = T(1)/(T(2)*sqrta);
+    T sqrta      = std::sqrt(a.val());
+    T inv_2sqrta = T(1) / (T(2) * sqrta);
 
-   return Dual2<T> (sqrta, inv_2sqrta * a.dx(), inv_2sqrta * a.dy());
+    return Dual2<T> (sqrta, inv_2sqrta * a.dx(), inv_2sqrta * a.dy());
 }
 
 // f(x) = 1/sqrt(x), f'(x) = -1/(2*x^(3/2))
 template<class T>
 inline Dual2<T> inversesqrt (const Dual2<T> &a)
 {
-   // do we want to print an error message?
-   if (a.val() <= T(0))
-      return Dual2<T> (T(0), T(0), T(0));
+    // do we want to print an error message?
+    if (a.val() <= T(0))
+        return Dual2<T> (T(0), T(0), T(0));
 
-   T sqrta, inv_neg2asqrta;
-   sqrta          = std::sqrt(a.val());
-   inv_neg2asqrta = -T(1)/(T(2)*a.val()*sqrta);
+    T sqrta          = std::sqrt(a.val());
+    T inv_neg2asqrta = -T(1)/(T(2)*a.val()*sqrta);
 
-   return Dual2<T> (T(1)/sqrta, inv_neg2asqrta * a.dx(), inv_neg2asqrta * a.dy());
+    return Dual2<T> (T(1)/sqrta, inv_neg2asqrta * a.dx(), inv_neg2asqrta * a.dy());
 }
 
 // (fx) = x*(1-a) + y*a, f'(x) = (1-a)x' + (y - x)*a' + a*y'
@@ -714,34 +718,6 @@ inline Dual2<T> mix (const Dual2<T> &x, const Dual2<T> &y, const Dual2<T> &a)
 
    return Dual2<T> (mixval, (T(1) - a.val())*x.dx() + (y.val() - x.val())*a.dx() + a.val()*y.dx(),
                             (T(1) - a.val())*x.dy() + (y.val() - x.val())*a.dy() + a.val()*y.dy());
-}
-
-// f(x) = sqrt(x*x + y*y), f'(x) = (x x' + y y')/sqrt(x*x + y*y)
-template<class T>
-inline Dual2<T> dual_hypot (const Dual2<T> &x, const Dual2<T> &y)
-{
-   if (x.val() == T(0) && y.val() == T(0))
-      return Dual2<T> (T(0), T(0), T(0));
-
-   T hypotxy =  std::sqrt(x.val()*x.val() + y.val()*y.val());
-   T denom = T(1) / hypotxy;
-
-   return Dual2<T> (hypotxy, (x.val()*x.dx() + y.val()*y.dx()) * denom,
-                             (x.val()*x.dy() + y.val()*y.dy()) * denom);
-}
-
-// f(x) = sqrt(x*x + y*y + z*z), f'(x) = (x x' + y y' + z z')/sqrt(x*x + y*y + z*z)
-template<class T>
-inline Dual2<T> dual_hypot (const Dual2<T> &x, const Dual2<T> &y, const Dual2<T> &z)
-{
-   if (x.val() == T(0) && y.val() == T(0) && z.val() == T(0))
-      return Dual2<T> (T(0), T(0), T(0));
-
-   T hypotxyz =  std::sqrt(x.val()*x.val() + y.val()*y.val() + z.val()*z.val());
-   T denom = T(1) / hypotxyz;
-
-   return Dual2<T> (hypotxyz, (x.val()*x.dx() + y.val()*y.dx() + z.val()*z.dx()) * denom,
-                              (x.val()*x.dy() + y.val()*y.dy() + z.val()*z.dy()) * denom);
 }
 
 template<class T>

--- a/src/include/OSL/fastmath.h
+++ b/src/include/OSL/fastmath.h
@@ -1,0 +1,454 @@
+/*
+Copyright (c) 2009-2014 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "oslversion.h"
+#include <limits>
+#include <cstring>
+#include <cmath>
+
+OSL_NAMESPACE_ENTER
+
+#ifndef OSL_FAST_MATH
+#define OSL_FAST_MATH         1 /* this controls if OSL internals use the fast approximations or not */
+#endif
+
+// This file provides a set of replacements to libm that are faster at the expense
+// of some accuracy and robust handling of extreme values. One design goal for these
+// approximation was to avoid branches as much as possible and operate on single
+// precision values only so that SIMD versions should be straightforward ports
+// We also try to implement "safe" semantics (ie: clamp to valid range where possible)
+// natively since wrapping these inline calls in another layer would be wasteful.
+
+template <typename IN, typename OUT>
+static inline OUT bit_cast(const IN in) {
+    // NOTE: this is the only standards compliant way of doing this type of casting,
+    // luckily the compilers we care about know how to optimize away this idiom.
+    OUT out;
+    memcpy(&out, &in, sizeof(IN));
+    return out;
+}
+
+static inline float madd(const float a, const float b, const float c) {
+    // NOTE:  in the future we may want to explicitly ask for a fused multiply-add here
+    // NOTE2: GCC/ICC will turn this into a FMA unless explicitly asked not to,
+    //        clang seems to leave the code alone
+    return a * b + c;
+}
+
+inline float fast_acosf(float x) {
+    const float f = fabsf(x);
+    const float m = (f < 1.0f) ? 1.0f - (1.0f - f) : 1.0f; // clamp and crush denormals
+    // based on http://www.pouet.net/topic.php?which=9132&page=2
+    // 85% accurate (ulp 0)
+    // Examined 2130706434 values of acos: 15.2000597 avg ulp diff, 4492 max ulp, 4.51803e-05 max error // without "denormal crush"
+    // Examined 2130706434 values of acos: 15.2007108 avg ulp diff, 4492 max ulp, 4.51803e-05 max error // with "denormal crush"
+    const float a = sqrtf(1.0f - m) * (1.5707963267f + m * (-0.213300989f + m * (0.077980478f + m * -0.02164095f)));
+    return x < 0 ? float(M_PI) - a : a;
+}
+
+inline float fast_asinf(float x) {
+    // based on acosf approximation above
+    // max error is 4.51133e-05 (ulps are higher because we are consistently off by a little amount)
+    const float f = fabsf(x);
+    const float m = (f < 1.0f) ? 1.0f - (1.0f - f) : 1.0f; // clamp and crush denormals
+    const float a = float(M_PI_2) - sqrtf(1.0f - m) * (1.5707963267f + m * (-0.213300989f + m * (0.077980478f + m * -0.02164095f)));
+    return copysignf(a, x);
+}
+
+inline float fast_atanf(float x) {
+    const float a = fabsf(x);
+    const float k = a > 1.0f ? 1 / a : a;
+    const float s = 1.0f - (1.0f - k); // crush denormals
+    const float t = s * s;
+    // http://mathforum.org/library/drmath/view/62672.html
+    // Examined 4278190080 values of atan: 2.36864877 avg ulp diff, 302 max ulp, 6.55651e-06 max error      // (with  denormals)
+    // Examined 4278190080 values of atan: 171160502 avg ulp diff, 855638016 max ulp, 6.55651e-06 max error // (crush denormals)
+    float r = s * madd(0.43157974f, t, 1.0f) / madd(madd(0.05831938f, t, 0.76443945f), t, 1.0f);
+    if (a > 1.0f) r = 1.570796326794896557998982f - r;
+    return copysignf(r, x);
+}
+
+inline float fast_atan2f(float y, float x) {
+    // based on atan approximation above
+    // the special cases around 0 and infinity were tested explicitly
+    // the only case not handled correctly is x=NaN,y=0 which returns 0 instead of nan
+    const float a = fabsf(x);
+    const float b = fabsf(y);
+
+    const float k = (b == 0) ? 0.0f : ((a == b) ? 1.0f : (b > a ? a / b : b / a));
+    const float s = 1.0f - (1.0f - k); // crush denormals
+    const float t = s * s;
+
+    float r = s * madd(0.43157974f, t, 1.0f) / madd(madd(0.05831938f, t, 0.76443945f), t, 1.0f);
+
+    if (b > a) r = 1.570796326794896557998982f - r; // account for arg reduction
+    if (bit_cast<float, unsigned>(x) & 0x80000000u) // test sign bit of x
+        r = float(M_PI) - r;
+    return copysignf(r, y);
+}
+
+static inline float fast_log2f(float x) {
+    // NOTE: clamp to avoid special cases and make result "safe" from large negative values/nans
+    if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
+    if (x > std::numeric_limits<float>::max()) x = std::numeric_limits<float>::max();
+    // based on https://github.com/LiraNuna/glsl-sse2/blob/master/source/vec4.h
+    unsigned bits = bit_cast<float, unsigned>(x);
+    int exponent = int(bits >> 23) - 127;
+    float f = bit_cast<unsigned, float>((bits & 0x007FFFFF) | 0x3f800000) - 1.0f;
+    // Examined 2130706432 values of log2 on [1.17549435e-38,3.40282347e+38]: 0.0797524457 avg ulp diff, 3713596 max ulp, 7.62939e-06 max error
+    // ulp histogram:
+    //  0  = 97.46%
+    //  1  =  2.29%
+    //  2  =  0.11%
+    float f2 = f * f;
+    float f4 = f2 * f2;
+    float hi = madd(f, -0.00931049621349f,  0.05206469089414f);
+    float lo = madd(f,  0.47868480909345f, -0.72116591947498f);
+    hi = madd(f, hi, -0.13753123777116f);
+    hi = madd(f, hi,  0.24187369696082f);
+    hi = madd(f, hi, -0.34730547155299f);
+    lo = madd(f, lo,  1.442689881667200f);
+    return ((f4 * hi) + (f * lo)) + exponent;
+}
+
+inline float fast_logf(float x) {
+    // Examined 2130706432 values of logf on [1.17549435e-38,3.40282347e+38]: 0.313865375 avg ulp diff, 5148137 max ulp, 7.62939e-06 max error
+    return fast_log2f(x) * float(M_LN2);
+}
+
+inline float fast_log10f(float x) {
+    // Examined 2130706432 values of log10f on [1.17549435e-38,3.40282347e+38]: 0.631237033 avg ulp diff, 4471615 max ulp, 3.8147e-06 max error
+    return fast_log2f(x) * float(M_LN2 / M_LN10);
+}
+
+inline float fast_logbf(float x) {
+    // don't bother with denormals
+    if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
+    if (x > std::numeric_limits<float>::max()) x = std::numeric_limits<float>::max();
+    unsigned bits = bit_cast<float, unsigned>(x);
+    return int(bits >> 23) - 127;
+}
+
+inline float fast_exp2f(float x) {
+    // clamp to safe range for final addition
+    if (x < -126.0f) x = -126.0f;
+    if (x >  126.0f) x =  126.0f;
+    // range reduction
+    int m = int(x); x -= m;
+    x = 1.0f - (1.0f - x); // crush denormals (does not affect max ulps!)
+    // 5th degree polynomial generated with sollya
+    // Examined 2247622658 values of exp2 on [-126,126]: 2.75764912 avg ulp diff, 232 max ulp
+    // ulp histogram:
+    //  0  = 87.81%
+    //  1  =  4.18%
+    float r = 1.33336498402e-3f;
+    r = madd(x, r, 9.810352697968e-3f);
+    r = madd(x, r, 5.551834031939e-2f);
+    r = madd(x, r, 0.2401793301105f);
+    r = madd(x, r, 0.693144857883f);
+    r = madd(x, r, 1.0f);
+    // multiply by 2 ^ m by adding in the exponent
+    // NOTE: left-shift of negative number is undefined behavior
+    return bit_cast<unsigned, float>(bit_cast<float, unsigned>(r) + (unsigned(m) << 23));
+}
+
+inline float fast_expf(float x) {
+    // Examined 2237485550 values of exp on [-87.3300018,87.3300018]: 2.6666452 avg ulp diff, 230 max ulp
+    return fast_exp2f(x * float(1 / M_LN2));
+}
+
+inline float fast_exp10f(float x) {
+    // Examined 2217701018 values of exp10 on [-37.9290009,37.9290009]: 2.71732409 avg ulp diff, 232 max ulp
+    return fast_exp2f(x * float(M_LN10 / M_LN2));
+}
+
+inline float fast_expm1f(float x) {
+    if (fabsf(x) < 1e-5f) {
+        x = 1.0f - (1.0f - x); // crush denormals
+        return madd(0.5f, x * x, x);
+    } else
+        return fast_expf(x) - 1.0f;
+}
+
+inline float fast_sinhf(float x) {
+    float a = fabsf(x);
+    if (a > 1.0f) {
+        // Examined 53389559 values of sinh on [1,87.3300018]: 33.6886442 avg ulp diff, 178 max ulp
+        float e = fast_expf(a);
+        return copysignf(0.5f * e - 0.5f / e, x);
+    } else {
+        a = 1.0f - (1.0f - a); // crush denorms
+        float a2 = a * a;
+        // degree 7 polynomial generated with sollya
+        // Examined 2130706434 values of sinh on [-1,1]: 1.19209e-07 max error
+        float r = 2.03945513931e-4f;
+        r = madd(r, a2, 8.32990277558e-3f);
+        r = madd(r, a2, 0.1666673421859f);
+        r = madd(r * a, a2, a);
+        return copysignf(r, x);
+    }
+}
+
+inline float fast_coshf(float x) {
+    // Examined 2237485550 values of cosh on [-87.3300018,87.3300018]: 1.78256726 avg ulp diff, 178 max ulp
+    float e = fast_expf(fabsf(x));
+    return 0.5f * e + 0.5f / e;
+}
+
+inline float fast_tanhf(float x) {
+    // Examined 4278190080 values of tanh on [-3.40282347e+38,3.40282347e+38]: 3.12924e-06 max error
+    // NOTE: ulp error is high because of sub-optimal handling around the origin
+    float e = fast_expf(2.0f * fabsf(x));
+    return copysignf(1 - 2 / (1 + e), x);
+}
+
+static inline int fast_rintf(float x) {
+    // used by sin/cos/tan range reduction
+    return static_cast<int>(x + copysignf(0.5f, x));
+}
+
+inline float fast_sinf(float x) {
+    // very accurate argument reduction from SLEEF
+    // starts failing around x=262000
+    // Results on: [-2pi,2pi]
+    // Examined 2173837240 values of sin: 0.00662760244 avg ulp diff, 2 max ulp, 1.19209e-07 max error
+    int q = fast_rintf(x * float(M_1_PI));
+    x = madd(q, -0.78515625f*4, x);
+    x = madd(q, -0.00024187564849853515625f*4, x);
+    x = madd(q, -3.7747668102383613586e-08f*4, x);
+    x = madd(q, -1.2816720341285448015e-12f*4, x);
+    x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+    float s = x * x;
+    if ((q & 1) != 0) x = -x;
+    // this polynomial approximation has very low error on [-pi/2,+pi/2]
+    // 1.19209e-07 max error in total over [-2pi,+2pi]
+    float u = 2.6083159809786593541503e-06f;
+    u = madd(u, s, -0.0001981069071916863322258f);
+    u = madd(u, s, +0.00833307858556509017944336f);
+    u = madd(u, s, -0.166666597127914428710938f);
+    u = madd(s, u * x, x);
+    // For large x, the argument reduction can fail and the polynomial can be
+    // evaluated with arguments outside the valid internal. Just clamp the bad
+    // values away (setting to 0.0f means no branches need to be generated).
+    if (fabsf(u) > 1.0f) u = 0.0f;
+    return u;
+}
+
+
+inline float fast_cosf(float x) {
+    // same argument reduction as fast_sinf
+    int q = fast_rintf(x * float(M_1_PI));
+    x = madd(q, -0.78515625f*4, x);
+    x = madd(q, -0.00024187564849853515625f*4, x);
+    x = madd(q, -3.7747668102383613586e-08f*4, x);
+    x = madd(q, -1.2816720341285448015e-12f*4, x);
+    x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+    float s = x * x;
+    // polynomial from SLEEF's sincosf, max error is
+    // 4.33127e-07 over [-2pi,2pi] (98% of values are "exact")
+    float u = -2.71811842367242206819355e-07f;
+    u = madd(u, s, +2.47990446951007470488548e-05f);
+    u = madd(u, s, -0.00138888787478208541870117f);
+    u = madd(u, s, +0.0416666641831398010253906f);
+    u = madd(u, s, -0.5f);
+    u = madd(u, s, +1.0f);
+    if ((q & 1) != 0) u = -u;
+    if (fabsf(u) > 1.0f) u = 0.0f;
+    return u;
+}
+
+inline void fast_sincosf(float x, float* sine, float* cosine) {
+    // same argument reduction as fast_sinf
+    int q = fast_rintf(x * float(M_1_PI));
+    x = madd(q, -0.78515625f*4, x);
+    x = madd(q, -0.00024187564849853515625f*4, x);
+    x = madd(q, -3.7747668102383613586e-08f*4, x);
+    x = madd(q, -1.2816720341285448015e-12f*4, x);
+    x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+    float s = x * x;
+    // NOTE: same exact polynomials as fast_sinf and fast_cosf above
+    if ((q & 1) != 0) x = -x;
+    float su = 2.6083159809786593541503e-06f;
+    su = madd(su, s, -0.0001981069071916863322258f);
+    su = madd(su, s, +0.00833307858556509017944336f);
+    su = madd(su, s, -0.166666597127914428710938f);
+    su = madd(s, su * x, x);
+    float cu = -2.71811842367242206819355e-07f;
+    cu = madd(cu, s, +2.47990446951007470488548e-05f);
+    cu = madd(cu, s, -0.00138888787478208541870117f);
+    cu = madd(cu, s, +0.0416666641831398010253906f);
+    cu = madd(cu, s, -0.5f);
+    cu = madd(cu, s, +1.0f);
+    if ((q & 1) != 0) cu = -cu;
+    if (fabsf(su) > 1.0f) su = 0.0f;
+    if (fabsf(cu) > 1.0f) cu = 0.0f;
+    *sine   = su;
+    *cosine = cu;
+}
+
+// NOTE: this approximation is only valid on [-8192.0,+8192.0], it starts becoming
+// really poor outside of this range because the reciprocal amplifies errors
+inline float fast_tanf(float x) {
+    // derived from SLEEF implementation
+    // note that we cannot apply the "denormal crush" trick everywhere because
+    // we sometimes need to take the reciprocal of the polynomial
+    int q = fast_rintf(x * float(2 * M_1_PI));
+    x = madd(q, -0.78515625f*2, x);
+    x = madd(q, -0.00024187564849853515625f*2, x);
+    x = madd(q, -3.7747668102383613586e-08f*2, x);
+    x = madd(q, -1.2816720341285448015e-12f*2, x);
+    if ((q & 1) == 0)
+    x = float(M_PI_4) - (float(M_PI_4) - x); // crush denormals (only if we aren't inverting the result later)
+    float s = x * x;
+    float u = 0.00927245803177356719970703f;
+    u = madd(u, s, 0.00331984995864331722259521f);
+    u = madd(u, s, 0.0242998078465461730957031f);
+    u = madd(u, s, 0.0534495301544666290283203f);
+    u = madd(u, s, 0.133383005857467651367188f);
+    u = madd(u, s, 0.333331853151321411132812f);
+    u = madd(s, u * x, x);
+    if ((q & 1) != 0) u = -1.0f / u;
+    return u;
+}
+
+inline float fast_safe_powf(float x, float y) {
+    if (y == 0) return 1.0f; // x^1=1
+    if (x == 0) return 0.0f; // 0^y=0
+    float sign = 1.0f;
+    if (x < 0) {
+        // if x is negative, only deal with integer powers
+        // powf returns NaN for non-integers, we will return 0 instead
+        int ybits = bit_cast<float, int>(y) & 0x7fffffff;
+        if (ybits >= 0x4b800000) {
+            // always even int, keep positive
+        } else if (ybits >= 0x3f800000) {
+            // bigger than 1, check
+            int k = (ybits >> 23) - 127;  // get exponent
+            int j =  ybits >> (23 - k);   // shift out possible fractional bits
+            if ((j << (23 - k)) == ybits) // rebuild number and check for a match
+                sign = bit_cast<int, float>(0x3f800000 | (j << 31)); // +1 for even, -1 for odd
+            else
+                return 0.0f; // not integer
+        } else {
+            return 0.0f; // not integer
+        }
+    }
+    return sign * fast_exp2f(y * fast_log2f(fabsf(x)));
+}
+
+inline float fast_erff(float x)
+{
+    // Abramowitz and Stegun, 7.1.25
+    const float p  =  0.47047f;
+    const float a1 =  0.3480242f;
+    const float a2 = -0.0958798f;
+    const float a3 =  0.7478556f;
+
+    float absx = fabsf(x);
+    float t = 1 / (1 + p * absx);
+    float acc = ((a3 * t + a2) * t + a1) * t;
+    acc *= fast_expf(-(absx * absx));
+    float res = 1 - acc;
+    return copysignf(res, x);
+}
+
+inline float fast_erfcf(float x)
+{
+    return 1.0f - fast_erff(x);
+}
+
+// Here we offer non-optimized "safe" versions of the standard functions
+
+template <typename T>
+inline T safe_sqrt(T x) {
+    return x >= 0 ? std::sqrt(x) : T(0);
+}
+
+template <typename T>
+inline T safe_inversesqrt (T x) {
+    return x > 0 ? T(1) / std::sqrt(x) : T(0);
+}
+
+template <typename T>
+inline T safe_acos(T x) {
+    if (x <= -1) return T(0);
+    if (x >= +1) return T(M_PI);
+    return std::acos(x);
+}
+
+template <typename T>
+inline T safe_asin(T x) {
+    if (x <= -1) return T(-M_PI_2);
+    if (x >= +1) return T(+M_PI_2);
+    return std::asin(x);
+}
+
+template <typename T>
+inline T safe_log2(T x) {
+    // match clamping from fast version
+    if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
+    if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
+    return log2f(x);
+}
+
+template <typename T>
+inline T safe_log(T x) {
+    // slightly different than fast version since clamping happens before scaling
+    if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
+    if (x > std::numeric_limits<T>::max()) x = std::numeric_limits<T>::max();
+    return std::log(x);
+}
+
+template <typename T>
+inline T safe_log10(T x) {
+    // slightly different than fast version since clamping happens before scaling
+    if (x < std::numeric_limits<T>::min()) x = std::numeric_limits<T>::min();
+    return log10f(x);
+}
+
+template <typename T>
+inline T safe_pow(T x, T y) {
+    if (y == 0) return T(1);
+    if (x == 0) return T(0);
+    // if x is negative, only deal with integer powers
+    if ((x < 0) && (y != floorf(y))) return T(0);
+    // FIXME: this does not match "fast" variant because clamping limits are different
+    T r = std::pow(x, y);
+    // Clamp to avoid Inf values.  We purposely clamp at considerably
+    // less than FLOAT_MAX (but still bigger than anyone is likely to
+    // need) so that subsequent additions or multiplications are less
+    // likely to overflow and end up with an Inf right afterwards.
+    const T big = T(1e30);
+    if (r < -big) return -big;
+    if (r >  big) return  big;
+    return r;
+}
+
+OSL_NAMESPACE_EXIT

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1591,28 +1591,38 @@ DECLFOLDER(constfold_ ## name)                                          \
 
 
 
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (sqrt, OIIO::safe_sqrtf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (inversesqrt, OIIO::safe_inversesqrt)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (cos, cosf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (sin, sinf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (acos, OIIO::safe_acosf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (asin, OIIO::safe_asinf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (floor, floorf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (ceil, ceilf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp, expf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp2, exp2f)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (expm1, expm1f)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (erf, erff)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (erfc, erfcf)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log, OIIO::safe_log)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log10, OIIO::safe_log10)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log2, OIIO::safe_log2)
-AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (logb, OIIO::safe_logb)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (sqrt   , safe_sqrt)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (inversesqrt, safe_inversesqrt)
 AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (degrees, OIIO::degrees)
 AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (radians, OIIO::radians)
-
-
-
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (floor  , floorf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (ceil   , ceilf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (erf    , fast_erff)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (erfc   , fast_erfcf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (logb   , fast_logbf)
+#if OSL_FAST_MATH
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (cos    , fast_cosf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (sin    , fast_sinf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (acos   , fast_acosf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (asin   , fast_asinf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp    , fast_expf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp2   , fast_exp2f)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (expm1  , fast_expm1f)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log    , fast_logf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log10  , fast_log10f)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log2   , fast_log2f)
+#else
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (cos    , cosf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (sin    , sinf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (acos   , safe_acos)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (asin   , safe_asin)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp    , expf)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (exp2   , exp2f)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (expm1  , expm1f)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log    , safe_log)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log10  , safe_log10)
+AUTO_DECLFOLDER_FLOAT_OR_TRIPLE (log2   , safe_log2)
+#endif
 
 DECLFOLDER(constfold_pow)
 {
@@ -1643,7 +1653,11 @@ DECLFOLDER(constfold_pow)
         int ncomps = X.typespec().is_triple() ? 3 : 1;
         float result[3];
         for (int i = 0;  i < ncomps;  ++i)
+#if OSL_FAST_MATH
+            result[i] = fast_safe_powf (x[i], y);
+#else
             result[i] = safe_pow (x[i], y);
+#endif
         int cind = rop.add_constant (X.typespec(), &result);
         rop.turn_into_assign (op, cind, "const fold");
         return 1;

--- a/src/liboslexec/gabornoise.cpp
+++ b/src/liboslexec/gabornoise.cpp
@@ -114,7 +114,11 @@ struct GaborParams {
         bandwidth(Imath::clamp(opt.bandwidth,0.01f,100.0f)),
         periodic(false)
     {
-        float TWO_to_bandwidth = powf (2.0f, bandwidth);
+#if OSL_FAST_MATH
+        float TWO_to_bandwidth = fast_exp2f(bandwidth);
+#else
+        float TWO_to_bandwidth = exp2f(bandwidth);
+#endif
         static const float SQRT_PI_OVER_LN2 = sqrtf (M_PI / M_LN2);
         a = Gabor_Frequency * ((TWO_to_bandwidth - 1.0) / (TWO_to_bandwidth + 1.0)) * SQRT_PI_OVER_LN2;
         // Calculate the maximum radius from which we consider the kernel
@@ -212,14 +216,22 @@ gabor_sample (GaborParams &gp, const Vec3 &x_c, fast_rng &rng,
         float cos_omega_p = lerp(-1.0f, 1.0f, rng());
         float sin_omega_p = sqrtf (std::max (0.0f, 1.0f - cos_omega_p*cos_omega_p));
         float sin_omega_t, cos_omega_t;
+#if OSL_FAST_MATH
+        fast_sincosf (omega_t, &sin_omega_t, &cos_omega_t);
+#else
         OIIO::sincos (omega_t, &sin_omega_t, &cos_omega_t);
+#endif
         omega = Vec3 (cos_omega_t*sin_omega_p, sin_omega_t*sin_omega_p, cos_omega_p).normalized();
     } else {
         // otherwise hybrid
         float omega_r = gp.omega.length();
         float omega_t =  float(M_TWO_PI) * rng();
         float sin_omega_t, cos_omega_t;
+#if OSL_FAST_MATH
+        fast_sincosf (omega_t, &sin_omega_t, &cos_omega_t);
+#else
         OIIO::sincos (omega_t, &sin_omega_t, &cos_omega_t);
+#endif
         omega = omega_r * Vec3(cos_omega_t, sin_omega_t, 0.0f);
     }
     phi = float(M_TWO_PI) * rng();

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -359,10 +359,23 @@ static colorSystem colorSystems[] = {
 // (about 5 KB of data).
 #define BB_DRAPER 800.0f /* really 798K, below this visible BB is negligible */
 #define BB_MAX_TABLE_RANGE 12000.0f /* max temp for which we use the table */
-#define BB_TABLE_XPOWER 1.5f
-#define BB_TABLE_YPOWER 5.0f
+#define BB_TABLE_XPOWER 1.5f       // NOTE: not used, hardcoded into expressions below
+#define BB_TABLE_YPOWER 5.0f       // NOTE: decode is hardcoded
 #define BB_TABLE_SPACING 2.0f
 
+inline float BB_TABLE_MAP(float i) {
+    // return powf (i, BB_TABLE_XPOWER) * BB_TABLE_SPACING + BB_DRAPER;
+    float is = sqrtf(i);
+    float ip = is * is * is; // ^3/2
+    return ip * BB_TABLE_SPACING + BB_DRAPER;
+}
+
+inline float BB_TABLE_UNMAP(float T) {
+    // return powf ((T - BB_DRAPER) / BB_TABLE_SPACING, 1.0f/BB_TABLE_XPOWER);
+    float t  = (T - BB_DRAPER) / BB_TABLE_SPACING;
+    float ic = cbrtf(t);
+    return ic * ic; // ^2/3
+}
 
 
 bool
@@ -409,7 +422,7 @@ ShadingSystemImpl::set_colorspace (ustring colorspace)
             m_blackbody_table.clear ();
             float lastT = 0;
             for (int i = 0;  lastT <= BB_MAX_TABLE_RANGE;  ++i) {
-                float T = powf (float(i), BB_TABLE_XPOWER) * BB_TABLE_SPACING + BB_DRAPER;
+                float T = BB_TABLE_MAP(float(i));
                 lastT = T;
                 bb_spectrum spec (T);
                 Color3 rgb = XYZ_to_RGB (spectrum_to_XYZ (spec));
@@ -461,11 +474,14 @@ ShadingSystemImpl::blackbody_rgb (float T)
     if (T < BB_DRAPER)
         return Color3(1.0e-6f,0.0f,0.0f);  // very very dim red
     if (T < BB_MAX_TABLE_RANGE) {
-        float t = powf ((T - BB_DRAPER) / BB_TABLE_SPACING, 1.0f/BB_TABLE_XPOWER);
+        float t = BB_TABLE_UNMAP(T);
         int ti = (int)t;
         t -= ti;
         Color3 rgb = lerp (m_blackbody_table[ti], m_blackbody_table[ti+1], t);
-        return colpow(rgb, BB_TABLE_YPOWER);
+        //return colpow(rgb, BB_TABLE_YPOWER);
+        Color3 rgb2 = rgb * rgb;
+        Color3 rgb4 = rgb2 * rgb2;
+        return rgb4 * rgb; // ^5
     }
     // Otherwise, compute for real
     bb_spectrum spec (T);

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -96,7 +96,7 @@ struct Sphere : public Primitive {
         Dual2<float> ny(n.val().y, n.dx().y, n.dy().y);
         Dual2<float> nz(n.val().z, n.dx().z, n.dy().z);
         Dual2<float> u = (atan2(nx, nz) + Dual2<float>(M_PI)) * 0.5f * float(M_1_PI);
-        Dual2<float> v = acos(ny) * float(M_1_PI);
+        Dual2<float> v = safe_acos(ny) * float(M_1_PI);
         float xz2 = nx.val() * nx.val() + nz.val() * nz.val();
         if (xz2 > 0) {
             const float PI = float(M_PI);


### PR DESCRIPTION
This adds a set of `fast_*` math routines that are much faster than both the system libraries as well as some optimized variants (like Intel's libimf) at the expense of a bit of precision. I have tried to document the precision caveats in the code -- but these should mostly be oblivious to reasonable shaders.

I have provided a fallback via a `#define` so that its easy to use the system math library if desired.

On some test shaders that make heavy use of these functions, I am seeing a 5-10% speedup over Intel's optimized library (with minute image differences, but nothing objectionable).

I have also simplified the lookup from the blackbody table to avoid calls to `powf` altogether as this is a very costly function.
