### PR TITLE
Keep and report stats on texture calls and handles

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -386,6 +386,13 @@ public:
 
     llvm::Function *layer_func () const { return ll.current_function(); }
 
+    /// Call this when JITing a texture-like call, to track how many.
+    void generated_texture_call (bool handle) {
+        shadingsys().m_stat_tex_calls_codegened += 1;
+        if (handle)
+            shadingsys().m_stat_tex_calls_as_handles += 1;
+    }
+
     LLVM_Util ll;
 
 private:

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2222,6 +2222,7 @@ LLVMGEN (llvm_gen_texture)
     args.push_back (rop.ll.void_ptr (dalphadx ? dalphadx : rop.ll.void_ptr_null()));
     args.push_back (rop.ll.void_ptr (dalphady ? dalphady : rop.ll.void_ptr_null()));
     rop.ll.call_function ("osl_texture", &args[0], (int)args.size());
+    rop.generated_texture_call (texture_handle != NULL);
     return true;
 }
 
@@ -2294,6 +2295,7 @@ LLVMGEN (llvm_gen_texture3d)
     args.push_back (rop.ll.void_ptr (dalphady ? dalphady : rop.ll.void_ptr_null()));
     args.push_back (rop.ll.void_ptr_null());  // No dalphadz for now
     rop.ll.call_function ("osl_texture3d", &args[0], (int)args.size());
+    rop.generated_texture_call (texture_handle != NULL);
     return true;
 }
 
@@ -2357,6 +2359,7 @@ LLVMGEN (llvm_gen_environment)
         args.push_back (rop.ll.void_ptr_null());
     }
     rop.ll.call_function ("osl_environment", &args[0], (int)args.size());
+    rop.generated_texture_call (texture_handle != NULL);
     return true;
 }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -987,14 +987,14 @@ BackendLLVM::run ()
     int nlayers = group().nlayers();
     m_layer_remap.resize (nlayers);
     m_num_used_layers = 0;
-    if (shadingsys().debug() >= 1)
+    if (debug() >= 1)
         std::cout << "\nLayers used:\n";
     for (int layer = 0;  layer < nlayers;  ++layer) {
         bool lastlayer = (layer == (nlayers-1));
         if (lastlayer ||
             (! group()[layer]->unused() && !group()[layer]->empty_instance()))
         {
-            if (shadingsys().debug() >= 1)
+            if (debug() >= 1)
                 std::cout << "  " << layer << "\n";
             m_layer_remap[layer] = m_num_used_layers++;
         }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1126,6 +1126,8 @@ private:
     atomic_int m_stat_middlemen_eliminated; ///< Stat: middlemen eliminated
     atomic_int m_stat_const_connections;  ///< Stat: const connections elim'd
     atomic_int m_stat_global_connections; ///< Stat: global connections elim'd
+    atomic_int m_stat_tex_calls_codegened;///< Stat: total texture calls
+    atomic_int m_stat_tex_calls_as_handles;///< Stat: texture calls with handles
     double m_stat_master_load_time;       ///< Stat: time loading masters
     double m_stat_optimization_time;      ///< Stat: time spent optimizing
     double m_stat_opt_locking_time;       ///<   locking time

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -631,6 +631,8 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     m_stat_middlemen_eliminated = 0;
     m_stat_const_connections = 0;
     m_stat_global_connections = 0;
+    m_stat_tex_calls_codegened = 0;
+    m_stat_tex_calls_as_handles = 0;
     m_stat_master_load_time = 0;
     m_stat_optimization_time = 0;
     m_stat_getattribute_time = 0;
@@ -1133,6 +1135,8 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("stat:middlemen_eliminated", int, m_stat_middlemen_eliminated);
     ATTR_DECODE ("stat:const_connections", int, m_stat_const_connections);
     ATTR_DECODE ("stat:global_connections", int, m_stat_global_connections);
+    ATTR_DECODE ("stat:tex_calls_codegened", int, m_stat_tex_calls_codegened);
+    ATTR_DECODE ("stat:tex_calls_as_handles", int, m_stat_tex_calls_as_handles);
     ATTR_DECODE ("stat:master_load_time", float, m_stat_master_load_time);
     ATTR_DECODE ("stat:optimization_time", float, m_stat_optimization_time);
     ATTR_DECODE ("stat:opt_locking_time", float, m_stat_opt_locking_time);
@@ -1563,6 +1567,9 @@ ShadingSystemImpl::getstats (int level) const
             << Strutil::timeintervalformat (m_stat_llvm_jit_time, 2) << "\n";
     }
 
+    out << "  Texture calls compiled: "
+        << (int)m_stat_tex_calls_codegened
+        << " (" << (int)m_stat_tex_calls_as_handles << " used handles)\n";
     out << "  Regex's compiled: " << m_stat_regexes << "\n";
     out << "  Largest generated function local memory size: "
         << m_stat_max_llvm_local_mem/1024 << " KB\n";


### PR DESCRIPTION
I did this to help me debug something (which turned out not to be a bug), but it's still a useful item to keep in the stats output.
