### PR TITLE
Critical bug fix -- error in keeping track of which layers have been run

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -754,6 +754,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
 
     // Setup the symbols
     m_named_values.clear ();
+    m_layers_already_run.clear ();
     BOOST_FOREACH (Symbol &s, inst()->symbols()) {
         // Skip constants -- we always inline scalar constants, and for
         // array constants we will just use the pointers to the copy of
@@ -819,7 +820,6 @@ BackendLLVM::build_llvm_instance (bool groupentry)
     // records for each.
     find_basic_blocks ();
     find_conditionals ();
-    m_layers_already_run.clear ();
 
     build_llvm_code (inst()->maincodebegin(), inst()->maincodeend());
 


### PR DESCRIPTION
When a shader needs the value of a connected parameter, it runs the upstream layer it's connected to, if it hasn't been run already.  But, to keep a bzillion of these checks from occurring needlessly, it also tries to keep track (when building the LLVM ops) of which ones certainly have already been called, so that it isn't generating code to constantly check it at runtime. We were very subtly getting this wrong.  It's crucial not to do this for things pulled by init ops. They are inherently conditional, and also the m_layers_already_run set hadn't been cleared yet when they were run! So certain particular constructs of layer connections and init ops could result in it incorrectly skipping the execution of a layer by thinking it had already been run, even though it hadn't.