### PR TITLE
oslc bug fix for code generation of struct parameters copied whole.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,8 +515,9 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             render-microfacet render-oren-nayar render-veachmis render-ward
             shortcircuit spline splineinverse string 
             struct struct-array struct-array-mixture
-            struct-err struct-in-struct-init struct-layers struct-with-array 
-            struct-within-struct ternary
+            struct-err struct-in-struct-init struct-init-copy struct-layers
+            struct-with-array struct-within-struct
+            ternary
             testshade-expr
             texture-alpha texture-blur texture-derivs texture-field3d
             texture-firstchannel texture-interp 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -311,11 +311,14 @@ protected:
     /// true, we are (perhaps recursively) copying entire arrays, of
     /// or within the struct, and intindex is the element number if we
     /// know it -- these two items let us take some interesting shortcuts
-    /// with whole arrays (copyarray versus assigning elements).
+    /// with whole arrays (copyarray versus assigning elements). Pass
+    /// paraminit=true if we're doing the assignment as init ops of a
+    /// shader param.
     void codegen_assign_struct (StructSpec *structspec,
                                 ustring dstsym, ustring srcsym,
                                 Symbol *arrayindex,
-                                bool copywholearrays, int intindex);
+                                bool copywholearrays, int intindex,
+                                bool paraminit);
 
 protected:
     NodeType m_nodetype;          ///< Type of node this is

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -202,6 +202,13 @@ BackendLLVM::llvm_run_connected_layers (Symbol &sym, int symindex,
 
 
 
+LLVMGEN (llvm_gen_nop)
+{
+    return true;
+}
+
+
+
 LLVMGEN (llvm_gen_useparam)
 {
     ASSERT (! rop.inst()->unused() &&

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1827,7 +1827,7 @@ RuntimeOptimizer::eliminate_middleman ()
                             dsym = downinst->mastersymbol(c.dst.param);
                         const Symbol *usym = upinst->symbol(upstream_symbol);
                         if (! usym)
-                            usym = downinst->mastersymbol(upstream_symbol);
+                            usym = upinst->mastersymbol(upstream_symbol);
                         ASSERT (dsym && usym);
                         std::cout << "Removed " << inst()->layername() << "."
                                   << s.name() << " middleman for " 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2120,7 +2120,8 @@ RuntimeOptimizer::optimize_instance ()
         }
 
         // Elide unconnected parameters that are never read.
-        changed += remove_unused_params ();
+        if (optimize() >= 1)
+            changed += remove_unused_params ();
 
         // FIXME -- we should re-evaluate whether writes_globals() is still
         // true for this layer.

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1720,13 +1720,13 @@ RuntimeOptimizer::remove_unused_params ()
     // Get rid of unused params' init ops and clear their read/write ranges
     FOREACH_PARAM (Symbol &s, inst()) {
         if (param_never_used(s) && s.has_init_ops()) {
-            turn_into_nop (s.initbegin(), s.initend(),
-                           "remove init ops of unused param");
+            std::string why;
+            if (debug() > 1)
+                why = Strutil::format ("remove init ops of unused param %s %s", s.typespec().c_str(), s.name());
+            turn_into_nop (s.initbegin(), s.initend(), why);
             s.set_initrange (0, 0);
             s.clear_rw();   // mark as totally unused
             ++alterations;
-            if (debug() > 1)
-                std::cout << "Realized that param " << s.name() << " is not needed\n";
         }
     }
 
@@ -2707,21 +2707,16 @@ RuntimeOptimizer::run ()
         inst()->copy_code_from_master (group());
         mark_outgoing_connections();
     }
-    if (shadingsys().m_opt_merge_instances == 1)
-        shadingsys().merge_instances (group());
 
-    m_params_holding_globals.resize (nlayers);
-
-    // Optimize each layer, from first to last
+    // Inventory the network and print pre-optimized debug info
     size_t old_nsyms = 0, old_nops = 0;
     for (int layer = 0;  layer < nlayers;  ++layer) {
         set_inst (layer);
-        if (inst()->unused())
-            continue;
-        if (debug() && optimize() >= 1) {
+        if (debug() /* && optimize() >= 1*/) {
             std::cout.flush ();
             std::cout << "Before optimizing layer " << layer << " " 
                       << inst()->layername() << " (" << inst()->id() << ") :\n"
+                      << (inst()->unused() ? " UNUSED" : "")
                       << " connections in=" << inst()->nconnections()
                       << " out=" << inst()->outgoing_connections()
                       << (inst()->writes_globals() ? " writes_globals" : "")
@@ -2736,15 +2731,24 @@ RuntimeOptimizer::run ()
                       << "\n--------------------------------\n\n";
             std::cout.flush ();
         }
-
         old_nsyms += inst()->symbols().size();
         old_nops += inst()->ops().size();
+    }
 
+    if (shadingsys().m_opt_merge_instances == 1)
+        shadingsys().merge_instances (group());
+
+    m_params_holding_globals.resize (nlayers);
+
+    // Optimize each layer, from first to last
+    for (int layer = 0;  layer < nlayers;  ++layer) {
+        set_inst (layer);
+        if (inst()->unused())
+            continue;
         // N.B. we need to resolve isconnected() calls before the instance
         // is otherwise optimized, or else isconnected() may not reflect
         // the original connectivity after substitutions are made.
         resolve_isconnected ();
-
         optimize_instance ();
     }
 
@@ -2802,6 +2806,7 @@ RuntimeOptimizer::run ()
             track_variable_lifetimes ();
             std::cout << "After optimizing layer " << layer << " " 
                       << inst()->layername() << " (" << inst()->id() << ") :\n"
+                      << (inst()->unused() ? " UNUSED" : "")
                       << " connections in=" << inst()->nconnections()
                       << " out=" << inst()->outgoing_connections()
                       << (inst()->writes_globals() ? " writes_globals" : "")

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -868,6 +868,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (neg,         neg,                 neg,           true,      0);
     OP (neq,         compare_op,          neq,           true,      0);
     OP (noise,       noise,               noise,         true,      0);
+    OP (nop,         nop,                 none,          true,      0);
     OP (normal,      construct_triple,    triple,        true,      0);
     OP (normalize,   generic,             normalize,     true,      0);
     OP (or,          andor,               or,            true,      0);

--- a/testsuite/struct-init-copy/Astruct.h
+++ b/testsuite/struct-init-copy/Astruct.h
@@ -1,0 +1,4 @@
+
+struct Astruct {
+    float s, t;
+};

--- a/testsuite/struct-init-copy/a.osl
+++ b/testsuite/struct-init-copy/a.osl
@@ -1,0 +1,7 @@
+#include "Astruct.h"
+
+shader a (output Astruct Aout = {-1, -1})
+{
+    Aout.s = u;
+    Aout.t = v;
+}

--- a/testsuite/struct-init-copy/b.osl
+++ b/testsuite/struct-init-copy/b.osl
@@ -1,0 +1,9 @@
+#include "Astruct.h"
+
+shader b (Astruct Ain = {0,0},
+          output Astruct Bout = Ain,
+          output color Cout = 0)
+{
+    Cout = color (Bout.s, Bout.t, 0);
+    printf ("%g  : should be %g %g 0\n", Cout, u, v);
+}

--- a/testsuite/struct-init-copy/ref/out.txt
+++ b/testsuite/struct-init-copy/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect a.Aout to b.Ain
+
+Output Cout to out.exr
+0.5 0.5 0  : should be 0.5 0.5 0

--- a/testsuite/struct-init-copy/run.py
+++ b/testsuite/struct-init-copy/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("--layer a a --layer b b --connect a Aout b Ain -o Cout out.exr")


### PR DESCRIPTION
When a shader param that was a struct had its value initialized by copying    another struct WHOLE, it neglected to set the "method" name for the init    ops for each field. This made it incorectly chalk up the init ops to the    struct param itself (which is just a dummy placeholder) instead of the    fields, and under some circumstances this could simply leave the struct    fields uninitialized.

It was fine all along if the struct param's fields were initialized one    by one -- in that case, the init ops were correctly associated with each    field individually. It was only the case of initializing by copying    another whole struct that was problematic.

The solution is to pass a flag to codegen_assign_struct indicating if we    are generating that code for a parameter initialization, in which case    it will do the proper calls to associate the init ops with the right    variable. This is just like we already did for the field-by-field case    handled in codegen_struct_initializers.

The fix to the main bug consists of the changes to `ast.h` and `codegen.cpp` (particularly line 575ff). The test of it is the material in `testsuite`. The rest are just some miscellaneous improvements to debugging (and a typo or two) that I found along the way in the quest to track this down.

