### PR TITLE
Bug fix with unconditional running of earlier layers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             geomath getattribute-camera getsymbol-nonheap gettextureinfo
             group-outputs groupstring
             hyperb ieee_fp if incdec initops intbits isconnected
-            layers layers-Ciassign layers-lazy layers-repeatedoutputs
+            layers layers-Ciassign layers-lazy
+            layers-nonlazycopy layers-repeatedoutputs
             logic loop matrix message mergeinstances-nouserdata
             metadata-braces miscmath missing-shader
             noise noise-cell

--- a/testsuite/layers-nonlazycopy/a.osl
+++ b/testsuite/layers-nonlazycopy/a.osl
@@ -1,0 +1,7 @@
+surface a ( output closure color CCout = 0 )
+{
+    CCout = diffuse(N) * color(0,0.18,0);
+    Ci = CCout;
+    printf ("a: CCout = %s\n", CCout);
+    printf ("a: Ci = %s\n", Ci);
+}

--- a/testsuite/layers-nonlazycopy/b.osl
+++ b/testsuite/layers-nonlazycopy/b.osl
@@ -1,0 +1,6 @@
+surface b ( closure color CCin = 0 )
+{
+    printf("\nb: CCin = %s\n", CCin);
+    Ci = CCin + diffuse(N) * color(.18,0,0);
+    printf("b: Ci = %s\n",Ci);
+}

--- a/testsuite/layers-nonlazycopy/ref/out.txt
+++ b/testsuite/layers-nonlazycopy/ref/out.txt
@@ -1,0 +1,10 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect alayer.CCout to blayer.CCin
+a: CCout = (0, 0.18, 0) * diffuse ((0, 0, 1))
+a: Ci = (0, 0.18, 0) * diffuse ((0, 0, 1))
+
+b: CCin = (0, 0.18, 0) * diffuse ((0, 0, 1))
+b: Ci = (0, 0.18, 0) * diffuse ((0, 0, 1))
+	+ (0.18, 0, 0) * diffuse ((0, 0, 1))
+

--- a/testsuite/layers-nonlazycopy/run.py
+++ b/testsuite/layers-nonlazycopy/run.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# Example that failed with a prior bug.
+# The test case is that layer a modifies Ci so is unconditional, but also
+# its output CCout is connected to layer b's CCin. There was a bug where
+# the earlier layer was run and its values copied before (duh, not after)
+# b's params would be initialized, thus overwriting the copied values.
+
+
+command += testshade("-layer alayer a -layer blayer b --connect alayer CCout blayer CCin")
+


### PR DESCRIPTION
Subtlety: When generating code for the "group entry" (last) layer, which
is also responsible for executing all earlier layers that are marked as
needing to run unconditionally (non-lazily), it is important that the
group entry layer initialize its input parameters BEFORE it runs the
earlier unconditional layers and copies the upstream outputs to its own
inputs. Of course. Because, duh, if it first runs the upstream layer and
copies the upsteam outputs to its own input, THEN zeroes out or
otherwise initializes its inputs, it will overwrite the value set by the
earlier layer.