### PR TITLE
New option: opt_merge_instances_with_userdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             group-outputs groupstring
             hyperb ieee_fp if incdec initops intbits isconnected
             layers layers-Ciassign layers-lazy layers-repeatedoutputs
-            logic loop matrix message metadata-braces miscmath missing-shader
+            logic loop matrix message mergeinstances-nouserdata
+            metadata-braces miscmath missing-shader
             noise noise-cell
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter
             noise-perlin noise-uperlin noise-simplex noise-usimplex

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -138,7 +138,8 @@ public:
     ///         opt_simplify_param, opt_constant_fold, opt_stale_assign,
     ///         opt_elide_useless_ops, opt_elide_unconnected_outputs,
     ///         opt_peephole, opt_coalesce_temps, opt_assign, opt_mix
-    ///         opt_merge_instances, opt_fold_getattribute
+    ///         opt_merge_instances, opt_merge_instance_with_userdata,
+    ///         opt_fold_getattribute
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Set LLVM extra debug level (0)
     ///    int max_local_mem_KB   Error if shader group needs more than this

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -515,8 +515,13 @@ public:
     int id () const { return m_id; }
 
     /// Does this instance potentially write to any global vars?
-    ///
     bool writes_globals () const { return m_writes_globals; }
+    void writes_globals (bool val) { m_writes_globals = val; }
+
+    /// Does this instance potentially read userdata to initialize any of
+    /// its parameters?
+    bool userdata_params () const { return m_userdata_params; }
+    void userdata_params (bool val) { m_userdata_params = val; }
 
     /// Should this instance only be run lazily (i.e., not
     /// unconditionally)?
@@ -611,8 +616,11 @@ public:
     }
 
     /// Make our own version of the code and args from the master.
-    ///
     void copy_code_from_master (ShaderGroup &group);
+
+    /// Check the params to re-assess writes_globals and userdata_params.
+    /// Sorry, can't think of a short name that isn't too cryptic.
+    void evaluate_writes_globals_and_userdata_params ();
 
     /// Small data structure to hold just the symbol info that the
     /// instance overrides from the master copy.
@@ -628,6 +636,7 @@ public:
         const char *valuesourcename () const { return Symbol::valuesourcename(valuesource()); }
         bool connected_down () const { return m_connected_down; }
         void connected_down (bool c) { m_connected_down = c; }
+        bool connected () const { return valuesource() == Symbol::ConnectedVal; }
         bool lockgeom () const { return m_lockgeom; }
         void lockgeom (bool l) { m_lockgeom = l; }
         friend bool equivalent (const SymOverrideInfo &a, const SymOverrideInfo &b) {
@@ -656,6 +665,7 @@ private:
     std::vector<ustring> m_sparams;     ///< string param values
     int m_id;                           ///< Unique ID for the instance
     bool m_writes_globals;              ///< Do I have side effects?
+    bool m_userdata_params;             ///< Might I read userdata for params?
     bool m_run_lazily;                  ///< OK to run this layer lazily?
     bool m_outgoing_connections;        ///< Any outgoing connections?
     bool m_renderer_outputs;            ///< Any outputs params render outputs?
@@ -1005,6 +1015,7 @@ private:
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_opt_mix;                       ///< Special 'mix' optimizations
     char m_opt_merge_instances;           ///< Merge identical instances?
+    bool m_opt_merge_instances_with_userdata; ///< Merge identical instances if they have userdata?
     bool m_opt_fold_getattribute;         ///< Constant-fold getattribute()?
     bool m_opt_middleman;                 ///< Middle-man optimization?
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!

--- a/testsuite/layers-Ciassign/ref/out.txt
+++ b/testsuite/layers-Ciassign/ref/out.txt
@@ -1,8 +1,8 @@
 Compiled a.osl -> a.oso
 Compiled b.osl -> b.oso
 Connect alayer.out to blayer.in
-b start, Ci = ''
 a start, Ci = ''
 a end, Ci = '(1, 0, 0) * emission ()'
+b start, Ci = '(1, 0, 0) * emission ()'
 b end, Ci = '(0, 1, 0.5) * emission ()'
 

--- a/testsuite/mergeinstances-nouserdata/a.osl
+++ b/testsuite/mergeinstances-nouserdata/a.osl
@@ -1,0 +1,5 @@
+shader a (float x = 1 [[ int lockgeom=0 ]], output color Cout = 0)
+{
+    Cout = x*noise(P);
+    printf ("a: %g\n", Cout);
+}

--- a/testsuite/mergeinstances-nouserdata/b.osl
+++ b/testsuite/mergeinstances-nouserdata/b.osl
@@ -1,0 +1,5 @@
+shader b (color C1 = 0, color C2 = 0, output color Cout = 0)
+{
+    Cout = C1 + C2;
+    printf ("b: %g\n", Cout);
+}

--- a/testsuite/mergeinstances-nouserdata/ref/out.txt
+++ b/testsuite/mergeinstances-nouserdata/ref/out.txt
@@ -1,0 +1,9 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect a1.Cout to b.C1
+Connect a2.Cout to b.C2
+
+Output b.Cout to out.exr
+a: 0.5 0.193125 0.37725
+a: 0.5 0.193125 0.37725
+b: 1 0.38625 0.7545

--- a/testsuite/mergeinstances-nouserdata/run.py
+++ b/testsuite/mergeinstances-nouserdata/run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+# This test is specifically to test the opt_merge_instances_with_userdata
+# option. If working correctly when set to zero, the a1 and a2 layers should
+# NOT merge, and thus you will see two printf output line from "a".
+# On the other hand, a single "a" printf means that the a1 and a2 layers
+# merged, which is the correct default but should not happen when you
+# set opt_merge_instances_with_userdata=0.
+
+command = testshade("-options opt_merge_instances_with_userdata=0 " +
+                    "-layer a1 a -layer a2 a -layer b b -connect a1 Cout b C1 " +
+                    " -connect a2 Cout b C2 -o b.Cout out.exr")


### PR DESCRIPTION
The existing opt_merge_instances, when on (default), will merge shader instances within a group when they are completely isomorphic, having the same code, symbols, instance parameter values, and upstream connections. When two matching instances are found, they are combined into one.

However... we have discovered an interesting edge case, wherein the two retrieve userdata (geometry-bound parameters) and even though they are both retrieving what appears to be the same-named userdata, the particular renderer (not mine!) allows a level of flexibility where the renderer can bind different userdata ("hook the 's1' interpolated variable to this instance's 's' input parameter"), and that happens in a way where OSL per se doesn't really know that it's been bound to a different name than the name of the parameter. So if they have two instances, where different alternate userdata values are bound (again, in a way not discernable to OSL itself), it would be bad to merge the instances. Of course, they can turn off opt_merge_instances to avoid any spooky bugs, but that turns off all instance merging, even in nodes where no userdata is involved, and so the problem can't crop up.

Whew, okay, now that we're all on the same page, it should be clear how it's useful to have a new opt_merge_instances_with_userdata, which if turned off will prevent instances from merging if they need userdata (though other instances not using any userdata will still merge, assuming that the old opt_merge_instances is still turned on). The default for the new option is on, so in general nobody but this one site (or others in the future who need this) will need to care about it.

To implement this, of course we need to track this in the right places. Fairly straightforward. In fact, the code changes are smaller than the explanation above of why we're doing it.

Along the way, I also spotted a bug: although we were tracking whether shaders wrote global variables (P, N, Ci, and so on), and in theory were forcing instances that write globals to run unconditionally (rather than lazily), it turned out that we never set the flag. So now that's restored. It's not a total coincidence that I found this, because the places where we need to track whether an instance reads userdata is basically the same spot as where we should have been (and now are) tracking whether any globals are written.