### PR TITLE
Add a small benchmark command line option to oslinfo

### DIFF
--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -43,6 +43,7 @@ Sony Pictures Imageworks terms, above.
 
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/argparse.h>
+#include <OpenImageIO/timer.h>
 
 #include "OSL/oslquery.h"
 using namespace OSL;
@@ -51,6 +52,7 @@ using namespace OSL;
 static std::string searchpath;
 static bool verbose = false;
 static bool help = false;
+static bool benchmark = false;
 static std::string oneparam;
 
 
@@ -144,6 +146,7 @@ print_metadata (const OSLQuery::Parameter &m)
 static void
 oslinfo (const std::string &name)
 {
+    OIIO::Timer t(benchmark);
     OSLQuery g;
     g.open (name, searchpath);
     std::string e = g.geterror();
@@ -151,6 +154,12 @@ oslinfo (const std::string &name)
         std::cout << "ERROR opening shader \"" << name << "\" (" << e << ")\n";
         return;
     }
+    if (benchmark) {
+        // display timings in an easy to sort form
+        std::cout << t.stop() << " sec for " << name << "\n";
+        return; // don't show anything else, we are just benchmarking
+    }
+
     if (oneparam.empty()) {
         std::cout << g.shadertype() << " \"" << g.shadername() << "\"\n";
         if (verbose) {
@@ -235,6 +244,7 @@ main (int argc, char *argv[])
                 "-h", &help, "Print help message",
                 "--help", &help, "",
                 "-v", &verbose, "Verbose",
+                "--bench", &benchmark, "Benchmark shader loading time",
                 "-p %s", &searchpath, "Set searchpath for shaders",
                 "--param %s", &oneparam, "Output information in just this parameter",
                 NULL);


### PR DESCRIPTION
This can be handy to profile how long a given set of shaders take to load, and identify the slowest ones (by just piping the output to sort).