### PR TITLE
Various cleanups on testrender and add "both" mode to microfacet closure

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4474,9 +4474,9 @@ anisotropic case {\cf U} must be a vector orthogonal to {\cf N} to specify the
 direction.  These values are expected to be the alpha values of the distribution
 as it appears in the literature, not a universal roughness measure.
 The {\cf eta} parameter is the index of refraction of the material, and
-{\cf refract} is a boolean flag to make the BSDF refractive instead of
-reflective. The implementation must not rely on {\cf U} when the roughness is
-isotropic or the given vector is zero.
+{\cf refract} is a enumeration flag that controls if the BSDF is reflective ({\cf 0}),
+refractive ({\cf 1}) or both at once ({\cf 2}). The implementation must not rely on
+{\cf U} when the roughness is isotropic or the given vector is zero.
 
 The list of supported distributions will change from renderer to renderer, and
 also the behavior when an unsupported distribution is requested. It is up to the

--- a/src/testrender/shading.h
+++ b/src/testrender/shading.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sampling.h"
 #include "OSL/dual_vec.h"
 #include "OSL/oslexec.h"
 #include "OSL/oslclosure.h"
@@ -11,23 +12,17 @@ OSL_NAMESPACE_ENTER
 /// Individual BSDF (diffuse, phong, refraction, etc ...)
 /// Actual implementations of this class are private
 struct BSDF {
-    BSDF(bool singular) : singular(singular) {}
+    BSDF() {}
     virtual float albedo(const ShaderGlobals& sg) const { return 1; }
     virtual float eval  (const ShaderGlobals& sg, const Vec3& wi, float& pdf) const = 0;
-    virtual float sample(const ShaderGlobals& sg, float rx, float ry, Dual2<Vec3>& wi, float& invpdf) const = 0;
-
-    bool singular; // if true, only a single direction is possible (light loop not required)
+    virtual float sample(const ShaderGlobals& sg, float rx, float ry, float rz, Dual2<Vec3>& wi, float& pdf) const = 0;
 };
 
 /// Represents a weighted sum of BSDFS
 /// NOTE: no need to inherit from BSDF here because we use a "flattened" representation and therefore never nest these
 ///
 struct CompositeBSDF {
-    CompositeBSDF() : num_bsdfs(0), num_bytes(0), all_singular(true) {}
-
-    bool singular() const {
-        return all_singular;
-    }
+    CompositeBSDF() : num_bsdfs(0), num_bytes(0) {}
 
     void prepare(const ShaderGlobals& sg, const Color3& path_weight, bool absorb) {
         float w = 1 / (path_weight.x + path_weight.y + path_weight.z);
@@ -46,33 +41,28 @@ struct CompositeBSDF {
         Color3 result(0, 0, 0); pdf = 0;
         for (int i = 0; i < num_bsdfs; i++) {
             float bsdf_pdf = 0;
-            result += weights[i] * bsdfs[i]->eval(sg, wi, bsdf_pdf);
-            pdf += pdfs[i] * bsdf_pdf;
+            Color3 bsdf_weight = weights[i] * bsdfs[i]->eval(sg, wi, bsdf_pdf);
+            MIS::update_eval(&result, &pdf, bsdf_weight, bsdf_pdf, pdfs[i]);
         }
         return result;
     }
 
-    Color3 sample(const ShaderGlobals& sg, float rx, float ry, Dual2<Vec3>& wi, float& invpdf) const {
+    Color3 sample(const ShaderGlobals& sg, float rx, float ry, float rz, Dual2<Vec3>& wi, float& pdf) const {
         float accum = 0;
         for (int i = 0; i < num_bsdfs; i++) {
             if (rx < (pdfs[i] + accum)) {
                 rx = (rx - accum) / pdfs[i];
                 rx = std::min(rx, 0.99999994f); // keep result in [0,1)
-                Color3 result = weights[i] * bsdfs[i]->sample(sg, rx, ry, wi, invpdf);
+                Color3 result = weights[i] * (bsdfs[i]->sample(sg, rx, ry, rz, wi, pdf) / pdfs[i]);
+                pdf *= pdfs[i];
                 // we sampled PDF i, now figure out how much the other bsdfs contribute to the chosen direction
-                Color3 other_result(0, 0, 0);
-                float other_pdfs = 0;
                 for (int j = 0; j < num_bsdfs; j++) {
                     if (i == j) continue;
                     float bsdf_pdf = 0;
-                    other_result += weights[j] * bsdfs[j]->eval(sg, wi.val(), bsdf_pdf);
-                    other_pdfs += pdfs[j] * bsdf_pdf;
+                    Color3 bsdf_weight = weights[j] * bsdfs[j]->eval(sg, wi.val(), bsdf_pdf);
+		            MIS::update_eval(&result, &pdf, bsdf_weight, bsdf_pdf, pdfs[j]);
                 }
-                // combine the result of the other bsdfs by MIS
-                float d = 1 / (pdfs[i] + invpdf * other_pdfs);
-                result += invpdf * other_result;
-                invpdf *= d;
-                return result * d;
+                return result;
             }
             accum += pdfs[i];
         }
@@ -86,7 +76,6 @@ struct CompositeBSDF {
         if (num_bytes + sizeof(BSDF_Type) > MaxSize) return false;
         weights[num_bsdfs] = w;
         bsdfs  [num_bsdfs] = new (pool + num_bytes) BSDF_Type(params);
-        all_singular &= bsdfs[num_bsdfs]->singular;
         num_bsdfs++;
         num_bytes += sizeof(BSDF_Type);
         return true;
@@ -105,7 +94,6 @@ private:
     BSDF*  bsdfs[MaxEntries];
     char   pool[MaxSize];
     int    num_bsdfs, num_bytes;
-    bool   all_singular;
 };
 
 struct ShadingResult {

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -29,7 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <map>
-#include <OpenImageIO/hash.h>
+#include <boost/unordered_map.hpp>
+#include <OpenImageIO/ustring.h>
 #include "OSL/oslexec.h"
 
 OSL_NAMESPACE_ENTER

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -29,7 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <map>
-#include <OpenImageIO/hash.h>
+#include <boost/unordered_map.hpp>
+#include <OpenImageIO/ustring.h>
 #include "OSL/oslexec.h"
 
 OSL_NAMESPACE_ENTER


### PR DESCRIPTION
Standardize testrender pdf calculation (there was a mix of pdf vs. invpdf in there).

Add a mode to microfacet that lets reflection and refraction be described in a single closure (which is advantageous for sampling).