### PR TITLE
Put a TextureOptions and NoiseParams in the ShadingContext, rather than alloca

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -300,6 +300,18 @@ public:
 
     /// Return a pointer to the texture system (if available).
     virtual TextureSystem *texturesys () const;
+
+    /// Options we use for noise calls.
+    struct NoiseOpt {
+        int anisotropic;
+        int do_filter;
+        Vec3 direction;
+        float bandwidth;
+        float impulses;
+        NoiseOpt () : anisotropic(0), do_filter(true),
+            direction(1.0f,0.0f,0.0f), bandwidth(1.0f), impulses(16.0f) { }
+    };
+
 };
 
 

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -207,6 +207,9 @@ DECL (osl_naninf_check, "xiXiXXiXiiX")
 DECL (osl_uninit_check, "xLXXXiXii")
 DECL (osl_get_attribute, "iXiXXiiXX")
 DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
+DECL (osl_get_texture_options, "XX");
+DECL (osl_get_noise_options, "XX");
+DECL (osl_get_trace_options, "XX");
 
 
 // The following are defined inside llvm_ops.cpp. Only include these
@@ -332,14 +335,12 @@ DECL (osl_stof_fs, "fs")
 DECL (osl_substr_ssii, "ssii")
 DECL (osl_regex_impl, "iXsXisi")
 
-DECL (osl_noiseparams_clear, "xX")
 DECL (osl_noiseparams_set_anisotropic, "xXi")
 DECL (osl_noiseparams_set_do_filter, "xXi")
 DECL (osl_noiseparams_set_direction, "xXv")
 DECL (osl_noiseparams_set_bandwidth, "xXf")
 DECL (osl_noiseparams_set_impulses, "xXf")
 
-DECL (osl_texture_clear, "xX")
 DECL (osl_texture_set_firstchannel, "xXi")
 DECL (osl_texture_set_swrap, "xXs")
 DECL (osl_texture_set_twrap, "xXs")
@@ -372,7 +373,6 @@ DECL (osl_texture3d_alpha, "iXsXXXXXiXXXXXXXX")
 DECL (osl_environment, "iXsXXXXiXXXXXX")
 DECL (osl_get_textureinfo, "iXXXiiiX")
 
-DECL (osl_trace_clear, "xX")
 DECL (osl_trace_set_mindist, "xXf")
 DECL (osl_trace_set_maxdist, "xXf")
 DECL (osl_trace_set_shade, "xXi")

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1921,11 +1921,8 @@ llvm_gen_texture_options (BackendLLVM &rop, int opnum,
                           llvm::Value* &alpha, llvm::Value* &dalphadx,
                           llvm::Value* &dalphady)
 {
-    // Reserve space for the TextureOpt, with alignment
-    int tosize = OIIO::round_to_multiple ((int)sizeof(TextureOpt), (int)sizeof(char*));
-    llvm::Value* opt = rop.ll.op_alloca (rop.ll.type_void_ptr(), tosize);
-    opt = rop.ll.void_ptr (opt);
-    rop.ll.call_function ("osl_texture_clear", opt);
+    llvm::Value* opt = rop.ll.call_function ("osl_get_texture_options",
+                                             rop.sg_void_ptr());
     llvm::Value* missingcolor = NULL;
     TextureOpt optdefaults;  // So we can check the defaults
     bool swidth_set = false, twidth_set = false, rwidth_set = false;
@@ -2313,12 +2310,8 @@ static llvm::Value *
 llvm_gen_trace_options (BackendLLVM &rop, int opnum,
                         int first_optional_arg)
 {
-    // Reserve space for the TraceOpt, with alignment
-    int tosize = OIIO::round_to_multiple ((int)sizeof(RendererServices::TraceOpt), (int)sizeof(char*));
-    llvm::Value* opt = rop.ll.op_alloca (rop.ll.type_void_ptr(), tosize);
-    opt = rop.ll.void_ptr (opt);
-    rop.ll.call_function ("osl_trace_clear", opt);
-
+    llvm::Value* opt = rop.ll.call_function ("osl_get_trace_options",
+                                             rop.sg_void_ptr());
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));
@@ -2412,12 +2405,8 @@ static llvm::Value *
 llvm_gen_noise_options (BackendLLVM &rop, int opnum,
                         int first_optional_arg)
 {
-    // Reserve space for the NoiseParams, with alignment
-    int optsize = OIIO::round_to_multiple ((int)sizeof(NoiseParams), (int)sizeof(char*));
-    llvm::Value* opt = rop.ll.op_alloca (rop.ll.type_void_ptr(), optsize);
-    opt = rop.ll.void_ptr (opt);
-    rop.ll.call_function ("osl_noiseparams_clear", opt);
-
+    llvm::Value* opt = rop.ll.call_function ("osl_get_noise_options",
+                                             rop.sg_void_ptr());
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -170,22 +170,6 @@ tex_interp_to_code (ustring modename)
 
 
 
-// Layout of structure we use to pass noise parameters
-struct NoiseParams {
-    int anisotropic;
-    int do_filter;
-    Vec3 direction;
-    float bandwidth;
-    float impulses;
-
-    NoiseParams ()
-        : anisotropic(0), do_filter(true), direction(1.0f,0.0f,0.0f),
-          bandwidth(1.0f), impulses(16.0f)
-    {
-    }
-};
-
-
 OSL_NAMESPACE_EXIT
 
 
@@ -1067,14 +1051,6 @@ osl_regex_impl (void *sg_, const char *subject, void *results, int nresults,
  */
 
 OSL_SHADEOP void
-osl_texture_clear (void *opt)
-{
-    // Use "placement new" to clear the texture options
-    new (opt) TextureOpt;
-}
-
-
-OSL_SHADEOP void
 osl_texture_set_firstchannel (void *opt, int x)
 {
     ((TextureOpt *)opt)->firstchannel = x;
@@ -1479,20 +1455,10 @@ OSL_SHADEOP int osl_get_textureinfo(void *sg_,    void *fin_,
 
 
 
-// Noise helper functions
-OSL_SHADEOP void
-osl_noiseparams_clear (void *opt)
-{
-    // Use "placement new" to clear the noise options
-    new (opt) NoiseParams;
-}
-
-
-
 OSL_SHADEOP void
 osl_noiseparams_set_anisotropic (void *opt, int a)
 {
-    ((NoiseParams *)opt)->anisotropic = a;
+    ((RendererServices::NoiseOpt *)opt)->anisotropic = a;
 }
 
 
@@ -1500,7 +1466,7 @@ osl_noiseparams_set_anisotropic (void *opt, int a)
 OSL_SHADEOP void
 osl_noiseparams_set_do_filter (void *opt, int a)
 {
-    ((NoiseParams *)opt)->do_filter = a;
+    ((RendererServices::NoiseOpt *)opt)->do_filter = a;
 }
 
 
@@ -1508,7 +1474,7 @@ osl_noiseparams_set_do_filter (void *opt, int a)
 OSL_SHADEOP void
 osl_noiseparams_set_direction (void *opt, void *dir)
 {
-    ((NoiseParams *)opt)->direction = VEC(dir);
+    ((RendererServices::NoiseOpt *)opt)->direction = VEC(dir);
 }
 
 
@@ -1516,7 +1482,7 @@ osl_noiseparams_set_direction (void *opt, void *dir)
 OSL_SHADEOP void
 osl_noiseparams_set_bandwidth (void *opt, float b)
 {
-    ((NoiseParams *)opt)->bandwidth = b;
+    ((RendererServices::NoiseOpt *)opt)->bandwidth = b;
 }
 
 
@@ -1524,18 +1490,12 @@ osl_noiseparams_set_bandwidth (void *opt, float b)
 OSL_SHADEOP void
 osl_noiseparams_set_impulses (void *opt, float i)
 {
-    ((NoiseParams *)opt)->impulses = i;
+    ((RendererServices::NoiseOpt *)opt)->impulses = i;
 }
 
 
 
 // Trace
-
-OSL_SHADEOP void
-osl_trace_clear (void *opt)
-{
-    new ((RendererServices::TraceOpt *)opt) RendererServices::TraceOpt;
-}
 
 OSL_SHADEOP void
 osl_trace_set_mindist (void *opt, float x)

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -735,6 +735,18 @@ struct GenericPNoise {
 PNOISE_IMPL_DERIV_OPT (genericpnoise, GenericPNoise)
 
 
+// Utility: retrieve a pointer to the ShadingContext's noise params
+// struct, also re-initialize its contents.
+OSL_SHADEOP void *
+osl_get_noise_options (void *sg_)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    RendererServices::NoiseOpt *opt = sg->context->noise_options_ptr ();
+    new (opt) RendererServices::NoiseOpt;
+    return opt;
+}
+
+
 } // namespace pvt
 OSL_NAMESPACE_EXIT
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1437,6 +1437,12 @@ public:
 
     PerThreadInfo *thread_info () { return m_threadinfo; }
 
+    TextureOpt *texture_options_ptr () { return &m_textureopt; }
+
+    RendererServices::NoiseOpt *noise_options_ptr () { return &m_noiseopt; }
+
+    RendererServices::TraceOpt *trace_options_ptr () { return &m_traceopt; }
+
     void * alloc_scratch (size_t size, size_t align=1) {
         return m_scratch_pool.alloc (size, align);
     }
@@ -1502,6 +1508,10 @@ private:
     int m_max_warnings;                 ///< To avoid processing too many warnings
     int m_stat_get_userdata_calls;      ///< Number of calls to get_userdata
     int m_stat_layers_executed;         ///< Number of layers executed
+
+    TextureOpt m_textureopt;            ///< texture call options
+    RendererServices::NoiseOpt m_noiseopt; ///< noise call options
+    RendererServices::TraceOpt m_traceopt; ///< trace call options
 
     SimplePool<20 * 1024> m_closure_pool;
     SimplePool<64*1024> m_scratch_pool;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2923,6 +2923,31 @@ osl_bind_interpolated_param (void *sg_, const void *name, long long type,
 
 
 
+// Utility: retrieve a pointer to the ShadingContext's texture options
+// struct, also re-initialize its contents.
+OSL_SHADEOP void *
+osl_get_texture_options (void *sg_)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    TextureOpt *opt = sg->context->texture_options_ptr ();
+    new (opt) TextureOpt;
+    return opt;
+}
+
+
+
+// Utility: retrieve a pointer to the ShadingContext's trace options
+// struct, also re-initialize its contents.
+OSL_SHADEOP void *
+osl_get_trace_options (void *sg_)
+{
+    ShaderGlobals *sg = (ShaderGlobals *)sg_;
+    RendererServices::TraceOpt *opt = sg->context->trace_options_ptr ();
+    new (opt) RendererServices::TraceOpt;
+    return opt;
+}
+
+
 
 #ifndef OSL_STATIC_LIBRARY
 // Symbols needed to resolve some linkage issues because we pull some


### PR DESCRIPTION
Put a TextureOptions and NoiseParams in the ShadingContext, rather than generating code to alloca them on the stack when needed. The alloca seems to tickle an LLVM bug that generates incorrect code on 64 bit Windows, making OSL as a whole unstable on that platform. Hopefully, this provides a workaround that avoids the LLVM bugs.
