### PR TITLE
More uniform path for python binary retrieval

### DIFF
--- a/testsuite/aastep/run.py
+++ b/testsuite/aastep/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 64 64 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/and-or-not-synonyms/run.py
+++ b/testsuite/and-or-not-synonyms/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += oslinfo("-v test")
 command += testshade("test")

--- a/testsuite/arithmetic/run.py
+++ b/testsuite/arithmetic/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/array-derivs/run.py
+++ b/testsuite/array-derivs/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/array-range/run.py
+++ b/testsuite/array-range/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/array/run.py
+++ b/testsuite/array/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/blackbody/run.py
+++ b/testsuite/blackbody/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade ("-g 1000 64 -od half -o Cout out.exr test")
 outputs += [ "out.exr" ]

--- a/testsuite/blendmath/run.py
+++ b/testsuite/blendmath/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/breakcont/run.py
+++ b/testsuite/breakcont/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/bug-array-heapoffsets/run.py
+++ b/testsuite/bug-array-heapoffsets/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 64 64 --layer A textureRGB --layer B endRGB --connect A Cout B Cin  -od uint8 -o Cfinal out.tif")
 outputs = [ "out.tif" ]

--- a/testsuite/bug-locallifetime/run.py
+++ b/testsuite/bug-locallifetime/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/bug-outputinit/run.py
+++ b/testsuite/bug-outputinit/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # See the test.osl source for explanation of this test
 

--- a/testsuite/bug-param-duplicate/run.py
+++ b/testsuite/bug-param-duplicate/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-param myparam 0.25 -param myparam 1.0 test")

--- a/testsuite/bug-peep/run.py
+++ b/testsuite/bug-peep/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/cellnoise/run.py
+++ b/testsuite/cellnoise/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 512 512 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/closure/run.py
+++ b/testsuite/closure/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/color/run.py
+++ b/testsuite/color/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/comparison/run.py
+++ b/testsuite/comparison/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/component-range/run.py
+++ b/testsuite/component-range/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/const-array-fill/run.py
+++ b/testsuite/const-array-fill/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/const-array-params/run.py
+++ b/testsuite/const-array-params/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/debug-uninit/run.py
+++ b/testsuite/debug-uninit/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("--debuguninit -o Cout Cout.tif test")

--- a/testsuite/debugnan/run.py
+++ b/testsuite/debugnan/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("--debugnan -g 2 2 -o Cout Cout.tif test")

--- a/testsuite/derivs-muldiv-clobber/run.py
+++ b/testsuite/derivs-muldiv-clobber/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/derivs/run.py
+++ b/testsuite/derivs/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/error-dupes/run.py
+++ b/testsuite/error-dupes/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/exit/run.py
+++ b/testsuite/exit/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/exponential/run.py
+++ b/testsuite/exponential/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/function-earlyreturn/run.py
+++ b/testsuite/function-earlyreturn/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/function-outputelem/run.py
+++ b/testsuite/function-outputelem/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/function-simple/run.py
+++ b/testsuite/function-simple/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/geomath/run.py
+++ b/testsuite/geomath/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/getsymbol-nonheap/run.py
+++ b/testsuite/getsymbol-nonheap/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-od half -o a a.exr -o b b.exr -o c c.exr -g 64 64 test")
 outputs = [ "a.exr", "b.exr", "c.exr", "out.txt" ]

--- a/testsuite/group-outputs/run.py
+++ b/testsuite/group-outputs/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("--groupoutputs -od half -o a a.exr -o b b.exr -o c c.exr -g 64 64 test")
 outputs = [ "a.exr", "b.exr", "c.exr", "out.txt" ]

--- a/testsuite/hyperb/run.py
+++ b/testsuite/hyperb/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/ieee_fp/run.py
+++ b/testsuite/ieee_fp/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/if/run.py
+++ b/testsuite/if/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/incdec/run.py
+++ b/testsuite/incdec/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/initops/run.py
+++ b/testsuite/initops/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 3 3 --param a 10.0 test")

--- a/testsuite/intbits/run.py
+++ b/testsuite/intbits/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/isconnected/run.py
+++ b/testsuite/isconnected/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 1 1 --layer upstream upstream --layer downstream test " +
                     "--connect upstream out downstream a " +

--- a/testsuite/layers-Ciassign/run.py
+++ b/testsuite/layers-Ciassign/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-layer alayer a --layer blayer b --connect alayer out blayer in")

--- a/testsuite/layers-lazy/run.py
+++ b/testsuite/layers-lazy/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 2 2 -layer alayer a -layer blayer b --layer clayer c --connect alayer f_out clayer f_in --connect alayer c_out clayer c_in --connect blayer out clayer unused")

--- a/testsuite/layers/run.py
+++ b/testsuite/layers/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in")

--- a/testsuite/lazyglobals/run.py
+++ b/testsuite/lazyglobals/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 2 2 changeuv printuv")

--- a/testsuite/logic/run.py
+++ b/testsuite/logic/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/loop/run.py
+++ b/testsuite/loop/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/matrix/run.py
+++ b/testsuite/matrix/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/message/run.py
+++ b/testsuite/message/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade ("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in --connect alayer dummy blayer dummy")

--- a/testsuite/metadata-braces/run.py
+++ b/testsuite/metadata-braces/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += oslinfo("-v test")
 command += testshade("test")

--- a/testsuite/miscmath/run.py
+++ b/testsuite/miscmath/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/missing-shader/run.py
+++ b/testsuite/missing-shader/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 --layer lay1 foo --layer lay2 bar --connect lay1 x lay2 y")

--- a/testsuite/noise-cell/run.py
+++ b/testsuite/noise-cell/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename cell -param offset 0.0 -param scale 1.0 testnoise")

--- a/testsuite/noise-gabor/run.py
+++ b/testsuite/noise-gabor/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename gabor testnoise")

--- a/testsuite/noise-gabor2d-filter/run.py
+++ b/testsuite/noise-gabor2d-filter/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/noise-gabor3d-filter/run.py
+++ b/testsuite/noise-gabor3d-filter/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/noise-perlin/run.py
+++ b/testsuite/noise-perlin/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename perlin testnoise")

--- a/testsuite/noise-simplex/run.py
+++ b/testsuite/noise-simplex/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename simplex testnoise")

--- a/testsuite/noise-uperlin/run.py
+++ b/testsuite/noise-uperlin/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename uperlin -param offset 0.0 -param scale 1.0 testnoise")

--- a/testsuite/noise-usimplex/run.py
+++ b/testsuite/noise-usimplex/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testnoise.osl")
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif -param noisename usimplex -param offset 0.0 -param scale 1.0 testnoise")

--- a/testsuite/noise/run.py
+++ b/testsuite/noise/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade ("-g 512 512 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/oslc-D/run.py
+++ b/testsuite/oslc-D/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 command = oslc ("-Dfoo=bar test.osl")
 command += testshade ("test")

--- a/testsuite/oslc-empty/run.py
+++ b/testsuite/oslc-empty/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("-d test.osl")

--- a/testsuite/oslc-err-arrayindex/run.py
+++ b/testsuite/oslc-err-arrayindex/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-closuremul/run.py
+++ b/testsuite/oslc-err-closuremul/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-format/run.py
+++ b/testsuite/oslc-err-format/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-intoverflow/run.py
+++ b/testsuite/oslc-err-intoverflow/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-noreturn/run.py
+++ b/testsuite/oslc-err-noreturn/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-paramdefault/run.py
+++ b/testsuite/oslc-err-paramdefault/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/oslc-err-struct-dup/run.py
+++ b/testsuite/oslc-err-struct-dup/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/pnoise-cell/run.py
+++ b/testsuite/pnoise-cell/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testpnoise.osl")
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename cell -param offset 0.0 -param scale 1.0 testpnoise")

--- a/testsuite/pnoise-gabor/run.py
+++ b/testsuite/pnoise-gabor/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testpnoise.osl")
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename gabor testpnoise")

--- a/testsuite/pnoise-perlin/run.py
+++ b/testsuite/pnoise-perlin/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testpnoise.osl")
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename perlin testpnoise")

--- a/testsuite/pnoise-uperlin/run.py
+++ b/testsuite/pnoise-uperlin/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = oslc("../common/shaders/testpnoise.osl")
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif -param noisename uperlin -param offset 0.0 -param scale 1.0 testpnoise")

--- a/testsuite/pnoise/run.py
+++ b/testsuite/pnoise/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 512 512 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/pointcloud-fold/run.py
+++ b/testsuite/pointcloud-fold/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-param radius 1000.0 rdcloud")

--- a/testsuite/pointcloud/run.py
+++ b/testsuite/pointcloud/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 16 16 -od uint8 -o Cout out0.tif wrcloud")
 command += testshade("-g 256 256 -param radius 0.01 -od uint8 -o Cout out1.tif rdcloud")

--- a/testsuite/raytype/run.py
+++ b/testsuite/raytype/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("--raytype glossy test")

--- a/testsuite/render-background/run.py
+++ b/testsuite/render-background/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 failthresh = 0.005   # allow a little more LSB noise between platforms
 failpercent = 1

--- a/testsuite/render-bumptest/run.py
+++ b/testsuite/render-bumptest/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 outputs = [ "out.exr" ]
 command = testrender("-r 256 256 -aa 4 bumptest.xml out.exr")

--- a/testsuite/render-cornell/run.py
+++ b/testsuite/render-cornell/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 failthresh = 0.005   # allow a little more LSB noise between platforms
 outputs = [ "out.exr" ]

--- a/testsuite/render-furnace-diffuse/run.py
+++ b/testsuite/render-furnace-diffuse/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 outputs = [ "out.exr" ]
 command = testrender("-r 320 240 -aa 20 scene.xml out.exr")

--- a/testsuite/render-microfacet/run.py
+++ b/testsuite/render-microfacet/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 failthresh = 0.005
 failpercent = 0.1

--- a/testsuite/render-oren-nayar/run.py
+++ b/testsuite/render-oren-nayar/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 failthresh = 0.03   # allow a little more LSB noise between platforms
 failpercent = .5

--- a/testsuite/render-veachmis/run.py
+++ b/testsuite/render-veachmis/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 outputs = [ "out.exr" ]
 command = testrender("-r 320 240 -aa 4 veach.xml out.exr")

--- a/testsuite/render-ward/run.py
+++ b/testsuite/render-ward/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 failthresh = 0.006
 failpercent = 0.35

--- a/testsuite/reparam/run.py
+++ b/testsuite/reparam/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade ("-g 128 128 --layer testlay -param:lockgeom=0 scale 5.0 test -iters 2 -reparam testlay scale 15.0 -od uint8 -o Cout out.tif")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 import os
 import glob

--- a/testsuite/shortcircuit/run.py
+++ b/testsuite/shortcircuit/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/spline-nonuniformknots/run.py
+++ b/testsuite/spline-nonuniformknots/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 256 64 -od uint8 -o Cout out.tif test")
 outputs = [ "out.tif", "out.txt" ]

--- a/testsuite/spline/run.py
+++ b/testsuite/spline/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 -od uint8 -o Cspline color.tif -o DxCspline dcolor.tif -o Fspline float.tif -o DxFspline dfloat.tif -o NumKnots numknots.tif test")
 

--- a/testsuite/splineinverse/run.py
+++ b/testsuite/splineinverse/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 3 1 --center test")

--- a/testsuite/string/run.py
+++ b/testsuite/string/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/struct-array-mixture/run.py
+++ b/testsuite/struct-array-mixture/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/struct-array/run.py
+++ b/testsuite/struct-array/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/struct-err/run.py
+++ b/testsuite/struct-err/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # command = oslc("test.osl")
 # don't even need that -- it's automatic

--- a/testsuite/struct-layers/run.py
+++ b/testsuite/struct-layers/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("--layer alayer a --layer blayer b --connect alayer st_out.s blayer x.s --connect alayer st_out.t blayer x.t --connect alayer st_out blayer y --connect alayer r blayer r")

--- a/testsuite/struct-with-array/run.py
+++ b/testsuite/struct-with-array/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/struct-within-struct/run.py
+++ b/testsuite/struct-within-struct/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/struct/run.py
+++ b/testsuite/struct/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/ternary/run.py
+++ b/testsuite/ternary/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/texture-alpha/run.py
+++ b/testsuite/texture-alpha/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 command += testshade("-g 128 128 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-blur/run.py
+++ b/testsuite/texture-blur/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-derivs/run.py
+++ b/testsuite/texture-derivs/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 128 128 --center -od uint8 -o Cout out.tif -o dx dx.tif -o dy dy.tif -param scale 128.0 test")
 outputs = [ "out.txt", "out.tif", "dx.tif", "dy.tif" ]

--- a/testsuite/texture-firstchannel/run.py
+++ b/testsuite/texture-firstchannel/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 command += testshade("-g 128 128 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-interp/run.py
+++ b/testsuite/texture-interp/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-missingcolor/run.py
+++ b/testsuite/texture-missingcolor/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 command += testshade("-g 64 64 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-simple/run.py
+++ b/testsuite/texture-simple/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-smallderivs/run.py
+++ b/testsuite/texture-smallderivs/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-swirl/run.py
+++ b/testsuite/texture-swirl/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 512 512 --center --param swirl 2.0 -od uint8 -o Cout out.tif swirl")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-width/run.py
+++ b/testsuite/texture-width/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-withderivs/run.py
+++ b/testsuite/texture-withderivs/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 256 256 --center -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]

--- a/testsuite/texture-wrap/run.py
+++ b/testsuite/texture-wrap/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += "maketx ../common/textures/mandrill.tif --wrap clamp -o mandrill.tx ; \n"
 command += testshade("-g 64 64 --center -od uint8 -o Cblack black.tif -o Cclamp clamp.tif -o Cperiodic periodic.tif -o Cmirror mirror.tif -o Cdefault default.tif test")

--- a/testsuite/trailing-commas/run.py
+++ b/testsuite/trailing-commas/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += oslinfo("-v test")
 command += testshade("test")

--- a/testsuite/transform/run.py
+++ b/testsuite/transform/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/transformc/run.py
+++ b/testsuite/transformc/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/trig/run.py
+++ b/testsuite/trig/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/typecast/run.py
+++ b/testsuite/typecast/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/unknown-instruction/run.py
+++ b/testsuite/unknown-instruction/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 # Test what happens when an oso file contains an unknown instruction
 

--- a/testsuite/vecctr/run.py
+++ b/testsuite/vecctr/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")

--- a/testsuite/vector/run.py
+++ b/testsuite/vector/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("test")

--- a/testsuite/wavelength_color/run.py
+++ b/testsuite/wavelength_color/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command += testshade("-g 1000 64 -od float -o Cout out.exr test")
 outputs = [ "out.txt", "out.exr" ]

--- a/testsuite/xml/run.py
+++ b/testsuite/xml/run.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 
 command = testshade("-g 2 2 test")


### PR DESCRIPTION
Starting an executable python script with

    #!/usr/bin/env python

is preferable to

    #!/usr/bin/python

especially for those using a custom python that differs from that in /usr/bin. So once and for all, switch all the test scripts.
