### PR TITLE
Harmonize the way all binaries use --stats versus --runstats

### DIFF
--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -65,7 +65,7 @@ ShadingSystem *shadingsys = NULL;
 bool debug = false;
 bool debug2 = false;
 bool verbose = false;
-bool stats = false;
+bool runstats = false;
 bool profile = false;
 bool O0 = false, O1 = false, O2 = false;
 bool debugnan = false;
@@ -102,7 +102,8 @@ void getargs(int argc, const char *argv[])
                 "-v", &verbose, "Verbose messages",
                 "--debug", &debug, "Lots of debugging info",
                 "--debug2", &debug2, "Even more debugging info",
-                "--stats", &stats, "Print run statistics",
+                "--runstats", &runstats, "Print run statistics",
+                "--stats", &runstats, "", // DEPRECATED 1.7
                 "--profile", &profile, "Print profile information",
                 "-r %d %d", &xres, &yres, "Render a WxH image",
                 "-aa %d", &aa, "Trace NxN rays per pixel",
@@ -661,7 +662,7 @@ int main (int argc, const char *argv[]) {
     delete out;
 
     // Print some debugging info
-    if (debug || stats || profile) {
+    if (debug || runstats || profile) {
         double runtime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup: " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -63,7 +63,7 @@ static std::string dataformatname = "";
 static bool debug = false;
 static bool debug2 = false;
 static bool verbose = false;
-static bool stats = false;
+static bool runstats = false;
 static bool profile = false;
 static bool O0 = false, O1 = false, O2 = false;
 static bool pixelcenters = false;
@@ -422,7 +422,8 @@ getargs (int argc, const char *argv[])
                 "-t %d", &num_threads, "Render using N threads (default: auto-detect)",
                 "--debug", &debug, "Lots of debugging info",
                 "--debug2", &debug2, "Even more debugging info",
-                "--stats", &stats, "Print run statistics",
+                "--runstats", &runstats, "Print run statistics",
+                "--stats", &runstats, "",  // DEPRECATED 1.7
                 "--profile", &profile, "Print profile information",
                 "-g %d %d", &xres, &yres, "Make an X x Y grid of shading points",
                 "-o %L %L", &outputvars, &outputfiles,
@@ -1021,7 +1022,7 @@ test_shade (int argc, const char *argv[])
     }
 
     // Print some debugging info
-    if (debug || stats || profile) {
+    if (debug || runstats || profile) {
         double runtime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup: " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";


### PR DESCRIPTION
--stats if applicable, prints statistics about the program inputs.

--runstats prints runtime statistics about the operation of the program itself (timing, memory, etc.)

oslinfo (and oiiotool) used this convention already, but testrender and testshade used --stats to print run statistics.
