### PR TITLE
Add "or", "and" and "not" as synonyms to "&&", "||" and "!".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ endmacro ()
 
 # List all the individual testsuite tests here, except those that need
 # special installed tests.
-TESTSUITE ( aastep arithmetic array array-derivs array-range
+TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             blackbody blendmath breakcont
             bug-array-heapoffsets
             bug-locallifetime bug-outputinit bug-param-duplicate bug-peep

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -137,7 +137,7 @@ static std::stack<TypeSpec> typespec_stack; // just for function_declaration
 %left <i> SHL_OP SHR_OP
 %left <i> '+' '-'
 %left <i> '*' '/' '%'
-%right <i> UMINUS_PREC '!' '~'
+%right <i> UMINUS_PREC NOT_OP '~'
 %right <i> INCREMENT DECREMENT
 %left <i> '(' ')'
 %left <i> '[' ']'
@@ -867,7 +867,7 @@ binary_expression
 unary_op
         : '-'                           { $$ = ASTNode::Sub; }
         | '+'                           { $$ = ASTNode::Add; }
-        | '!'                           { $$ = ASTNode::Not; }
+        | NOT_OP                        { $$ = ASTNode::Not; }
         | '~'                           { $$ = ASTNode::Compl; }
         ;
 

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -867,6 +867,7 @@ binary_expression
 unary_op
         : '-'                           { $$ = ASTNode::Sub; }
         | '+'                           { $$ = ASTNode::Add; }
+        | '!'                           { $$ = ASTNode::Not; }
         | NOT_OP                        { $$ = ASTNode::Not; }
         | '~'                           { $$ = ASTNode::Compl; }
         ;

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -157,6 +157,8 @@ void preprocess (const char *yytext);
 "vector"		{  SETLINE;  return (yylval.i=VECTORTYPE); }
 "void"			{  SETLINE;  return (yylval.i=VOIDTYPE); }
 "while"			{  SETLINE;  return (yylval.i=WHILE); }
+"or"			{  SETLINE;  return (yylval.i=OR_OP); }
+"and"			{  SETLINE;  return (yylval.i=AND_OP); }
 
  /* reserved words */
 "bool"|"case"|"char"|"class"|"const"|"default"|"double" |    \

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -159,6 +159,7 @@ void preprocess (const char *yytext);
 "while"			{  SETLINE;  return (yylval.i=WHILE); }
 "or"			{  SETLINE;  return (yylval.i=OR_OP); }
 "and"			{  SETLINE;  return (yylval.i=AND_OP); }
+"not"			{  SETLINE;  return (yylval.i=NOT_OP); }
 
  /* reserved words */
 "bool"|"case"|"char"|"class"|"const"|"default"|"double" |    \
@@ -249,6 +250,7 @@ void preprocess (const char *yytext);
 {WHITE} 		{  }
 
  /* catch-all rule for any other single characters */
+!			{  SETLINE;  return (yylval.i = NOT_OP); }
 .			{  SETLINE;  return (yylval.i = *YYText()); }
 
 %%

--- a/testsuite/and-or-not-synonyms/ref/out.txt
+++ b/testsuite/and-or-not-synonyms/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled test.osl -> test.oso
+shader "test"
+    "myparam" "int"
+		Default value: 0
+myparam = 0
+

--- a/testsuite/and-or-not-synonyms/run.py
+++ b/testsuite/and-or-not-synonyms/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python 
+
+command += oslinfo("-v test")
+command += testshade("test")

--- a/testsuite/and-or-not-synonyms/test.osl
+++ b/testsuite/and-or-not-synonyms/test.osl
@@ -1,0 +1,12 @@
+shader test 
+(
+    int myparam = 0 
+    )
+{
+    if (
+            !myparam || (myparam > 0 && myparam < 0.5) or
+            (not myparam and myparam > 10))
+    {
+        printf ("myparam = %d\n", myparam);
+    }
+}


### PR DESCRIPTION
From this discussion:
https://groups.google.com/forum/#!topic/osl-dev/nds648OuPvM
