### PR TITLE
Bug fix with instance merging -- never merge the group entry layer.

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2387,13 +2387,15 @@ ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
     int nlayers = group.nlayers();
 
     // Loop over all layers...
-    for (int a = 0;  a < nlayers;  ++a) {
+    for (int a = 0;  a < nlayers-1;  ++a) {
         if (group[a]->unused())    // Don't merge a layer that's not used
             continue;
         // Check all later layers...
         for (int b = a+1;  b < nlayers;  ++b) {
             if (group[b]->unused())    // Don't merge a layer that's not used
                 continue;
+            if (b == nlayers-1)   // Don't merge the last layer -- causes
+                continue;         // many tears because it's the group entry
 
             // Now we have two used layers, a and b, to examine.
             // See if they are mergeable (identical).  All the heavy


### PR DESCRIPTION
It turns out that it's a bad idea to do "instance merging" of the last layer, also known as the "group entry" layer. It's very rare that the circumstances would lead to it in any real world shader groups, but I ran across it in a contrived layered example (with two layers of the same shader master, no connections, same instance parameter values, no outputs used) The bottom line is that the group entry layer must generate a proper LLVM function, and having it marked as "unused" because of merging leads to a cascade of hard-to-understand errors.
