### PR TITLE
Fix bugs when deserializing shader group strings with unsized arrays.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             texture-width texture-withderivs texture-wrap
             trailing-commas transform transformc trig typecast
             unknown-instruction
-            vararray-connect vararray-default vararray-param
+            vararray-connect vararray-default
+            vararray-deserialize vararray-param
             vecctr vector
             wavelength_color xml )
 endif ()

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1928,7 +1928,7 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
             break;  // error
         }
         if (Strutil::parse_char (p, '[')) {
-            int arraylen;
+            int arraylen = -1;
             Strutil::parse_int (p, arraylen);
             Strutil::parse_char (p, ']');
             type.arraylen = arraylen;
@@ -1945,27 +1945,59 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
         }
         string_view paramname (paramname_string);
         int lockgeom = true;
-        int nvals = type.numelements() * type.aggregate;
+        // For speed, reserve space. Note that for "unsized" arrays,
+        // numelements() will return 1, so we only preallocate 1 slot
+        // and let it grow as needed. That's ok. For everything else, we
+        // will reserve the right amount up front.
+        int vals_to_preallocate = type.numelements() * type.aggregate;
+        // Stop parsing values when we hit the limit based on the
+        // declaration.
+        int max_vals = type.is_unsized_array() ? 1<<28 : vals_to_preallocate;
         if (type.basetype == TypeDesc::INT) {
             intvals.clear ();
-            intvals.resize (nvals, 0);
-            for (int i = 0; i < nvals; ++i) {
-                if (! Strutil::parse_int (p, intvals[i]))
+            intvals.reserve (vals_to_preallocate);
+            int i;
+            for (i = 0; i < max_vals; ++i) {
+                int val = 0;
+                if (Strutil::parse_int (p, val))
+                    intvals.push_back (val);
+                else
                     break;
             }
+            if (type.is_unsized_array()) {
+                // For unsized arrays, now set the size based on how many
+                // values we actually read.
+                type.arraylen = std::max (1, i/type.aggregate);
+            }
+            // Zero-pad if we parsed fewer values than we needed
+            intvals.resize (type.numelements()*type.aggregate, 0);
+            ASSERT (type.numelements()*type.aggregate == int(intvals.size()));
             Parameter (paramname, type, &intvals[0], lockgeom);
         } else if (type.basetype == TypeDesc::FLOAT) {
             floatvals.clear ();
-            floatvals.resize (nvals, 0.0f);
-            for (int i = 0; i < nvals; ++i) {
-                if (! Strutil::parse_float (p, floatvals[i]))
+            floatvals.reserve (vals_to_preallocate);
+            int i;
+            for (i = 0; i < max_vals; ++i) {
+                float val = 0;
+                if (Strutil::parse_float (p, val))
+                    floatvals.push_back (val);
+                else
                     break;
             }
+            if (type.is_unsized_array()) {
+                // For unsized arrays, now set the size based on how many
+                // values we actually read.
+                type.arraylen = std::max (1, i/type.aggregate);
+            }
+            // Zero-pad if we parsed fewer values than we needed
+            floatvals.resize (type.numelements()*type.aggregate, 0);
+            ASSERT (type.numelements()*type.aggregate == int(floatvals.size()));
             Parameter (paramname, type, &floatvals[0], lockgeom);
         } else if (type.basetype == TypeDesc::STRING) {
             stringvals.clear ();
-            stringvals.resize (nvals);
-            for (int i = 0; i < nvals; ++i) {
+            stringvals.reserve (vals_to_preallocate);
+            int i;
+            for (i = 0; i < max_vals; ++i) {
                 std::string unescaped;
                 string_view s;
                 Strutil::skip_whitespace (p);
@@ -1980,8 +2012,16 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
                     if (s.size() == 0)
                         break;
                 }
-                stringvals[i] = ustring(s);
+                stringvals.push_back (ustring(s));
             }
+            if (type.is_unsized_array()) {
+                // For unsized arrays, now set the size based on how many
+                // values we actually read.
+                type.arraylen = std::max (1, i/type.aggregate);
+            }
+            // Zero-pad if we parsed fewer values than we needed
+            stringvals.resize (type.numelements()*type.aggregate, ustring());
+            ASSERT (type.numelements()*type.aggregate == int(stringvals.size()));
             Parameter (paramname, type, &stringvals[0], lockgeom);
         }
 

--- a/testsuite/vararray-deserialize/ref/out.txt
+++ b/testsuite/vararray-deserialize/ref/out.txt
@@ -1,0 +1,18 @@
+Compiled test.osl -> test.oso
+farr array length 5
+  [0] = 1.1
+  [1] = 1.2
+  [2] = 1.3
+  [3] = 1.4
+  [4] = 1.5
+carr array length 2
+  [0] = 0.1 0.2 0.3
+  [1] = 0.4 0.5 0.6
+iarr array length 2
+  [0] = 11
+  [1] = 12
+sarr array length 3
+  [0] = "foo"
+  [1] = "bar"
+  [2] = "baz"
+

--- a/testsuite/vararray-deserialize/run.py
+++ b/testsuite/vararray-deserialize/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command += testshade("-group serial.oslgroup")

--- a/testsuite/vararray-deserialize/serial.oslgroup
+++ b/testsuite/vararray-deserialize/serial.oslgroup
@@ -1,0 +1,7 @@
+param float[] farr 1.1 1.2 1.3 1.4 1.5 ;
+param int[] iarr 11 12 ;
+param string[] sarr "foo" "bar" "baz" ;
+param color[] carr 0.1 0.2 0.3 0.4 0.5 0.6 ;
+shader test ;
+
+

--- a/testsuite/vararray-deserialize/test.osl
+++ b/testsuite/vararray-deserialize/test.osl
@@ -1,0 +1,43 @@
+void print_array_contents (string name, int arr[])
+{
+    printf ("%s array length %d\n", name, arraylength(arr));
+    for (int i = 0; i < arraylength(arr); ++i)
+        printf ("  [%d] = %d\n", i, arr[i]);
+}
+
+
+void print_array_contents (string name, float arr[])
+{
+    printf ("%s array length %d\n", name, arraylength(arr));
+    for (int i = 0; i < arraylength(arr); ++i)
+        printf ("  [%d] = %g\n", i, arr[i]);
+}
+
+
+void print_array_contents (string name, color arr[])
+{
+    printf ("%s array length %d\n", name, arraylength(arr));
+    for (int i = 0; i < arraylength(arr); ++i)
+        printf ("  [%d] = %g\n", i, arr[i]);
+}
+
+
+void print_array_contents (string name, string arr[])
+{
+    printf ("%s array length %d\n", name, arraylength(arr));
+    for (int i = 0; i < arraylength(arr); ++i)
+        printf ("  [%d] = \"%s\"\n", i, arr[i]);
+}
+
+
+shader test (float  farr[] = {0},
+             color  carr[] = {0},
+             int    iarr[] = {0},
+             string sarr[] = {""}
+    )
+{
+    print_array_contents ("farr", farr);
+    print_array_contents ("carr", carr);
+    print_array_contents ("iarr", iarr);
+    print_array_contents ("sarr", sarr);
+}


### PR DESCRIPTION
When an unsized array parameter comes in (like: param int[] 1 2 3 4) we
don't actually know the parameter type yet, because the shader itself
hasn't been declared. So, first of all, handle the "int[]" part without
ending up with an uninitialized length, duh. But then, we can't
preallocate at that point, because we don't know how many ints there
will be, so grow the array as we read them, and then reset the type to
the right length that we actually saw.