### PR TITLE
Fix subtle optimizer bug with constant folding of format()

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -210,7 +210,7 @@ DECL (osl_dict_value, "iXiXLX")
 DECL (osl_raytype_name, "iXX")
 DECL (osl_range_check, "iiiXXi")
 DECL (osl_naninf_check, "xiXiXXiXiiX")
-DECL (osl_uninit_check, "xLXXXiXiXiXXii")
+DECL (osl_uninit_check, "xLXXXiXiXXiXiXii")
 DECL (osl_get_attribute, "iXiXXiiXX")
 DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
 DECL (osl_get_texture_options, "XX");

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1265,7 +1265,8 @@ DECLFOLDER(constfold_format)
         newargs[1] = rop.add_constant (ustring(prefix + suffix));
         ustring opname = op.opname();
         rop.turn_into_nop (op, "partial constant fold format()");
-        rop.insert_code (opnum, opname, newargs);
+        rop.insert_code (opnum, opname, newargs,
+                         RuntimeOptimizer::RecomputeRWRanges);
         return 1;
     }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -647,13 +647,15 @@ BackendLLVM::llvm_generate_debug_uninit (const Opcode &op)
                                 ll.constant(group().name()),
                                 ll.constant(layer()),
                                 ll.constant(inst()->layername()),
+                                ll.constant(inst()->shadername().c_str()),
                                 ll.constant(int(&op - &inst()->ops()[0])),
                                 ll.constant(op.opname()),
+                                ll.constant(i),
                                 ll.constant(sym.name()),
                                 offset,
                                 ncheck
                               };
-        ll.call_function ("osl_uninit_check", args, 13);
+        ll.call_function ("osl_uninit_check", args, 15);
     }
 }
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -452,7 +452,8 @@ RuntimeOptimizer::turn_into_nop (int begin, int end, string_view why)
 void
 RuntimeOptimizer::insert_code (int opnum, ustring opname,
                                const int *argsbegin, const int *argsend,
-                               bool recompute_rw_ranges, int relation)
+                               RecomputeRWRangesOption recompute_rw_ranges,
+                               InsertRelation relation)
 {
     OpcodeVec &code (inst()->ops());
     std::vector<int> &opargs (inst()->args());
@@ -555,7 +556,8 @@ RuntimeOptimizer::insert_code (int opnum, ustring opname,
 void
 RuntimeOptimizer::insert_code (int opnum, ustring opname,
                                const std::vector<int> &args_to_add,
-                               bool recompute_rw_ranges, int relation)
+                               RecomputeRWRangesOption recompute_rw_ranges,
+                               InsertRelation relation)
 {
     const int *argsbegin = (args_to_add.size())? &args_to_add[0]: NULL;
     const int *argsend = argsbegin + args_to_add.size();
@@ -567,7 +569,8 @@ RuntimeOptimizer::insert_code (int opnum, ustring opname,
 
 
 void
-RuntimeOptimizer::insert_code (int opnum, ustring opname, int relation,
+RuntimeOptimizer::insert_code (int opnum, ustring opname,
+                               InsertRelation relation,
                                int arg0, int arg1, int arg2, int arg3)
 {
     int args[4];
@@ -576,7 +579,7 @@ RuntimeOptimizer::insert_code (int opnum, ustring opname, int relation,
     if (arg1 >= 0) args[nargs++] = arg1;
     if (arg2 >= 0) args[nargs++] = arg2;
     if (arg3 >= 0) args[nargs++] = arg3;
-    insert_code (opnum, opname, args, args+nargs, true, relation);
+    insert_code (opnum, opname, args, args+nargs, RecomputeRWRanges, relation);
 }
 
 
@@ -589,7 +592,8 @@ RuntimeOptimizer::insert_useparam (size_t opnum,
 {
     ASSERT (params_to_use.size() > 0);
     OpcodeVec &code (inst()->ops());
-    insert_code (opnum, u_useparam, params_to_use, 1);
+    insert_code (opnum, u_useparam, params_to_use,
+                 RecomputeRWRanges, GroupWithNext);
 
     // All ops are "read"
     code[opnum].argwrite (0, false);
@@ -1665,7 +1669,8 @@ RuntimeOptimizer::peephole2 (int opnum)
                 newargs.push_back (oparg(op,i));
             turn_into_nop (op, "combine closure+mul");
             turn_into_nop (next, "combine closure+mul");
-            insert_code (opnum, u_closure, newargs, true, 1);
+            insert_code (opnum, u_closure, newargs,
+                         RecomputeRWRanges, GroupWithNext);
             if (debug() > 1)
                 std::cout << "op " << opnum << "-" << (op2num) 
                           << " combined closure+mul\n";            

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -335,11 +335,11 @@ RuntimeOptimizer::turn_into_new_op (Opcode &op, ustring newop, int newarg0,
     DASSERT (opnum >= 0 && opnum < (int)inst()->ops().size());
     if (debug() > 1)
         std::cout << "turned op " << opnum
-                  << " from " << op.opname() << " to "
+                  << " from '" << op_string(op) << "' to '"
                   << newop << ' ' << inst()->symbol(newarg0)->name() << ' '
                   << inst()->symbol(newarg1)->name() << ' '
                   << (newarg2<0 ? "" : inst()->symbol(newarg2)->name().c_str())
-                  << (why.size() ? " : " : "") << why << "\n";
+                  << (why.size() ? "' : " : "'") << why << "\n";
     op.reset (newop, newarg2<0 ? 2 : 3);
     inst()->args()[op.firstarg()+0] = newarg0;
     op.argwriteonly (0);
@@ -363,9 +363,9 @@ RuntimeOptimizer::turn_into_assign (Opcode &op, int newarg, string_view why)
     int opnum = &op - &(inst()->ops()[0]);
     if (debug() > 1)
         std::cout << "turned op " << opnum
-                  << " from " << op.opname() << " to "
+                  << " from '" << op_string(op) << "' to '"
                   << opargsym(op,0)->name() << " = " 
-                  << inst()->symbol(newarg)->name()
+                  << inst()->symbol(newarg)->name() << "'"
                   << (why.size() ? " : " : "") << why << "\n";
     op.reset (u_assign, 2);
     inst()->args()[op.firstarg()+1] = newarg;
@@ -420,7 +420,7 @@ RuntimeOptimizer::turn_into_nop (Opcode &op, string_view why)
     if (op.opname() != u_nop) {
         if (debug() > 1)
             std::cout << "turned op " << (&op - &(inst()->ops()[0]))
-                      << " from " << op.opname() << " to nop"
+                      << " from '" << op_string(op) << "' to 'nop'"
                       << (why.size() ? " : " : "") << why << "\n";
         op.reset (u_nop, 0);
         return 1;
@@ -442,7 +442,7 @@ RuntimeOptimizer::turn_into_nop (int begin, int end, string_view why)
         }
     }
     if (debug() > 1 && changed)
-        std::cout << "turned ops " << begin << "-" << (end-1) << " into nop"
+        std::cout << "turned ops " << begin << "-" << (end-1) << " into 'nop'"
                   << (why.size() ? " : " : "") << why << "\n";
     return changed;
 }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -347,6 +347,13 @@ public:
 
     void stop_optimizing () { m_stop_optimizing = true; }
 
+    std::string op_string (const Opcode &op) {
+        std::string s = op.opname().string();
+        for (int a = 0;  a < op.nargs();  ++a)
+            s = s + ' ' + opargsym(op,a)->name().string();
+        return s;
+    }
+
 private:
     int m_optimize;                   ///< Current optimization level
     bool m_opt_simplify_param;            ///< Turn instance params into const?

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -236,29 +236,35 @@ public:
 
     void make_symbol_room (int howmany=1);
 
-    /// Insert instruction 'opname' with arguments 'args_to_add' into the 
-    /// code at instruction 'opnum'.  The existing code and concatenated 
-    /// argument lists can be found in code and opargs, respectively, and
-    /// allsyms contains pointers to all symbols.  mainstart is a reference
-    /// to the address where the 'main' shader begins, and may be modified
-    /// if the new instruction is inserted before that point.
-    /// If recompute_rw_ranges is true, also adjust all symbols' read/write
-    /// ranges to take the new instruction into consideration.
-    /// Relation indicates its relation to surrounding instructions:
-    /// 0 means none, -1 means it should have the same method, sourcefile,
-    /// and sourceline as the preceeding instruction, 1 means it should
-    /// have the same method, sourcefile, and sourceline as the subsequent
-    /// instruction.
+    enum RecomputeRWRangesOption { DontRecomputeRWRanges, RecomputeRWRanges };
+    enum InsertRelation { NoRelation=0, GroupWithPrevious=-1, GroupWithNext=1 };
+    /// Insert instruction 'opname' with arguments 'args_to_add' into
+    /// the code at instruction 'opnum'.  The existing code and
+    /// concatenated argument lists can be found in code and opargs,
+    /// respectively, and allsyms contains pointers to all symbols.
+    /// mainstart is a reference to the address where the 'main' shader
+    /// begins, and may be modified if the new instruction is inserted
+    /// before that point.  The recompute_rw_ranges parameter determines
+    /// whether all symbols' read/write ranges should be adjusted to
+    /// take the new instruction into consideration.  Relation indicates
+    /// its relation to surrounding instructions: GroupWithPrevious
+    /// means it should have the same method, sourcefile, and sourceline
+    /// as the preceeding instruction; GroupWithNext means it should
+    /// have the same method, sourcefile, and sourceline as the
+    /// subsequent instruction; NoRelation means we have no information,
+    /// so don't copy that info from anywhere.
     void insert_code (int opnum, ustring opname,
                       const std::vector<int> &args_to_add,
-                      bool recompute_rw_ranges=false, int relation=0);
+                      RecomputeRWRangesOption recompute_rw_ranges,
+                      InsertRelation relation=GroupWithNext);
     /// insert_code with begin/end arg array pointers.
     void insert_code (int opnum, ustring opname,
                       const int *argsbegin, const int *argsend,
-                      bool recompute_rw_ranges=false, int relation=0);
+                      RecomputeRWRangesOption recompute_rw_ranges,
+                      InsertRelation relation=GroupWithNext);
     /// insert_code with explicit arguments (up to 4, a value of -1 means
     /// the arg isn't used).  Presume recompute_rw_ranges is true.
-    void insert_code (int opnum, ustring opname, int relation,
+    void insert_code (int opnum, ustring opname, InsertRelation relation,
                       int arg0=-1, int arg1=-1, int arg2=-1, int arg3=-1);
 
     void insert_useparam (size_t opnum, const std::vector<int> &params_to_use);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2913,7 +2913,8 @@ OSL_SHADEOP void
 osl_uninit_check (long long typedesc_, void *vals_,
                   void *sg, const void *sourcefile, int sourceline,
                   const char *groupname, int layer, const char *layername,
-                  int opnum, const char *opname,
+                  const char *shadername,
+                  int opnum, const char *opname, int argnum,
                   void *symbolname, int firstcheck, int nchecks)
 {
     TypeDesc typedesc = TYPEDESC(typedesc_);
@@ -2944,11 +2945,11 @@ osl_uninit_check (long long typedesc_, void *vals_,
             }
     }
     if (uninit) {
-        ctx->error ("Detected possible use of uninitialized value in %s at %s:%d (group %s, layer %d %s, op %d '%s')",
-                    USTR(symbolname), USTR(sourcefile), sourceline,
+        ctx->error ("Detected possible use of uninitialized value in %s %s at %s:%d (group %s, layer %d %s, shader %s, op %d '%s', arg %d)",
+                    typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
                     groupname ? groupname: "<unnamed group>",
                     layer, layername ? layername : "<unnamed layer>",
-                    opnum, USTR(opname));
+                    shadername, opnum, USTR(opname), argnum);
     }
 }
 

--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
-ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 0 'assign')
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 0 'assign', arg 1)
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 1 'color')
-ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11 (group <unnamed group>, layer 0 , op 2 'texture')
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 1 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 , shader test, op 2 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
-ERROR: Detected possible use of uninitialized value in i_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 3 'assign')
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 3 'assign', arg 1)
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in f_uninit at test.osl:10 (group <unnamed group>, layer 0 , op 4 'color')
-ERROR: Detected possible use of uninitialized value in s_uninit at test.osl:11 (group <unnamed group>, layer 0 , op 5 'texture')
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 4 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 , shader test, op 5 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename


### PR DESCRIPTION
Undetected for quite some time, it seems that the constant folding of format() involved inserting an op, and the insert_code() call omitted a vital parameter that would instruct it to recompute the read/write ranges of symbols after the insertion. This could lead to a cascade of bad things later, and in particular could cause it to make mistakes where a symbol assignment might be removed if it (incorrectly) thought it would not be subsequently read.

It must have needed a very precise set of circumstances -- we've had this bug in the code for over a year, it never was reported as a bug, and we only discovered it when for other reasons we resurrected a scene and a version of our shader library from a couple years ago and found it had some weird errors. Somehow none of our current shaders seem to trigger it.

The real fix for the bug is just the one-line change at 1266 of constfold.cpp.

But along the way, I made a number of changes to help track down the problem and to make the code less error prone in the future:

* Changed the call sequence of insert_code to make the recompute_rw_range paramter required, not optional, and also made it (and also the 'relation' parameter) be typed enums rather than bool and int, respectively. So instead of calling ```insert_code (..., true, 1, ...)```, instead now you'd call ```insert_code (..., RecomputeRWRanges, GroupWithNext, ...)```. I like this idiom of eschewing bool parameters in favor of enums, and am starting to use it more frequently in new code.

* Improved the optimizer debug output so that the explanations of how ops were changed from one instruction to another, print the full argument list of the pre-changed version.

* Changed the error output for debug_uninit when uninitialized values are found, to say which shader it happened in, which argument to the instruction and the type (in addition to the name) of the argument that appears to be uninitialized.


