### PR TITLE
Add query for which getattribute() calls a shader group might make.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -263,6 +263,22 @@ public:
     ///   ptr userdata_offsets       Retrieves a pointer to the array of
     ///                                 int describing the userdata offsets
     ///                                 within the heap.
+    ///   int num_attributes_needed  The number of attribute/scope pairs that
+    ///                                are known to be queried by the group (the
+    ///                                length of the attributes_needed and
+    ///                                attribute_scopes arrays).
+    ///   ptr attributes_needed      Retrieves a pointer to the ustring array
+    ///                                containing the names of the needed attributes.
+    ///	                               Note that if the same attribute
+    ///                                is requested in multiple scopes, it will
+    ///                                appear in the array multiple times - once for
+    ///                                each scope in which is is queried.
+    ///   ptr attribute_scopes       Retrieves a pointer to a ustring array containing
+    ///                                the scopes associated with each attribute query
+    ///                                in the attributes_needed array.
+    ///   int unknown_attributes_needed  Nonzero if additonal attributes may be
+    ///                                  needed, whose names will not be known
+    ///                                  until the shader actually runs.
     ///   string pickle              Retrieves a serialized representation
     ///                                 of the shader group declaration.
     /// Note: the attributes referred to as "string" are actually on the app

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -185,8 +185,22 @@ struct UserDataNeeded {
     }
 };
 
+// Struct defining an attribute needed by a shader group
+struct AttributeNeeded {
+    ustring name;
+    ustring scope;
 
+    AttributeNeeded (ustring name, ustring scope = ustring())
+        : name(name), scope(scope) {}
 
+    friend bool operator< (const AttributeNeeded &a, const AttributeNeeded &b) {
+        if (a.name != b.name)
+            return a.name < b.name;
+        if (a.scope != b.scope)
+            return a.scope < b.scope;
+        return false;  // they are equal
+    }
+};
 
 // Prefix for OSL shade up declarations, so LLVM can find them
 #define OSL_SHADEOP extern "C" OSL_LLVM_EXPORT
@@ -1359,9 +1373,12 @@ private:
     std::vector<TypeDesc> m_userdata_types;
     std::vector<int> m_userdata_offsets;
     std::vector<char> m_userdata_derivs;
+    std::vector<ustring> m_attributes_needed;
+    std::vector<ustring> m_attribute_scopes;
     std::vector<ustring> m_renderer_outputs; ///< Names of renderer outputs
     bool m_unknown_textures_needed;
     bool m_unknown_closures_needed;
+    bool m_unknown_attributes_needed;
     atomic_ll m_executions;          ///< Number of times the group executed
     atomic_ll m_stat_total_shading_time_ticks; ///< Total shading time (ticks)
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -58,7 +58,8 @@ static ustring u_nop    ("nop"),
                u_pointcloud_write ("pointcloud_write"),
                u_isconnected ("isconnected"),
                u_setmessage ("setmessage"),
-               u_getmessage ("getmessage");
+               u_getmessage ("getmessage"),
+               u_getattribute ("getattribute");
 
 
 OSL_NAMESPACE_ENTER
@@ -2811,10 +2812,12 @@ RuntimeOptimizer::run ()
 
     m_unknown_textures_needed = false;
     m_unknown_closures_needed = false;
+    m_unknown_attributes_needed = false;
     m_textures_needed.clear();
     m_closures_needed.clear();
     m_globals_needed.clear();
     m_userdata_needed.clear();
+    m_attributes_needed.clear();
     for (int layer = 0;  layer < nlayers;  ++layer) {
         set_inst (layer);
         if (inst()->unused())
@@ -2864,6 +2867,34 @@ RuntimeOptimizer::run ()
                 } else {
                     m_unknown_closures_needed = true;
                 }
+            } else if (op.opname() == u_getattribute) {
+                Symbol *sym1 = opargsym (op, 1);
+                ASSERT (sym1 && sym1->typespec().is_string());
+                if (sym1->is_constant()) {
+                    if (op.nargs() == 3) {
+                        // getattribute( attributename, result )
+                        m_attributes_needed.insert( AttributeNeeded( *(ustring *)sym1->data() ) );
+                    } else {
+                        ASSERT (op.nargs() == 4 || op.nargs() == 5);
+                        Symbol *sym2 = opargsym (op, 2);
+                        if (sym2->typespec().is_string()) {
+                            // getattribute( scopename, attributename, result ) or
+                            // getattribute( scopename, attributename, arrayindex, result )
+                            if (sym2->is_constant()) {
+                                m_attributes_needed.insert( AttributeNeeded(
+                                    *(ustring *)sym2->data(), *(ustring *)sym1->data()
+                                ) );
+                            } else {
+                                m_unknown_attributes_needed = true;
+                            }
+                        } else {
+                            // getattribute( attributename, arrayindex, result )
+                            m_attributes_needed.insert( AttributeNeeded( *(ustring *)sym1->data() ) );
+                        }
+                    }
+                } else { // sym1 not constant
+                    m_unknown_attributes_needed = true;
+                }
             }
         }
     }
@@ -2897,6 +2928,13 @@ RuntimeOptimizer::run ()
             BOOST_FOREACH (UserDataNeeded f, m_userdata_needed)
                 shadingcontext()->info ("    %s %s %s", f.name, f.type,
                                         f.derivs ? "(derivs)" : "");
+        }
+        if (m_attributes_needed.size()) {
+            shadingcontext()->info ("Group needs attributes:");
+            BOOST_FOREACH (const AttributeNeeded &f, m_attributes_needed)
+                shadingcontext()->info ("    %s %s", f.name, f.scope);
+            if (m_unknown_attributes_needed)
+                shadingcontext()->info ("    Also may construct attribute names on the fly.");
         }
     }
 }

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -393,8 +393,10 @@ private:
     std::set<ustring> m_textures_needed;
     std::set<ustring> m_closures_needed;
     std::set<ustring> m_globals_needed;
+    std::set<AttributeNeeded> m_attributes_needed;
     bool m_unknown_textures_needed;
     bool m_unknown_closures_needed;
+    bool m_unknown_attributes_needed;
     std::set<UserDataNeeded> m_userdata_needed;
     double m_stat_opt_locking_time;       ///<   locking time
     double m_stat_specialization_time;    ///<   specialization time

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1312,6 +1312,34 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
         *(ustring *)val = ustring(group->serialize());
         return true;
     }
+
+    if (name == "num_attributes_needed" && type == TypeDesc::TypeInt) {
+        if (! group->optimized())
+            optimize_group (*group);
+        *(int *)val = (int)group->m_attributes_needed.size();
+        return true;
+    }
+    if (name == "attributes_needed" && type.basetype == TypeDesc::PTR) {
+        if (! group->optimized())
+            optimize_group (*group);
+        size_t n = group->m_attributes_needed.size();
+        *(ustring **)val = n ? &group->m_attributes_needed[0] : NULL;
+        return true;
+    }
+    if (name == "attribute_scopes" && type.basetype == TypeDesc::PTR) {
+        if (! group->optimized())
+            optimize_group (*group);
+        size_t n = group->m_attribute_scopes.size();
+        *(ustring **)val = n ? &group->m_attribute_scopes[0] : NULL;
+        return true;
+    }
+    if (name == "unknown_attributes_needed" && type == TypeDesc::TypeInt) {
+        if (! group->optimized())
+            optimize_group (*group);
+        *(int *)val = (int)group->m_unknown_attributes_needed;
+        return true;
+    }
+
     return false;
 }
 
@@ -2463,6 +2491,11 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group)
         group.m_userdata_names.push_back (n.name);
         group.m_userdata_types.push_back (n.type);
         group.m_userdata_derivs.push_back (n.derivs);
+    }
+    group.m_unknown_attributes_needed = rop.m_unknown_attributes_needed;
+    BOOST_FOREACH (const AttributeNeeded &f, rop.m_attributes_needed) {
+        group.m_attributes_needed.push_back (f.name);
+        group.m_attribute_scopes.push_back (f.scope);
     }
 
     BackendLLVM lljitter (*this, group, ctx);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -767,6 +767,26 @@ test_group_attributes (ShaderGroup *group)
                       << userdata_offsets[i] << " deriv="
                       << userdata_derivs[i] << "\n";
     }
+    int nattr = 0;
+    if (shadingsys->getattribute (group, "num_attributes_needed", nattr) && nattr) {
+        std::cout << "Need " << nattr << " attributes:\n";
+        ustring *names = NULL;
+        ustring *scopes = NULL;
+        shadingsys->getattribute (group, "attributes_needed",
+                                  TypeDesc::PTR, &names);
+        shadingsys->getattribute (group, "attribute_scopes",
+                                  TypeDesc::PTR, &scopes);
+        DASSERT (names && scopes);
+        for (int i = 0; i < nattr; ++i)
+            std::cout << "    " << names[i] << ' '
+                      << scopes[i] << "\n";
+
+        int unk = 0;
+        shadingsys->getattribute (group, "unknown_attributes_needed", unk);
+        if (unk)
+            std::cout << "    and unknown attributes\n";
+    }
+
 }
 
 


### PR DESCRIPTION
New shader group queries for "num_attributes_needed", "attributes_needed", "attribute_scopes", "unknown_attributes_needed". These follow the convention for the existing texture and closure queries.

The motivation for this is to allow OSL to be used in another non-rendering context in Gaffer - we have a prototype which is already massively outperforming Gaffer's existing expression engine, and this will allow further features and performance enhancements.

I would like to add unit tests for this - any advice as to how to go about that? On the same subject, I'm actually seeing 97 failures when I do "make test", both on master and on this branch, but I'm not sure how to dive in closer to see how/why things are failing - is more verbose output available somewhere? Presumably there's just a problem with my setup rather than them being genuine.