### PR TITLE
Do not optimize away layers connected to globals

### DIFF
--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -193,6 +193,16 @@ Symbol::print (std::ostream &out, int maxvals) const
         if (symtype() == SymTypeParam && ! lockgeom())
             out << " lockgeom=0";
     }
+    if (symtype() == SymTypeGlobal) {
+        if (connected())
+            out << " connected";
+        if (connected_down())
+            out << " down-connected";
+        if (!connected() && !connected_down())
+            out << " unconnected";
+        if (renderer_output())
+            out << " renderer-output";
+    }
     out << "\n";
     if (symtype() == SymTypeConst) {
         out << "\tconst: ";

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -357,6 +357,14 @@ ShaderInstance::copy_code_from_master (ShaderGroup &group)
             "should not have copied m_instsymbols yet");
     m_instsymbols = m_master->m_symbols;
 
+    // Handle connections to globals
+    for (int c = 0;  c < nconnections();  ++c) {
+        const Connection &con (connection (c));
+        Symbol *dstsym (symbol (con.dst.param));
+        if (dstsym->symtype() == SymTypeGlobal)
+			dstsym->valuesource (Symbol::ConnectedVal);
+	}
+
     // Copy the instance override data
     // Also set the renderer_output flags where needed.
     ASSERT (m_instoverrides.size() == (size_t)std::max(0,lastparam()));

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -641,9 +641,10 @@ RuntimeOptimizer::add_useparam (SymbolPtrVec &allsyms)
             int argind = op.firstarg() + a;
             SymbolPtr s = inst()->argsymbol (argind);
             DASSERT (s->dealias() == s);
-            // If this arg is a param and is read, remember it
-            if (s->symtype() != SymTypeParam && s->symtype() != SymTypeOutputParam)
-                continue;  // skip non-params
+           // If this arg is a param or a global and is read, remember it
+			if (s->symtype() != SymTypeParam && s->symtype() != SymTypeOutputParam && s->symtype() != SymTypeGlobal)
+                continue;  // skip all other types
+
             // skip if we've already 'usedparam'ed it unconditionally
             if (s->initialized() && in_main_code)
                 continue;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1745,8 +1745,10 @@ ShadingSystemImpl::ConnectShaders (string_view srclayer, string_view srcparam,
     }
 
     dstinst->add_connection (srcinstindex, srccon, dstcon);
-    dstinst->instoverride(dstcon.param)->valuesource (Symbol::ConnectedVal);
-    srcinst->instoverride(srccon.param)->connected_down (true);
+    if (dstcon.param < dstinst->lastparam())
+        dstinst->instoverride(dstcon.param)->valuesource (Symbol::ConnectedVal);
+    if (srccon.param < srcinst->lastparam())
+        srcinst->instoverride(srccon.param)->connected_down (true);
     srcinst->outgoing_connections (true);
 
     // if (debug())


### PR DESCRIPTION
When a layer is connected **only** to globals, it gets optimized away.

Let's take the swirl shader from the testsuite and break it into two parts

```
shader
swirl1 (float swirl = 0,
       output float s = 0, output float t = 0)
{
    float s1 = -1 + 2*u;
    float t1 = -1 + 2*v;

    float r = hypot (s1, t1);

    s = s1*cos(swirl*r) - t1*sin(swirl*r);
    t = s1*sin(swirl*r) + t1*cos(swirl*r);
}
```

```
shader
swirl2 (string texturename = "grid.tx",
       float s = u, float t = v,
       output color Cout = 0)
{
    Cout = texture(texturename, s, t,
                           "wrap", "periodic");
}
```

If you run this command
```
testshade -g 512 512 -od uint8 --o Cout out.tif --param swirl 2.0 --layer alayer swirl1 --layer blayer swirl2 --connect alayer s blayer s --connect alayer t blayer s
```
connecting outputs from the first layer to inputs of the second layer, you get the expected result.

![out](https://cloud.githubusercontent.com/assets/1331631/6177677/c88cf176-b308-11e4-9492-0c1e8a70a0cb.jpg)

But if you run 
```
testshade -g 512 512 -od uint8 --o Cout out.tif --param swirl 2.0 --layer alayer swirl1 --layer blayer swirl2 --connect alayer s blayer u --connect alayer t blayer v
```
writing the outputs of the first layer to (u,v), you get

![out wrong](https://cloud.githubusercontent.com/assets/1331631/6177745/47782424-b309-11e4-9ad3-24553be2caa1.jpg)

OSL does not take into account connections to globals and therefore considers that the first layer does nothing.

The change in ```shadingsys.cpp``` is not related to this issue but fixes out of range access to ```m_instoverrides``` vector. I am unsure if ```std::vector``` does not perform this check anyway but it feels safer.