### PR TITLE
Fix two bugs related to renderer outputs

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -58,6 +58,7 @@ ShaderInstance::ShaderInstance (ShaderMaster::ref master,
       m_layername(layername),
       m_writes_globals(false), m_run_lazily(false),
       m_outgoing_connections(false),
+      m_renderer_outputs(false),
       m_firstparam(m_master->m_firstparam), m_lastparam(m_master->m_lastparam),
       m_maincodebegin(m_master->m_maincodebegin),
       m_maincodeend(m_master->m_maincodeend)
@@ -335,8 +336,10 @@ ShaderInstance::copy_code_from_master (ShaderGroup &group)
                 si->connected_down (m_instoverrides[i].connected_down());
                 si->lockgeom (m_instoverrides[i].lockgeom());
             }
-            if (shadingsys().is_renderer_output (layername(), si->name(), &group))
+            if (shadingsys().is_renderer_output (layername(), si->name(), &group)) {
                 si->renderer_output (true);
+                renderer_outputs (true);
+            }
         }
     }
     off_t symmem = vectorbytes(m_instsymbols) - vectorbytes(m_instoverrides);
@@ -426,9 +429,10 @@ ShaderInstance::compute_run_lazily ()
         // group) or shaders that alter global variables (unless
         // 'lazyglobals' is turned on).
         if (shadingsys().m_lazyglobals)
-            run_lazily (outgoing_connections());
+            run_lazily (outgoing_connections() && ! renderer_outputs());
         else
-            run_lazily (outgoing_connections() && ! writes_globals());
+            run_lazily (outgoing_connections() && ! writes_globals()
+                                               && ! renderer_outputs());
 #if 0
         // Suggested warning below... but are there use cases where people
         // want these to run (because they will extract the results they

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -533,6 +533,11 @@ public:
     ///
     void outgoing_connections (bool out) { m_outgoing_connections = out; }
 
+    /// Does this instance have any renderer outputs?
+    bool renderer_outputs () const { return m_renderer_outputs; }
+    /// Set whether this instance has renderer outputs
+    void renderer_outputs (bool out) { m_renderer_outputs = out; }
+
     int maincodebegin () const { return m_maincodebegin; }
     int maincodeend () const { return m_maincodeend; }
 
@@ -594,7 +599,8 @@ public:
 
     /// Does it appear that the layer is completely unused?
     ///
-    bool unused () const { return run_lazily() && ! outgoing_connections(); }
+    bool unused () const { return run_lazily() && ! outgoing_connections()
+                                               && ! renderer_outputs(); }
 
     /// Is the instance reduced to nothing but an 'end' instruction and no
     /// symbols?
@@ -652,6 +658,7 @@ private:
     bool m_writes_globals;              ///< Do I have side effects?
     bool m_run_lazily;                  ///< OK to run this layer lazily?
     bool m_outgoing_connections;        ///< Any outgoing connections?
+    bool m_renderer_outputs;            ///< Any outputs params render outputs?
     ConnectionVec m_connections;        ///< Connected input params
     int m_firstparam, m_lastparam;      ///< Subset of symbols that are params
     int m_maincodebegin, m_maincodeend; ///< Main shader code range

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2194,7 +2194,12 @@ ShadingSystemImpl::is_renderer_output (ustring layername, ustring paramname,
             return true;
     }
     const std::vector<ustring> &aovs (m_renderer_outputs);
-    return std::find (aovs.begin(), aovs.end(), paramname) != aovs.end();
+    if (std::find (aovs.begin(), aovs.end(), paramname) != aovs.end())
+        return true;
+    ustring name2 = ustring::format ("%s.%s", layername, paramname);
+    if (std::find (aovs.begin(), aovs.end(), name2) != aovs.end())
+        return true;
+    return false;
 }
 
 


### PR DESCRIPTION
1. When deciding whether an output param is a renderer output, we should have checked if the renderer output list contained the layer-specified output name, as well as the unqualified (any layer) name. We did it right for the group-specific output list, but not for the renderer-wide output list.

2. Don't consider a layer unused if its outputs are renderer outputs. We were optimizing away layers, or skipping them during "lazy" evaluation, if they weren't setting any "globals" and didn't have any downstream connections. But if it sets a renderer output, it needs to be run unconditionally.
