### PR TITLE
Allow renderer outputs to be specified as "layer.param".

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -447,7 +447,7 @@ public:
           m_name(name), m_typespec(datatype), m_symtype(symtype),
           m_has_derivs(false), m_const_initializer(false),
           m_connected_down(false),
-          m_initialized(false), m_lockgeom(false),
+          m_initialized(false), m_lockgeom(false), m_renderer_output(false),
           m_valuesource(DefaultVal), m_free_data(false), m_fieldid(-1),
           m_scope(0), m_dataoffset(-1),
           m_node(declaration_node), m_alias(NULL),
@@ -630,6 +630,9 @@ public:
     bool lockgeom () const { return m_lockgeom; }
     void lockgeom (bool lock) { m_lockgeom = lock; }
 
+    bool renderer_output () const { return m_renderer_output; }
+    void renderer_output (bool v) { m_renderer_output = v; }
+
     bool is_constant () const { return symtype() == SymTypeConst; }
 
     /// Stream output
@@ -647,6 +650,7 @@ protected:
     unsigned m_connected_down:1;///< Connected to a later/downtream layer
     unsigned m_initialized:1;   ///< If a param, has it been initialized?
     unsigned m_lockgeom:1;      ///< Is the param not overridden by geom?
+    unsigned m_renderer_output:1; ///< Is this sym a renderer output?
     char m_valuesource;         ///< Where did the value come from?
     bool m_free_data;           ///< Free m_data upon destruction?
     short m_fieldid;            ///< Struct field of this var (or -1)

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -188,6 +188,8 @@ Symbol::print (std::ostream &out, int maxvals) const
             out << " down-connected";
         if (!connected() && !connected_down())
             out << " unconnected";
+        if (renderer_output())
+            out << " renderer-output";
         if (symtype() == SymTypeParam && ! lockgeom())
             out << " lockgeom=0";
     }

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -308,7 +308,7 @@ ShaderInstance::add_connection (int srclayer, const ConnectedParam &srccon,
 
 
 void
-ShaderInstance::copy_code_from_master ()
+ShaderInstance::copy_code_from_master (ShaderGroup &group)
 {
     ASSERT (m_instops.empty() && m_instargs.empty());
     // reserve with enough room for a few insertions
@@ -323,17 +323,20 @@ ShaderInstance::copy_code_from_master ()
     m_instsymbols = m_master->m_symbols;
 
     // Copy the instance override data
+    // Also set the renderer_output flags where needed.
     ASSERT (m_instoverrides.size() == (size_t)std::max(0,lastparam()));
     ASSERT (m_instsymbols.size() >= (size_t)std::max(0,lastparam()));
     if (m_instoverrides.size()) {
         for (size_t i = 0, e = lastparam();  i < e;  ++i) {
+            Symbol *si = &m_instsymbols[i];
             if (m_instoverrides[i].valuesource() != Symbol::DefaultVal) {
-                Symbol *si = &m_instsymbols[i];
                 si->data (param_storage(i));
                 si->valuesource (m_instoverrides[i].valuesource());
                 si->connected_down (m_instoverrides[i].connected_down());
                 si->lockgeom (m_instoverrides[i].lockgeom());
             }
+            if (shadingsys().is_renderer_output (layername(), si->name(), &group))
+                si->renderer_output (true);
         }
     }
     off_t symmem = vectorbytes(m_instsymbols) - vectorbytes(m_instoverrides);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -786,7 +786,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
             continue;
         // Skip if it's never read and isn't connected
         if (! s.everread() && ! s.connected_down() && ! s.connected()
-              && ! shadingsys().is_renderer_output(s.name(), &group()))
+              && ! s.renderer_output())
             continue;
         // Set initial value for params (may contain init ops)
         llvm_assign_initial_value (s);

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -605,7 +605,7 @@ public:
 
     /// Make our own version of the code and args from the master.
     ///
-    void copy_code_from_master ();
+    void copy_code_from_master (ShaderGroup &group);
 
     /// Small data structure to hold just the symbol info that the
     /// instance overrides from the master copy.
@@ -905,7 +905,8 @@ public:
     void pointcloud_stats (int search, int get, int results, int writes=0);
 
     /// Is the named symbol among the renderer outputs?
-    bool is_renderer_output (ustring name, ShaderGroup *group) const;
+    bool is_renderer_output (ustring layername, ustring paramname,
+                             ShaderGroup *group) const;
 
     /// Serialize/pickle a group description into text.
     std::string serialize_group (ShaderGroup *group);

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1120,7 +1120,7 @@ RuntimeOptimizer::unread_after (const Symbol *A, int opnum)
             return false;   // Asked not do do this optimization
         if (A->connected_down())
             return false;   // Connected to something downstream
-        if (shadingsys().is_renderer_output (A->name(), &group()))
+        if (A->renderer_output())
             return false;   // This is a renderer output -- don't cull it
     }
 
@@ -1282,8 +1282,7 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
         // If it's also never read before this assignment and isn't a
         // designated renderer output (which we obviously must write!), just
         // replace its default value entirely and get rid of the assignment.
-        if (R->firstread() > opnum &&
-                ! shadingsys().is_renderer_output (R->name(), &group()) &&
+        if (R->firstread() > opnum && ! R->renderer_output() &&
                 m_opt_elide_unconnected_outputs) {
             make_param_use_instanceval (R, "- written once, with a constant, before any reads");
             replace_param_value (R, A->data(), A->typespec());
@@ -1407,7 +1406,7 @@ public:
                 return false;   // Asked not to do this optimization
             if (sym.connected_down())
                 return false;   // Connected to something downstream
-            if (m_rop.shadingsys().is_renderer_output (sym.name(), &m_rop.group()))
+            if (sym.renderer_output())
                 return false;   // This is a renderer output
             return (sym.lastuse() < sym.initend());
         }
@@ -2641,7 +2640,7 @@ RuntimeOptimizer::run ()
         set_inst (layer);
         if (inst()->unused())
             continue;
-        inst()->copy_code_from_master ();
+        inst()->copy_code_from_master (group());
         if (debug() && optimize() >= 1) {
             std::cout.flush ();
             std::cout << "Before optimizing layer " << layer << " " 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2168,15 +2168,20 @@ ShadingSystemImpl::raytype_bit (ustring name)
 
 
 bool
-ShadingSystemImpl::is_renderer_output (ustring name, ShaderGroup *group) const
+ShadingSystemImpl::is_renderer_output (ustring layername, ustring paramname,
+                                       ShaderGroup *group) const
 {
     if (group) {
         const std::vector<ustring> &aovs (group->m_renderer_outputs);
-        if (std::find (aovs.begin(), aovs.end(), name) != aovs.end())
+        if (std::find (aovs.begin(), aovs.end(), paramname) != aovs.end())
+            return true;
+        // Try "layer.name"
+        ustring name2 = ustring::format ("%s.%s", layername, paramname);
+        if (std::find (aovs.begin(), aovs.end(), name2) != aovs.end())
             return true;
     }
     const std::vector<ustring> &aovs (m_renderer_outputs);
-    return std::find (aovs.begin(), aovs.end(), name) != aovs.end();
+    return std::find (aovs.begin(), aovs.end(), paramname) != aovs.end();
 }
 
 


### PR DESCRIPTION
This allows you to designate a named output to be a "renderer output" (thus immune from unused output elision, among other things) only if it is part of a particular layer, if you so desire. Of course, you can just give a plain unqualified name, too, which would designate ANY outputs of the same name (in any layer) as being so preserved, as it always has worked.

As an example, this may come in handy if you have shader group where a bunch of the instances have output parameters named "Cout", but only a particular one is designated as needing to be queried by the renderer after shader execution (so the others may be free to be optimized away).

Because this makes the instance->is_renderer_output() test much more expensive (because it needs to concatenate the string), we also refactor slightly so the "is it an output" test is done just once for each instance param at the start of runtime optimization, the result stored in a bit in the Symbol struct, so can be very easily tested the zillions of times the optimizer may need to know.
