### PR TITLE
Fix load shader with closure array in/out parameter

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -775,8 +775,8 @@ BackendLLVM::llvm_assign_impl (Symbol &Result, Symbol &Src,
 
     llvm::Value *arrind = arrayindex >= 0 ? ll.constant (arrayindex) : NULL;
 
-    if (Result.typespec().is_closure_based() || Src.typespec().is_closure_based()) {
-        if (Src.typespec().is_closure_based()) {
+    if (Result.typespec().is_closure() || Src.typespec().is_closure()) {
+        if (Src.typespec().is_closure()) {
             llvm::Value *srcval = llvm_load_value (Src, 0, arrind, 0);
             llvm_store_value (srcval, Result, 0, arrind, 0);
         } else {

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -168,7 +168,7 @@ OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name)
         } else if (typespec.simpletype().basetype == TypeDesc::STRING) {
             sym.dataoffset ((int) m_master->m_sdefaults.size());
             expand (m_master->m_sdefaults, t.aggregate * t.numelements());
-        } else if (typespec.is_closure()) {
+        } else if (typespec.is_closure_based()) {
             // Closures are pointers, so we allocate a string default taking
             // adventage of their default being NULL as well.
             sym.dataoffset ((int) m_master->m_sdefaults.size());


### PR DESCRIPTION
A shader with a closure array parameter compiles, but does not load at runtime.
This commit fixes it.

e.g.
shader Test(closure color param[4], output closure color outParam[4])
{ ... }
