### PR TITLE
Change logic of lazy evaluation -- unconnected layers are now lazy.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -116,7 +116,9 @@ public:
     ///    int lazylayers         Evaluate shader layers only when their
     ///                              outputs are first needed (1)
     ///    int lazyglobals        Run layers lazily even if they write to
-    ///                              globals (0)
+    ///                              globals (1)
+    ///    int lazyunconnected    Run layers lazily even if they have no
+    ///                              output connections (1). For debugging.
     ///    int lazy_userdata      Retrieve userdata lazily (0).
     ///    int greedyjit          Optimize and compile all shaders up front,
     ///                              versus only as needed (0).

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1021,8 +1021,10 @@ BackendLLVM::run ()
     for (int layer = 0;  layer < nlayers;  ++layer) {
         // Skip unused or empty layers, unless they are callable entry
         // points.
-        if (group().is_entry_layer(layer) ||
-            (! group()[layer]->unused() && !group()[layer]->empty_instance())) {
+        ShaderInstance *inst = group()[layer];
+        bool is_single_entry = (layer == (nlayers-1) && group().num_entry_layers() == 0);
+        if (inst->entry_layer() || is_single_entry ||
+            (! inst->unused() && !inst->empty_instance())) {
             if (debug() >= 1)
                 std::cout << "  " << layer << "\n";
             m_layer_remap[layer] = m_num_used_layers++;
@@ -1096,8 +1098,9 @@ BackendLLVM::run ()
     // for the initialization and all public entry points.
     group().llvm_compiled_init ((RunLLVMGroupFunc) ll.getPointerToFunction(init_func));
     for (int layer = 0; layer < nlayers; ++layer) {
-        if (group().is_entry_layer (layer))
-            group().llvm_compiled_layer (layer, (RunLLVMGroupFunc) ll.getPointerToFunction(funcs[layer]));
+        llvm::Function* f = funcs[layer];
+        if (f && group().is_entry_layer (layer))
+            group().llvm_compiled_layer (layer, (RunLLVMGroupFunc) ll.getPointerToFunction(f));
     }
     if (group().num_entry_layers())
         group().llvm_compiled_version (NULL);

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -561,6 +561,7 @@ LLVM_Util::execengine (llvm::ExecutionEngine *exec)
 void *
 LLVM_Util::getPointerToFunction (llvm::Function *func)
 {
+    DASSERT (func && "passed NULL to getPointerToFunction");
     llvm::ExecutionEngine *exec = execengine();
 #if OSL_LLVM_VERSION >= 33
     if (USE_MCJIT)

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2702,8 +2702,6 @@ RuntimeOptimizer::run ()
 
     for (int layer = 0;  layer < nlayers;  ++layer) {
         set_inst (layer);
-        if (inst()->unused())
-            continue;
         // These need to happen before merge_instances
         inst()->copy_code_from_master (group());
         mark_outgoing_connections();
@@ -2722,8 +2720,18 @@ RuntimeOptimizer::run ()
         if (debug() && optimize() >= 1) {
             std::cout.flush ();
             std::cout << "Before optimizing layer " << layer << " " 
-                      << inst()->layername() 
-                      << ", I get:\n" << inst()->print(group())
+                      << inst()->layername() << " (" << inst()->id() << ") :\n"
+                      << " connections in=" << inst()->nconnections()
+                      << " out=" << inst()->outgoing_connections()
+                      << (inst()->writes_globals() ? " writes_globals" : "")
+                      << (inst()->userdata_params() ? " userdata_params" : "")
+                      << (inst()->run_lazily() ? " run_lazily" : " run_unconditionally")
+                      << (inst()->outgoing_connections() ? " outgoing_connections" : "")
+                      << (inst()->renderer_outputs() ? " renderer_outputs" : "")
+                      << (inst()->writes_globals() ? " writes_globals" : "")
+                      << (inst()->entry_layer() ? " entry_layer" : "")
+                      << (inst()->last_layer() ? " last_layer" : "")
+                      << "\n" << inst()->print(group())
                       << "\n--------------------------------\n\n";
             std::cout.flush ();
         }
@@ -2789,7 +2797,6 @@ RuntimeOptimizer::run ()
             collapse_syms ();
             collapse_ops ();
         }
-        inst()->compute_run_lazily (group());
         if (debug() && !inst()->unused()) {
             track_variable_lifetimes ();
             std::cout << "After optimizing layer " << layer << " " 
@@ -2802,6 +2809,8 @@ RuntimeOptimizer::run ()
                       << (inst()->outgoing_connections() ? " outgoing_connections" : "")
                       << (inst()->renderer_outputs() ? " renderer_outputs" : "")
                       << (inst()->writes_globals() ? " writes_globals" : "")
+                      << (inst()->entry_layer() ? " entry_layer" : "")
+                      << (inst()->last_layer() ? " last_layer" : "")
                       << "\n" << inst()->print(group()) 
                       << "\n--------------------------------\n\n";
             std::cout.flush ();

--- a/testsuite/layers-Ciassign/run.py
+++ b/testsuite/layers-Ciassign/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-command += testshade("-layer alayer a --layer blayer b --connect alayer out blayer in")
+command += testshade("--options lazyglobals=0 -layer alayer a --layer blayer b --connect alayer out blayer in")

--- a/testsuite/layers-entry/ref/out.txt
+++ b/testsuite/layers-entry/ref/out.txt
@@ -13,16 +13,11 @@ Output D.out to out.exr
 Running layer A:
   layer A, in = 1, out = 2
 (node A) exit layer 0 A node
-(node C) enter layer 2 C node
-Running layer C:
-  layer C, in = 3, out = 6
-(node C) exit layer 2 C node
 (node D) enter layer 3 D node
 Running layer D:
   layer D, in = 4, out = 8
 (node D) exit layer 3 D node
-(node F) enter layer 5 F node
-Running layer F:
+Running layer G:
 (node E) enter layer 4 E node
 Running layer E:
 (node B) enter layer 1 B node
@@ -31,9 +26,6 @@ Running layer B:
 (node B) exit layer 1 B node
   layer E, in = 4, out = 9
 (node E) exit layer 4 E node
-  layer F, in = 9, out = 15
-(node F) exit layer 5 F node
-Running layer G:
   layer G, in = 9, out = 16
 (node G) exit layer 6 G node
 

--- a/testsuite/layers-entry/run.py
+++ b/testsuite/layers-entry/run.py
@@ -30,13 +30,11 @@
 #
 #
 # So by the default execution rules, the execution sequence will be:
-#   A   (because it sets a global)
-#   C   (because it's not connected to anything)
+#   A   (because it sets a global) [presuming lazyglobls == 0]
 #   D   (because it sets a renderer output)
-#   F   (because it's not connected to anything)
+#   G   (because it's the last layer -- presumed group entry point)
 #   E   (because F pulls its output)
 #   B   (because E pulls its output)
-#   G   (because it's the last layer -- presumed group entry point)
 #
 # But if we give explicit entry points and ask to execute layers B, F, E,
 # then the call sequence will be:
@@ -60,7 +58,7 @@ groupsetup = ("-layer A -param name A -param id 1 -param in 1.0 -param set_Ci 1 
               "-layer E -param name E -param id 5 -param in 5.0 node -connect B out E in " +
               "-layer F -param name F -param id 6 -param in 6.0 node -connect E out F in " +
               "-layer G -param name G -param id 7 -param in 7.0 node -connect E out G in " +
-              "--options llvm_debug_layers=1 "
+              "--options llvm_debug_layers=1,lazyglobals=0 "
               )
 
 command += "echo '\n' >> out.txt 2>&1 ; \n"


### PR DESCRIPTION
New logic: the only layers unconditionally run are (1) the LAST layer
(presumed to be the "root"), (2) any layer that sets a designated
renderer output, (3) any layer that sets a global, but only if
lazyglobals is off (it's on by default now). Everything else is run
"lazily", that is, only if and when its connected outputs are needed
downstream.

The old logic additionally considered a layer to be unconditional (i.e.,
not lazy) if it has NO outgoing connections, on the theory that is must
be the root, and also lazyglobals was not turned on by default. That
seemed like a recipe for inefficient shader evaluation, and it doesn't
look like any renderer needs or wants this.