### PR TITLE
Merge type and id fields in ClosureColor

### DIFF
--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -64,6 +64,11 @@ public:
 
 };
 
+// Forward declarations
+struct ClosureComponent;
+struct ClosureMul;
+struct ClosureAdd;
+
 /// ClosureColor is the base class for a lightweight tree representation
 /// of OSL closures for the sake of the executing OSL shader.
 ///
@@ -85,9 +90,24 @@ public:
 /// definitely one of the three kinds of subclasses: ClosureComponent,
 /// ClosureMul, ClosureAdd.
 struct OSLEXECPUBLIC ClosureColor {
-    enum ClosureType { COMPONENT, MUL, ADD };
+    enum ClosureID { COMPONENT_BASE_ID = 0, MUL = -1, ADD = -2 };
 
-    ClosureType type;
+    int id;
+
+    const ClosureComponent* as_comp() const {
+        DASSERT(id >= COMPONENT_BASE_ID);
+        return reinterpret_cast<const ClosureComponent*>(this);
+    }
+
+    const ClosureMul* as_mul() const {
+        DASSERT(id == MUL);
+        return reinterpret_cast<const ClosureMul*>(this);
+    }
+
+    const ClosureAdd* as_add() const {
+        DASSERT(id == ADD);
+        return reinterpret_cast<const ClosureAdd*>(this);
+    }
 };
 
 
@@ -100,7 +120,6 @@ struct OSLEXECPUBLIC ClosureColor {
 /// whatever type of custom primitive component it actually is.
 struct OSLEXECPUBLIC ClosureComponent : public ClosureColor
 {
-    int    id;       ///< Id of the component
     Vec3   w;        ///< Weight of this component
     char   mem[4];   ///< Memory for the primitive
                      ///  4 is the minimum, allocation
@@ -111,6 +130,13 @@ struct OSLEXECPUBLIC ClosureComponent : public ClosureColor
     ///
     void *data () { return &mem; }
     const void *data () const { return &mem; }
+
+    /// Handy methods for extracting the underlying parameters as a struct
+    template <typename T>
+    const T* as() const { return reinterpret_cast<const T*>(mem); }
+
+    template <typename T>
+    T* as() { return reinterpret_cast<const T*>(mem); }
 };
 
 

--- a/src/liboslexec/closure.cpp
+++ b/src/liboslexec/closure.cpp
@@ -112,23 +112,21 @@ print_component (std::ostream &out, const ClosureComponent *comp, ShadingSystemI
 static void
 print_closure (std::ostream &out, const ClosureColor *closure, ShadingSystemImpl *ss, const Color3 &w, bool &first)
 {
-    ClosureComponent *comp;
     if (closure == NULL)
         return;
 
-    switch (closure->type) {
+    switch (closure->id) {
         case ClosureColor::MUL:
-            print_closure(out, ((ClosureMul *)closure)->closure, ss, ((ClosureMul *)closure)->weight * w, first);
+            print_closure(out, closure->as_mul()->closure, ss, closure->as_mul()->weight * w, first);
             break;
         case ClosureColor::ADD:
-            print_closure(out, ((ClosureAdd *)closure)->closureA, ss, w, first);
-            print_closure(out, ((ClosureAdd *)closure)->closureB, ss, w, first);
+            print_closure(out, closure->as_add()->closureA, ss, w, first);
+            print_closure(out, closure->as_add()->closureB, ss, w, first);
             break;
-        case ClosureColor::COMPONENT:
-            comp = (ClosureComponent *)closure;
+        default:
             if (!first)
                 out << "\n\t+ ";
-            print_component (out, comp, ss, w);
+            print_component (out, closure->as_comp(), ss, w);
             first = false;
             break;
     }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3083,8 +3083,8 @@ LLVMGEN (llvm_gen_closure)
     }
 
     llvm::Value *comp_ptr = rop.ll.ptr_cast(comp_void_ptr, rop.llvm_type_closure_component_ptr());
-    // Get the address of the primitive buffer, which is the 3rd field
-    llvm::Value *mem_void_ptr = rop.ll.GEP (comp_ptr, 0, 3);
+    // Get the address of the primitive buffer, which is the 2nd field
+    llvm::Value *mem_void_ptr = rop.ll.GEP (comp_ptr, 0, 2);
     mem_void_ptr = rop.ll.ptr_cast(mem_void_ptr, rop.ll.type_void_ptr());
 
     // If the closure has a "prepare" method, call

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -347,7 +347,6 @@ BackendLLVM::llvm_type_closure_component ()
         return m_llvm_type_closure_component;
 
     std::vector<llvm::Type*> comp_types;
-    comp_types.push_back (ll.type_int());     // parent.type
     comp_types.push_back (ll.type_int());     // id
     comp_types.push_back (ll.type_triple());  // w
     comp_types.push_back (ll.type_int());     // fake field for char mem[4]

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1483,7 +1483,6 @@ public:
         int alignment = m_shadingsys.find_closure(id)->alignment;
         size_t alignment_offset = closure_alignment_offset_calc(alignment);
         ClosureComponent *comp = (ClosureComponent *) (m_closure_pool.alloc(needed + alignment_offset, alignment) + alignment_offset);
-        comp->type = ClosureColor::COMPONENT;
         comp->id = id;
         comp->w = w;
         return comp;
@@ -1491,7 +1490,7 @@ public:
 
     ClosureMul *closure_mul_allot (const Color3 &w, const ClosureColor *c) {
         ClosureMul *mul = (ClosureMul *) m_closure_pool.alloc(sizeof(ClosureMul));
-        mul->type = ClosureColor::MUL;
+        mul->id = ClosureColor::MUL;
         mul->weight = w;
         mul->closure = c;
         return mul;
@@ -1499,7 +1498,7 @@ public:
 
     ClosureMul *closure_mul_allot (float w, const ClosureColor *c) {
         ClosureMul *mul = (ClosureMul *) m_closure_pool.alloc(sizeof(ClosureMul));
-        mul->type = ClosureColor::MUL;
+        mul->id = ClosureColor::MUL;
         mul->weight.setValue (w,w,w);
         mul->closure = c;
         return mul;
@@ -1507,7 +1506,7 @@ public:
 
     ClosureAdd *closure_add_allot (const ClosureColor *a, const ClosureColor *b) {
         ClosureAdd *add = (ClosureAdd *) m_closure_pool.alloc(sizeof(ClosureAdd));
-        add->type = ClosureColor::ADD;
+        add->id = ClosureColor::ADD;
         add->closureA = a;
         add->closureB = b;
         return add;


### PR DESCRIPTION
These two fields were redundant with each other. Merging them lines things up a bit more nicely internally (closure data starts at offset 16 instead of 20).

Also added some convenience methods to reduce the need for verbose casts in client code.