### PR TITLE
Support for closure arrays in shader inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             blackbody blendmath breakcont
             bug-array-heapoffsets
             bug-locallifetime bug-outputinit bug-param-duplicate bug-peep
-            cellnoise closure color comparison
+            cellnoise closure closure-array color comparison
             compile-buffer
             component-range const-array-params const-array-fill
             debugnan debug-uninit

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -778,8 +778,8 @@ BackendLLVM::llvm_assign_impl (Symbol &Result, Symbol &Src,
 
     llvm::Value *arrind = arrayindex >= 0 ? ll.constant (arrayindex) : NULL;
 
-    if (Result.typespec().is_closure_based() || Src.typespec().is_closure_based()) {
-        if (Src.typespec().is_closure_based()) {
+    if (Result.typespec().is_closure() || Src.typespec().is_closure()) {
+        if (Src.typespec().is_closure()) {
             llvm::Value *srcval = llvm_load_value (Src, 0, arrind, 0);
             llvm_store_value (srcval, Result, 0, arrind, 0);
         } else {

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -168,7 +168,7 @@ OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name_
         } else if (typespec.simpletype().basetype == TypeDesc::STRING) {
             sym.dataoffset ((int) m_master->m_sdefaults.size());
             expand (m_master->m_sdefaults, nvals);
-        } else if (typespec.is_closure()) {
+        } else if (typespec.is_closure_based()) {
             // Closures are pointers, so we allocate a string default taking
             // adventage of their default being NULL as well.
             sym.dataoffset ((int) m_master->m_sdefaults.size());

--- a/testsuite/closure-array/a.osl
+++ b/testsuite/closure-array/a.osl
@@ -1,0 +1,8 @@
+shader a (output closure color output_closure = 0)
+{
+	printf("Shader a \n");
+    for (int i = 1; i < 3 ; ++i)
+    {
+        output_closure += color(u/i, 2.0, 0.0) * diffuse(N);
+    }
+}

--- a/testsuite/closure-array/b.osl
+++ b/testsuite/closure-array/b.osl
@@ -1,0 +1,10 @@
+shader b (closure color input_closures[2] = {0})
+{
+    printf("Shader b \n");
+    for (int i = 0; i < 2 ; ++i)
+    {
+        printf("In %d : %s\n", i, input_closures[i]);
+        Ci += input_closures[i];
+    }
+    printf("Ci : %s \n", Ci);
+}

--- a/testsuite/closure-array/c.osl
+++ b/testsuite/closure-array/c.osl
@@ -1,0 +1,8 @@
+shader c (
+    closure color in0 = 0,
+    closure color in1 = 0,
+    output closure color output_closures[2] = {in0, in1}
+    )
+{
+    printf("Shader c \n");
+}

--- a/testsuite/closure-array/d.osl
+++ b/testsuite/closure-array/d.osl
@@ -1,0 +1,8 @@
+shader d (output closure color output_closure = 0)
+{
+	printf("Shader d \n");
+    for (int i = 1; i < 4 ; ++i)
+    {
+        output_closure += color(v/i, 0.0, 3.0) * diffuse(N);
+    }
+}

--- a/testsuite/closure-array/ref/out.opt.txt
+++ b/testsuite/closure-array/ref/out.opt.txt
@@ -1,0 +1,22 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Compiled c.osl -> c.oso
+Compiled d.osl -> d.oso
+Connect alayer.output_closure to clayer.in0
+Connect dlayer.output_closure to clayer.in1
+Connect clayer.output_closures to blayer.input_closures
+Shader b 
+Shader a 
+Shader d 
+Shader c 
+In 0 : (0.5, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.25, 2, 0) * diffuse ((0, 0, 1))
+In 1 : (0.5, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.25, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.166667, 0, 3) * diffuse ((0, 0, 1))
+Ci : (0.5, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.25, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.5, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.25, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.166667, 0, 3) * diffuse ((0, 0, 1)) 
+

--- a/testsuite/closure-array/ref/out.txt
+++ b/testsuite/closure-array/ref/out.txt
@@ -1,0 +1,22 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Compiled c.osl -> c.oso
+Compiled d.osl -> d.oso
+Connect alayer.output_closure to clayer.in0
+Connect dlayer.output_closure to clayer.in1
+Connect clayer.output_closures to blayer.input_closures
+Shader b 
+Shader a 
+Shader d 
+Shader c 
+In 0 : (0.5, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.25, 2, 0) * diffuse ((0, 0, 1))
+In 1 : (0.5, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.25, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.166667, 0, 3) * diffuse ((0, 0, 1))
+Ci : (0.5, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.25, 2, 0) * diffuse ((0, 0, 1))
+	+ (0.5, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.25, 0, 3) * diffuse ((0, 0, 1))
+	+ (0.166667, 0, 3) * diffuse ((0, 0, 1)) 
+

--- a/testsuite/closure-array/run.py
+++ b/testsuite/closure-array/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command += testshade ("-layer alayer a -layer dlayer d --layer clayer c --layer blayer b  --connect alayer output_closure clayer in0 --connect dlayer output_closure clayer in1 --connect clayer output_closures blayer input_closures ")


### PR DESCRIPTION
In RB-1.6 shaders with closure arrays inputs will compile but will not load at runtime (see test case)