### PR TITLE
Give Pixar a site file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ endif
 ifneq (${shell echo ${OSL_SITE} | grep imageworks},)
 include ${working_dir}/site/spi/Makefile-bits
 endif
+ifneq (${shell echo ${OSL_SITE} | grep pixar},)
+include ${working_dir}/site/pixar/Makefile-bits
+endif
 
 # Set up variables holding the names of platform-dependent directories --
 # set these after evaluating site-specific instructions

--- a/site/pixar/Makefile-bits
+++ b/site/pixar/Makefile-bits
@@ -1,0 +1,28 @@
+# Pixar-specific settings
+
+ifneq (${VERBOSE},)
+$(info Including pixar/Makefile-bits)
+endif
+
+MY_CMAKE_FLAGS += -DUSE_fPIC:BOOL=1
+MY_CMAKE_FLAGS += -DENABLE_RTTI:BOOL=1
+MY_CMAKE_FLAGS += -DSTOP_ON_WARNING:BOOL=0
+MY_CMAKE_FLAGS += -DHIDE_SYMBOLS:BOOL=1
+MY_CMAKE_FLAGS += -DBUILDSTATIC:BOOL=1
+MY_CMAKE_FLAGS += -DLINKSTATIC:BOOL=1
+MY_CMAKE_FLAGS += -DUSE_FAST_MATH:BOOL=1
+MY_CMAKE_FLAGS += -DILMBASE_LIB_AREA:STRING=${ILMBASE_HOME}/lib/linux-ix86-64/gcc4.1
+MY_CMAKE_FLAGS += -DILMBASE_CUSTOM:BOOL=True
+MY_CMAKE_FLAGS += -DILMBASE_CUSTOM_LIBRARIES:STRING="Half-fPIC Iex-fPIC IexMath-fPIC IlmThread-fPIC  Imath-fPIC"
+
+# Don't build testshade or testrender (mostly because they require the
+# image-handling parts of OIIO, which Pixar doesn't build)
+MY_CMAKE_FLAGS += -DOSL_BUILD_TESTS:BOOL=0
+
+# Don't let OSL create a default OIIO::TextureSystem. If the renderer
+# doesn't pass in whatever proxy it wants, it will assert.
+MY_CMAKE_FLAGS += -DOSL_NO_DEFAULT_TEXTURESYSTEM:BOOL=1
+
+ifneq (${VERBOSE},)
+$(info MY_CMAKE_FLAGS: $(MY_CMAKE_FLAGS))
+endif

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -78,7 +78,15 @@ stdoslpath ()
         boost::filesystem::path path (program);  // our program
         path = path.parent_path ();  // now the bin dir of our program
         path = path.parent_path ();  // now the parent dir
-        path = path / "shaders";
+        boost::filesystem::path savepath = path;
+        // We search two spots: ../../lib/osl/include, and ../shaders
+        path = savepath / "lib" / "osl" / "include";
+        if (OIIO::Filesystem::exists (path.string())) {
+            path = path / "stdosl.h";
+            if (OIIO::Filesystem::exists (path.string()))
+                return path.string();
+        }
+        path = savepath / "shaders";
         if (OIIO::Filesystem::exists (path.string())) {
             path = path / "stdosl.h";
             if (OIIO::Filesystem::exists (path.string()))


### PR DESCRIPTION
Just like we have for site/spi (and I'm happy to do for other sites that want to enshrine their weird build flags in the trunk so they don't need customizations on their end).

I'm only guessing about the contents, but with this structure in place, they can give it any additional customization it needs.

I also made a second search path for stdosl.h for where I know PRMan wants to look.

Note that this depends on a couple of the recently added build options.
