### PR TITLE
ShadingSystem: add a new version of execute() that takes a ShadingContext *

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -412,9 +412,13 @@ public:
     /// 'run' is false, do all the usual preparation, but don't actually
     /// run the shader.  Return true if the shader executed (or could
     /// have executed, if 'run' had been true), false the shader turned
-    /// out to be empty.
-    bool execute (ShadingContext &ctx, ShaderGroup &sas,
+    /// out to be empty. If ctx is NULL, then execute will request one
+    /// (based on the running thread) on its own and then return it when
+    /// it's done.
+    bool execute (ShadingContext *ctx, ShaderGroup &sas,
                   ShaderGlobals &ssg, bool run=true);
+    bool execute (ShadingContext &ctx, ShaderGroup &sas,
+                  ShaderGlobals &ssg, bool run=true); // DEPRECATED (1.6)
 
     /// Get a raw pointer to a named symbol (such as you'd need to pull
     /// out the value of an output parameter).  ctx is the shading

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -818,7 +818,7 @@ public:
 
     void release_context (ShadingContext *ctx);
 
-    bool execute (ShadingContext &ctx, ShaderGroup &group,
+    bool execute (ShadingContext *ctx, ShaderGroup &group,
                   ShaderGlobals &ssg, bool run=true);
 
     const void* get_symbol (ShadingContext &ctx, ustring layername,

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -256,10 +256,19 @@ ShadingSystem::release_context (ShadingContext *ctx)
 
 
 bool
-ShadingSystem::execute (ShadingContext &ctx, ShaderGroup &sas,
+ShadingSystem::execute (ShadingContext *ctx, ShaderGroup &sas,
                         ShaderGlobals &ssg, bool run)
 {
     return m_impl->execute (ctx, sas, ssg, run);
+}
+
+
+
+bool
+ShadingSystem::execute (ShadingContext &ctx, ShaderGroup &sas,
+                        ShaderGlobals &ssg, bool run)
+{
+    return m_impl->execute (&ctx, sas, ssg, run);
 }
 
 
@@ -2084,10 +2093,18 @@ ShadingSystemImpl::release_context (ShadingContext *ctx)
 
 
 bool
-ShadingSystemImpl::execute (ShadingContext &ctx, ShaderGroup &group,
+ShadingSystemImpl::execute (ShadingContext *ctx, ShaderGroup &group,
                             ShaderGlobals &ssg, bool run)
 {
-    return ctx.execute (group, ssg, run);
+    bool free_context = false;
+    if (! ctx) {
+        ctx = get_context();
+        free_context = true;
+    }
+    bool result = ctx->execute (group, ssg, run);
+    if (free_context)
+        release_context (ctx);
+    return result;
 }
 
 


### PR DESCRIPTION
ShadingSystem: add a new version of execute() that takes a ShadingContext *, and if NULL, execute() will get and release the context for you. Easy.

This is just a convenience function, but makes it simpler to execute a shader without the app needing to keep track of shading context ownership itself. It's only a minuscule amount more expensive than when the app fully tracks it.
