### PR TITLE
Bug fix from==to case of getmatrix constant folding

### DIFF
--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1797,28 +1797,23 @@ DECLFOLDER(constfold_getmatrix)
     ustring from = *(ustring *)From.data();
     ustring to = *(ustring *)To.data();
     ustring commonsyn = rop.inst()->shadingsys().commonspace_synonym();
-    if (from == to || (from == Strings::common && to == commonsyn) ||
-        (from == commonsyn && to == Strings::common)) {
-        static Matrix44 ident (1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1);
-        int cind = rop.add_constant (TypeDesc::TypeMatrix, &ident);
-        rop.turn_into_assign (op, cind, "getmatrix identity matrix");
-        return 1;
-    }
+
     // Shader and object spaces will vary from execution to execution,
     // so we can't optimize those away.
     if (from == Strings::shader || from == Strings::object ||
         to == Strings::shader || to == Strings::object)
         return 0;
+
     // But whatever spaces are left *may* be optimizable if they are
     // not time-varying.
     RendererServices *rs = rop.shadingsys().renderer();
     Matrix44 Mfrom, Mto;
     bool ok = true;
-    if (from == Strings::common || from == commonsyn)
+    if (from == Strings::common || from == commonsyn || from == to)
         Mfrom.makeIdentity ();
     else
         ok &= rs->get_matrix (rop.shaderglobals(), Mfrom, from);
-    if (to == Strings::common || to == commonsyn)
+    if (to == Strings::common || to == commonsyn || from == to)
         Mto.makeIdentity ();
     else
         ok &= rs->get_inverse_matrix (rop.shaderglobals(), Mto, to);


### PR DESCRIPTION
Not found in the wild, but when I was viewing this section of code, I realized that the optimization here would transform the code incorrectly. I removed the incorrect code and just folded that case to be recognized in a later clause in the function, which did handle the transformation correctly.
