### PR TITLE
Basic shader profiling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,12 @@ Language, standard libary, and compiler changes (for shader writers):
   that they were rarely used, but beware a change in appearance. (1.6.1)
 
 API changes, new options, new ShadingSystem features (for renderer writers):
+* New ShadingSystem attribute int "profile", if set to 1, will include
+  in the runtime statistics output a measure of how much total time was
+  spent executing shaders, as well as the identities and times of the 5
+  shader groups that spent the most time executing.  Note that this
+  option is 0 (off) by default, since turning it on can add
+  significantly to total runtime for some scenes.  #418 (1.6.2)
 * New per-ShaderGroup attributes:
    * You can retrieve information about all closures that an optimized group
      might create using new queries "num_closures_needed", "closures_needed",

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -111,8 +111,10 @@ using OIIO::string_view;
 // Sort out smart pointers
 #ifdef OSL_USING_CPLUSPLUS11
   using std::shared_ptr;
+  using std::weak_ptr;
 #else
   using boost::shared_ptr;
+  using boost::weak_ptr;
 #endif
 
 

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -91,6 +91,9 @@ ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
        return false;
     }
 
+    int profile = shadingsys().m_profile;
+    OIIO::Timer timer (profile);
+
     // Allocate enough space on the heap
     size_t heap_size_needed = sgroup.llvm_groupdata_size();
     if (heap_size_needed > m_heap.size()) {
@@ -124,6 +127,12 @@ ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
 
     // Process any queued up error messages, warnings, printfs from shaders
     process_errors ();
+
+    if (profile) {
+        long long ticks = timer.ticks();
+        shadingsys().m_stat_total_shading_time_ticks += ticks;
+        sgroup.m_stat_total_shading_time_ticks += ticks;
+    }
 
     return true;
 }

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -589,6 +589,7 @@ ShaderGroup::ShaderGroup (string_view name)
     m_name(name)
 {
     m_executions = 0;
+    m_stat_total_shading_time_ticks = 0;
 }
 
 
@@ -601,6 +602,7 @@ ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
     m_name(name)
 {
     m_executions = 0;
+    m_stat_total_shading_time_ticks = 0;
 }
 
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -66,6 +66,7 @@ bool debug = false;
 bool debug2 = false;
 bool verbose = false;
 bool stats = false;
+bool profile = false;
 bool O0 = false, O1 = false, O2 = false;
 bool debugnan = false;
 int xres = 640, yres = 480, aa = 1, max_bounces = 1000000, rr_depth = 5;
@@ -102,6 +103,7 @@ void getargs(int argc, const char *argv[])
                 "--debug", &debug, "Lots of debugging info",
                 "--debug2", &debug2, "Even more debugging info",
                 "--stats", &stats, "Print run statistics",
+                "--profile", &profile, "Print profile information",
                 "-r %d %d", &xres, &yres, "Render a WxH image",
                 "-aa %d", &aa, "Trace NxN rays per pixel",
                 "-t %d", &num_threads, "Render using N threads (default: auto-detect)",
@@ -606,6 +608,7 @@ int main (int argc, const char *argv[]) {
     // Setup common attributes
     shadingsys->attribute ("debug", debug2 ? 2 : (debug ? 1 : 0));
     shadingsys->attribute ("compile_report", debug|debug2);
+    shadingsys->attribute("profile", 1);
     const char *opt_env = getenv ("TESTSHADE_OPT");  // overrides opt
     if (opt_env)
         shadingsys->attribute ("optimize", atoi(opt_env));
@@ -661,7 +664,7 @@ int main (int argc, const char *argv[]) {
     delete out;
 
     // Print some debugging info
-    if (debug || stats) {
+    if (debug || stats || profile) {
         double runtime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup: " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -62,6 +62,7 @@ static bool debug = false;
 static bool debug2 = false;
 static bool verbose = false;
 static bool stats = false;
+static bool profile = false;
 static bool O0 = false, O1 = false, O2 = false;
 static bool pixelcenters = false;
 static bool debugnan = false;
@@ -256,6 +257,7 @@ getargs (int argc, const char *argv[])
                 "--debug", &debug, "Lots of debugging info",
                 "--debug2", &debug2, "Even more debugging info",
                 "--stats", &stats, "Print run statistics",
+                "--profile", &profile, "Print profile information",
                 "-g %d %d", &xres, &yres, "Make an X x Y grid of shading points",
                 "-o %L %L", &outputvars, &outputfiles,
                         "Output (variable, filename)",
@@ -670,6 +672,11 @@ test_shade (int argc, const char *argv[])
     // the TextureSystem (that just makes 'create' make its own TS), and
     // an error handler.
     shadingsys = new ShadingSystem (&rend, NULL, &errhandler);
+
+    // Register the layout of all closures known to this renderer
+    // Any closure used by the shader which is not registered, or
+    // registered with a different number of arguments will lead
+    // to a runtime error.
     register_closures(shadingsys);
 
     // Remember that each shader parameter may optionally have a
@@ -792,6 +799,8 @@ test_shade (int argc, const char *argv[])
 
     if (debug)
         test_group_attributes (shadergroup.get());
+    if (profile)
+        shadingsys->attribute ("profile", 1);
 
     if (num_threads < 1)
         num_threads = boost::thread::hardware_concurrency();
@@ -837,7 +846,7 @@ test_shade (int argc, const char *argv[])
     }
 
     // Print some debugging info
-    if (debug || stats) {
+    if (debug || stats || profile) {
         double runtime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup: " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";


### PR DESCRIPTION
ShadingSystem::attribute ("profile", 1) turns on profiling, which will attempt to time the total amount of runtime spent actually executing shaders.  This will be included in the runtime statistics, both as a total as well as listing the "top 5" individual shader groups that accounted for the most time.

Profiling isn't free -- it adds a small runtime cost, because it must do timer queries before and after the main entry point to every shader invocation, so only turn it on if you are interested in the results. (That said, it's surprisingly inexpensive -- doesn't seem to throw runtime off by more than 1%.)

Example output looks like this:

```
Execution profile:
  Total shader execution time: 43.32s
  Most expensive shader groups:
    8.08s sky_barry/material
    3.48s sky/material
    2.39s sam/sam_head_bangs_safari.hair
    1.97s flnt/flnt_head_base_def.hair
    1.97s sam_accessories/sam_pony_base_safari.hair
```
