### PR TITLE
oslc fix: allow comma operator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Language, standard libary, and compiler changes (for shader writers):
   directly seen by the camera will directly reproduce the closure weight
   in the final pixel, regardless of it being a surface or volume. Thus,
   you don't need to weight it by PI. #427 (1.6.2)
+* The "comma operator" now works in the way you would expect in other
+  C-like languages. #451 (1.6.2)
 
 API changes, new options, new ShadingSystem features (for renderer writers):
 * New ShadingSystem attribute int "profile", if set to 1, will include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter
             noise-perlin noise-uperlin noise-simplex noise-usimplex
             pnoise pnoise-cell pnoise-gabor pnoise-perlin pnoise-uperlin
-            oslc-D
+            oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-paramdefault

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -61,7 +61,7 @@ Language Specification
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 7 Jan, 2015 \\
+\date{{\large Date: 9 Jan, 2015 \\
 %~ (with corrections, 2 Oct 2014)
 }
 \bigskip
@@ -5052,9 +5052,7 @@ nothing (empty, no token).
     <shadertype> <identifier> <metadata-block-opt> 
     "(" <shader-formal-params-opt> ")" "{" <statement-list> "}"
 
-<shadertype> ::= "displacement" | "imager" | "integrator" | 
-    "shader" | "surface" | "volume"
-% "light"
+<shadertype> ::= "displacement" |  "shader" | "surface" | "volume"
 
 <shader-formal-params> ::= <shader-formal-param> \{ "," <shader-formal-param> \}
 
@@ -5138,7 +5136,7 @@ nothing (empty, no token).
 <statement-list> ::= <statement> \{ <statement> \}
 
 <statement> ::= 
-<expression-opt> ";"
+<compound-expression-opt> ";"
 \alt <scoped-statements>
 \alt <local-declaration>
 \alt <conditional-statement>
@@ -5149,12 +5147,13 @@ nothing (empty, no token).
 
 <scoped-statements> ::= "{" <statement-list-opt> "}"
 
-<conditional-statement> ::= \spc \\ "if" "(" <expression> ")" <statement>
-\alt "if" "(" <expression> ")" <statement> "else" <statement>
+<conditional-statement> ::= \spc \\ "if" "(" <compound-expression> ")" <statement>
+\alt "if" "(" <compound-expression> ")" <statement> "else" <statement>
 
-<loop-statement> ::= \spc \\ "while" "(" <expression> ")" <statement>
-\alt "do" <statement> "while" "(" <expression> ")" ";"
-\alt "for" "(" <for-init-statement-opt>  <expression-opt> ";" <expression-opt> ")" <statement>
+<loop-statement> ::= \spc \\ "while" "(" <compound-expression> ")" <statement>
+\alt "do" <statement> "while" "(" <compound-expression> ")" ";"
+\alt "for" "(" <for-init-statement-opt>  <compound-expression-opt> ";" 
+                <compound-expression-opt> ")" <statement>
 
 <for-init-statement> ::= \spc \\ <expression-opt> ";"
 \alt <variable-declaration>
@@ -5182,12 +5181,14 @@ nothing (empty, no token).
 \alt <incdec-op> <variable-ref>
 \alt <expression> <binary-op> <expression>
 \alt <unary-op> <expression>
-\alt "(" <expression> ")"
+\alt "(" <compound-expression> ")"
 \alt <function-call>
 \alt <assign-expression>
 \alt <ternary-expression>
 \alt <typecast-expression>
 \alt <variable-ref>
+
+<compound-expression> ::= <expression> \{ "," <expression> \}
 
 <variable-lvalue> ::= <identifier> <array-deref-opt> <component-deref-opt>
 \alt <variable_lvalue> "[" <expression> "]"

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -68,6 +68,7 @@ public:
         loop_statement_node, loopmod_statement_node, return_statement_node,
         binary_expression_node, unary_expression_node,
         assign_expression_node, ternary_expression_node,
+        comma_operator_node,
         typecast_expression_node, type_constructor_node,
         function_call_node,
         literal_node,
@@ -275,9 +276,9 @@ protected:
     bool check_arglist (const char *funcname, ref arg,
                         const char *formals, bool coerce=false);
 
-    /// Follow a list of nodes, generating code for each in turn.
-    ///
-    static void codegen_list (ref node);
+    /// Follow a list of nodes, generating code for each in turn, and return
+    /// the Symbol* for the last thing generated.
+    static Symbol * codegen_list (ref node, Symbol *dest = NULL);
 
     /// Generate code for all the children of this node.
     ///
@@ -750,6 +751,24 @@ public:
     ref trueexpr () const { return child (1); }
     ref falseexpr () const { return child (2); }
 };
+
+
+
+class ASTcomma_operator : public ASTNode
+{
+public:
+    ASTcomma_operator (OSLCompilerImpl *comp, ASTNode *exprlist)
+        : ASTNode (comma_operator_node, comp, Nothing, exprlist)
+    { }
+
+    const char *nodetypename () const { return "comma_operator"; }
+    const char *childname (size_t i) const { return "expression_list"; }
+    TypeSpec typecheck (TypeSpec expected);
+    Symbol *codegen (Symbol *dest = NULL);
+
+    ref expr () const { return child (0); }
+};
+
 
 
 

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -347,13 +347,16 @@ ASTNode::codegen_children ()
 
 
 
-void
-ASTNode::codegen_list (ref node)
+Symbol *
+ASTNode::codegen_list (ref node, Symbol *dest)
 {
+    Symbol *sym = NULL;
     while (node) {
-        node->codegen ();
+        bool last = (node->nextptr() == NULL);
+        sym = node->codegen (last ? dest : NULL);
         node = node->next ();
     }
+    return sym;
 }
 
 
@@ -1423,6 +1426,16 @@ ASTternary_expression::codegen (Symbol *dest)
     m_compiler->ircode(ifop).set_jump (falselabel, donelabel);
 
     return dest;
+}
+
+
+
+Symbol *
+ASTcomma_operator::codegen (Symbol *dest)
+{
+    return codegen_list (expr(), dest);
+    // N.B. codegen_list already returns the type of the LAST node in
+    // the list, just like the comma operator is supposed to do.
 }
 
 

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -690,6 +690,16 @@ ASTternary_expression::typecheck (TypeSpec expected)
 
 
 TypeSpec
+ASTcomma_operator::typecheck (TypeSpec expected)
+{
+    return m_typespec = typecheck_list (expr(), expected);
+    // N.B. typecheck_list already returns the type of the LAST node in
+    // the list, just like the comma operator is supposed to do.
+}
+
+
+
+TypeSpec
 ASTtypecast_expression::typecheck (TypeSpec expected)
 {
     // FIXME - closures

--- a/testsuite/oslc-comma/comma.osl
+++ b/testsuite/oslc-comma/comma.osl
@@ -1,0 +1,32 @@
+// Test the comma operator in for statements
+
+shader comma ()
+{
+    // First, test the "common case" of a for loop with multiple 
+    // variables updated
+    float sum = 0, amp = 0.5, freq = 1;
+    for (int i = 0; i < 4; i++, amp *= 0.5, freq *= 2)
+        sum += amp * snoise(P * freq);
+    printf ("for loop: amp = %g, freq = %g, sum = %g\n", amp, freq, sum);
+
+    // test comma-separated assignment statements
+    int a = 1, b = 0;
+    int lo, hi;
+    if (a < b)
+        lo = a, hi = b;
+    else
+        hi = a, lo = b;
+    printf ("Lo = %d, hi = %d   (expect: 0,1)\n", lo, hi);
+
+    // Test the return value of a commma expression
+    float x = 3.14;
+    int y = 5;
+    int z = (x, y);
+    printf ("z = %d  (expect: 5)\n", z);
+
+    // Test proper associativity involving assignments
+    int i, j;
+    i = 1, 2, 3;
+    j = 4, 5, 6;
+    printf ("i = %d, j = %d   (expect: 1,4 NOT 3,6)\n", i, j);
+}

--- a/testsuite/oslc-comma/ref/out.txt
+++ b/testsuite/oslc-comma/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled comma.osl -> comma.oso
+for loop: amp = 0.03125, freq = 16, sum = 0
+Lo = 0, hi = 1   (expect: 0,1)
+z = 5  (expect: 5)
+i = 1, j = 4   (expect: 1,4 NOT 3,6)
+

--- a/testsuite/oslc-comma/run.py
+++ b/testsuite/oslc-comma/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("comma")


### PR DESCRIPTION
Recently noticed that the "comma operator" does not work as expected. You can see this with a common idiom of incrementing multiple counters in a for loop, like this:

    for (int i=0; i < j; ++i, a *= 2) ...

It's not specific to 'for', of course; in general the comma operator should work in the same places it would in C. To do this properly, we need to split the grammatical 'expression' into the simple kind and a compound_expression, and also add a new AST node for the comma operator (because it's special: a,b has the type and value of b).