### PR TITLE
Support metadata consisting of arrays of any of the simple types.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Language, standard libary, and compiler changes (for shader writers):
 * The "gabor" varieties of noise were found to have a serious mathematical
   bug, which after fixing results in a change to the pattern. We are hoping
   that they were rarely used, but beware a change in appearance. (1.6.1)
+* We have clarified that shader metadata may be arrays (still not structs
+  or closures) and fixed the implementation to support this (in addition
+  to several other ways that metadata was brittle). (1.6.2)
 
 API changes, new options, new ShadingSystem features (for renderer writers):
 * New ShadingSystem attribute int "profile", if set to 1, will include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             oslc-err-noreturn oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-variadic-macro
+            oslinfo-metadata
             pointcloud pointcloud-fold
             printf-whole-array
             raytype reparam

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -1108,8 +1108,9 @@ have an on/off checkbox, is intended to be a filename, etc.
 Metadata is specified inside double brackets {\cf [[} and {\cf ]]}
 enclosing a comma-separated list of metadata items.  Each metadatum
 looks like a parameter declaration --- having a data type, name, and
-initializer.  However, metadata may only be simple types (not arrays,
-structs, or closures) and their value initializers must be numeric or
+initializer.  However, metadata may only be simple types or arrays
+of simple types (not structs or closures)
+and their value initializers must be numeric or
 string constants (not computed expressions).
 
 Metadata about the shader as a whole is placed between the shader name

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -404,7 +404,8 @@ public:
     /// initialization of literal values and place it in 'out'.
     /// Return whether the full initialization is comprised only of
     /// literals (and no init ops are needed).
-    bool param_default_literals (const Symbol *sym, std::string &out);
+    bool param_default_literals (const Symbol *sym, std::string &out,
+                                 const std::string &separator=" ") const;
 
     // Special code generation for structure initializers
     Symbol *codegen_struct_initializers (ref init);
@@ -426,7 +427,7 @@ private:
     // init==NULL) and append it to 'out'.  Return whether the full
     // initialization is comprised only of literals (no init ops needed).
     bool param_one_default_literal (const Symbol *sym, ASTNode *init,
-                                    std::string &out);
+                      std::string &out, const std::string &separator=" ") const;
 
     ustring m_name;     ///< Name of the symbol (unmangled)
     Symbol *m_sym;      ///< Ptr to the symbol this declares

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -96,11 +96,11 @@ public:
 
     /// Error reporting
     ///
-    void error (ustring filename, int line, const char *format, ...);
+    void error (ustring filename, int line, const char *format, ...) const;
 
     /// Warning reporting
     ///
-    void warning (ustring filename, int line, const char *format, ...);
+    void warning (ustring filename, int line, const char *format, ...) const;
 
     /// Have we hit an error?
     ///
@@ -359,7 +359,7 @@ private:
     std::string m_main_filename; ///< Main input filename
     std::string m_cwd;        ///< Current working directory
     ASTNode::ref m_shader;    ///< The shader's syntax tree
-    bool m_err;               ///< Has an error occurred?
+    mutable bool m_err;       ///< Has an error occurred?
     SymbolTable m_symtab;     ///< Symbol table
     TypeSpec m_current_typespec;  ///< Currently-declared type
     bool m_current_output;        ///< Currently-declared output status

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -74,7 +74,7 @@ IDENT           ({ALPHA}|[_$])({ALPHA}|{DIGIT}|[_$\.])*
  /* C preprocessor (cpp) directives */
 COMMENT         \#[^\n]*\n
  /* Hints */
-HINTPATTERN     \%{IDENT}(\{([^\}\\"]|{STR})*\})?
+HINTPATTERN     \%{IDENT}
 
 
  /* Note for lex newbies: the following '%{ .. %}' section contains literal

--- a/src/liboslexec/osoreader.h
+++ b/src/liboslexec/osoreader.h
@@ -137,6 +137,9 @@ public:
     /// be called by the lexer.
     int lineno () const { return m_lineno; }
 
+    /// Return a reference to the error handler
+    ErrorHandler& errhandler () { return m_err; }
+
     /// Pointer to the one and only lexer in effect.  This is 'public',
     /// but NOBODY should modify this except for this class and the
     /// lexer internals.

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -37,67 +37,14 @@ using namespace OSL;
 using namespace OSL::pvt;
 
 #include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/strutil.h>
 namespace Filesystem = OIIO::Filesystem;
+namespace Strutil = OIIO::Strutil;
+using OIIO::string_view;
 
 
 OSL_NAMESPACE_ENTER
 namespace pvt {
-
-
-// ptr is a pointer to a char pointer.  Read chars from *ptr until you
-// hit the end of the string, or the next char is one of stop1 or stop2.
-// At that point, return what we hit, and also update *ptr to then point
-// to the next character following the stop character.
-static std::string
-readuntil (const char **ptr, char stop1, char stop2=-1)
-{
-    std::string s;
-    while (**ptr == ' ')
-        ++(*ptr);
-    while (**ptr && **ptr != stop1 && **ptr != stop2) {
-        s += (**ptr);
-        ++(*ptr);
-    }
-    if (**ptr == stop1 || **ptr == stop2)
-        ++(*ptr);
-    while (**ptr == ' ')
-        ++(*ptr);
-    return s;
-}
-
-
-
-static TypeDesc
-string_to_type (const char *s)
-{
-    TypeDesc t;
-    std::string tname = readuntil (&s, ' ');
-    if (tname == "int")
-        t = TypeDesc::TypeInt;
-    if (tname == "float")
-        t = TypeDesc::TypeFloat;
-    if (tname == "color")
-        t = TypeDesc::TypeColor;
-    if (tname == "point")
-        t = TypeDesc::TypePoint;
-    if (tname == "vector")
-        t = TypeDesc::TypeVector;
-    if (tname == "normal")
-        t = TypeDesc::TypeNormal;
-    if (tname == "matrix")
-        t = TypeDesc::TypeMatrix;
-    if (tname == "string")
-        t = TypeDesc::TypeString;
-    if (*s == '[') {
-        ++s;
-        if (*s == ']')
-            t.arraylen = -1;
-        else
-            t.arraylen = atoi (s);
-    }
-    return t;
-}
-
 
 
 // Custom subclass of OSOReader that just reads the .oso file and fills
@@ -223,56 +170,67 @@ OSOReaderQuery::parameter_done ()
 
 
 void
-OSOReaderQuery::hint (const char *hintstring)
+OSOReaderQuery::hint (const char *h)
 {
-    if (m_reading_param && ! strncmp (hintstring, "%meta{", 6)) {
-        hintstring += 6;
+    string_view hintstring (h);
+    if (! Strutil::parse_char (hintstring, '%'))
+        return;
+    if (m_reading_param && Strutil::parse_prefix(hintstring, "meta{")) {
         // std::cerr << "  Metadata '" << hintstring << "'\n";
-        std::string type = readuntil (&hintstring, ',', '}');
-        std::string name = readuntil (&hintstring, ',', '}');
+        Strutil::skip_whitespace (hintstring);
+        std::string type = Strutil::parse_until (hintstring, ",}");
+        Strutil::parse_char (hintstring, ',');
+        std::string name = Strutil::parse_until (hintstring, ",}");
+        Strutil::parse_char (hintstring, ',');
         // std::cerr << "    " << name << " : " << type << "\n";
         OSLQuery::Parameter p;
         p.name = name;
-        p.type = string_to_type (type.c_str());
+        p.type = TypeDesc (type.c_str());
         if (p.type.basetype == TypeDesc::STRING) {
-            while (*hintstring == ' ')
-                ++hintstring;
-            while (hintstring[0] == '\"') {
-                ++hintstring;
-                p.sdefault.push_back (ustring (readuntil (&hintstring, '\"')));
+            string_view val;
+            while (Strutil::parse_string (hintstring, val)) {
+                p.sdefault.push_back (ustring(val));
+                if (Strutil::parse_char (hintstring, '}'))
+                    break;
+                Strutil::parse_char (hintstring, ',');
             }
         } else if (p.type.basetype == TypeDesc::INT) {
-            while (*hintstring == ' ')
-                ++hintstring;
-            while (*hintstring && *hintstring != '}') {
-                p.idefault.push_back (atoi (hintstring));
-                readuntil (&hintstring, ',', '}');
+            int val;
+            while (Strutil::parse_int (hintstring, val)) {
+                p.idefault.push_back (val);
+                Strutil::parse_char (hintstring, ',');
             }
         } else if (p.type.basetype == TypeDesc::FLOAT) {
-            while (*hintstring == ' ')
-                ++hintstring;
-            while (*hintstring && *hintstring != '}') {
-                p.fdefault.push_back (atof (hintstring));
-                readuntil (&hintstring, ',', '}');
+            float val;
+            while (Strutil::parse_float (hintstring, val)) {
+                p.fdefault.push_back (val);
+                Strutil::parse_char (hintstring, ',');
             }
         }
+        Strutil::parse_char (hintstring, '}');
         m_query.m_params[m_query.nparams()-1].metadata.push_back (p);
         return;
     }
-    if (m_reading_param && ! strncmp (hintstring, "%structfields{", 14)) {
-        hintstring += 14;
+    if (m_reading_param && Strutil::parse_prefix(hintstring, "structfields{")) {
         OSLQuery::Parameter &param (m_query.m_params[m_query.nparams()-1]);
-        while (*hintstring) {
-            param.fields.push_back (ustring (readuntil (&hintstring, ',', '}')));
+        string_view ident;
+        while (1) {
+            string_view ident = Strutil::parse_identifier (hintstring);
+            if (ident.length()) {
+                param.fields.push_back (ustring(ident));
+                Strutil::parse_char (hintstring, ',');
+            } else {
+                break;
+            }
         }
+        Strutil::parse_char (hintstring, '}');
         return;
     }
-    if (m_reading_param && ! strncmp (hintstring, "%struct{", 8)) {
-        hintstring += 8;
-        if (*hintstring == '\"')  // skip quote
-            ++hintstring;
-        OSLQuery::Parameter &param (m_query.m_params[m_query.nparams()-1]);
-        param.structname = readuntil (&hintstring, '\"', '}');
+    if (m_reading_param && Strutil::parse_prefix(hintstring, "struct{")) {
+        string_view str;
+        Strutil::parse_string (hintstring, str);
+        m_query.m_params[m_query.nparams()-1].structname = str;
+        Strutil::parse_char (hintstring, '}');
         return;
     }
     // std::cerr << "Hint '" << hintstring << "'\n";

--- a/testsuite/oslinfo-metadata/metadata.osl
+++ b/testsuite/oslinfo-metadata/metadata.osl
@@ -1,0 +1,8 @@
+surface metadata (
+    int myparam1 = 1 [[ int i = 0, float f = 1.0, string s = "foo" ]],
+    int myparam2 = 2 [[ string s[2] = { "foo", "bar" } ]],
+    int myparam3 = 3 [[ float minmax[2] = { 42, 44 } ]],
+    int myparam4 = 4 [[ color c = color(1,2,3) ]]
+    )
+{
+}

--- a/testsuite/oslinfo-metadata/ref/out.txt
+++ b/testsuite/oslinfo-metadata/ref/out.txt
@@ -1,0 +1,16 @@
+Compiled metadata.osl -> metadata.oso
+surface "metadata"
+    "myparam1" "int"
+		Default value: 1
+		metadata: int i = 0
+		metadata: float f = 1
+		metadata: string s = "foo"
+    "myparam2" "int"
+		Default value: 2
+		metadata: string[2] s = "foo" "bar"
+    "myparam3" "int"
+		Default value: 3
+		metadata: float[2] minmax = 42 44
+    "myparam4" "int"
+		Default value: 4
+		metadata: color c = 1 2 3

--- a/testsuite/oslinfo-metadata/run.py
+++ b/testsuite/oslinfo-metadata/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = oslinfo("-v metadata")


### PR DESCRIPTION
Also, overhaul oslquery/oslinfo metadata parsing, it was quite brittle and broken for aggregate types such as colors.

This patch overhauls oslquery's parsing of metadata.  Aggregate types (points, colors, etc.) are fine now for metadata, and also you can have metadata that is an array of a basic type. Still no structs or closures, or metadata itself having metadata.
