### PR TITLE
Fix subtle optimizer bug

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1707,6 +1707,9 @@ public:
     /// Is the symbol a constant whose value is 1?
     static bool is_one (const Symbol &A);
 
+    /// For debugging, express A's constant value as a string.
+    static std::string const_value_as_string (const Symbol &A);
+
     /// Set up m_in_conditional[] to be true for all ops that are inside of
     /// conditionals, false for all unconditionally-executed ops,
     /// m_in_loop[] to be true for all ops that are inside a loop, and


### PR DESCRIPTION
Fix subtle optimizer bug -- under some very specific circumstances, an output parameter whose default value comes from "init ops" but which actually got an instance value, and was also connected to a downstream layer, could be eliminated but incorrectly, by passing along to the downstream shader the constant value it would have been assigned by default, rather than the constant instance value.

In addition to the bug fix itself, I also added some additional debugging aids.
