### PR TITLE
Big speedup loading large shaders -- look up symbols with hashmap, not linear search

### DIFF
--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -589,9 +589,15 @@ ShadingSystemImpl::loadshader (string_view cname)
     bool ok = oso.parse_file (filename);
     ShaderMaster::ref r = ok ? oso.master() : NULL;
     m_shader_masters[name] = r;
+    double loadtime = timer();
+    {
+        spin_lock lock (m_stat_mutex);
+        m_stat_master_load_time += loadtime;
+    }
     if (ok) {
         ++m_stat_shaders_loaded;
-        info ("Loaded \"%s\" (took %s)", filename.c_str(), Strutil::timeintervalformat(timer(), 2).c_str());
+        info ("Loaded \"%s\" (took %s)", filename.c_str(),
+              Strutil::timeintervalformat(loadtime, 2).c_str());
         ASSERT (r);
         r->resolve_syms ();
         // if (debug()) {
@@ -636,9 +642,15 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
     bool ok = reader.parse_memory (buffer);
     ShaderMaster::ref r = ok ? reader.master() : NULL;
     m_shader_masters[name] = r;
+    double loadtime = timer();
+    {
+        spin_lock lock (m_stat_mutex);
+        m_stat_master_load_time += loadtime;
+    }
     if (ok) {
         ++m_stat_shaders_loaded;
-        info ("Loaded \"%s\" (took %s)", shadername, Strutil::timeintervalformat(timer(), 2).c_str());
+        info ("Loaded \"%s\" (took %s)", shadername,
+              Strutil::timeintervalformat(loadtime, 2).c_str());
         ASSERT (r);
         r->resolve_syms ();
         // if (debug()) {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1108,6 +1108,7 @@ private:
     atomic_int m_stat_middlemen_eliminated; ///< Stat: middlemen eliminated
     atomic_int m_stat_const_connections;  ///< Stat: const connections elim'd
     atomic_int m_stat_global_connections; ///< Stat: global connections elim'd
+    double m_stat_master_load_time;       ///< Stat: time loading masters
     double m_stat_optimization_time;      ///< Stat: time spent optimizing
     double m_stat_opt_locking_time;       ///<   locking time
     double m_stat_specialization_time;    ///<   runtime specialization time

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -622,6 +622,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_middlemen_eliminated = 0;
     m_stat_const_connections = 0;
     m_stat_global_connections = 0;
+    m_stat_master_load_time = 0;
     m_stat_optimization_time = 0;
     m_stat_getattribute_time = 0;
     m_stat_getattribute_fail_time = 0;
@@ -1115,6 +1116,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("stat:middlemen_eliminated", int, m_stat_middlemen_eliminated);
     ATTR_DECODE ("stat:const_connections", int, m_stat_const_connections);
     ATTR_DECODE ("stat:global_connections", int, m_stat_global_connections);
+    ATTR_DECODE ("stat:master_load_time", float, m_stat_master_load_time);
     ATTR_DECODE ("stat:optimization_time", float, m_stat_optimization_time);
     ATTR_DECODE ("stat:opt_locking_time", float, m_stat_opt_locking_time);
     ATTR_DECODE ("stat:specialization_time", float, m_stat_specialization_time);
@@ -1439,6 +1441,8 @@ ShadingSystemImpl::getstats (int level) const
     out << "    Loaded:    " << m_stat_shaders_loaded << "\n";
     out << "    Masters:   " << m_stat_shaders_loaded << "\n";
     out << "    Instances: " << m_stat_instances << "\n";
+    out << "  Time loading masters: "
+        << Strutil::timeintervalformat (m_stat_master_load_time, 2) << "\n";
     out << "  Shading groups:   " << m_stat_groups << "\n";
     out << "    Total instances in all groups: " << m_stat_groupinstances << "\n";
     float iperg = (float)m_stat_groupinstances/std::max(m_stat_groups,1);


### PR DESCRIPTION
Profiling was showing OSOReaderToMaster::instruction_arg as a hot spot when loading large shaders. This is because of a linear search to find symbol index from its name. I'm sure this made sense for short test shaders I was using when first bringing OSL online, but now we have immense shaders. Switch to a hash map for these lookups.

This results in over a 3x speedup of shader load time (which now is reported in the stats), on a scene with our production shaders.
