### PR TITLE
Enable oslc output of shader-wide metadata, and OSLQuery reading it properly

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -773,7 +773,13 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename)
     oso ("%s %s", shaderdecl->shadertypename(), 
          shaderdecl->shadername().c_str());
 
-    // FIXME -- output global hints and metadata
+    // output global hints and metadata
+    int hints = 0;
+    for (ASTNode::ref m = shaderdecl->metadata();  m;  m = m->next()) {
+        if (hints++ == 0)
+            oso ("\t");
+        write_oso_metadata (m.get());
+    }
 
     oso ("\n");
 

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -177,7 +177,7 @@ OSOReaderQuery::hint (const char *h)
     string_view hintstring (h);
     if (! Strutil::parse_char (hintstring, '%'))
         return;
-    if (m_reading_param && Strutil::parse_prefix(hintstring, "meta{")) {
+    if (Strutil::parse_prefix(hintstring, "meta{")) {
         // std::cerr << "  Metadata '" << hintstring << "'\n";
         Strutil::skip_whitespace (hintstring);
         std::string type = Strutil::parse_until (hintstring, ",}");
@@ -210,7 +210,10 @@ OSOReaderQuery::hint (const char *h)
             }
         }
         Strutil::parse_char (hintstring, '}');
-        m_query.m_params[m_query.nparams()-1].metadata.push_back (p);
+        if (m_reading_param) // Parameter metadata
+            m_query.m_params[m_query.nparams()-1].metadata.push_back (p);
+        else // global shader metadata
+            m_query.m_meta.push_back (p);
         return;
     }
     if (m_reading_param && Strutil::parse_prefix(hintstring, "structfields{")) {

--- a/testsuite/oslinfo-metadata/metadata.osl
+++ b/testsuite/oslinfo-metadata/metadata.osl
@@ -1,4 +1,6 @@
-surface metadata (
+surface metadata
+        [[ string description = "everything is awesome" ]]
+   (
     int myparam1 = 1 [[ int i = 0, float f = 1.0, string s = "foo" ]],
     int myparam2 = 2 [[ string s[2] = { "foo", "bar" } ]],
     int myparam3 = 3 [[ float minmax[2] = { 42, 44 } ]],

--- a/testsuite/oslinfo-metadata/ref/out.txt
+++ b/testsuite/oslinfo-metadata/ref/out.txt
@@ -1,5 +1,6 @@
 Compiled metadata.osl -> metadata.oso
 surface "metadata"
+		metadata: string description = "everything is awesome"
     "myparam1" "int"
 		Default value: 1
 		metadata: int i = 0


### PR DESCRIPTION
Contributed by Steve Agland from Animal Logic. Steve sent this to us quite a while back, there was some delay in working out the CLA, and when it was finally done, LG dropped the ball and took embarrassingly long to integrate the patch.  So sorry for the delay, Steve.
