### PR TITLE
cmake: Better detection of Clang version, including Apple vs OSS Clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ cmake_minimum_required (VERSION 2.6)
 if (NOT CMAKE_VERSION VERSION_LESS 2.8.4)
     cmake_policy (SET CMP0017 NEW)
 endif ()
+if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+    cmake_policy (SET CMP0025 NEW)  # Detect AppleClang for new CMake
+endif ()
 if (NOT CMAKE_VERSION VERSION_LESS 3.2.2)
     cmake_policy (SET CMP0042 OLD)
     cmake_policy (SET CMP0046 OLD)
@@ -47,6 +50,18 @@ if (CMAKE_USE_FOLDERS)
     set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 endif ()
 
+## turn on more detailed warnings and consider warnings as errors
+set (STOP_ON_WARNING ON CACHE BOOL "Stop building if there are any compiler warnings")
+if (NOT MSVC)
+    add_definitions ("-Wall")
+    if (STOP_ON_WARNING)
+        add_definitions ("-Werror")
+    endif ()
+endif ()
+
+message (STATUS "CMAKE_CXX_COMPILER is ${CMAKE_CXX_COMPILER}")
+message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
+
 # Figure out which compiler we're using
 if (CMAKE_COMPILER_IS_GNUCC)
     execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpversion
@@ -56,38 +71,98 @@ if (CMAKE_COMPILER_IS_GNUCC)
         message (STATUS "Using gcc ${GCC_VERSION} as the compiler")
     endif ()
 endif ()
-message (STATUS "CMAKE_CXX_COMPILER is ${CMAKE_CXX_COMPILER}")
-message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+# Figure out which compiler we're using, for tricky cases
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lang")
+    # If using any flavor of clang, set CMAKE_COMPILER_IS_CLANG. If it's
+    # Apple's variety, set CMAKE_COMPILER_IS_APPLECLANG and
+    # APPLECLANG_VERSION_STRING, otherwise for generic clang set
+    # CLANG_VERSION_STRING.
     set (CMAKE_COMPILER_IS_CLANG 1)
-    if (VERBOSE)
-        message (STATUS "Using clang as the compiler")
+    EXECUTE_PROCESS( COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE clang_full_version_string )
+    if (clang_full_version_string MATCHES "Apple")
+        set (CMAKE_CXX_COMPILER_ID "AppleClang")
+        set (CMAKE_COMPILER_IS_APPLECLANG 1)
+        string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" APPLECLANG_VERSION_STRING ${clang_full_version_string})
+        if (VERBOSE)
+            message (STATUS "The compiler is Clang: ${CMAKE_CXX_COMPILER_ID} version ${APPLECLANG_VERSION_STRING}")
+        endif ()
+    else ()
+        string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
+        if (VERBOSE)
+            message (STATUS "The compiler is Clang: ${CMAKE_CXX_COMPILER_ID} version ${CLANG_VERSION_STRING}")
+        endif ()
     endif ()
-endif ()
-# Second try: for earlier versions of CMake, the CMAKE_CXX_COMPILER_ID
-# appears to be unreliable and may say "GNU" despite using clang, so
-# directly match against the compiler name.
-if (CMAKE_CXX_COMPILER MATCHES "[Cc]lang")
-    set (CMAKE_COMPILER_IS_CLANG 1)
-    if (VERBOSE)
-        message (STATUS "The compiler seems to be clang")
-    endif ()
-endif ()
-if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     set (CMAKE_COMPILER_IS_INTEL 1)
     if (VERBOSE)
         message (STATUS "Using Intel as the compiler")
     endif ()
 endif ()
 
-## turn on more detailed warnings and consider warnings as errors
-set (STOP_ON_WARNING ON CACHE BOOL "Stop building if there are any compiler warnings")
-if (NOT MSVC)
-    add_definitions ("-Wall")
-    if (STOP_ON_WARNING)
-        add_definitions ("-Werror")
+# Options common to gcc and clang
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    # CMake doesn't automatically know what do do with
+    # include_directories(SYSTEM...) when using clang or gcc.
+    set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
+    # Ensure this macro is set for stdint.h
+    add_definitions ("-D__STDC_LIMIT_MACROS")
+    # this allows native instructions to be used for sqrtf instead of a function call
+    add_definitions ("-fno-math-errno")
+    if (HIDE_SYMBOLS AND NOT DEBUGMODE)
+        # Turn default symbol visibility to hidden
+        set (VISIBILITY_COMMAND "-fvisibility=hidden -fvisibility-inlines-hidden")
+        add_definitions (${VISIBILITY_COMMAND})
+        if (CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
+            # Linux/FreeBSD/Hurd: also hide all the symbols of dependent
+            # libraries to prevent clashes if an app using OIIO is linked
+            # against other verions of our dependencies.
+            set (VISIBILITY_MAP_COMMAND "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/libOpenImageIO/libOpenImageIO.map")
+        endif ()
+    endif ()
+    if (LLVM_STATIC AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT DEBUGMODE)
+        # Linux: When linking against LLVM statically, we can also hide
+        # all its symbols to prevent clashes if OSL is linked against an
+        # app that also embeds LLVM.
+        set (VISIBILITY_MAP_COMMAND "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/liboslexec/liboslexec.map")
     endif ()
 endif ()
+
+# Clang-specific options
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
+    # Disable some warnings for Clang, for some things that are too awkward
+    # to change just for the sake of having no warnings.
+    add_definitions ("-Wno-unused-function")
+    add_definitions ("-Wno-overloaded-virtual")
+    add_definitions ("-Wno-unneeded-internal-declaration")
+    add_definitions ("-Wno-unused-private-field")
+    add_definitions ("-Wno-tautological-compare")
+    # disable warning about unused command line arguments
+    add_definitions ("-Qunused-arguments")
+    # Don't warn if we ask it not to warn about warnings it doesn't know
+    add_definitions ("-Wunknown-warning-option")
+    add_definitions ("-Wno-unknown-pragmas")
+    # disable warning in flex-generated code
+    add_definitions ("-Wno-null-conversion")
+    add_definitions ("-Wno-error=strict-overflow")
+    if (DEBUGMODE)
+        add_definitions ("-Wno-unused-function -Wno-unused-variable")
+    endif ()
+    if (CLANG_VERSION_STRING VERSION_GREATER 3.5 OR
+        APPLECLANG_VERSION_STRING VERSION_GREATER 6.0)
+        add_definitions ("-Wno-unused-local-typedefs")
+    endif ()
+endif ()
+
+# gcc specific options
+if (CMAKE_COMPILER_IS_GNUCC AND (NOT CMAKE_COMPILER_IS_CLANG))
+    if (NOT ${GCC_VERSION} VERSION_LESS 4.8)
+        # suppress a warning that Boost::Python hits in g++ 4.8
+        add_definitions ("-Wno-error=unused-local-typedefs")
+        add_definitions ("-Wno-unused-local-typedefs")
+    endif ()
+endif ()
+
 
 ## enable RTTI
 ##   NOTE: LLVM builds without RTTI by default so beware
@@ -127,43 +202,6 @@ endif()
 set (USE_fPIC OFF CACHE BOOL "Build with -fPIC")
 if (USE_fPIC)
     add_definitions ("-fPIC")
-endif ()
-
-if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
-    # CMake doesn't automatically know what do do with
-    # include_directories(SYSTEM...) when using clang or gcc.
-    set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
-    
-    # this allows native instructions to be used for sqrtf instead of a function call
-    add_definitions ("-fno-math-errno")
-endif ()
-
-if (CMAKE_COMPILER_IS_CLANG)
-    # disable warning about unused command line arguments
-    add_definitions ("-Qunused-arguments -Wno-unknown-pragmas")
-    # disable warning in flex-generated code
-    add_definitions ("-Wno-null-conversion")
-    if (DEBUGMODE)
-        add_definitions ("-Wno-unused-function -Wno-unused-variable")
-    endif ()
-endif ()
-
-if (CMAKE_COMPILER_IS_GNUCC)
-    add_definitions ("-Wno-error=strict-overflow")
-endif ()
-
-if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_GNUCC)
-    if (HIDE_SYMBOLS AND NOT DEBUGMODE)
-        # Turn default symbol visibility to hidden
-        set (VISIBILITY_COMMAND "-fvisibility=hidden")
-        add_definitions (${VISIBILITY_COMMAND})
-    endif ()
-    if (LLVM_STATIC AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT DEBUGMODE)
-        # Linux: When linking against LLVM statically, we can also hide
-        # all its symbols to prevent clashes if OSL is linked against an
-        # app that also embeds LLVM.
-        set (VISIBILITY_MAP_COMMAND "-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/liboslexec/liboslexec.map")
-    endif ()
 endif ()
 
 # Try to detect if this is an OSX distro new enough that the system library
@@ -216,11 +254,17 @@ if (EXTRA_CPP_ARGS)
     add_definitions ("${EXTRA_CPP_ARGS}")
 endif()
 
-if (OSL_BUILD_CPP11)
-    message (STATUS "Building for C++11")
-    add_definitions ("-std=c++11")
+if (OIIO_BUILD_CPP11 OR OIIO_BUILD_CPP14)
+    if (OIIO_BUILD_CPP11)
+        message (STATUS "Building for C++11")
+        add_definitions ("-std=c++11")
+    endif()
+    if (OIIO_BUILD_CPP14)
+        message (STATUS "Building for C++14")
+        add_definitions ("-std=c++14")
+    endif()
     if (CMAKE_COMPILER_IS_CLANG)
-        # C++11 doesn't like 'register' keyword, which is in Qt headers
+        # C++ >= 11 doesn't like 'register' keyword, which is in Qt headers
         add_definitions ("-Wno-deprecated-register")
     endif ()
 endif ()
@@ -249,6 +293,12 @@ if (NOT USE_SIMD STREQUAL "")
     endif ()
 endif ()
 
+# Set the default namespace
+if (OSL_NAMESPACE)
+    add_definitions ("-DOSL_NAMESPACE=${OSL_NAMESPACE}")
+endif ()
+message(STATUS "Setting Namespace to: ${OSL_NAMESPACE}")
+
 set (CMAKE_MODULE_PATH
      "${PROJECT_SOURCE_DIR}/src/cmake/modules"
      "${PROJECT_SOURCE_DIR}/src/cmake")
@@ -259,16 +309,11 @@ include (externalpackages)
 include (oiio)
 include (flexbison)
 include_directories (
-      "${CMAKE_SOURCE_DIR}/src/include"
-      "${CMAKE_BINARY_DIR}/include/OSL"
-      "${OPENIMAGEIO_INCLUDES}"
+    "${CMAKE_SOURCE_DIR}/src/include"
+    "${CMAKE_BINARY_DIR}/include/OSL"
+    "${OPENIMAGEIO_INCLUDES}"
   )
 
-# Set the default namespace
-if (OSL_NAMESPACE)
-    add_definitions ("-DOSL_NAMESPACE=${OSL_NAMESPACE}")
-endif ()
-message(STATUS "Setting Namespace to: ${OSL_NAMESPACE}")
 
 ###########################################################################
 # Paths for install tree customization.  Note that relative paths are relative


### PR DESCRIPTION
Refactoring for simplification of the compiler-specific bits of the CMakefile.

Also synchronizes with the CMake scripts for OIIO -- there were places where they did basically the same things, but expressed differently or in different orders. I tried to make them more similar for ease of maintenance and transferring good ideas between them.
