### PR TITLE
Execution order refactor, and per-layer explicit execution order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             geomath getattribute-camera getsymbol-nonheap gettextureinfo
             group-outputs groupstring
             hyperb ieee_fp if incdec initops intbits isconnected
-            layers layers-Ciassign layers-lazy
+            layers layers-Ciassign layers-entry layers-lazy
             layers-nonlazycopy layers-repeatedoutputs
             logic loop matrix message mergeinstances-nouserdata
             metadata-braces miscmath missing-shader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,8 @@ macro ( TESTSUITE )
         # Run the test unoptimized, unless it's a "render_*" or "oslinfo_*"
         # test, which we don't bother testing unoptimized.
         if (NOT _testname MATCHES "^render" AND
-            NOT _testname MATCHES "^oslinfo")
+            NOT _testname MATCHES "^oslinfo" AND
+            NOT EXISTS "${_testdir}/OPTIMIZEONLY")
           set (_env TESTSHADE_OPT=0 OPENIMAGEIOHOME=${OPENIMAGEIOHOME})
           add_test ( NAME ${_testname}
                      COMMAND env ${_env} ${_runtest} )

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -143,6 +143,8 @@ public:
     ///         opt_fold_getattribute, opt_middleman, opt_texture_handle
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Set LLVM extra debug level (0)
+    ///    int llvm_debug_layers  Extra printfs upon entering and leaving
+    ///                              layer functions.
     ///    int llvm_mcjit         Use LLVM MCJIT if available (0).
     ///    int max_local_mem_KB   Error if shader group needs more than this
     ///                              much local storage to execute (1024K)

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -460,13 +460,14 @@ class Symbol {
 public:
     Symbol (ustring name, const TypeSpec &datatype, SymType symtype,
             ASTNode *declaration_node=NULL) 
-        : m_data(NULL),
+        : m_data(NULL), m_name(name), m_typespec(datatype),
           m_size(datatype.is_unsized_array() ? 0 : (int)datatype.simpletype().size()),
-          m_name(name), m_typespec(datatype), m_symtype(symtype),
+          m_symtype(symtype),
           m_has_derivs(false), m_const_initializer(false),
           m_connected_down(false),
           m_initialized(false), m_lockgeom(false), m_renderer_output(false),
-          m_valuesource(DefaultVal), m_free_data(false), m_fieldid(-1),
+          m_valuesource(DefaultVal), m_free_data(false),
+          m_fieldid(-1), m_layer(-1),
           m_scope(0), m_dataoffset(-1), m_initializers(0),
           m_node(declaration_node), m_alias(NULL),
           m_initbegin(0), m_initend(0),
@@ -596,6 +597,9 @@ public:
     int fieldid () const { return m_fieldid; }
     void fieldid (int id) { m_fieldid = id; }
 
+    int layer () const { return m_layer; }
+    void layer (int id) { m_layer = id; }
+
     int initbegin () const { return m_initbegin; }
     void initbegin (int i) { m_initbegin = i; }
     int initend () const { return m_initend; }
@@ -688,9 +692,9 @@ public:
 
 protected:
     void *m_data;               ///< Pointer to the data
-    int m_size;                 ///< Size of data (in bytes)
     ustring m_name;             ///< Symbol name (unmangled)
     TypeSpec m_typespec;        ///< Data type of the symbol
+    int m_size;                 ///< Size of data (in bytes)
     char m_symtype;             ///< Kind of symbol (param, local, etc.)
     unsigned m_has_derivs:1;    ///< Step to derivs (0 == has no derivs)
     unsigned m_const_initializer:1; ///< initializer is a constant expression
@@ -701,6 +705,7 @@ protected:
     char m_valuesource;         ///< Where did the value come from?
     bool m_free_data;           ///< Free m_data upon destruction?
     short m_fieldid;            ///< Struct field of this var (or -1)
+    short m_layer;              ///< Layer (within the group) this belongs to
     int m_scope;                ///< Scope where this symbol was declared
     int m_dataoffset;           ///< Offset of the data (-1 for unknown)
     int m_initializers;         ///< Number of default initializers

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -75,6 +75,9 @@ public:
     /// This will end up being the group entry if 'groupentry' is true.
     llvm::Function* build_llvm_instance (bool groupentry);
 
+    /// Create an llvm function for group initialization code.
+    llvm::Function* build_llvm_init ();
+
     /// Build up LLVM IR code for the given range [begin,end) or
     /// opcodes, putting them (initially) into basic block bb (or the
     /// current basic block if bb==NULL).

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -722,13 +722,11 @@ BackendLLVM::build_llvm_instance (bool groupentry)
 
     // Set up a new IR builder
     ll.new_builder (entry_bb);
-#if 0 /* helpful for debugging */
     if (llvm_debug() && groupentry)
         llvm_gen_debug_printf (Strutil::format("\n\n\n\nGROUP! %s",group().name()));
-    if (llvm_debug())
+    if (shadingsys().llvm_debug_layers())
         llvm_gen_debug_printf (Strutil::format("enter layer %d %s %s",
                                this->layer(), inst()->layername(), inst()->shadername()));
-#endif
     if (shadingsys().countlayerexecs())
         ll.call_function ("osl_incr_layers_executed", sg_void_ptr());
 
@@ -871,11 +869,9 @@ BackendLLVM::build_llvm_instance (bool groupentry)
     // llvm_gen_debug_printf ("done copying connections");
 
     // All done
-#if 0 /* helpful for debugging */
-    if (llvm_debug())
+    if (shadingsys().llvm_debug_layers())
         llvm_gen_debug_printf (Strutil::format("exit layer %d %s %s",
                                this->layer(), inst()->layername(), inst()->shadername()));
-#endif
     ll.op_return();
 
     if (llvm_debug())

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -894,6 +894,7 @@ public:
     int optimize () const { return m_optimize; }
     int llvm_optimize () const { return m_llvm_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
+    int llvm_debug_layers () const { return m_llvm_debug_layers; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
     bool opt_texture_handle () const { return m_opt_texture_handle; }
     int max_warnings_per_thread() const { return m_max_warnings_per_thread; }
@@ -1072,6 +1073,7 @@ private:
     int m_llvm_optimize;                  ///< OSL optimization strategy
     int m_debug;                          ///< Debugging output
     int m_llvm_debug;                     ///< More LLVM debugging output
+    int m_llvm_debug_layers;              ///< Add layer enter/exit printfs
     ustring m_debug_groupname;            ///< Name of sole group to debug
     ustring m_debug_layername;            ///< Name of sole layer to debug
     ustring m_opt_layername;              ///< Name of sole layer to optimize

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1210,7 +1210,6 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
         return true;
     }
     if (name == "layer_names" && type.basetype == TypeDesc::STRING) {
-        m_renderer_outputs.clear ();
         size_t n = std::min (type.numelements(), (size_t)group->nlayers());
         for (size_t i = 0;  i < n;  ++i)
             ((ustring *)val)[i] = (*group)[i]->layername();

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -591,7 +591,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_opt_middleman(true), m_opt_texture_handle(true),
       m_optimize_nondebug(false),
       m_llvm_optimize(0),
-      m_debug(0), m_llvm_debug(0),
+      m_debug(0), m_llvm_debug(0), m_llvm_debug_layers(0),
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
       m_max_local_mem_KB(2048),
@@ -992,6 +992,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
+    ATTR_SET ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_SET ("strict_messages", int, m_strict_messages);
     ATTR_SET ("range_checking", int, m_range_checking);
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
@@ -1091,6 +1092,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("llvm_optimize", int, m_llvm_optimize);
     ATTR_DECODE ("debug", int, m_debug);
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
+    ATTR_DECODE ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
     ATTR_DECODE ("range_checking", int, m_range_checking);
     ATTR_DECODE ("unknown_coordsys_error", int, m_unknown_coordsys_error);
@@ -1443,6 +1445,7 @@ ShadingSystemImpl::getstats (int level) const
     INTOPT (llvm_optimize);
     INTOPT (debug);
     INTOPT (llvm_debug);
+    BOOLOPT (llvm_debug_layers);
     BOOLOPT (lazylayers);
     BOOLOPT (lazyglobals);
     BOOLOPT (lazy_userdata);

--- a/testsuite/layers-entry/node.osl
+++ b/testsuite/layers-entry/node.osl
@@ -1,0 +1,13 @@
+shader node (
+    string name = "<unknown>",
+    float in = 0.5 [[ int lockgeom=0 ]],
+    int id = 0 [[ int lockgeom=0 ]],
+    int set_Ci = 0,
+    output float out = 0)
+{
+    printf ("Running layer %s:\n", name);
+    out = in + id;
+    if (set_Ci)
+        Ci = diffuse(N);
+    printf ("  layer %s, in = %g, out = %g\n", name, in, out);
+}

--- a/testsuite/layers-entry/ref/out.txt
+++ b/testsuite/layers-entry/ref/out.txt
@@ -1,0 +1,86 @@
+Compiled node.osl -> node.oso
+
+
+default execution:
+Connect B.out to E.in
+Connect E.out to F.in
+Connect E.out to G.in
+
+Marking group outputs, not global renderer outputs.
+Output D.out to out.exr
+(node G) enter layer 6 G node
+(node A) enter layer 0 A node
+Running layer A:
+  layer A, in = 1, out = 2
+(node A) exit layer 0 A node
+(node C) enter layer 2 C node
+Running layer C:
+  layer C, in = 3, out = 6
+(node C) exit layer 2 C node
+(node D) enter layer 3 D node
+Running layer D:
+  layer D, in = 4, out = 8
+(node D) exit layer 3 D node
+(node F) enter layer 5 F node
+Running layer F:
+(node E) enter layer 4 E node
+Running layer E:
+(node B) enter layer 1 B node
+Running layer B:
+  layer B, in = 2, out = 4
+(node B) exit layer 1 B node
+  layer E, in = 4, out = 9
+(node E) exit layer 4 E node
+  layer F, in = 9, out = 15
+(node F) exit layer 5 F node
+Running layer G:
+  layer G, in = 9, out = 16
+(node G) exit layer 6 G node
+
+
+explicit execution by layer (BFE):
+Connect B.out to E.in
+Connect E.out to F.in
+Connect E.out to G.in
+
+Marking group outputs, not global renderer outputs.
+Entry layers: B(1) F(5) E(4)
+Output D.out to out.exr
+(node B) checking for already-run layer 1 B node
+(node B) enter layer 1 B node
+Running layer B:
+  layer B, in = 2, out = 4
+(node B) exit layer 1 B node
+(node F) checking for already-run layer 5 F node
+(node F) enter layer 5 F node
+Running layer F:
+(node E) checking for already-run layer 4 E node
+(node E) enter layer 4 E node
+Running layer E:
+  layer E, in = 4, out = 9
+(node E) exit layer 4 E node
+  layer F, in = 9, out = 15
+(node F) exit layer 5 F node
+(node E) checking for already-run layer 4 E node
+(node E)   taking early exit, already executed layer 4 E node
+
+
+explicit execution by output (E.out):
+Connect B.out to E.in
+Connect E.out to F.in
+Connect E.out to G.in
+
+Marking group outputs, not global renderer outputs.
+Entry layers: B(1) F(5) E(4)
+Entry outputs: E.out
+Output D.out to out.exr
+(node E) checking for already-run layer 4 E node
+(node E) enter layer 4 E node
+Running layer E:
+(node B) checking for already-run layer 1 B node
+(node B) enter layer 1 B node
+Running layer B:
+  layer B, in = 2, out = 4
+(node B) exit layer 1 B node
+  layer E, in = 4, out = 9
+(node E) exit layer 4 E node

--- a/testsuite/layers-entry/run.py
+++ b/testsuite/layers-entry/run.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+
+# This test verifies the execution order for both the default lazy
+# execution, and the explicit entry points.
+#
+# The group looks like this:
+#
+#     layer A   (sets global Ci, no connections)
+#
+#
+#     layer B   (connected downstream to E)
+#   ____|
+#  |
+#  |  layer C   (no connections)
+#  |
+#  |
+#  |  layer D   (no connections, but sets a renderer output)
+#  |    |____>
+#  |
+#  +----+
+#       V
+#     layer E   (connected upstream to B, downstream to F and G)
+#  +----|
+#  |    V
+#  |  layer F   (connected upstream to E)
+#  |
+#  +----v
+#     layer G   (connected upstream to E, and it's the last layer)
+#
+#
+# So by the default execution rules, the execution sequence will be:
+#   A   (because it sets a global)
+#   C   (because it's not connected to anything)
+#   D   (because it sets a renderer output)
+#   F   (because it's not connected to anything)
+#   E   (because F pulls its output)
+#   B   (because E pulls its output)
+#   G   (because it's the last layer -- presumed group entry point)
+#
+# But if we give explicit entry points and ask to execute layers B, F, E,
+# then the call sequence will be:
+#   B   (because we ask for it)
+#   F   (because we ask for it)
+#         (note: then B does NOT get called gain, because it already ran)
+#   E   (because F asks for it)
+#   (then we should see F end)
+#   (then E does NOT get called again, because it already ran)
+#
+# Finally, if we merely ask it to run whatever layer is necessary for
+# output E.out, then we should see:
+#   E   (because that's what makes E.out)
+#   B   (because E pulls its output)
+#
+
+groupsetup = ("-layer A -param name A -param id 1 -param in 1.0 -param set_Ci 1 node " +
+              "-layer B -param name B -param id 2 -param in 2.0 node " +
+              "-layer C -param name C -param id 3 -param in 3.0 node " +
+              "-layer D -param name D -param id 4 -param in 4.0 node " +
+              "-layer E -param name E -param id 5 -param in 5.0 node -connect B out E in " +
+              "-layer F -param name F -param id 6 -param in 6.0 node -connect E out F in " +
+              "-layer G -param name G -param id 7 -param in 7.0 node -connect E out G in " +
+              "--options llvm_debug_layers=1 "
+              )
+
+command += "echo '\n' >> out.txt 2>&1 ; \n"
+command += "echo 'default execution:' >> out.txt 2>&1 ; \n"
+command += testshade(groupsetup +
+                     "-groupoutputs -o D.out out.exr ")
+
+command += "echo '\n' >> out.txt 2>&1 ; \n"
+command += "echo 'explicit execution by layer (BFE):' >> out.txt 2>&1 ; \n"
+command += testshade(groupsetup +
+                     "-O2 -groupoutputs -o D.out out.exr " +
+                     "-entry B -entry F -entry E "
+                     )
+
+command += "echo '\n' >> out.txt 2>&1 ; \n"
+command += "echo 'explicit execution by output (E.out):' >> out.txt 2>&1 ; \n"
+command += testshade(groupsetup +
+                     "-O2 -groupoutputs -o D.out out.exr " +
+                     "-entry B -entry F -entry E --entryoutput E.out "
+                     )


### PR DESCRIPTION
Execution order refactor, and per-layer explicit execution order
    
Let's review what happens when you call
    
    shadingsys->execute (contextptr, shadergroup, shaderglobals);
    
This executes the given shader group on the context, with a specific set of shader globals. The group may be composed of many individual layers (shader nodes), and execution proceeds from first to last layer, executing those that must be run unconditionally and skipping those that can be run lazily. Of course, if a layer executes, it may trigger lazy execution of other not-yet-run layers. The unconditional layers are the layers that set global variables (like Ci or P), the layers whose outputs are connected to designated renderer outputs (AOVs and the like), and layers that have no connected outputs at all (under the theory that this must be the "root" node).

This all remains the same with this patch, but *additionally* there is another option where you can explicitly declare the "entry points" of a shader group,

    std::vector<const char *> entrynames;  // fill with layer names
    shadingsys->attribute (shadergroup, "entry_layers",
                           TypeDesc(TypeDesc::STRING, nentries),
                           &entrynames[0]);

and then execute the group layer by layer:
    
    shadingsys->execute_init (contextptr, shadergroup, shaderglobals);
    shadingsys->execute_layer (contextptr, shaderglobals, layernumber);
    ...
    shadingsys->execute_cleanup (contextptr);
    
The execute_init binds and prepares the context, execute_layer will run each layer (identified by number, and must correspond to one of the declared entry layers of the group). As before, other layers will execute lazily when their results are "pulled" by connections. However, if you are going to take the approach of manually calling layers, it's all up to you -- no layers (whose results aren't pulled downstream) will run unconditionally, even if they appear to set global variables or appear to be connected to renderer outputs.

The "all in one shot" approach still works just fine, and is probably the usual way of doing things. But for renderer that need even more control over which layers are executed and when, this provides an alternate calling sequence that gives more flexibility.

Some things that had to be done along the way:
    
* It used to be that the "last" layer was the presumed sole group entry point (or "root"), and its code was the one that did certain   initialization and the calling of the unconditionally-executed layers.   But now, the app can call any (declared entry) layer, in any order, so   we can't count on that initialization working. Instead, we now generate   an additional initialization function, which is called by execute_init.
    
* For lazy evaluation, it used to be that the *caller* of an earlier layer was responsible for marking it as run (so it wouldn't be run twice). But now nodes can get called by the app, so the "this layer ran" flag is set by the layer itself rather than the caller.
    
* For the reason immediately above, no layer's LLVM IR code is truly      empty; at the vest least, it marks the "this layer ran" flag. So the      prior test for "this whole group does nothing" no longer can count on      simply checking the post-LLVM optimized IR for being empty but for a      return statement. This forced us to move the 'group does nothing'      detection entirely out of LLVM generation and into the time of our      runtime optimization.
    
* Groups must track their declared list of possible externally-called      entry points.
    
* Augment testshade to be able to declare and call explicit entry      layers.
    
* New test: testsuite/layers-entry tests both the default and explicit      layer execution models, with a test carefully designed to have      different layer execution orders for the two calling strategies.
