### PR TITLE
Refactor optimize_instance

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -60,6 +60,10 @@ public:
     /// instance variables and connections.
     void optimize_instance ();
 
+    /// One optimization pass over a range of instructions [begin, end).
+    /// Return the number of changes made.
+    int optimize_ops (int beginop, int endop);
+
     /// Post-optimization cleanup of a layer: add 'useparam' instructions,
     /// track variable lifetimes, coalesce temporaries.
     void post_optimize_instance ();


### PR DESCRIPTION
RuntimeOptimizer::optimize_instance() was getting really big and unwieldy.  This refactor, which just moves code without changing any behavior, breaks it into two pieces: (1) optimize_instance still loops over passes, and does per-pass optimizations and other housekeeping; (2) optimize_ops does all the per-op optimizations, over a range of ops.  So the guts of the loop over ops has just been broken out into a separate function.

The added benefit, which will be apparent in a future review of something I'm working on, is that there is utility in calling the optimize_ops over shorter ranges of ops, for particular purposes. Stay tuned. I wanted to do the code movement as a separate review because once I start changing it, it will be hard to follow the diffs if it moves around in the same review.