### PR TITLE
Bug fix in variable declaration + assignment of nested structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ TESTSUITE ( aastep arithmetic array array-derivs array-range
             render-microfacet render-oren-nayar render-veachmis render-ward
             shortcircuit spline splineinverse string 
             struct struct-array struct-array-mixture
-            struct-err struct-layers struct-with-array 
+            struct-err struct-in-struct-init struct-layers struct-with-array 
             struct-within-struct ternary
             texture-alpha texture-blur texture-derivs texture-field3d
             texture-firstchannel texture-interp 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -303,6 +303,20 @@ protected:
     /// N.B.: just conveniently wraps the compiler's identical method.
     const char *type_c_str (const TypeSpec &type) const;
 
+    /// Assign the struct variable named by srcsym to the struct
+    /// variable named by dstsym by assigning each field individually.
+    /// In the case of dstsym naming an array of structs, arrayindex
+    /// should be a symbol holding the index of the individual array
+    /// element that should be copied into.  If 'copywholearrays' is
+    /// true, we are (perhaps recursively) copying entire arrays, of
+    /// or within the struct, and intindex is the element number if we
+    /// know it -- these two items let us take some interesting shortcuts
+    /// with whole arrays (copyarray versus assigning elements).
+    void codegen_assign_struct (StructSpec *structspec,
+                                ustring dstsym, ustring srcsym,
+                                Symbol *arrayindex,
+                                bool copywholearrays, int intindex);
+
 protected:
     NodeType m_nodetype;          ///< Type of node this is
     ref m_next;                   ///< Next node in the list
@@ -672,20 +686,6 @@ public:
 
     ref var () const { return child (0); }
     ref expr () const { return child (1); }
-private:
-    /// Assign the struct variable named by srcsym to the struct
-    /// variable named by dstsym by assigning each field individually.
-    /// In the case of dstsym naming an array of structs, arrayindex
-    /// should be a symbol holding the index of the individual array
-    /// element that should be copied into.  If 'copywholearrays' is
-    /// true, we are (perhaps recursively) copying entire arrays, of
-    /// or within the struct, and intindex is the element number if we
-    /// know it -- these two items let us take some interesting shortcuts
-    /// with whole arrays (copyarray versus assigning elements).
-    void codegen_assign_struct (StructSpec *structspec,
-                                ustring dstsym, ustring srcsym,
-                                Symbol *arrayindex,
-                                bool copywholearrays, int intindex);
 };
 
 

--- a/testsuite/struct-in-struct-init/ref/out.txt
+++ b/testsuite/struct-in-struct-init/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+y = { 42, 3.14 }
+

--- a/testsuite/struct-in-struct-init/run.py
+++ b/testsuite/struct-in-struct-init/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = testshade("test")

--- a/testsuite/struct-in-struct-init/test.osl
+++ b/testsuite/struct-in-struct-init/test.osl
@@ -1,0 +1,22 @@
+struct InnerStruct {
+    float a;
+};
+
+
+struct OuterStruct {
+    int b;
+    InnerStruct in;
+};
+
+
+shader
+test (output color Cout = 0)
+{
+    OuterStruct x;
+    x.b = 42;
+    x.in.a = 3.14;
+
+    // Here is the variable declaration and initialization we are testing
+    OuterStruct y = x;
+    printf ("y = { %d, %g }\n", y.b, y.in.a);
+}


### PR DESCRIPTION
There was a case involving this kind of setup:

    struct InnerStruct { ...fields... };
    struct OuterStruct { InnerStruct inner; }
    OuterStruct x = ...;
    OuterStruct y = x;    <----- THIS

where incorrect oso code would be generated, to wit: directly assigning x.inner to y.inner (illegal!), instead of assigning the individual fields of x.inner to the corresponding field of y.inner.

We'd solved this a while back for ordinary variable assignment, with the solution implemented in ASTassign_expression::codegen_assign_struct, which needed to operate recursively to handle structs-within-structs as far down as necessary. But the way initialization assignments like the above were handled by ASTvariable_declaration was naive and botched it for nested structs.

This patch moves ASTassign_expression::codegen_assign_struct() into the parent class (ASTnode) so that it may be used by ASTvariable_declaration to do it correctly there as well.

Oy, this has been wrong all along. I hope there aren't too many shaders that were broken but that nobody noticed, and that in now getting correct code generated, have an appearance change. But it was plainly wrong before.

Also fixed what I think is a minor latent bug in codegen_assign_struct, as well as fixed some needless clutter.