### PR TITLE
Allow trailing commas 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             texture-missingcolor texture-simple
             texture-smallderivs texture-swirl
             texture-width texture-withderivs texture-wrap
-            transform transformc trig typecast
+            trailing-commas transform transformc trig typecast
             unknown-instruction vecctr vector
             wavelength_color xml )
 

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -196,6 +196,10 @@ shader_formal_params
                 {
                     $$ = concat ($1, $3);
                 }
+        | shader_formal_params ','
+                {
+                    $$ = $1;
+                }
         ;
 
 shader_formal_param
@@ -255,6 +259,10 @@ metadata_block_opt
 metadata
         : metadatum
         | metadata ',' metadatum        { $$ = concat ($1, $3); }
+        | metadata ','                  
+                { 
+                    $$ = $1; 
+                }
         ;
 
 metadatum
@@ -319,6 +327,10 @@ function_formal_params
         | function_formal_params ',' function_formal_param
                 {
                     $$ = concat ($1, $3);
+                }
+        | function_formal_params ','
+                {
+                    $$ = $1;
                 }
         ;
 

--- a/testsuite/trailing-commas/ref/out.txt
+++ b/testsuite/trailing-commas/ref/out.txt
@@ -1,0 +1,9 @@
+Compiled test.osl -> test.oso
+shader "test"
+    "myparam" "int"
+		Default value: 0
+		metadata: int foo = 1
+		metadata: string mymetadata = "blah{}blah"
+		metadata: int bar = 5
+myparam = 0
+

--- a/testsuite/trailing-commas/run.py
+++ b/testsuite/trailing-commas/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python 
+
+command += oslinfo("-v test")
+command += testshade("test")

--- a/testsuite/trailing-commas/test.osl
+++ b/testsuite/trailing-commas/test.osl
@@ -1,0 +1,25 @@
+void
+test_func
+    (
+        int arg,
+    )
+    [[
+        string help = "this is function metadata with trailing comma",
+    ]]
+{
+    return;
+}
+    
+
+shader test 
+    [[
+    string help = "This is shader metadata",
+    ]]
+(
+    int myparam = 0 [[ int foo = 1,
+                       string mymetadata = "blah{}blah",
+                       int bar = 5, ]],
+    )
+{
+    printf ("myparam = %d\n", myparam);
+}


### PR DESCRIPTION
...in function argument, shader argument, and metadata lists.  From:

https://groups.google.com/forum/#!topic/osl-dev/swRNU97n16Y