### PR TITLE
Remove unused insert_useparam and add_useparam from oslcomp

### DIFF
--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -307,9 +307,6 @@ public:
                                           const SymbolPtrVec &opargs,
                                           const SymbolPtrVec &allsyms);
     static void coalesce_temporaries (SymbolPtrVec &symtab);
-    static void insert_useparam (OpcodeVec &code, size_t opnum,
-                                 SymbolPtrVec &opargs, SymbolPtrVec &allsyms, 
-                                 SymbolPtrVec &params);
 
     const std::string main_filename () const { return m_main_filename; }
     const std::string cwd () const { return m_cwd; }
@@ -330,8 +327,6 @@ private:
     }
 
     void track_variable_dependencies ();
-    void add_useparam ();
-    void insert_useparam (size_t opnum, SymbolPtrVec &params);
     void coalesce_temporaries () {
         coalesce_temporaries (m_symtab.allsyms());
     }


### PR DESCRIPTION
For a very long time now, we have not used the 'useparam' stuff on the oslc compiler side at all, instead doing it all as part of the runtime compilation and JIT. So remove the remaining clutter from liboslcomp.
