### PR TITLE
Refactor of track_variable_lifetimes for vastly improved performance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -127,6 +127,7 @@ Performance improvements:
   16 floats. #486 (1.6.4)
 * Improved optimizations -- caught some additional places where assignments
   could be found to be useless and eliminated. #403 (1.6.4)
+* Improved speed of runtime optimization for large shaders. #499 (1.6.5)
 
 Bug fixes and other improvements:
 * oslinfo --param lets you ask for information on just one parameter of


### PR DESCRIPTION
For some really complex shaders, we profiled track_variable_lifetimes to be an important bottleneck in shader runtime optimization time.

Part of this function was an outer loop over every instruction, and any time it found a loop instruction, it would then loop over EVERY symbol, looking for symbols that were modified within the loop body, and marking the symbol in such a way as to expand its lifetime to fill the whole loop (because its value may be needed the next iteration).

This refactor still loops over all instructions, but we use a simple stack to keep track of any nested loops we are a part of. For each instruction, it looks at just the symbols that are arguments of that instruction, and for those, extends its lifetime to fill any loops the instruction is part of.

This changes the work from `number_of_insructions*k1*total_number_of_symbols` (where k1 is the fraction of instructions that are loop instructions) to `number_of_instructions*k2` (where k2 is the number of symbol arguments per instruction, almost always 2 or 3). I'm seeing about a 50x reduction in amount of time spent inside this function, for very complex shaders.