### PR TITLE
oslcomp fix: add directory holding stdosl.h to the include path.

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -340,6 +340,8 @@ OSLCompilerImpl::compile (string_view filename,
         return false;
     }
 
+    std::vector<std::string> defines;
+    std::vector<std::string> includepaths;
     m_cwd = boost::filesystem::initial_path().string();
     m_main_filename = filename;
 
@@ -359,9 +361,11 @@ OSLCompilerImpl::compile (string_view filename,
     }
     if (stdoslpath.empty() || ! OIIO::Filesystem::exists(stdoslpath))
         warning (ustring(filename), 0, "Unable to find \"stdosl.h\"");
+    else {
+        // Add the directory of stdosl.h to the include paths
+        includepaths.push_back (OIIO::Filesystem::parent_path (stdoslpath));
+    }
 
-    std::vector<std::string> defines;
-    std::vector<std::string> includepaths;
     read_compile_options (options, defines, includepaths);
 
     std::string preprocess_result;

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -80,7 +80,6 @@ stdoslpath ()
         path = path.parent_path ();  // now the parent dir
         path = path / "shaders";
         if (OIIO::Filesystem::exists (path.string())) {
-            // includepaths.push_back(path.string());
             path = path / "stdosl.h";
             if (OIIO::Filesystem::exists (path.string()))
                 return path.string();


### PR DESCRIPTION
This is the way it had always been, but I broke it with the compile_buffer patch. That caused problems for situations where other headers in that directory were assumed to be includable without having to separately specify the path on the command line.