### PR TITLE
Shader params that are arrays of unspecified length

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,10 @@ Language, standard libary, and compiler changes (for shader writers):
   parameter lists and metadata lists. #447 (1.6.2)
 * oslc bug fixed in variable declaration + assignment of nested structs.
   #453 (1.6.2)
+* It is now supported to have shader parameters that are arrays of
+  unspecified length (like 'float foo[] = {0}'). Their length will be
+  fixed when they are assigned an instance value of fixed length, or when
+  connected to another layer's output parameter of fixed length. #481 (1.6.4)
 
 API changes, new options, new ShadingSystem features (for renderer writers):
 * New ShadingSystem attribute int "profile", if set to 1, will include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,9 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             texture-smallderivs texture-swirl
             texture-width texture-withderivs texture-wrap
             trailing-commas transform transformc trig typecast
-            unknown-instruction vecctr vector
+            unknown-instruction
+            vararray-connect vararray-param
+            vecctr vector
             wavelength_color xml )
 
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -630,6 +630,12 @@ public:
     bool lockgeom () const { return m_lockgeom; }
     void lockgeom (bool lock) { m_lockgeom = lock; }
 
+    int  arraylen () const { return m_typespec.arraylength(); }
+    void arraylen (int len) {
+        m_typespec.make_array(len);
+        m_size = m_typespec.simpletype().size();
+    }
+
     bool renderer_output () const { return m_renderer_output; }
     void renderer_output (bool v) { m_renderer_output = v; }
 

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -134,7 +134,7 @@ ASTvariable_declaration::typecheck_initlist (ref init, TypeSpec type,
     // Loop over a list of initializers (it's just 1 if not an array)...
     for (int i = 0;  init;  init = init->next(), ++i) {
         // Check for too many initializers for an array
-        if (type.is_array() && (i+1) > type.arraylength()) {
+        if (type.is_array() && (i > type.arraylength() && type.arraylength() > -1)) {
             error ("Too many initializers for a '%s'", type_c_str(type));
             break;
         }

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -151,27 +151,14 @@ void *
 ShaderInstance::param_storage (int index)
 {
     const Symbol *sym = m_instsymbols.size() ? symbol(index) : mastersymbol(index);
-    TypeDesc t = sym->typespec().simpletype();
-    if (t.basetype == TypeDesc::INT) {
-        return &m_iparams[sym->dataoffset()];
-    } else if (t.basetype == TypeDesc::FLOAT) {
-        return &m_fparams[sym->dataoffset()];
-    } else if (t.basetype == TypeDesc::STRING) {
-        return &m_sparams[sym->dataoffset()];
-    } else {
-        return NULL;
-    }
-}
 
-
-
-const void *
-ShaderInstance::param_storage (int index) const
-{
-    const Symbol *sym = m_instsymbols.size() ? symbol(index) : mastersymbol(index);
-
-    // Get the data offset. If there are instance overrides for symbols, check whether
-    // we are overriding the array size, otherwise just read the offset from the symbol.
+    // Get the data offset. If there are instance overrides for symbols,
+    // check whether we are overriding the array size, otherwise just read
+    // the offset from the symbol.  Overrides for arraylength -- which occur
+    // when an indefinite-sized array parameter gets a value (with a concrete
+    // length) -- are special, because in that case the new storage is
+    // allocated at the end of the previous parameter list, and thus is not
+    // where the master may have thought it was.
     int offset;
     if (m_instoverrides.size() && m_instoverrides[index].arraylen())
         offset = m_instoverrides[index].dataoffset();
@@ -188,6 +175,16 @@ ShaderInstance::param_storage (int index) const
     } else {
         return NULL;
     }
+}
+
+
+
+const void *
+ShaderInstance::param_storage (int index) const
+{
+    // Rather than repeating code here, just use const_cast and call the
+    // non-const version of this method.
+    return (const_cast<ShaderInstance*>(this))->param_storage(index);
 }
 
 
@@ -215,19 +212,6 @@ ShaderInstance::parameters (const ParamValueList &params)
 
     m_instoverrides.resize (std::max (0, lastparam()));
 
-    {
-        // Adjust the stats
-        ShadingSystemImpl &ss (shadingsys());
-        spin_lock lock (ss.m_stat_mutex);
-        size_t symmem = vectorbytes(m_instoverrides);
-        size_t parammem = (vectorbytes(m_iparams) + vectorbytes(m_fparams) +
-                           vectorbytes(m_sparams));
-        ss.m_stat_mem_inst_syms += symmem;
-        ss.m_stat_mem_inst_paramvals += parammem;
-        ss.m_stat_mem_inst += (symmem+parammem);
-        ss.m_stat_memory += (symmem+parammem);
-    }
-
     // Set the initial lockgeom on the instoverrides, based on the master.
     for (int i = 0, e = (int)m_instoverrides.size(); i < e; ++i)
         m_instoverrides[i].lockgeom (master()->symbol(i)->lockgeom());
@@ -239,21 +223,29 @@ ShaderInstance::parameters (const ParamValueList &params)
         if (i >= 0) {
             // if (shadingsys().debug())
             //     shadingsys().info (" PARAMETER %s %s", p.name(), p.type());
-            const Symbol *sm = master()->symbol(i);
-            SymOverrideInfo *so = &m_instoverrides[i];
-            TypeSpec t = sm->typespec();
-            // don't allow assignment of closures
-            if (t.is_closure()) {
-                shadingsys().warning ("skipping assignment of closure: %s", sm->name().c_str());
+            const Symbol *sm = master()->symbol(i);    // This sym in the master
+            SymOverrideInfo *so = &m_instoverrides[i]; // Slot for sym's override info
+            TypeSpec sm_typespec = sm->typespec(); // Type of the master's param
+            if (sm_typespec.is_closure_based()) {
+                // Can't assign a closure instance value.
+                shadingsys().warning ("skipping assignment of closure: %s", sm->name());
                 continue;
             }
-            if (t.is_structure())
-                continue;
-            // check type of parameter and matching symbol
-            if (!compatible(t.simpletype(), p.type())) {
-                shadingsys().warning ("attempting to set parameter with wrong type: %s (expected '%s', received '%s')", sm->name().c_str(), t.c_str(), p.type().c_str());
+            if (sm_typespec.is_structure())
+                continue;    // structs are just placeholders; skip
+
+            // Check type of parameter and matching symbol. Note that the
+            // compatible accounts for indefinite-length arrays.
+            TypeDesc paramtype = sm_typespec.simpletype();
+            TypeDesc valuetype = p.type();
+            if (!compatible(paramtype, valuetype)) {
+                shadingsys().warning ("attempting to set parameter with wrong type: %s (expected '%s', received '%s')",
+                                      sm->name(), paramtype, valuetype);
                 continue;
             }
+
+            // Mark that the override as an instance value
+            so->valuesource (Symbol::InstanceVal);
 
             // Lock the param against geometric primitive overrides if the
             // master thinks it was so locked, AND the Parameter() call
@@ -263,62 +255,71 @@ ShaderInstance::parameters (const ParamValueList &params)
                              p.interp() == ParamValue::INTERP_CONSTANT);
             so->lockgeom (lockgeom);
 
-            // Todo: Should we check for default values in case of unsized array?
-            bool assignmentToUnsizedArray = t.arraylength() == -1 && p.type().arraylen > 0;
-            if (!assignmentToUnsizedArray) {
-                // If the instance value is the same as the master's default,
-                // just skip the parameter, let it "keep" the default.
-                void *defaultdata = m_master->param_default_storage(i);
-                if (lockgeom &&
-                      memcmp (defaultdata, p.data(), t.simpletype().size()) == 0) {
-                    // Must reset valuesource to default, in case the parameter
-                    // was set already, and now is being changed back to default.
-                    so->valuesource (Symbol::DefaultVal);
-                    void *data = param_storage(i);
-                    memcpy (data, p.data(), t.simpletype().size()); // clobber old value
-                    continue;
-                }
-            } else if (so->arraylen() != p.type().arraylen) {
-                so->arraylen(p.type().arraylen);
-                // Allocate space for the new param size
-
-                // Skip structs for now, they're just placeholders
-                if      (t.is_structure()) {
-                }
-                else if (t.simpletype().basetype == TypeDesc::FLOAT) {
+            if (paramtype.arraylen < 0) {
+                // An array of definite size was supplied to a parameter
+                // that was an array of indefinite size. Magic! The trick
+                // here is that we need to allocate paramter space at the
+                // END of the ordinary param storage, since when we assigned
+                // data offsets to each parameter, we didn't know the length
+                // needed to allocate this param in its proper spot.
+                ASSERT (valuetype.arraylen > 0);
+                // Store the actual length in the shader instance parameter
+                // override info.
+                so->arraylen (valuetype.arraylen);
+                // Allocate space for the new param size at the end of its
+                // usual parameter area, and set the new dataoffset to that
+                // position.
+                int nelements = valuetype.arraylen * valuetype.aggregate;
+                if (paramtype.basetype == TypeDesc::FLOAT) {
                     so->dataoffset((int) m_fparams.size());
-                    expand (m_fparams, p.type().size());
-                } else if (t.simpletype().basetype == TypeDesc::INT) {
+                    expand (m_fparams, nelements);
+                } else if (paramtype.basetype == TypeDesc::INT) {
                     so->dataoffset((int) m_iparams.size());
-                    expand (m_iparams, p.type().size());
-                } else if (t.simpletype().basetype == TypeDesc::STRING) {
+                    expand (m_iparams, nelements);
+                } else if (paramtype.basetype == TypeDesc::STRING) {
                     so->dataoffset((int) m_sparams.size());
-                    expand (m_sparams, p.type().size());
-                } else if (t.is_closure()) {
-                    // Closures are pointers, so we allocate a string default taking
-                    // adventage of their default being NULL as well.
-                    so->dataoffset((int) m_sparams.size());
-                    expand (m_sparams, p.type().size());
+                    expand (m_sparams, nelements);
                 } else {
                     ASSERT (0 && "unexpected type");
                 }
-
-                // Todo: this is not taking into account interactive rendering editing
-                //       with different size... should we support that?
+                // FIXME: There's a tricky case that we overlook here, where
+                // an indefinite-length-array parameter is given DIFFERENT
+                // definite length in subsequent rerenders. Don't do that.
+            }
+            else {
+                // If the instance value is the same as the master's default,
+                // just skip the parameter, let it "keep" the default.
+                // Note that this can't/shouldn't happen for the indefinite-
+                // sized array case, which is why we have it in the 'else'
+                // clause of that test.
+                void *defaultdata = m_master->param_default_storage(i);
+                if (lockgeom &&
+                      memcmp (defaultdata, p.data(), valuetype.size()) == 0) {
+                    // Must reset valuesource to default, in case the parameter
+                    // was set already, and now is being changed back to default.
+                    so->valuesource (Symbol::DefaultVal);
+                }
             }
 
-            so->valuesource (Symbol::InstanceVal);
-            void *data = param_storage(i);
-
-            memcpy (data, p.data(), t.simpletype().size());
-            // if (shadingsys().debug())
-            //     shadingsys().info ("    sym %s offset %llu address %p",
-            //             sm->name().c_str(),
-            //             (unsigned long long)sm->dataoffset(), data);
+            // Copy the supplied data into place.
+            memcpy (param_storage(i), p.data(), valuetype.size());
         }
         else {
-            shadingsys().warning ("attempting to set nonexistent parameter: %s", p.name().c_str());
+            shadingsys().warning ("attempting to set nonexistent parameter: %s", p.name());
         }
+    }
+
+    {
+        // Adjust the stats
+        ShadingSystemImpl &ss (shadingsys());
+        spin_lock lock (ss.m_stat_mutex);
+        size_t symmem = vectorbytes(m_instoverrides);
+        size_t parammem = (vectorbytes(m_iparams) + vectorbytes(m_fparams) +
+                           vectorbytes(m_sparams));
+        ss.m_stat_mem_inst_syms += symmem;
+        ss.m_stat_mem_inst_paramvals += parammem;
+        ss.m_stat_mem_inst += (symmem+parammem);
+        ss.m_stat_memory += (symmem+parammem);
     }
 }
 

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -140,16 +140,6 @@ OSOReaderToMaster::shader (const char *shadertype, const char *name)
 
 
 
-// Helper function to expand vec by 'size' elements, initializing them to 0.
-template<class T>
-inline void
-expand (std::vector<T> &vec, size_t size)
-{
-    vec.resize (vec.size() + size, T(0));
-}
-
-
-
 void
 OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name)
 {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -150,6 +150,16 @@ struct OpDescriptor {
 
 
 
+// Helper function to expand vec by 'size' elements, initializing them to 0.
+template<class T>
+inline void
+expand (std::vector<T> &vec, size_t size)
+{
+    vec.resize (vec.size() + size, T(0));
+}
+
+
+
 // Struct to hold records about what user data a group needs
 struct UserDataNeeded {
     ustring name;
@@ -625,12 +635,15 @@ public:
     /// Small data structure to hold just the symbol info that the
     /// instance overrides from the master copy.
     struct SymOverrideInfo {
-        char m_valuesource;
-        bool m_connected_down;
-        bool m_lockgeom;
+        // Using bit fields to keep the data in 8 bytes in total.
+        char m_valuesource:    3;
+        bool m_connected_down: 1;
+        bool m_lockgeom:       1;
+        int  m_arraylen:      27;
+        int  m_data_offset;
 
         SymOverrideInfo () : m_valuesource(Symbol::DefaultVal),
-                             m_connected_down(false), m_lockgeom(true) { }
+                             m_connected_down(false), m_lockgeom(true), m_arraylen(0), m_data_offset(0) { }
         void valuesource (Symbol::ValueSource v) { m_valuesource = v; }
         Symbol::ValueSource valuesource () const { return (Symbol::ValueSource) m_valuesource; }
         const char *valuesourcename () const { return Symbol::valuesourcename(valuesource()); }
@@ -639,9 +652,14 @@ public:
         bool connected () const { return valuesource() == Symbol::ConnectedVal; }
         bool lockgeom () const { return m_lockgeom; }
         void lockgeom (bool l) { m_lockgeom = l; }
+        int  arraylen () const { return m_arraylen; }
+        void arraylen (int s) { m_arraylen = s; }
+        int  dataoffset () const { return m_data_offset; }
+        void dataoffset (int o) { m_data_offset = o; }
         friend bool equivalent (const SymOverrideInfo &a, const SymOverrideInfo &b) {
             return a.valuesource() == b.valuesource() &&
-                   a.lockgeom() == b.lockgeom();
+                   a.lockgeom()    == b.lockgeom()    &&
+                   a.arraylen()    == b.arraylen();
         }
     };
     typedef std::vector<SymOverrideInfo> SymOverrideInfoVec;

--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -235,6 +235,7 @@ simple_typename
 
 arraylen_opt
         : '[' INT_LITERAL ']'           { $$ = $2; }
+        | '[' ']'                       { $$ = -1; }
         | /* empty */                   { $$ = 0; }
         ;
 

--- a/src/liboslexec/osoreader.cpp
+++ b/src/liboslexec/osoreader.cpp
@@ -69,11 +69,12 @@ OSOReader::parse_file (const std::string &filename)
     osoreader = this;
     osolexer = new osoFlexLexer (&input);
     assert (osolexer);
-    bool ok = ! osoparse ();   // osoparse returns nonzero if error
+    int errcode = osoparse ();   // osoparse returns nonzero if error
+    bool ok = ! errcode;   // osoparse returns nonzero if error
     if (ok) {
 //        m_err.info ("Correctly parsed %s", filename.c_str());
     } else {
-        m_err.error ("Failed parse of %s", filename.c_str());
+        m_err.error ("Failed parse of %s (error code %d)", filename.c_str(), errcode);
     }
     delete osolexer;
     osolexer = NULL;

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -113,9 +113,9 @@ bool
 equivalent (const TypeSpec &a, const TypeSpec &b)
 {
     return (a == b) || 
-        (a.is_vectriple_based() && b.is_vectriple_based() &&
+        (((a.is_vectriple_based() && b.is_vectriple_based()) || equivalent(a.m_simple, b.m_simple))  &&
          a.is_closure() == b.is_closure() &&
-         a.arraylength() == b.arraylength()) ||
+         (a.arraylength() == b.arraylength() || (a.arraylength() == -1 && b.arraylength() >0))) ||
         (a.is_structure() && b.is_structure() &&
          equivalent(a.structspec(), b.structspec()));
 }

--- a/testsuite/vararray-connect/ref/out.txt
+++ b/testsuite/vararray-connect/ref/out.txt
@@ -1,0 +1,10 @@
+Compiled test.osl -> test.oso
+Compiled upstream.osl -> upstream.oso
+Connect u.fout to t.a
+a array length 4
+  [0] = 2.1
+  [1] = 2.2
+  [2] = 2.3
+  [3] = 2.4
+b array length -1
+

--- a/testsuite/vararray-connect/run.py
+++ b/testsuite/vararray-connect/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python 
+
+#command += testshade("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in")
+command += testshade("-layer u upstream -layer t test -connect u fout t a")

--- a/testsuite/vararray-connect/test.osl
+++ b/testsuite/vararray-connect/test.osl
@@ -1,0 +1,13 @@
+void print_array_contents (string name, float f[])
+{
+    printf ("%s array length %d\n", name, arraylength(f));
+    for (int i = 0; i < arraylength(f); ++i)
+        printf ("  [%d] = %g\n", i, f[i]);
+}
+
+
+shader test (float a[] = {0}, float b[] = {0})
+{
+    print_array_contents ("a", a);
+    print_array_contents ("b", b);
+}

--- a/testsuite/vararray-connect/upstream.osl
+++ b/testsuite/vararray-connect/upstream.osl
@@ -1,0 +1,7 @@
+shader upstream (output float fout[4] = { 0, 0, 0, 0 })
+{
+    fout[0] = 2.1;
+    fout[1] = 2.2;
+    fout[2] = 2.3;
+    fout[3] = 2.4;
+}

--- a/testsuite/vararray-param/ref/out.txt
+++ b/testsuite/vararray-param/ref/out.txt
@@ -1,0 +1,9 @@
+Compiled test.osl -> test.oso
+a array length 5
+  [0] = 1.1
+  [1] = 1.2
+  [2] = 1.3
+  [3] = 1.4
+  [4] = 1.5
+b array length -1
+

--- a/testsuite/vararray-param/run.py
+++ b/testsuite/vararray-param/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python 
+
+#command += testshade("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in")
+command += testshade("-param:type=float[5] a 1.1,1.2,1.3,1.4,1.5 test")

--- a/testsuite/vararray-param/test.osl
+++ b/testsuite/vararray-param/test.osl
@@ -1,0 +1,13 @@
+void print_array_contents (string name, float f[])
+{
+    printf ("%s array length %d\n", name, arraylength(f));
+    for (int i = 0; i < arraylength(f); ++i)
+        printf ("  [%d] = %g\n", i, f[i]);
+}
+
+
+shader test (float a[] = {0}, float b[] = {0})
+{
+    print_array_contents ("a", a);
+    print_array_contents ("b", b);
+}


### PR DESCRIPTION
You could previously declare OSL functions that have parameters that are arrays of unspecified length (like 'float foo[]'), but there was not an effective way to make shader parameters like that.

This patch, mostly the work of Max Liani from Animal Logic (with a little touch-up from LG), more or less fully enables shader parameters that are arrays of unspecified length. When an instance value is provided, which must itself be of definite length, it fixes the length of the shader parameter. Or, within a shader group, when an upstream shader's output parameter (of definite length) is connected to a downstream shader's parameter of unspecified length, it fixes the length. This provides some interesting new flexibility to write shaders that take arrays as parameters, without knowing the maximum length when you are writing or compiling the shader.

It's still a little dicey to alter one of these parameters for "re-rendering". Even if you mark it as "lockgeom=0", once the length becomes fixed, it's fixed, and you can't (without redeclaring the shader group and starting over) change its length again. So beware of situations like that.

Max - I hope you approve of my changes. The overall logic is still as you had it, I just fixed a couple edge cases to address some bugs that I noticed when I made the test cases, and added lots of comments.
