### PR TITLE
In debug mode, don't warn about unused functions or variables with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,9 @@ if (CMAKE_COMPILER_IS_CLANG)
     add_definitions ("-Qunused-arguments -Wno-unknown-pragmas")
     # disable warning in flex-generated code
     add_definitions ("-Wno-null-conversion")
+    if (DEBUGMODE)
+        add_definitions ("-Wno-unused-function -Wno-unused-variable")
+    endif ()
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
Often when debugging, I comment things out, then get frustrated by clang warnings that a static function or local variable (whose use was commented out) is no longer used and breaks the build.

So at least turning off these warnings when in debug mode on clang.
