### PR TITLE
Group deserialization: allow quoting of shader and layer names

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1901,9 +1901,13 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
         string_view keyword = Strutil::parse_word (p);
 
         if (keyword == "shader") {
-            string_view shadername = Strutil::parse_identifier (p);
-            Strutil::skip_whitespace (p);
-            string_view layername = Strutil::parse_until (p, " \t\r\n,;");
+            string_view shadername, layername;
+            if (! Strutil::parse_string (p, shadername) ||
+                ! Strutil::parse_string (p, layername)) {
+                err = true;
+                errdesc = "Badly formed shader name or layer name";
+                break;
+            }
             Shader (usage, shadername, layername);
             Strutil::parse_char (p, ';') || Strutil::parse_char (p, ',');
             Strutil::skip_whitespace (p);


### PR DESCRIPTION
I wrote a group spec by hand and accidentally quoted the shader name. Took me a couple awkward minutes to figure out the error message I was getting. 
