### PR TITLE
Clear derivs in gettextureinfo output

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2703,6 +2703,9 @@ LLVMGEN (llvm_gen_gettextureinfo)
 
     llvm::Value *r = rop.ll.call_function ("osl_get_textureinfo", &args[0], args.size());
     rop.llvm_store_value (r, Result);
+    /* Do not leave derivs uninitialized */
+    if (Data.has_derivs())
+        rop.llvm_zero_derivs (Data);
 
     return true;
 }


### PR DESCRIPTION
This was affecting shaders using the "averagecolor" attribute and corrupting
computations later on.