### PR TITLE
Vararray defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,10 +356,10 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
-            oslc-err-noreturn oslc-err-paramdefault
+            oslc-err-noreturn oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-variadic-macro
-            oslinfo-metadata oslinfo-noparams
+            oslinfo-arrayparams oslinfo-metadata oslinfo-noparams
             pointcloud pointcloud-fold
             printf-whole-array
             raytype reparam
@@ -377,7 +377,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             texture-width texture-withderivs texture-wrap
             trailing-commas transform transformc trig typecast
             unknown-instruction
-            vararray-connect vararray-param
+            vararray-connect vararray-default vararray-param
             vecctr vector
             wavelength_color xml )
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -205,7 +205,15 @@ public:
 
     /// Returns the length of the array, or 0 if not an array.
     ///
-    int arraylength () const { return m_simple.arraylen; }
+    int arraylength () const { return abs(m_simple.arraylen); }
+
+    /// Is this a variable length array?
+    ///
+    bool is_varlen_array() const { return m_simple.arraylen < 0; }
+
+    /// Number of elements
+    ///
+    int numelements() const { return (m_simple.arraylen == 0) ? 1 : arraylength(); }
 
     /// Alter this typespec to make it into an array of the given length
     /// (including 0 -> make it not be an array).  The basic type (not

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -301,7 +301,7 @@ ASTNode::coerce (Symbol *sym, const TypeSpec &type, bool acceptfloat)
     if (acceptfloat && sym->typespec().is_float())
         return sym;
 
-    if (type.arraylength() == -1 && sym->typespec().is_array() &&
+    if (type.is_varlen_array() && sym->typespec().is_array() &&
         equivalent (sym->typespec().elementtype(), type.elementtype())) {
         // coercion not necessary to pass known length array to 
         // array parameter of unspecified length.

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -225,6 +225,11 @@ shader_formal_param
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($4);
+                    if ($1 && t.is_varlen_array()) {
+                        oslcompiler->error (oslcompiler->filename(),
+                                            @3.first_line,
+                                            "shader output parameter '%s' can't be unsized array", $3);
+                    }
                     ASTvariable_declaration *var;
                     var = new ASTvariable_declaration (oslcompiler, t, 
                                                    ustring($3), $5, true,
@@ -460,7 +465,7 @@ def_expression
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
-                    if (t.arraylength() < 1)
+                    if ($2 < 1)
                         oslcompiler->error (oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length for %s", $1);

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -49,17 +49,17 @@ TypeSpec::string () const
     std::string str;
     if (is_closure() || is_closure_array()) {
         str += "closure color";
-        if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-        else if (arraylength() < 0)
+        if (is_varlen_array())
             str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
     }
     else if (structure() > 0) {
         str += Strutil::format ("struct %d", structure());
-        if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-        else if (arraylength() < 0)
+        if (is_varlen_array())
             str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
     } else {
         str += simpletype().c_str();
     }

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -817,7 +817,7 @@ ASTNode::check_arglist (const char *funcname, ASTNode::ref arg,
             continue;
         // Allow a fixed-length array match to a formal array with
         // unspecified length, if the element types are the same.
-        if (formaltype.arraylength() < 0 && argtype.arraylength() &&
+        if (formaltype.is_varlen_array() && argtype.arraylength() &&
               formaltype.elementtype() == argtype.elementtype())
             continue;
 
@@ -1440,11 +1440,10 @@ OSLCompilerImpl::code_from_type (TypeSpec type) const
     }
 
     if (type.is_array()) {
-        int len = type.arraylength ();
-        if (len > 0)
-            out += Strutil::format ("[%d]", len);
-        else
+        if (type.is_varlen_array())
             out += "[]";
+        else
+            out += Strutil::format ("[%d]", type.arraylength());
     }
 
     return out;

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -177,7 +177,7 @@ BackendLLVM::llvm_assign_zero (const Symbol &sym)
     // This even works for closures.
     int len;
     if (sym.typespec().is_closure_based())
-        len = sizeof(void *) * std::max(1,sym.typespec().arraylength());
+        len = sizeof(void *) * sym.typespec().numelements();
     else
         len = sym.derivsize();
     // N.B. derivsize() includes derivs, if there are any

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -233,10 +233,15 @@ RuntimeOptimizer::add_constant (const TypeSpec &type, const void *data,
 {
     int ind = find_constant (type, data);
     if (ind < 0) {
+        // support varlen arrays
+        TypeSpec newtype = type;
+        if (type.is_varlen_array())
+          newtype.make_array(datatype.numelements());
+
         Symbol newconst (ustring::format ("$newconst%d", m_next_newconst++),
-                         type, SymTypeConst);
+                         newtype, SymTypeConst);
         void *newdata;
-        TypeDesc t (type.simpletype());
+        TypeDesc t (newtype.simpletype());
         size_t n = t.aggregate * t.numelements();
         if (datatype == TypeDesc::UNKNOWN)
             datatype = t;
@@ -795,7 +800,7 @@ RuntimeOptimizer::simplify_params ()
             // Plain default value without init ops -- turn it into a constant
             make_symbol_room (1);
             s = inst()->symbol(i);  // In case make_symbol_room changed ptrs
-            int cind = add_constant (s->typespec(), s->data());
+            int cind = add_constant (s->typespec(), s->data(), s->typespec().simpletype());
             global_alias (i, cind); // Alias this symbol to the new const
         } else if (s->valuesource() == Symbol::DefaultVal && s->has_init_ops()) {
             // Default val comes from init ops -- special cases?  Yes,

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2237,7 +2237,7 @@ ShadingSystemImpl::decode_connected_param (string_view connectionname,
 
     c.type = sym->typespec();
 
-    if (bracket && c.type.arraylength()) {
+    if (bracket && c.type.is_array()) {
         // There was at least one set of brackets that appears to be
         // selecting an array element.
         c.arrayindex = atoi (bracket+1);
@@ -2776,7 +2776,7 @@ OSL::OSLQuery::init (const ShaderGroup *group, int layernum)
             const TypeSpec &ts (sym->typespec());
             p.type = ts.simpletype();
             p.isoutput = (sym->symtype() == SymTypeOutputParam);
-            p.varlenarray = (p.type.arraylen < 0);
+            p.varlenarray = ts.is_varlen_array();
             p.isstruct = ts.is_structure() || ts.is_structure_array();
             p.isclosure = ts.is_closure_based();
             p.data = sym->data();

--- a/testsuite/oslc-err-outputparamvararray/ref/out.txt
+++ b/testsuite/oslc-err-outputparamvararray/ref/out.txt
@@ -1,0 +1,2 @@
+test.osl:2: error: shader output parameter 'c' can't be unsized array
+FAILED test.osl

--- a/testsuite/oslc-err-outputparamvararray/run.py
+++ b/testsuite/oslc-err-outputparamvararray/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python 
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-outputparamvararray/test.osl
+++ b/testsuite/oslc-err-outputparamvararray/test.osl
@@ -1,0 +1,4 @@
+shader
+test (output color c[] = {color(1,1,1)})
+{
+}

--- a/testsuite/oslinfo-arrayparams/arrayparams.osl
+++ b/testsuite/oslinfo-arrayparams/arrayparams.osl
@@ -1,0 +1,8 @@
+surface arrayparams (
+    float farrayparam[1] = {1},
+    float farrayparamunsized[] = {7,8,9},
+    vector varrayparam[3] = {vector(1,2,3), vector(4,5,6), vector(7,8,9)},
+    vector varrayparamunsized[] = {vector(1,1,1), vector(2,2,2), vector(3,3,3), vector(3,2,1)}
+    )
+{
+}

--- a/testsuite/oslinfo-arrayparams/ref/out.txt
+++ b/testsuite/oslinfo-arrayparams/ref/out.txt
@@ -1,0 +1,10 @@
+Compiled arrayparams.osl -> arrayparams.oso
+surface "arrayparams"
+    "farrayparam" "float[1]"
+		Default value: [ 1 ]
+    "farrayparamunsized" "float[]"
+		Default value: [ 7 8 9 ]
+    "varrayparam" "vector[3]"
+		Default value: [ 1 2 3 4 5 6 7 8 9 ]
+    "varrayparamunsized" "vector[]"
+		Default value: [ 1 1 1 2 2 2 3 3 3 3 2 1 ]

--- a/testsuite/oslinfo-arrayparams/run.py
+++ b/testsuite/oslinfo-arrayparams/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = oslinfo("-v arrayparams")

--- a/testsuite/vararray-connect/ref/out.txt
+++ b/testsuite/vararray-connect/ref/out.txt
@@ -6,5 +6,6 @@ a array length 4
   [1] = 2.2
   [2] = 2.3
   [3] = 2.4
-b array length -1
+b array length 1
+  [0] = 0
 

--- a/testsuite/vararray-default/ref/out.txt
+++ b/testsuite/vararray-default/ref/out.txt
@@ -1,0 +1,9 @@
+Compiled test.osl -> test.oso
+a array length 3
+  [0] = 0
+  [1] = 1
+  [2] = 2.3
+b array length 2
+  [0] = (9 9 9)
+  [1] = (1 2.3 4)
+

--- a/testsuite/vararray-default/run.py
+++ b/testsuite/vararray-default/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command += testshade("test")

--- a/testsuite/vararray-default/test.osl
+++ b/testsuite/vararray-default/test.osl
@@ -1,0 +1,19 @@
+void print_array_contents (string name, float f[])
+{
+    printf ("%s array length %d\n", name, arraylength(f));
+    for (int i = 0; i < arraylength(f); ++i)
+        printf ("  [%d] = %g\n", i, f[i]);
+}
+
+void print_array_contents (string name, vector v[])
+{
+    printf ("%s array length %d\n", name, arraylength(v));
+    for (int i = 0; i < arraylength(v); ++i)
+        printf ("  [%d] = (%g)\n", i, v[i]);
+}
+
+shader test (float a[] = {0,1,2.3}, vector b[] = {9, vector(1,2.3,4)})
+{
+    print_array_contents ("a", a);
+    print_array_contents ("b", b);
+}

--- a/testsuite/vararray-param/ref/out.txt
+++ b/testsuite/vararray-param/ref/out.txt
@@ -5,5 +5,6 @@ a array length 5
   [2] = 1.3
   [3] = 1.4
   [4] = 1.5
-b array length -1
+b array length 1
+  [0] = 0
 


### PR DESCRIPTION
This changeset is to properly handle defaults for vararray parameters.  Without the patch, the following cases won't won't work/may crash if the vararray initializer has length > 1:
- oslinfo   (see testsuite/oslinfo-arrayparams)
- OSL arraylength() (see testsuite/vararray-connect, testsuite/vararray-param)
- OSL array access (see testsuite/vararray-default)

I also tightened up the parser grammar to error if a vararray output is specified (see testsuite/oslc-err-outputparamvararray).  This should probably be noted explicitly in the language spec.

A small patch it also required to OIIO for the TypeDesc struct.
