### PR TITLE
Have the context lazily grab texture_thread_info.

### DIFF
--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -53,7 +53,7 @@ ShadingContext::ShadingContext (ShadingSystemImpl &shadingsys,
 {
     m_shadingsys.m_stat_contexts += 1;
     m_threadinfo = threadinfo ? threadinfo : shadingsys.get_perthread_info ();
-    m_texture_thread_info = shadingsys.texturesys()->get_perthread_info ();
+    m_texture_thread_info = NULL;
 }
 
 
@@ -73,7 +73,7 @@ ShadingContext::~ShadingContext ()
 bool
 ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
 {
-    m_texture_thread_info = m_shadingsys.texturesys()->get_perthread_info ();
+    m_texture_thread_info = NULL;
     m_attribs = &sgroup;
 
     // Optimize if we haven't already

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1459,7 +1459,11 @@ public:
 
     PerThreadInfo *thread_info () const { return m_threadinfo; }
 
-    TextureSystem::Perthread *texture_thread_info () const { return m_texture_thread_info; }
+    TextureSystem::Perthread *texture_thread_info () const {
+        if (! m_texture_thread_info)
+            m_texture_thread_info = shadingsys().texturesys()->get_perthread_info ();
+        return m_texture_thread_info;
+    }
 
     TextureOpt *texture_options_ptr () { return &m_textureopt; }
 
@@ -1524,7 +1528,7 @@ private:
     ShadingSystemImpl &m_shadingsys;    ///< Backpointer to shadingsys
     RendererServices *m_renderer;       ///< Ptr to renderer services
     PerThreadInfo *m_threadinfo;        ///< Ptr to our thread's info
-    TextureSystem::Perthread *m_texture_thread_info; ///< Ptr to texture thread info
+    mutable TextureSystem::Perthread *m_texture_thread_info; ///< Ptr to texture thread info
     ShaderGroup *m_attribs;             ///< Ptr to shading attrib state
     std::vector<char> m_heap;           ///< Heap memory
     typedef boost::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;


### PR DESCRIPTION
For short shaders that don't use texture at all (and therefore don't
need the thread-specific pointer), this was causing undue overhead.