### PR TITLE
Fix OSLQuery crash reading OSO with local variables and no parameters.

### DIFF
--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -145,26 +145,28 @@ OSOReaderQuery::symdefault (const char *def)
 void
 OSOReaderQuery::parameter_done ()
 {
-    m_reading_param = false;
+    if (m_reading_param && m_query.nparams() > 0) {
+       // Make sure all value defaults have the right number of elements in
+       // case they were only partially initialized.
+       OSLQuery::Parameter &p (m_query.m_params.back());
+       int nvalues = p.type.numelements() * p.type.aggregate;
+       if (p.type.basetype == TypeDesc::INT) {
+           p.idefault.resize (nvalues, 0);
+           p.data = &p.idefault[0];
+       }
+       else if (p.type.basetype == TypeDesc::FLOAT) {
+           p.fdefault.resize (nvalues, 0);
+           p.data = &p.fdefault[0];
+       }
+       else if (p.type.basetype == TypeDesc::STRING) {
+           p.sdefault.resize (nvalues, ustring());
+           p.data = &p.sdefault[0];
+       }
+       if (p.spacename.size())
+           p.spacename.resize (p.type.numelements(), ustring());
+    }
 
-    // Make sure all value defaults have the right number of elements in
-    // case they were only partially initialized.
-    OSLQuery::Parameter &p (m_query.m_params.back());
-    int nvalues = p.type.numelements() * p.type.aggregate;
-    if (p.type.basetype == TypeDesc::INT) {
-        p.idefault.resize (nvalues, 0);
-        p.data = &p.idefault[0];
-    }
-    else if (p.type.basetype == TypeDesc::FLOAT) {
-        p.fdefault.resize (nvalues, 0);
-        p.data = &p.fdefault[0];
-    }
-    else if (p.type.basetype == TypeDesc::STRING) {
-        p.sdefault.resize (nvalues, ustring());
-        p.data = &p.sdefault[0];
-    }
-    if (p.spacename.size())
-        p.spacename.resize (p.type.numelements(), ustring());
+    m_reading_param = false;
 }
 
 


### PR DESCRIPTION
With this test.oso:

```
OpenShadingLanguage 1.00
surface test
local color C
code ___main___
   end
```

This crashes:

```
oslinfo test.oso
```
