### PR TITLE
Handle "space" in shader parameter default value

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -649,6 +649,10 @@ ASTvariable_declaration::param_one_default_literal (const Symbol *sym,
             ASTNode::ref val = ctr->args();
             float f[3];
             int nargs = 0;
+			if (val.get() && val->nodetype() == ASTNode::literal_node && val->typespec().is_string()) {
+				val = val->next();
+				completed = false;
+			}
             for (int c = 0;  c < 3;  ++c) {
                 if (val.get())
                     ++nargs;


### PR DESCRIPTION
When declaring a shader parameter, a default value like
```
point a = point ("space", x, y, z),
```
is not recognized as an %initexpr% and the "space" is ignored

Let's take a very simple shader:
```
shader test (point a = point ("shader", 0,0,0))
{
	point b = point ("shader", 0, 0, 0);
}
```
which results in the following oso file (slightly edited to keep it small):

```
shader test
param	point 	a	0 0 0		%read{2147483647,-1} %write{2147483647,-1}
local	point	b	%read{2147483647,-1} %write{0,0}
const	string	$const1	"shader"		%read{0,0} %write{2147483647,-1}
const	float	$const3	0		%read{0,0} %write{2147483647,-1}
code ___main___
	point		b $const1 $const3 $const3 $const3 	%filename{"test.osl"} %line{4} %argrw{"wrrrr"}
	end
```

Comparing with the code that initializes ``b``, one can see that there is no way ``a`` will get the right initial value.

With the proposed patch, the resulting oso is: 

```
shader test
param	point	a	0 0 0		%read{2147483647,-1} %write{0,0} %initexpr
local	point	b	%read{2147483647,-1} %write{1,1}
const	string	$const1	"shader"		%read{0,1} %write{2147483647,-1}
const	float	$const3	0		%read{0,1} %write{2147483647,-1}
code a
	point		a $const1 $const3 $const3 $const3 	%filename{"test.osl"} %line{2} %argrw{"wrrrr"}
code ___main___
	point		b $const1 $const3 $const3 $const3 	%filename{"test.osl"} %line{4} %argrw{"wrrrr"}
	end
```
There is now an %initexpr% attached to ``a`` with code that matches  ``b`` initialization.