### PR TITLE
Bug fix with closure code generation

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -134,7 +134,7 @@ ASTvariable_declaration::typecheck_initlist (ref init, TypeSpec type,
     // Loop over a list of initializers (it's just 1 if not an array)...
     for (int i = 0;  init;  init = init->next(), ++i) {
         // Check for too many initializers for an array
-        if (type.is_array() && (i > type.arraylength() && type.arraylength() > -1)) {
+        if (type.is_array() && (i >= type.arraylength() && type.arraylength() > -1)) {
             error ("Too many initializers for a '%s'", type_c_str(type));
             break;
         }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3068,16 +3068,17 @@ LLVMGEN (llvm_gen_closure)
         ASSERT(p.offset < clentry->struct_size);
         Symbol &sym = *rop.opargsym (op, carg + 2 + weighted);
         TypeDesc t = sym.typespec().simpletype();
-        if (t.vecsemantics == TypeDesc::NORMAL || t.vecsemantics == TypeDesc::POINT)
-            t.vecsemantics = TypeDesc::VECTOR;
-        if (!sym.typespec().is_closure_array() && !sym.typespec().is_structure() && t == p.type) {
+        if (!sym.typespec().is_closure_array() && !sym.typespec().is_structure()
+            && equivalent(t,p.type)) {
             llvm::Value* dst = rop.ll.offset_ptr (mem_void_ptr, p.offset);
             llvm::Value* src = rop.llvm_void_ptr (sym);
             rop.ll.op_memcpy (dst, src, (int)p.type.size(),
                              4 /* use 4 byte alignment for now */);
         } else {
-            rop.shadingcontext()->error ("Incompatible formal argument %d to '%s' closure. Prototypes don't match renderer registry.",
-                                    carg + 1, closure_name.c_str());
+            rop.shadingcontext()->error ("Incompatible formal argument %d to '%s' closure (%s %s, expected %s). Prototypes don't match renderer registry (%s:%d).",
+                                         carg + 1, closure_name,
+                                         sym.typespec().c_str(), sym.name(), p.type,
+                                         op.sourcefile(), op.sourceline());
         }
     }
 


### PR DESCRIPTION
I'm really not sure why this didn't ever come up earlier, but I found a minor bug in codegen for closure construction, wherein testing whether the passed argument matches the prototype used a more exact test than was necessary (== versus equivalent()), and if a vector and color temporary were coalesced in just the right way, it would say it was a bad argument type passed.

Also improved a nearby error message.

Also, while inspecting diffs of recent checkins to see what might have exposed this problem, noticed that the recent array checkin introduced an off-by-one error in oslc argument checking. Unrelated to this issue, and thus far unreported! But fixing it anyway.
