### PR TITLE
CMake option to disallow creation of OIIO::TextureSystem.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ set (OSL_BUILD_CPP11 OFF CACHE BOOL "Compile in C++11 mode")
 set (OSL_BUILD_LIBCPLUSPLUS OFF CACHE BOOL "Compile with clang libc++")
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")
 set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, sse4.1, sse4.2)")
+set (OSL_NO_DEFAULT_TEXTURESYSTEM OFF CACHE BOOL "Do not use create a raw OIIO::TextureSystem")
 
 if (LLVM_NAMESPACE)
     add_definitions ("-DLLVM_NAMESPACE=${LLVM_NAMESPACE}")
@@ -201,6 +202,10 @@ if (USE_FAST_MATH)
 	add_definitions ("-DOSL_FAST_MATH=1")
 else ()
 	add_definitions ("-DOSL_FAST_MATH=0")
+endif ()
+
+if (OSL_NO_DEFAULT_TEXTURESYSTEM)
+    add_definitions ("-DOSL_NO_DEFAULT_TEXTURESYSTEM=1")
 endif ()
 
 if (EXTRA_CPP_ARGS)

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -60,10 +60,18 @@ RendererServices::RendererServices (TextureSystem *texsys)
         if (texsys) {// caller provided a texture system
             texturesys_ = texsys;
         } else { // Need to create a new texture system
+#if OSL_NO_DEFAULT_TEXTURESYSTEM
+            // This build option instructs OSL to never create a TextureSystem
+            // itself. (Most likely reason: this build of OSL is for a renderer
+            // that replaces OIIO's TextureSystem with its own, and therefore
+            // wouldn't want to accidentally make an OIIO one here.
+            ASSERT (0 && "RendererServices was not passed a working TextureSystem*");
+#else
             texturesys_ = TextureSystem::create (true /* shared */);
             // Make some good guesses about default options
             texturesys_->attribute ("automip",  1);
             texturesys_->attribute ("autotile", 64);
+#endif
         }
     }
 }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -661,11 +661,19 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
 
     // If we still don't have a texture system, create a new one
     if (! m_texturesys) {
+#if OSL_NO_DEFAULT_TEXTURESYSTEM
+        // This build option instructs OSL to never create a TextureSystem
+        // itself. (Most likely reason: this build of OSL is for a renderer
+        // that replaces OIIO's TextureSystem with its own, and therefore
+        // wouldn't want to accidentally make an OIIO one here.
+        ASSERT (0 && "ShadingSystem was not passed a working TextureSystem*");
+#else
         m_texturesys = TextureSystem::create (true /* shared */);
         ASSERT (m_texturesys);
         // Make some good guesses about default options
         m_texturesys->attribute ("automip",  1);
         m_texturesys->attribute ("autotile", 64);
+#endif
     }
 
     // Alternate way of turning on LLVM debug mode (temporary/experimental)


### PR DESCRIPTION
For renderers that supply their own TextureSystem class, this will cause an assertion if a TS isn't either passed to the ShadingSystem constructor or returned by RendererServices::texturesys(), and definitely won't construct a default OIIO TextureSystem on its own.

This is an unusual need (though not unreasonable), so if you don't know why this is useful, don't worry, it's not meant for you.
