### PR TITLE
Refactor adding symbols to be more clear and simplify

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -629,6 +629,18 @@ public:
         m_lastwrite  = std::max (m_lastwrite, lw);
     }
 
+    // Mark the symbol as always being read (and, if write==true, also
+    // that it's always written). Then is for when we don't know when
+    // it's read or written, but want to be sure it doesn't look unused.
+    void mark_always_used (bool write=false) {
+        m_firstread = 0;
+        m_lastread  = std::numeric_limits<int>::max();
+        if (write) {
+            m_firstwrite = 0;
+            m_lastwrite  = std::numeric_limits<int>::max();
+        }
+    }
+
     int firstread () const  { return m_firstread; }
     int lastread () const   { return m_lastread; }
     int firstwrite () const { return m_firstwrite; }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -103,6 +103,11 @@ public:
     /// necessary, and returning its index.
     int add_global (ustring name, const TypeSpec &type);
 
+    /// Add a new symbol to the current instance's symbol list. Don't push
+    /// onto the symbol table yourself during optimization; this does some
+    /// other essential housekeeping.
+    int add_symbol (const Symbol &sym);
+
     /// Turn the op into a simple assignment of the new symbol index to the
     /// previous first argument of the op.  That is, changes "OP arg0 arg1..."
     /// into "assign arg0 newarg".


### PR DESCRIPTION
Minor refactor of runtime optimizer internals. This encapsulates some code that's repeated a few times into a single add_symbol() call. Also, that call makes sure to temporarily mark a newly added symbol as used potentially at any time so any choices based on lifetime analysis will be extra conservative until the next time that lifetimes for all symbols are re-analyzed (which happens with each optimization pass over the code).

