### PR TITLE
Improve uninitialized value detection mode ("debug_uninit")

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -210,7 +210,7 @@ DECL (osl_dict_value, "iXiXLX")
 DECL (osl_raytype_name, "iXX")
 DECL (osl_range_check, "iiiXXi")
 DECL (osl_naninf_check, "xiXiXXiXiiX")
-DECL (osl_uninit_check, "xLXXXiXii")
+DECL (osl_uninit_check, "xLXXXiXiXiXXii")
 DECL (osl_get_attribute, "iXiXXiiXX")
 DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
 DECL (osl_get_texture_options, "XX");

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2855,6 +2855,8 @@ osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
 OSL_SHADEOP void
 osl_uninit_check (long long typedesc_, void *vals_,
                   void *sg, const void *sourcefile, int sourceline,
+                  const char *groupname, int layer, const char *layername,
+                  int opnum, const char *opname,
                   void *symbolname, int firstcheck, int nchecks)
 {
     TypeDesc typedesc = TYPEDESC(typedesc_);
@@ -2885,8 +2887,11 @@ osl_uninit_check (long long typedesc_, void *vals_,
             }
     }
     if (uninit) {
-        ctx->error ("Detected possible use of uninitialized value in %s at %s:%d",
-                    USTR(symbolname), USTR(sourcefile), sourceline);
+        ctx->error ("Detected possible use of uninitialized value in %s at %s:%d (group %s, layer %d %s, op %d '%s')",
+                    USTR(symbolname), USTR(sourcefile), sourceline,
+                    groupname ? groupname: "<unnamed group>",
+                    layer, layername ? layername : "<unnamed layer>",
+                    opnum, USTR(opname));
     }
 }
 

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
-ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10
+ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 3 'assign')
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10
-ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11
+ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 4 'color')
+ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11 (group <unnamed group>, layer 0 , op 5 'texture')
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename


### PR DESCRIPTION
Found a source of "false positives" -- we shouldn't do a check for
uninitialized values of the arguments to a "useparam" pseudoinstruction,
since by definition the parameters named may be uninitialized before the
useparam action itself copies the values from connected layers.

In the process, beef up the uninitialized value error message to point
not only to the OSL source file and line, but also to the specific group
and layer, and (mainly for me in debugging the feature) which
instruction it is.