### PR TITLE
Daniel Heckenberg + LG = vararray defaults without OIIO changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,10 +356,10 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
-            oslc-err-noreturn oslc-err-paramdefault
+            oslc-err-noreturn oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-variadic-macro
-            oslinfo-metadata oslinfo-noparams
+            oslinfo-arrayparams oslinfo-metadata oslinfo-noparams
             pointcloud pointcloud-fold
             printf-whole-array
             raytype reparam
@@ -377,7 +377,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             texture-width texture-withderivs texture-wrap
             trailing-commas transform transformc trig typecast
             unknown-instruction
-            vararray-connect vararray-param
+            vararray-connect vararray-default vararray-param
             vecctr vector
             wavelength_color xml )
 

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -342,8 +342,9 @@ ASTvariable_declaration::ASTvariable_declaration (OSLCompilerImpl *comp,
     if (type.is_structure() || type.is_structure_array()) {
         ASSERT (! m_ismetadata);
         // Add the fields as individual declarations
-        m_compiler->add_struct_fields (type.structspec(), m_sym->name(),
-                                       symtype, type.arraylength(), this);
+        m_compiler->add_struct_fields (type.structspec(), m_sym->name(), symtype,
+                                       type.is_unsized_array() ? -1 : type.arraylength(),
+                                       this);
     }
 }
 

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -301,7 +301,7 @@ ASTNode::coerce (Symbol *sym, const TypeSpec &type, bool acceptfloat)
     if (acceptfloat && sym->typespec().is_float())
         return sym;
 
-    if (type.arraylength() == -1 && sym->typespec().is_array() &&
+    if (type.is_unsized_array() && sym->typespec().is_array() &&
         equivalent (sym->typespec().elementtype(), type.elementtype())) {
         // coercion not necessary to pass known length array to 
         // array parameter of unspecified length.

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -225,6 +225,11 @@ shader_formal_param
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($4);
+                    if ($1 && t.is_unsized_array()) {
+                        oslcompiler->error (oslcompiler->filename(),
+                                            @3.first_line,
+                                            "shader output parameter '%s' can't be unsized array", $3);
+                    }
                     ASTvariable_declaration *var;
                     var = new ASTvariable_declaration (oslcompiler, t, 
                                                    ustring($3), $5, true,
@@ -460,7 +465,7 @@ def_expression
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
-                    if (t.arraylength() < 1)
+                    if ($2 < 1)
                         oslcompiler->error (oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length for %s", $1);

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -49,17 +49,17 @@ TypeSpec::string () const
     std::string str;
     if (is_closure() || is_closure_array()) {
         str += "closure color";
-        if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-        else if (arraylength() < 0)
+        if (is_unsized_array())
             str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
     }
     else if (structure() > 0) {
         str += Strutil::format ("struct %d", structure());
-        if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-        else if (arraylength() < 0)
+        if (is_unsized_array())
             str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
     } else {
         str += simpletype().c_str();
     }

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -134,7 +134,7 @@ ASTvariable_declaration::typecheck_initlist (ref init, TypeSpec type,
     // Loop over a list of initializers (it's just 1 if not an array)...
     for (int i = 0;  init;  init = init->next(), ++i) {
         // Check for too many initializers for an array
-        if (type.is_array() && (i >= type.arraylength() && type.arraylength() > -1)) {
+        if (type.is_array() && !type.is_unsized_array() && i >= type.arraylength()) {
             error ("Too many initializers for a '%s'", type_c_str(type));
             break;
         }
@@ -817,7 +817,7 @@ ASTNode::check_arglist (const char *funcname, ASTNode::ref arg,
             continue;
         // Allow a fixed-length array match to a formal array with
         // unspecified length, if the element types are the same.
-        if (formaltype.arraylength() < 0 && argtype.arraylength() &&
+        if (formaltype.is_unsized_array() && argtype.is_sized_array() &&
               formaltype.elementtype() == argtype.elementtype())
             continue;
 
@@ -1440,11 +1440,10 @@ OSLCompilerImpl::code_from_type (TypeSpec type) const
     }
 
     if (type.is_array()) {
-        int len = type.arraylength ();
-        if (len > 0)
-            out += Strutil::format ("[%d]", len);
-        else
+        if (type.is_unsized_array())
             out += "[]";
+        else
+            out += Strutil::format ("[%d]", type.arraylength());
     }
 
     return out;

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -177,7 +177,7 @@ BackendLLVM::llvm_assign_zero (const Symbol &sym)
     // This even works for closures.
     int len;
     if (sym.typespec().is_closure_based())
-        len = sizeof(void *) * std::max(1,sym.typespec().arraylength());
+        len = sizeof(void *) * sym.typespec().numelements();
     else
         len = sym.derivsize();
     // N.B. derivsize() includes derivs, if there are any

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -706,7 +706,8 @@ DECLFOLDER(constfold_arraylength)
     ASSERT (R.typespec().is_int() && A.typespec().is_array());
 
     // Try to turn R=arraylength(A) into R=C if the array length is known
-    int len = A.typespec().arraylength();
+    int len = A.typespec().is_unsized_array() ? A.initializers()
+                                              : A.typespec().arraylength();
     if (len > 0) {
         int cind = rop.add_constant (TypeSpec(TypeDesc::INT), &len);
         rop.turn_into_assign (op, cind, "const fold arraylength");

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -353,8 +353,7 @@ ShaderInstance::add_connection (int srclayer, const ConnectedParam &srccon,
                                 const ConnectedParam &dstcon)
 {
     // specialize symbol in case of dstcon is an unsized array
-    if (dstcon.type.arraylength() == -1)
-    {
+    if (dstcon.type.is_unsized_array()) {
         SymOverrideInfo *so = &m_instoverrides[dstcon.param];
         so->arraylen(srccon.type.arraylength());
 
@@ -448,7 +447,12 @@ ShaderInstance::copy_code_from_master (ShaderGroup &group)
     if (m_instoverrides.size()) {
         for (size_t i = 0, e = lastparam();  i < e;  ++i) {
             Symbol *si = &m_instsymbols[i];
-            if (m_instoverrides[i].valuesource() != Symbol::DefaultVal) {
+            if (m_instoverrides[i].valuesource() == Symbol::DefaultVal) {
+                // Fix the length of any default-value variable length array
+                // parameters.
+                if (si->typespec().is_unsized_array())
+                    si->arraylen (si->initializers());
+            } else {
                 if (m_instoverrides[i].arraylen())
                     si->arraylen (m_instoverrides[i].arraylen());
                 si->valuesource (m_instoverrides[i].valuesource());

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1133,7 +1133,8 @@ LLVMGEN (llvm_gen_arraylength)
     Symbol& A = *rop.opargsym (op, 1);
     DASSERT (Result.typespec().is_int() && A.typespec().is_array());
 
-    int len = A.typespec().arraylength();
+    int len = A.typespec().is_unsized_array() ? A.initializers()
+                                              : A.typespec().arraylength();
     rop.llvm_store_value (rop.ll.constant(len), Result);
     return true;
 }

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -140,6 +140,8 @@ ShaderMaster::resolve_syms ()
             // structs are just placeholders, their fields are separate
             // symbols that hold the real data.
             s.size (0);
+        } else if (s.typespec().is_unsized_array()) {
+            s.size (0);
         } else {
             s.size (s.typespec().simpletype().size());
             // FIXME -- some day we may want special padding here, like

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2237,7 +2237,7 @@ ShadingSystemImpl::decode_connected_param (string_view connectionname,
 
     c.type = sym->typespec();
 
-    if (bracket && c.type.arraylength()) {
+    if (bracket && c.type.is_array()) {
         // There was at least one set of brackets that appears to be
         // selecting an array element.
         c.arrayindex = atoi (bracket+1);
@@ -2776,7 +2776,7 @@ OSL::OSLQuery::init (const ShaderGroup *group, int layernum)
             const TypeSpec &ts (sym->typespec());
             p.type = ts.simpletype();
             p.isoutput = (sym->symtype() == SymTypeOutputParam);
-            p.varlenarray = (p.type.arraylen < 0);
+            p.varlenarray = ts.is_unsized_array();
             p.isstruct = ts.is_structure() || ts.is_structure_array();
             p.isclosure = ts.is_closure_based();
             p.data = sym->data();

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -112,10 +112,18 @@ equivalent (const StructSpec *a, const StructSpec *b)
 bool
 equivalent (const TypeSpec &a, const TypeSpec &b)
 {
-    return (a == b) || 
+    // The two complex types are equivalent if...
+    return
+        // they are actually identical (duh)
+        (a == b) ||
+        // or if the underlying simple types are equivalent
         (((a.is_vectriple_based() && b.is_vectriple_based()) || equivalent(a.m_simple, b.m_simple))  &&
+         //     ... and either both or neither are closures
          a.is_closure() == b.is_closure() &&
-         (a.arraylength() == b.arraylength() || (a.arraylength() == -1 && b.arraylength() >0))) ||
+         //     ... and, if arrays, they are the same length, or both unsized,
+         //         or one is unsized and the other isn't
+         (a.m_simple.arraylen == b.m_simple.arraylen || a.is_unsized_array() != b.is_unsized_array())) ||
+        // or if they are structs, and the structs are equivalent
         (a.is_structure() && b.is_structure() &&
          equivalent(a.structspec(), b.structspec()));
 }

--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -58,11 +58,16 @@ static std::string oneparam;
 static void
 print_default_string_vals (const OSLQuery::Parameter *p, bool verbose)
 {
+    size_t ne;
+    if (p->varlenarray || p->type.arraylen < 0)
+        ne = p->sdefault.size();
+    else
+        ne = p->type.numelements();
     if (verbose) {
-        for (size_t a = 0;  a < p->type.numelements();  ++a)
+        for (size_t a = 0;  a < ne;  ++a)
             std::cout << "\t\tDefault value: \"" << p->sdefault[a] << "\"\n";
     } else {
-        for (size_t a = 0;  a < p->type.numelements();  ++a)
+        for (size_t a = 0;  a < ne;  ++a)
             std::cout << "\"" << p->sdefault[a] << "\" ";
         std::cout << "\n";
     }
@@ -74,7 +79,11 @@ static void
 print_default_int_vals (const OSLQuery::Parameter *p, bool verbose)
 {
     size_t nf = p->type.aggregate;
-    size_t ne = p->type.numelements();
+    size_t ne;
+    if (p->varlenarray || p->type.arraylen < 0)
+        ne = p->idefault.size() / nf;
+    else
+        ne = p->type.numelements();
     if (verbose)
         std::cout << "\t\tDefault value:";
     if (p->type.arraylen || nf > 1)
@@ -94,7 +103,11 @@ static void
 print_default_float_vals (const OSLQuery::Parameter *p, bool verbose)
 {
     size_t nf = p->type.aggregate;
-    size_t ne = p->type.numelements();
+    size_t ne;
+    if (p->varlenarray || p->type.arraylen < 0)
+        ne = p->fdefault.size() / nf;
+    else
+        ne = p->type.numelements();
     if (verbose)
         std::cout << "\t\tDefault value:";
     if (p->type.arraylen || nf > 1)

--- a/testsuite/oslc-err-outputparamvararray/ref/out.txt
+++ b/testsuite/oslc-err-outputparamvararray/ref/out.txt
@@ -1,0 +1,2 @@
+test.osl:2: error: shader output parameter 'c' can't be unsized array
+FAILED test.osl

--- a/testsuite/oslc-err-outputparamvararray/run.py
+++ b/testsuite/oslc-err-outputparamvararray/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python 
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-outputparamvararray/test.osl
+++ b/testsuite/oslc-err-outputparamvararray/test.osl
@@ -1,0 +1,4 @@
+shader
+test (output color c[] = {color(1,1,1)})
+{
+}

--- a/testsuite/oslinfo-arrayparams/arrayparams.osl
+++ b/testsuite/oslinfo-arrayparams/arrayparams.osl
@@ -1,0 +1,8 @@
+surface arrayparams (
+    float farrayparam[1] = {1},
+    float farrayparamunsized[] = {7,8,9},
+    vector varrayparam[3] = {vector(1,2,3), vector(4,5,6), vector(7,8,9)},
+    vector varrayparamunsized[] = {vector(1,1,1), vector(2,2,2), vector(3,3,3), vector(3,2,1)}
+    )
+{
+}

--- a/testsuite/oslinfo-arrayparams/ref/out.txt
+++ b/testsuite/oslinfo-arrayparams/ref/out.txt
@@ -1,0 +1,10 @@
+Compiled arrayparams.osl -> arrayparams.oso
+surface "arrayparams"
+    "farrayparam" "float[1]"
+		Default value: [ 1 ]
+    "farrayparamunsized" "float[]"
+		Default value: [ 7 8 9 ]
+    "varrayparam" "vector[3]"
+		Default value: [ 1 2 3 4 5 6 7 8 9 ]
+    "varrayparamunsized" "vector[]"
+		Default value: [ 1 1 1 2 2 2 3 3 3 3 2 1 ]

--- a/testsuite/oslinfo-arrayparams/run.py
+++ b/testsuite/oslinfo-arrayparams/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = oslinfo("-v arrayparams")

--- a/testsuite/vararray-connect/ref/out.txt
+++ b/testsuite/vararray-connect/ref/out.txt
@@ -6,5 +6,6 @@ a array length 4
   [1] = 2.2
   [2] = 2.3
   [3] = 2.4
-b array length -1
+b array length 1
+  [0] = 0
 

--- a/testsuite/vararray-default/ref/out.txt
+++ b/testsuite/vararray-default/ref/out.txt
@@ -1,0 +1,9 @@
+Compiled test.osl -> test.oso
+a array length 3
+  [0] = 0
+  [1] = 1
+  [2] = 2.3
+b array length 2
+  [0] = (9 9 9)
+  [1] = (1 2.3 4)
+

--- a/testsuite/vararray-default/run.py
+++ b/testsuite/vararray-default/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command += testshade("test")

--- a/testsuite/vararray-default/test.osl
+++ b/testsuite/vararray-default/test.osl
@@ -1,0 +1,19 @@
+void print_array_contents (string name, float f[])
+{
+    printf ("%s array length %d\n", name, arraylength(f));
+    for (int i = 0; i < arraylength(f); ++i)
+        printf ("  [%d] = %g\n", i, f[i]);
+}
+
+void print_array_contents (string name, vector v[])
+{
+    printf ("%s array length %d\n", name, arraylength(v));
+    for (int i = 0; i < arraylength(v); ++i)
+        printf ("  [%d] = (%g)\n", i, v[i]);
+}
+
+shader test (float a[] = {0,1,2.3}, vector b[] = {9, vector(1,2.3,4)})
+{
+    print_array_contents ("a", a);
+    print_array_contents ("b", b);
+}

--- a/testsuite/vararray-param/ref/out.txt
+++ b/testsuite/vararray-param/ref/out.txt
@@ -5,5 +5,6 @@ a array length 5
   [2] = 1.3
   [3] = 1.4
   [4] = 1.5
-b array length -1
+b array length 1
+  [0] = 0
 


### PR DESCRIPTION
This is a proposed modification of #496 keeps track of the number of initializers in the Symbol structure itself, without the need for abusing TypeDesc or requiring any changes on the OIIO size.

(Aside: I wish GitHub had a way to propose modifications to PRs, on the PR itself. Or some kind of "multiple contributor PR" where people other than the original author can amend the patch. But it doesn't.)

If you guys like this, I will squash it into a single commit before merging. But I kept it separate for review so it's easy to see exactly what I changed compared to Daniel.
