### PR TITLE
OSLCompiler::compile_buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,11 +167,6 @@ set (USE_CPP11 OFF CACHE BOOL "Compile in C++11 mode")
 set (USE_LIBCPLUSPLUS OFF CACHE BOOL "Compile with clang libc++")
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")
 set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, sse4.1, sse4.2)")
-if (WIN32 OR OSL_SYSTEM_HAS_LIBCPP OR USE_LIBCPLUSPLUS OR USE_CPP11)
-    set (USE_BOOST_WAVE ON CACHE BOOL "Use Boost Wave as preprocessor")
-else ()
-    set (USE_BOOST_WAVE OFF CACHE BOOL "Use Boost Wave as preprocessor")
-endif ()
 
 if (LLVM_NAMESPACE)
     add_definitions ("-DLLVM_NAMESPACE=${LLVM_NAMESPACE}")
@@ -179,10 +174,6 @@ endif ()
 
 if (USE_EXTERNAL_PUGIXML)
     add_definitions ("-DUSE_EXTERNAL_PUGIXML")
-endif ()
-
-if (USE_BOOST_WAVE)
-    add_definitions ("-DUSE_BOOST_WAVE")
 endif ()
 
 if (USE_MCJIT)
@@ -348,6 +339,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             bug-array-heapoffsets
             bug-locallifetime bug-outputinit bug-param-duplicate bug-peep
             cellnoise closure color comparison
+            compile-buffer
             component-range const-array-params const-array-fill
             debugnan debug-uninit
             derivs derivs-muldiv-clobber error-dupes exit exponential

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,6 @@ ifneq (${USE_FAST_MATH},)
 MY_CMAKE_FLAGS += -DUSE_FAST_MATH:BOOL=${USE_FAST_MATH}
 endif
 
-ifneq (${USE_BOOST_WAVE},)
-MY_CMAKE_FLAGS += -DUSE_BOOST_WAVE:BOOL=${USE_BOOST_WAVE}
-endif
-
 ifneq (${ILMBASE_HOME},)
 MY_CMAKE_FLAGS += -DILMBASE_HOME:STRING=${ILMBASE_HOME}
 endif
@@ -282,7 +278,6 @@ help:
 	@echo "      LINKSTATIC=1             Link with static external libraries when possible"
 	@echo "  Finding and Using Dependencies:"
 	@echo "      BOOST_HOME=path          Custom Boost installation"
-	@echo "      USE_BOOST_WAVE=1         Use Boost 'wave' insted of cpp"
 	@echo "      ILMBASE_HOME=path        Custom Ilmbase installation"
 	@echo "      PARTIO_HOME=             Use Partio from the given location"
 	@echo "      USE_EXTERNAL_PUGIXML=1   Use the system PugiXML, not the one in OIIO"

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -78,8 +78,7 @@ ifeq ($(SP_OS), spinux1)
     -DBoost_VERSION=${CONSTRUCTED_BOOSTVERS} \
 	-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERS} \
 	-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
-	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_wave-gcc44-mt${BOOSTVERS_SUFFIX}.so" \
-	-DUSE_BOOST_WAVE=1
+	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_filesystem-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_regex-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_system-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_thread-gcc44-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERS}/libboost_wave-gcc44-mt${BOOSTVERS_SUFFIX}.so"
 
 endif  # endif spinux1
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -52,7 +52,8 @@ endmacro ()
 message (STATUS "BOOST_ROOT ${BOOST_ROOT}")
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
+  set (Boost_ADDITIONAL_VERSIONS "1.57" "1.56"
+                                 "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
                                  "1.49" "1.48" "1.47" "1.46" "1.45" "1.44"
                                  "1.43" "1.43.0" "1.42" "1.42.0")
 endif ()
@@ -65,15 +66,10 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem regex system thread)
-    if (USE_BOOST_WAVE)
-        list (APPEND Boost_COMPONENTS wave)
-    endif ()
-
+    set (Boost_COMPONENTS filesystem regex system thread wave)
     find_package (Boost 1.42 REQUIRED
                   COMPONENTS ${Boost_COMPONENTS}
                  )
-
 endif ()
 
 # On Linux, Boost 1.55 and higher seems to need to link against -lrt

--- a/src/include/OSL/oslcomp.h
+++ b/src/include/OSL/oslcomp.h
@@ -44,14 +44,21 @@ public:
     /// DEPRECATED -- it's ok to directly construct an OSLCompiler now.
     static OSLCompiler *create ();
 
-    OSLCompiler ();
+    OSLCompiler (ErrorHandler *errhandler=NULL);
     ~OSLCompiler ();
 
     /// Compile the given file, using the list of command-line options.
     /// Return true if ok, false if the compile failed.
     bool compile (string_view filename,
-                  const std::vector<string_view> &options,
+                  const std::vector<std::string> &options,
                   string_view stdoslpath = string_view());
+
+    /// Compile the given source code buffer, using the list of command-line
+    /// options, placing the resulting "oso" in osobuffer. Return true if
+    /// ok, false if the compile failed.
+    bool compile_buffer (string_view sourcecode, std::string &osobuffer,
+                         const std::vector<std::string> &options,
+                         string_view stdoslpath = string_view());
 
     /// Return the name of our compiled output (must be called after
     /// compile()).

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -295,7 +295,6 @@ preprocess (const char *yytext)
                         filename.erase (0, 1);
                 }
 	        oslcompiler->filename (ustring (filename));
-#ifdef USE_BOOST_WAVE
                 // Spooky workaround for Boost Wave bug: force_include
                 // is broken and doesn't give us the right lines/files, so
                 // instead we forcefully insert a '#include "stdosl.h"' into
@@ -304,7 +303,6 @@ preprocess (const char *yytext)
                 // So we fix it here, ugh.
                 if (filename == oslcompiler->main_filename())
                     --line;
-#endif
             }
             oslcompiler->lineno (line);
 	} else {

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -30,8 +30,10 @@ endif ()
 include_directories ( "${CMAKE_SOURCE_DIR}/src/liboslcomp" )
 
 FILE ( GLOB exec_headers "*.h" )
+FILE ( GLOB compiler_headers "../liboslcomp/*.h" )
 
 FLEX_BISON ( osolex.l osogram.y oso liboslexec_srcs exec_headers )
+FLEX_BISON ( ../liboslcomp/osllex.l ../liboslcomp/oslgram.y osl liboslexec_srcs compiler_headers )
 
 SET ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS" )
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2947,15 +2947,3 @@ osl_get_trace_options (void *sg_)
     return opt;
 }
 
-
-
-#ifndef OSL_STATIC_LIBRARY
-// Symbols needed to resolve some linkage issues because we pull some
-// components in from liboslcomp.
-int oslparse() { return 0; }
-class oslFlexLexer {
-public:
-    oslFlexLexer (std::istream *in, std::ostream *out);
-};
-oslFlexLexer::oslFlexLexer (std::istream *in, std::ostream *out) { }
-#endif

--- a/testsuite/compile-buffer/ref/out.txt
+++ b/testsuite/compile-buffer/ref/out.txt
@@ -1,0 +1,2 @@
+Hello, world!
+

--- a/testsuite/compile-buffer/run.py
+++ b/testsuite/compile-buffer/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python 
+
+# Don't have it compile the .osl to .oso -- the whole point is to verify
+# that we're doing it without file I/O
+compile_osl_files = False
+
+command = testshade("--inbuffer test")

--- a/testsuite/compile-buffer/test.osl
+++ b/testsuite/compile-buffer/test.osl
@@ -1,0 +1,8 @@
+
+shader
+test (output color Cout = 0
+     )
+{
+    Cout = distance (P, point(0)); // makes sure stdosl.h is found
+    printf ("Hello, world!\n");
+}

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -49,6 +49,8 @@ failureok = 0
 failthresh = 0.004
 failpercent = 0.03
 
+compile_osl_files = True
+
 #print ("srcdir = " + srcdir)
 #print ("tmpdir = " + tmpdir)
 #print ("path = " + path)
@@ -234,12 +236,13 @@ if os.path.exists("run.py") :
 
 # Force any local shaders to compile automatically, prepending the
 # compilation onto whatever else the individual run.py file requested.
-compiles = ""
-oslfiles = glob.glob ("*.osl")
-oslfiles.sort() ## sort the shaders to compile so that they always compile in the same order
-for testfile in oslfiles :
-    compiles += oslc (testfile)
-command = compiles + command
+if compile_osl_files :
+    compiles = ""
+    oslfiles = glob.glob ("*.osl")
+    oslfiles.sort() ## sort the shaders to compile so that they always compile in the same order
+    for testfile in oslfiles :
+        compiles += oslc (testfile)
+    command = compiles + command
 
 # If either out.exr or out.tif is in the reference directory but somehow
 # is not in the outputs list, put it there anyway!


### PR DESCRIPTION
Add OSLCompiler::compile_buffer that compiles osl source in a string into oso output in a string. When combined with ShadingSystem::LoadMemoryCompiledShader, this allows you to go from osl source in memory all the way to execution of the shader, without writing or reading any disk files.

Along the way, we changed a few other things of note:
- OSLCompiler::compile options to std::string vector, for simplicity.
- Remove old /bin/cpp usage, always use Boost Wave.
- Modify OSLCompiler to rely an an ErrorHandler instead of direct stderr output.
- The full OSLCompiler is now built into liboslexec (buy the shading system, get the compiler for free).
- Always use Boost Wave. No more reliance on /usr/bin/cpp, it's too much trouble to maintain parallel code paths, and at this point we totally trust Boost Wave.

(Open question: should we coalesce liboslexec, liboslcomp, and liboslquery into one big libosl? Or is there utility to having, in particular, just OSLQuery or just OSLCompiler linked against an app without dragging ShadingSystem and LLVM with it.)
