### PR TITLE
Allow get_context() to supply a TextureSystem::Perthread* to use for that context.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -400,7 +400,8 @@ public:
     /// lookup automatically (and at some additional cost).  The context
     /// can be used to shade many points; a typical usage is to allocate
     /// just one context per thread and use it for the whole run.
-    ShadingContext *get_context (PerThreadInfo *threadinfo=NULL);
+    ShadingContext *get_context (PerThreadInfo *threadinfo=NULL,
+                                 TextureSystem::Perthread *texture_threadinfo=NULL);
 
     /// Return a ShadingContext to the pool.
     ///

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -73,7 +73,6 @@ ShadingContext::~ShadingContext ()
 bool
 ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
 {
-    m_texture_thread_info = NULL;
     m_attribs = &sgroup;
 
     // Optimize if we haven't already

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -814,7 +814,8 @@ public:
 
     void destroy_thread_info (PerThreadInfo *threadinfo);
 
-    ShadingContext *get_context (PerThreadInfo *threadinfo = NULL);
+    ShadingContext *get_context (PerThreadInfo *threadinfo = NULL,
+                                 TextureSystem::Perthread *texture_threadinfo=NULL);
 
     void release_context (ShadingContext *ctx);
 
@@ -1463,6 +1464,10 @@ public:
         if (! m_texture_thread_info)
             m_texture_thread_info = shadingsys().texturesys()->get_perthread_info ();
         return m_texture_thread_info;
+    }
+
+    void texture_thread_info (TextureSystem::Perthread *t) {
+        m_texture_thread_info = t;
     }
 
     TextureOpt *texture_options_ptr () { return &m_textureopt; }


### PR DESCRIPTION
More texture per-thread tweaking: allow get_context() to supply aTextureSystem::Perthread* to use for that context.

This is helpful for renderers that want to save a bit of time by allocating such things up front.
