### PR TITLE
Fix bug in assigning elements of struct arrays.

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -469,10 +469,7 @@ ASTassign_expression::codegen (Symbol *dest)
     if (var()->nodetype() == index_node) {
         // Assigning to an individual component or array element
         index = (ASTindex *) var().get();
-        if (typespec().is_structure())
-            dest = var()->codegen();  // for structs, we'll need this
-        else
-            dest = NULL;
+        dest = NULL;
     } else if (var()->nodetype() == structselect_node) {
         dest = var()->codegen();
     } else {

--- a/testsuite/struct-array/ref/out.txt
+++ b/testsuite/struct-array/ref/out.txt
@@ -10,4 +10,6 @@ after c=a[2], c = { 15, 1 1 1 }
 after a[3]=c, a[3] = { 15, 1 1 1 }
 test array-of-struct assignmment:
 a2 = a; float f2; f = a2[2].f;  ==> 15 (should be 15)
+test array-of-struct array element assignmment:
+a3[0] = a3[1]; ===> 1 (should be 1) and [1 1 1] (should be [1 1 1])
 

--- a/testsuite/struct-array/test.osl
+++ b/testsuite/struct-array/test.osl
@@ -48,5 +48,13 @@ test ()
     float f2;
     f2 = a[2].f;
     printf ("a2 = a; float f2; f = a2[2].f;  ==> %g (should be %g)\n", f2, f);
-    
+
+    printf ("test array-of-struct array element assignmment:\n");
+    Astruct a3[5];
+    a3[0].f = 0.0;
+    a3[0].p = point(0.0);
+    a3[1].f = 1.0;
+    a3[1].p = point(1.0);
+    a3[0] = a3[1];
+    printf("a3[0] = a3[1]; ===> %g (should be %g) and [%g] (should be [%g])\n", a3[0].f, a3[1].f, a3[0].p, a3[1].p);
 }


### PR DESCRIPTION
This kind of thing:

```
struct S { float x; }
S a[2];
a[1] = a[0];
```

The generated code would not properly copy a[0].x to a[1].x.

LG is submitting this, but the patch is actually from Derek Haase (as is the testsuite case). LG confirms that it fixes the bug, doesn't break anything else, and looks correct.

Congrats on first OSL patch, Derek!
