### PR TITLE
Add ShadingSystem::optimize_group to force a group to optimize/JIT

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -492,6 +492,9 @@ public:
     /// data passed in via attribute("raytypes")).
     int raytype_bit (ustring name);
 
+    /// Ensure that the group has been optimized and JITed.
+    void optimize_group (ShaderGroup *group);
+
     /// If option "greedyjit" was set, this call will trigger all
     /// shader groups that have not yet been compiled to do so with the
     /// specified number of threads (0 means use all available HW cores).

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -417,6 +417,15 @@ ShadingSystem::archive_shadergroup (ShaderGroup *group, string_view filename)
 
 
 
+void
+ShadingSystem::optimize_group (ShaderGroup *group)
+{
+    ASSERT (group);
+    m_impl->optimize_group (*group);
+}
+
+
+
 static TypeDesc TypeFloatArray2 (TypeDesc::FLOAT, 2);
 
 


### PR DESCRIPTION
This can occasionally be handy to make it happen at a particular time, and not necessarily only as a side effect of shading.
