### PR TITLE
Fix for uninitialized static array in case of multithreaded access (vs2012)

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -221,10 +221,7 @@ BackendLLVM::llvm_zero_derivs (const Symbol &sym, llvm::Value *count)
     }
 }
 
-
-
-int
-BackendLLVM::ShaderGlobalNameToIndex (ustring name)
+namespace
 {
     // N.B. The order of names in this table MUST exactly match the
     // ShaderGlobals struct in oslexec.h, as well as the llvm 'sg' type
@@ -240,7 +237,11 @@ BackendLLVM::ShaderGlobalNameToIndex (ustring name)
         ustring("surfacearea"), ustring("raytype"),
         ustring("flipHandedness"), ustring("backfacing")
     };
+}
 
+int
+BackendLLVM::ShaderGlobalNameToIndex (ustring name)
+{
     for (int i = 0;  i < int(sizeof(fields)/sizeof(fields[0]));  ++i)
         if (name == fields[i])
             return i;


### PR DESCRIPTION
It seems that vs2012 does not guarantee that local static member are fully initialized when multiple thread access to the function. This commit fixes the problem we had with OSL arbitrarily not recognizing global symbols in shaders.
