### PR TITLE
OSLQuery: reliably tell when no constant default is available for a param

### DIFF
--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -233,6 +233,11 @@ OSOReaderQuery::hint (const char *h)
         Strutil::parse_char (hintstring, '}');
         return;
     }
+    if (m_reading_param && Strutil::parse_prefix(hintstring, "initexpr")) {
+        m_query.m_params[m_query.nparams()-1].validdefault = false;
+        return;
+    }
+
     // std::cerr << "Hint '" << hintstring << "'\n";
 }
 


### PR DESCRIPTION
There's always been a 'validdefault' field in the OSLQuery::Parameter structure, but it was always set to true.
- oslc -- add a %initexpr hint in the oso for parameters that are initialized by expressions (like myparam = u, or myparam = noise(P), i.e. is not a constant value at shader compilation time.
- oslquery -- if this hint is encountered for a parameter, mark its valliddefault = false.

Thus, a program using OSLQuery ought to be able to check the validdefault field, and if it's true, the default constant is valid, but if it's false, you can't count on the default constant being the true default.

Sorry, there are a few other changes mixed up here where I just couldn't help fix some of those '\t' things to be a little more compact.
