### PR TITLE
32bit build doesn't auto convert int to size_t

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -733,7 +733,7 @@ test_shade (int argc, const char *argv[])
         int num_layers = 0;
         shadingsys->getattribute (shadergroup.get(), "num_layers", num_layers);
         if (num_layers > 0) {
-            std::vector<const char *> layers (num_layers, NULL);
+            std::vector<const char *> layers (size_t(num_layers), NULL);
             shadingsys->getattribute (shadergroup.get(), "layer_names",
                                       TypeDesc(TypeDesc::STRING, num_layers),
                                       &layers[0]);


### PR DESCRIPTION
specifically cast to size_t
