### PR TITLE
Small spelling mistake - missing 't' in alignment

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -720,7 +720,7 @@ public:
 
     void register_closure (string_view name, int id, const ClosureParam *params,
                            PrepareClosureFunc prepare, SetupClosureFunc setup,
-                           int alignmen = 1);
+                           int alignment = 1);
 
     const ClosureEntry *get_entry (ustring name) const;
     const ClosureEntry *get_entry (int id) const {


### PR DESCRIPTION
I'm guessing the default value is preventing the compiler from detecting this name mismatch?