### PR TITLE
Fix missing logb derivative functions.

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -234,7 +234,6 @@ DECL (osl_sincos_dvdvdv, "xXXX")
 UNARY_OP_IMPL(log)
 UNARY_OP_IMPL(log2)
 UNARY_OP_IMPL(log10)
-UNARY_OP_IMPL(logb)
 UNARY_OP_IMPL(exp)
 UNARY_OP_IMPL(exp2)
 UNARY_OP_IMPL(expm1)
@@ -249,6 +248,9 @@ DECL (osl_pow_dvdvf, "xXXf")
 
 UNARY_OP_IMPL(sqrt)
 UNARY_OP_IMPL(inversesqrt)
+
+DECL (osl_logb_ff, "ff")
+DECL (osl_logb_vv, "xXX")
 
 DECL (osl_floor_ff, "ff")
 DECL (osl_floor_vv, "xXX")

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -61,6 +61,7 @@ static ustring op_ge("ge");
 static ustring op_gt("gt");
 static ustring op_if("if");
 static ustring op_le("le");
+static ustring op_logb("logb");
 static ustring op_lt("lt");
 static ustring op_min("min");
 static ustring op_neq("neq");
@@ -1691,7 +1692,8 @@ LLVMGEN (llvm_gen_generic)
 
     // Special cases: functions that have no derivs -- suppress them
     if (any_deriv_args)
-        if (op.opname() == op_floor || op.opname() == op_ceil ||
+        if (op.opname() == op_logb  ||
+            op.opname() == op_floor || op.opname() == op_ceil ||
             op.opname() == op_round || op.opname() == op_step ||
             op.opname() == op_trunc || 
             op.opname() == op_sign)


### PR DESCRIPTION
I'm not sure this fix is correct, but it solves a compile error when building with `USE_LLVM_BITCODE=OFF`, and a runtime error when compiling with it `ON`.

As I understand it `logb` is basically `log2` with rounding, but it's not clear to me what the derivatives should be.
