### PR TITLE
Dramatically speed up runtime optimization with flat_map

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1099,7 +1099,7 @@ RuntimeOptimizer::clear_stale_syms ()
 void
 RuntimeOptimizer::use_stale_sym (int sym)
 {
-    std::map<int,int>::iterator i = m_stale_syms.find(sym);
+    FastIntMap::iterator i = m_stale_syms.find(sym);
     if (i != m_stale_syms.end())
         m_stale_syms.erase (i);
 }
@@ -1129,7 +1129,7 @@ void
 RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
 {
     if (optimize() >= 2 && m_opt_stale_assign) {
-        std::map<int,int>::iterator i = m_stale_syms.find(sym);
+        FastIntMap::iterator i = m_stale_syms.find(sym);
         if (i != m_stale_syms.end()) {
             Opcode &uselessop (inst()->ops()[i->second]);
             if (uselessop.opname() != u_nop)
@@ -1392,7 +1392,7 @@ RuntimeOptimizer::dealias_symbol (int symindex, int opnum)
             symindex = i;
             continue;
         }
-        std::map<int,int>::const_iterator found;
+        FastIntMap::const_iterator found;
         found = m_symbol_aliases.find (symindex);
         if (found != m_symbol_aliases.end()) {
             // permanent alias for the sym
@@ -1422,7 +1422,6 @@ void
 RuntimeOptimizer::make_symbol_room (int howmany)
 {
     inst()->make_symbol_room (howmany);
-    m_block_aliases.resize (inst()->symbols().size()+howmany, -1);
 }
 
 


### PR DESCRIPTION
A big part of the runtime optimizer's housekeeping is keeping track of which symbols alias to which other symbols. For example if you have 'a=b' it will actually remember that they are the same, so then if you have c=a-b, it will understand this means c==0. Of course, it also clears it if you reassign something else to a. And if you get to the end of a basic block, it clears them all, since control could flow in from somewhere else with different assignments.  The basics of this was tracked by an alias array, length was the number of symbols, each element says which symbol this symbol is aliased to, if any, or -1 if it doesn't alias anything else.  And a common operation is to say "forget all the aliases", which is really filling the whole array with -1's.

Profiling on some enormous shaders showed that this was (after the latest fix to track_variable_lifetimes) the biggest hotspot in our runtime specialization. Especially the clearing operation. But we observe that within any particular basic block, most of the symbols won't be assigned at all.

So instead of having an array holding indices for all symbols, we just make it a map -- only have an entry if the symbol was aliased to something. This makes lookup and assignment/reassignment of an alias O(log n) instead of O(1), because it's a map search or insertion rather than a simple array lookup. But most of the time, the map only has a few entries. This speeds up runtime specialization by 4x.

Furthermore, if a sufficiently new version of Boost is available, we use boost::container::flat_map, which is a drop-in replacement for std::map that uses a sorted vector underneath. Lookup with binary search is still O(log n), but insertion and deletion becomes O(n), ick in theory, but in practice the enhanced memory locality tends to make it a net win for most usage patterns. This reduces another 30%, bring us to a net speed increase of 5x or better overall.
