### PR TITLE
optimizer bug fix

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1297,13 +1297,14 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
     // just alias it to the constant from here on out.
     if (// R is being assigned a constant of the right type:
         A->is_constant() && R->typespec() == A->typespec()
+                // FIXME -- can this be equivalent() rather than == ?
         // and it's written only on this op, and unconditionally:
         && R->firstwrite() == opnum && R->lastwrite() == opnum
         && !m_in_conditional[opnum]
         // and this is not a case of an init op for an output param that
-        // actually will get an instance value:
-        && ! (R->valuesource() == Symbol::InstanceVal &&
-              opnum < inst()->maincodebegin())
+        // actually will get an instance value or a connection:
+        && ! ((R->valuesource() == Symbol::InstanceVal || R->connected())
+              && R->initbegin() <= opnum && R->initend() > opnum)
         ) {
         // Alias it to the constant it's being assigned
         int cind = inst()->args()[op.firstarg()+1];


### PR DESCRIPTION
Recently, in #485 I fixed a bug in outparam_assign_elision(), which tries to notice output params whose values are assigned only once in the shader, to a constant value, and change it to eliminate the assignment but simply have an instance value with that value. That bug fix was realizing that if the op in question is an "init op" for the param (ops needed to establish a default that can't be statically constant), and the param has an instance value, then the init ops are moot, won't come into play, so it's wrong to redundantly turn it into an instance valued based on that assignment (in effect, it's incorrectly changing the instance value it will get).

OK, so the present bug is in the same spot and just an extension of this. Not only if it's got an instance value, but also if it's got an upstream connection, these init ops are moot and it's wrong to change the assumed value -- in fact moreso, because we'd be wiping out a connection.

While doing this simple fix, I also realized that there's another spot where I can conveniently remove all the init ops for those cases where they are moot -- instance params and connected params, both of which make the init ops moot, so we can simply remove them.
