### PR TITLE
Fix bug with merging of instances

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -617,6 +617,14 @@ public:
     bool everread () const  { return lastread() >= 0; }
     bool everwritten () const { return lastwrite() >= 0; }
     bool everused () const  { return everread() || everwritten(); }
+    // everused_in_group is an even more stringent test -- not only must
+    // the symbol not be used within the shader but it also must not be
+    // used elsewhere in the group, by being connected to something downstream
+    // or used as a renderer output.
+    bool everused_in_group () const {
+        return everused() || connected_down() || renderer_output();
+    }
+
     void set_read (int first, int last) {
         m_firstread = first;  m_lastread = last;
     }

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -655,7 +655,8 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
 
             if (! (equivalent(m_instoverrides[i], b.m_instoverrides[i]))) {
                 const Symbol *sym = mastersymbol(i);  // remember, it's pre-opt
-                if (! sym->everused())
+                const Symbol *bsym = b.mastersymbol(i);
+                if (! sym->everused_in_group() && ! bsym->everused_in_group())
                     continue;
                 return false;
             }
@@ -670,10 +671,10 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
     // Make sure that the two nodes have the same parameter values.  If
     // the group has already been optimized, it's got an
     // instance-specific symbol table to check; but if it hasn't been
-    // optimized, we check the symbol table int he master.
+    // optimized, we check the symbol table in the master.
     for (int i = firstparam();  i < lastparam();  ++i) {
         const Symbol *sym = optimized ? symbol(i) : mastersymbol(i);
-        if (! sym->everused())
+        if (! sym->everused_in_group())
             continue;
         if (sym->typespec().is_closure())
             continue;   // Closures can't have instance override values

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1675,6 +1675,8 @@ RuntimeOptimizer::peephole2 (int opnum)
 void
 RuntimeOptimizer::mark_outgoing_connections ()
 {
+    ASSERT (! inst()->m_instoverrides.size() &&
+            "don't call this before copy_code_from_master");
     inst()->outgoing_connections (false);
     FOREACH_PARAM (Symbol &s, inst())
         s.connected_down (false);
@@ -2541,13 +2543,7 @@ RuntimeOptimizer::collapse_syms ()
 
     // Mark our params that feed to later layers, so that unused params
     // that aren't needed downstream can be removed.
-    FOREACH_PARAM (Symbol &s, inst())
-        s.connected_down (false);
-    for (int lay = layer()+1;  lay < group().nlayers();  ++lay) {
-        BOOST_FOREACH (Connection &c, group()[lay]->m_connections)
-            if (c.srclayer == layer())
-                inst()->symbol(c.src.param)->connected_down (true);
-    }
+    mark_outgoing_connections ();
 
     SymbolVec new_symbols;          // buffer for new symbol table
     std::vector<int> symbol_remap;  // mapping of old sym index to new
@@ -2689,6 +2685,14 @@ RuntimeOptimizer::run ()
         shadingcontext()->info ("About to optimize shader group %s (%d layers):",
                            group().name(), nlayers);
 
+    for (int layer = 0;  layer < nlayers;  ++layer) {
+        set_inst (layer);
+        if (inst()->unused())
+            continue;
+        // These need to happen before merge_instances
+        inst()->copy_code_from_master (group());
+        mark_outgoing_connections();
+    }
     if (shadingsys().m_opt_merge_instances == 1)
         shadingsys().merge_instances (group());
 
@@ -2700,7 +2704,6 @@ RuntimeOptimizer::run ()
         set_inst (layer);
         if (inst()->unused())
             continue;
-        inst()->copy_code_from_master (group());
         if (debug() && optimize() >= 1) {
             std::cout.flush ();
             std::cout << "Before optimizing layer " << layer << " " 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2507,6 +2507,7 @@ ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
                     Connection &con = inst->connection(c);
                     if (con.srclayer == b) {
                         con.srclayer = a;
+                        A->outgoing_connections (true);
                         if (B->symbols().size()) {
                             ASSERT (A->symbol(con.src.param)->name() ==
                                     B->symbol(con.src.param)->name());


### PR DESCRIPTION
When two instances were being examined for possible merging, and
* a parameter was not actually used anywhere inside the shader at all
* but one or both instances have that parameter connected to downstream nodes
* the two nodes have difference instance values for the parameter
(Luckily, this is a very weird, unusual, particular circumstance.)

We weren't quite careful enough to not merge in those circumstances.
Tighten up some of the tests and preconditions for merging.