### PR TITLE
gettextureinfo constant fold fix: needs to call RS::get_texture_info

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -234,6 +234,10 @@ public:
     /// and the data has been put in *data.  Return false if the texture
     /// doesn't exist, doesn't have the requested data, if the data
     /// doesn't match the type requested. or some other failure.
+    ///
+    /// Note to renderers: if sg is NULL, that means get_texture_info is
+    /// being called speculatively by the runtime optimizer, and it doesn't
+    /// know which object the shader will be run on.
     virtual bool get_texture_info (ShaderGlobals *sg,
                                    ustring filename, int subimage,
                                    ustring dataname, TypeDesc datatype,

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2034,8 +2034,8 @@ DECLFOLDER(constfold_gettextureinfo)
         void *mydata = alloca (t.size ());
         // FIXME(ptex) -- exclude folding of ptex, since these things
         // can vary per face.
-        int result = rop.texturesys()->get_texture_info (filename, 0,
-                                                         dataname, t, mydata);
+        int result = rop.renderer()->get_texture_info (NULL, filename, 0,
+                                                       dataname, t, mydata);
         // Now we turn
         //       gettextureinfo result filename dataname data
         // into this for success:

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -139,7 +139,7 @@ RendererServices::texture (ustring filename, TextureOpt &options,
                                          nchannels, result, dresultds, dresultdt);
     if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size()) {
+        if (err.size() && sg) {
             sg->context->error ("[RendererServices::texture] %s", err);
         }
     }
@@ -160,7 +160,7 @@ RendererServices::texture3d (ustring filename, TextureOpt &options,
                                            dresultds, dresultdt, dresultdr);
     if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size()) {
+        if (err.size() && sg) {
             sg->context->error ("[RendererServices::texture3d] %s", err);
         }
     }
@@ -180,7 +180,7 @@ RendererServices::environment (ustring filename, TextureOpt &options,
                                              nchannels, result, dresultds, dresultdt);
     if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size()) {
+        if (err.size() && sg) {
             sg->context->error ("[RendererServices::environment] %s", err);
         }
     }
@@ -199,7 +199,7 @@ RendererServices::get_texture_info (ShaderGlobals *sg,
                                                    datatype, data);
     if (!status) {
         std::string err = texturesys()->geterror();
-        if (err.size()) {
+        if (err.size() && sg) {
             sg->context->error ("[RendererServices::get_texture_info] %s", err);
         }
     }


### PR DESCRIPTION
gettextureinfo constant fold fix: needs to call RS::get_texture_info(), but was incorrectly bypassing that straight to texturesys()->get_texture_info(). That's bad for a renderer that has a custom RS::get_texture_info and only a "mock" TextureSystem.