### PR TITLE
Fixes for linking and installing OSL on the Windows platform

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -27,6 +27,13 @@ if (NOT BUILDSTATIC)
         )
 endif ()
 
+# oslquery symbols used in oslexec
+if (NOT BUILDSTATIC)
+    LIST(APPEND liboslexec_srcs
+        ../liboslquery/oslquery.cpp
+        )
+endif ()
+
 include_directories ( "${CMAKE_SOURCE_DIR}/src/liboslcomp" )
 
 FILE ( GLOB exec_headers "*.h" )

--- a/src/liboslquery/CMakeLists.txt
+++ b/src/liboslquery/CMakeLists.txt
@@ -1,5 +1,6 @@
-SET ( liboslquery_srcs oslquery.cpp ../liboslexec/osoreader.cpp
+SET ( liboslquery_srcs oslquery.cpp querystub.cpp ../liboslexec/osoreader.cpp
       ../liboslexec/typespec.cpp )
+
 FILE ( GLOB compiler_headers "../liboslexec/*.h" )
 INCLUDE_DIRECTORIES ( ../liboslexec )
 

--- a/src/liboslquery/querystub.cpp
+++ b/src/liboslquery/querystub.cpp
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2015 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/// The purpose of this file is to provide a stub for the OSLQuery::init()
+/// method for an app that do not have a full ShadingSystem (oslinfo for
+/// instance)
+/// This enables such apps to link on the Windows platform while not
+/// introducing dependencies to liboslexec (where the actual method
+/// is implemented)
+
+#include "OSL/oslquery.h"
+using namespace OSL;
+
+
+
+bool
+OSLQuery::init (const ShaderGroup *group, int layernum)
+{
+    return false;
+}
+

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -15,11 +15,7 @@ endif ()
 TARGET_LINK_LIBRARIES (libtestshade oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} )
 SET_TARGET_PROPERTIES (libtestshade PROPERTIES PREFIX "")
 
-if (BUILDSTATIC)
-    INSTALL ( TARGETS libtestshade LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
-else ()
-    INSTALL (TARGETS libtestshade LIBRARY DESTINATION lib ARCHIVE DESTINATION lib )
-endif ()
+INSTALL ( TARGETS libtestshade RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 
 # The 'testshade_dso' executable
 ADD_EXECUTABLE ( testshade_dso testshade_dso.cpp )


### PR DESCRIPTION
The first commit is a leftover from a previous commit. Sorry about that

The second commit is the promised patch. Notice that dynamic linking requires to include `oslquery.cpp` in the list of source files for `liboslexec` (because `OSLQuery::open()` is needed). I have not provided a stub for this method because I guess a dependency from `liboslexec` towards `liboslquery` is not a concern.

Another concern with this patch is that `OSLQuery` symbols are now present into two different librairies which may not please all linkers. In any case, both builds (static/dynamic) are OK for Win32.