### PR TITLE
Option lazy_userdata causes lazy (on-demand) interpolation of userdata.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -116,6 +116,7 @@ public:
     ///                              outputs are first needed (1)
     ///    int lazyglobals        Run layers lazily even if they write to
     ///                              globals (0)
+    ///    int lazy_userdata      Retrieve userdata lazily (0).
     ///    int greedyjit          Optimize and compile all shaders up front,
     ///                              versus only as needed (0).
     ///    int lockgeom           Default 'lockgeom' value for shader params

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -206,6 +206,7 @@ DECL (osl_range_check, "iiiXXi")
 DECL (osl_naninf_check, "xiXiXXiXiiX")
 DECL (osl_uninit_check, "xLXXXiXii")
 DECL (osl_get_attribute, "iXiXXiiXX")
+DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
 
 
 // The following are defined inside llvm_ops.cpp. Only include these
@@ -383,7 +384,6 @@ DECL (osl_area, "fX")
 DECL (osl_filterwidth_fdf, "fX")
 DECL (osl_filterwidth_vdv, "xXX")
 DECL (osl_raytype_bit, "iXi")
-DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
 #endif
 
 

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -115,6 +115,9 @@ ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
     // Clear miscellaneous scratch space
     m_scratch_pool.clear ();
 
+    // Zero out stats for this execution
+    clear_runtime_stats ();
+
     if (run) {
         ssg.context = this;
         ssg.renderer = renderer();
@@ -128,6 +131,7 @@ ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
     // Process any queued up error messages, warnings, printfs from shaders
     process_errors ();
 
+    record_runtime_stats ();   // Transfer runtime stats to the shadingsys
     if (profile) {
         long long ticks = timer.ticks();
         shadingsys().m_stat_total_shading_time_ticks += ticks;

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -208,6 +208,14 @@ LLVMGEN (llvm_gen_useparam)
         Symbol& sym = *rop.opargsym (op, i);
         int symindex = rop.inst()->arg (op.firstarg()+i);
         rop.llvm_run_connected_layers (sym, symindex, opnum, &already_run);
+        // If it's an interpolated (userdata) parameter and we're
+        // initializing them lazily, now we have to do it.
+        if (sym.symtype() == SymTypeParam
+                && ! sym.lockgeom() && ! sym.typespec().is_closure()
+                && ! sym.connected() && ! sym.connected_down()
+                && rop.shadingsys().lazy_userdata()) {
+            rop.llvm_assign_initial_value (sym);
+        }
     }
     return true;
 }

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -1639,35 +1639,3 @@ OSL_SHADEOP int osl_raytype_bit (void *sg_, int bit)
 }
 
 
-
-
-/***********************************************************************
- * Utility routines
- */
-
-OSL_SHADEOP int
-osl_bind_interpolated_param (void *sg_, const void *name, long long type,
-                             int userdata_has_derivs, void *userdata_data,
-                             int symbol_has_derivs, void *symbol_data,
-                             int symbol_data_size,
-                             char *userdata_initialized, int userdata_index)
-{
-    char status = *userdata_initialized;
-    if (status == 0) {
-        // First time retrieving this userdata
-        ShaderGlobals *sg = (ShaderGlobals *)sg_;
-        bool ok = sg->renderer->get_userdata (userdata_has_derivs, USTR(name),
-                                              TYPEDESC(type),
-                                              sg, userdata_data);
-        // printf ("Binding %s %s : index %d, ok = %d\n", name,
-        //         TYPEDESC(type).c_str(),userdata_index, ok);
-        *userdata_initialized = status = 1 + ok;  // 1 = not found, 2 = found
-    }
-    if (status == 2) {
-        // If userdata was present, copy it to the shader variable
-        memcpy (symbol_data, userdata_data, symbol_data_size);
-        return 1;
-    }
-    return 0;  // no such user data
-}
-


### PR DESCRIPTION
The previous behavior was that unconnected, lockgeom=0 parameters (those
that must be resolved by get_userdata to retrieve a potentially
interpolated value) are resolved up front in the shader, so that individual
uses of that parameter don't need to check or worry about whether the
interpolation already happened.

But consider this shader logic:

```
if (condition)
    use userdata A
else
    use userdata B
```

Any particular execution of the shader, we would hope, would interpolate
either A or B, but not both. But the existing behavior was to do the
interpolations up front, so both got interpolated. If a particular
renderer had a very expensive implementation of get_userdata, this could
be a performance issue.

With this patch, when the lazy_userdata option is set to nonzero, will
instead do it lazily -- calling get_userdata the first time it's needed
in execution of the shader.

I added a statistic that tracks the number of get_userdata calls made.
This definitely shows that when the new option is turned on, fewer
get_userdata calls happen in my production scenes, though the total
render time does not change enough to measure. But there is another
particular user of OSL in whose renderer the get_userdata is potentially
expensive, so we're hoping that this makes a noticable time difference
for them.

This is still off by default for the moment, giving the old behavior.
As I gain confidence that it's for sure correct and always speeds things
up (I can imagine cases where it is a performance penalty, but don't
know if that will happen enough in practice to matter), I may change the
default to be on.
