### PR TITLE
Refactor methods to retrieve output symbol locations.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -47,6 +47,7 @@ typedef ShaderGroupRef ShadingAttribStateRef; // DEPRECATED name
 struct ClosureParam;
 struct PerThreadInfo;
 class ShadingContext;
+class ShaderSymbol;
 
 
 
@@ -434,10 +435,42 @@ public:
     /// separately, or by concatenating "layername.symbolname", but note
     /// that the latter will involve string manipulation inside get_symbol
     /// and is much more expensive than specifying them separately.
-    const void* get_symbol (ShadingContext &ctx, ustring layername,
-                            ustring symbolname, TypeDesc &type);
-    const void* get_symbol (ShadingContext &ctx, ustring symbolname,
-                            TypeDesc &type);
+    ///
+    /// These are considered somewhat deprecated, in favor of using
+    /// find_symbol(), symbol_typedesc(), and symbol_address().
+    const void* get_symbol (const ShadingContext &ctx, ustring layername,
+                            ustring symbolname, TypeDesc &type) const;
+    const void* get_symbol (const ShadingContext &ctx, ustring symbolname,
+                            TypeDesc &type) const;
+
+    /// Search for an output symbol by name (and optionally, layer) within
+    /// the optimized shader group. If the symbol is found, return an opaque
+    /// identifying pointer to it, otherwise return NULL. This is somewhat
+    /// expensive because of the name-based search, but once done, you can
+    /// reuse the pointer to the symbol for the lifetime of the group.
+    ///
+    /// If you give just a symbol name, it will search for the symbol in all
+    /// layers, last-to-first. If a specific layer is named, it will search
+    /// only that layer. You can specify a layer either by naming it
+    /// separately, or by concatenating "layername.symbolname", but note
+    /// that the latter will involve string manipulation inside find_symbol
+    /// and is much more expensive than specifying them separately.
+    const ShaderSymbol* find_symbol (const ShaderGroup &group,
+                             ustring layername, ustring symbolname) const;
+    const ShaderSymbol* find_symbol (const ShaderGroup &group,
+                                     ustring symbolname) const;
+
+    /// Given an opaque ShaderSymbol*, return the TypeDesc describing it.
+    /// Note that a closure will end up with a TypeDesc::UNKNOWN value.
+    TypeDesc symbol_typedesc (const ShaderSymbol *sym) const;
+
+    /// Given a context (that has executed a shader) and an opaque
+    /// ShserSymbol*, return the actual memory address where the value of
+    /// the symbol resides within the heap memory of the context. This
+    /// is only valid for the shader execution that had happened immediately
+    /// prior for this context, but it is a very inexpensive operation.
+    const void* symbol_address (const ShadingContext &ctx,
+                                const ShaderSymbol *sym) const;
 
     /// Return the statistics output as a huge string.
     ///

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -193,32 +193,20 @@ ShadingContext::process_errors () const
 
 
 
-Symbol *
-ShadingContext::symbol (ustring layername, ustring symbolname)
+const Symbol *
+ShadingContext::symbol (ustring layername, ustring symbolname) const
 {
-    ShaderGroup &sgroup (*attribs());
-    int nlayers = sgroup.nlayers ();
-    if (sgroup.llvm_compiled_version()) {
-        for (int layer = nlayers-1;  layer >= 0;  --layer) {
-            ShaderInstance *inst (sgroup[layer]);
-            if (layername.size() && layername != inst->layername())
-                continue;  // They asked for a specific layer and this isn't it
-            int symidx = inst->findsymbol (symbolname);
-            if (symidx >= 0)
-                return inst->symbol (symidx);
-        }
-    }
-    return NULL;
+    return attribs()->find_symbol (layername, symbolname);
 }
 
 
 
-void *
-ShadingContext::symbol_data (Symbol &sym)
+const void *
+ShadingContext::symbol_data (const Symbol &sym) const
 {
-    ShaderGroup &sgroup (*attribs());
-    if (! sgroup.llvm_compiled_version())
-        return NULL;   // can't retrieve symbol if we didn't JIT and runit
+    const ShaderGroup &sgroup (*attribs());
+    if (! sgroup.optimized())
+        return NULL;   // can't retrieve symbol if we didn't optimize it
 
     if (sym.dataoffset() >= 0 && (int)m_heap.size() > sym.dataoffset()) {
         // lives on the heap

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -789,6 +789,22 @@ ShaderGroup::~ShaderGroup ()
 
 
 
+const Symbol *
+ShaderGroup::find_symbol (ustring layername, ustring symbolname) const
+{
+    for (int layer = nlayers()-1;  layer >= 0;  --layer) {
+        const ShaderInstance *inst (m_layers[layer].get());
+        if (layername.size() && layername != inst->layername())
+            continue;  // They asked for a specific layer and this isn't it
+        int symidx = inst->findsymbol (symbolname);
+        if (symidx >= 0)
+            return inst->symbol (symidx);
+    }
+    return NULL;
+}
+
+
+
 std::string
 ShaderGroup::serialize () const
 {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1332,6 +1332,10 @@ public:
     void lock () const { m_mutex.lock(); }
     void unlock () const { m_mutex.unlock(); }
 
+    // Retrieve the Symbol* by layer and symbol name. If the layer name is
+    // empty, go back-to-front.
+    const Symbol* find_symbol (ustring layername, ustring symbolname) const;
+
 private:
     // Put all the things that are read-only (after optimization) and
     // needed on every shade execution at the front of the struct, as much
@@ -1446,11 +1450,13 @@ public:
     /// layer is specified, priority is given to later laters over earlier
     /// layers (if they name the same symbol). Return NULL if no such symbol
     /// is found.
-    Symbol * symbol (ustring layername, ustring symbolname);
-    Symbol * symbol (ustring symbolname) { return symbol (ustring(), symbolname); }
+    const Symbol * symbol (ustring layername, ustring symbolname) const;
+    const Symbol * symbol (ustring symbolname) const {
+        return symbol (ustring(), symbolname);
+    }
 
     /// Return a pointer to where the symbol's data lives.
-    void *symbol_data (Symbol &sym);
+    const void *symbol_data (const Symbol &sym) const;
 
     /// Return a reference to a compiled regular expression for the
     /// given string, being careful to cache already-created ones so we
@@ -1460,6 +1466,7 @@ public:
     /// Return a pointer to the shading attribs for this context.
     ///
     ShaderGroup *attribs () { return m_attribs; }
+    const ShaderGroup *attribs () const { return m_attribs; }
 
     /// Return a reference to the MessageList containing messages.
     ///


### PR DESCRIPTION
ShadingSystem::get_symbol() is what renderers call to retrieve the
memory location of renderer outputs, immediately after executing a
shader.  But it was more expensive than we ideally wanted.  Most of the
expense was in the name lookups, so we observe that if we can separate
the name resolution (expensive, but once per group) from the retrieval
of the address (once per shader execution, but cheap), we give renderers
a path to reduce per-shade overhead expense.

So we break it into two new methods: find_symbol(), which given a group
and the names will return an opaque pointer for the symbol that can be
reused for the lifetime of the shader group; and
symbol_address(ctx,sym), which retrieves the actual memory address of
the symbol for a particular shader execution of a context (inexpensive).
The old get_symbol() is now implemented in terms of these new
methods.

There is some fairly obvious refactoring and const-ifying to make this
happen.