### PR TITLE
Keep track of layers that are the unused duplicate after an instance merge

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -550,7 +550,7 @@ public:
     void run_lazily (bool lazy) { m_run_lazily = lazy; }
 
     /// Figure out whether the instance runs lazily, set m_run_lazily.
-    void compute_run_lazily ();
+    void compute_run_lazily (const ShaderGroup &group);
 
     /// Does this instance have any outgoing connections?
     ///
@@ -564,6 +564,9 @@ public:
     /// Set whether this instance has renderer outputs
     void renderer_outputs (bool out) { m_renderer_outputs = out; }
 
+    /// Was this instance merged away and now no longer needed?
+    bool merged_unused () const { return m_merged_unused; }
+
     int maincodebegin () const { return m_maincodebegin; }
     int maincodeend () const { return m_maincodeend; }
 
@@ -573,7 +576,7 @@ public:
     /// Return a begin/end Symbol* pair for the set of param symbols
     /// that is suitable to pass as a range for BOOST_FOREACH.
     friend std::pair<Symbol *,Symbol *> param_range (ShaderInstance *i) {
-        if (i->firstparam() == i->lastparam())
+        if (i->m_instsymbols.size() == 0 || i->firstparam() == i->lastparam())
             return std::pair<Symbol*,Symbol*> ((Symbol*)NULL, (Symbol*)NULL);
         else
             return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
@@ -581,7 +584,7 @@ public:
     }
 
     friend std::pair<const Symbol *,const Symbol *> param_range (const ShaderInstance *i) {
-        if (i->firstparam() == i->lastparam())
+        if (i->m_instsymbols.size() == 0 || i->firstparam() == i->lastparam())
             return std::pair<const Symbol*,const Symbol*> ((const Symbol*)NULL, (const Symbol*)NULL);
         else
             return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
@@ -698,6 +701,7 @@ private:
     bool m_run_lazily;                  ///< OK to run this layer lazily?
     bool m_outgoing_connections;        ///< Any outgoing connections?
     bool m_renderer_outputs;            ///< Any outputs params render outputs?
+    bool m_merged_unused;               ///< Unused because of a merge
     ConnectionVec m_connections;        ///< Connected input params
     int m_firstparam, m_lastparam;      ///< Subset of symbols that are params
     int m_maincodebegin, m_maincodeend; ///< Main shader code range

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2778,7 +2778,7 @@ RuntimeOptimizer::run ()
             collapse_syms ();
             collapse_ops ();
         }
-        inst()->compute_run_lazily ();
+        inst()->compute_run_lazily (group());
         if (debug() && !inst()->unused()) {
             track_variable_lifetimes ();
             std::cout << "After optimizing layer " << layer << " " 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1662,7 +1662,7 @@ ShadingSystemImpl::ShaderGroupEnd (void)
             ShaderInstance *inst = (*m_curgroup)[layer];
             if (! inst)
                 continue;
-            inst->compute_run_lazily ();
+            inst->compute_run_lazily (*m_curgroup);
         }
 
         // Merge instances now if they really want it bad, otherwise wait
@@ -2579,9 +2579,11 @@ ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
             // B won't be used, so mark it as having no outgoing
             // connections and clear its incoming connections (which are
             // no longer used).
+            ASSERT (B->merged_unused() == false);
             B->outgoing_connections (false);
             B->run_lazily (true);
             connectionmem += B->clear_connections ();
+            B->m_merged_unused = true;
             ASSERT (B->unused());
         }
     }


### PR DESCRIPTION
The usual easy checks for if something is unused -- no code and no symbols -- aren't reliable in this case.

