### PR TITLE
New OSL builtins for patterns: linearstep(), smooth_linearstep()

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -61,7 +61,7 @@ Language Specification
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 6 May, 2015 \\
+\date{{\large Date: 9 Oct, 2015 \\
 %~ (with corrections, 2 Oct 2014)
 }
 \bigskip
@@ -3315,6 +3315,14 @@ The \emph{type} may be any of of \float, \color, \point, \vector, or
 performed component-by-component (separately for $x$, $y$, and $z$).
 \apiend
 
+\apiitem{float {\ce linearstep} (float edge0, float edge1, float x)}
+\indexapi{linearstep()}
+\NEW % 1.7
+Returns 0 if $x \le {\mathit edge0}$, and 1 if $x \ge {\mathit edge1}$,
+and performs a linear
+interpolation between 0 and 1 when ${\mathit edge0} < x < {\mathit edge1}$.
+\apiend
+
 \apiitem{float {\ce smoothstep} (float edge0, float edge1, float x)}
 \indexapi{smoothstep()}
 Returns 0 if $x \le {\mathit edge0}$, and 1 if $x \ge {\mathit edge1}$,
@@ -3323,6 +3331,18 @@ interpolation between 0 and 1 when ${\mathit edge0} < x < {\mathit edge1}$.
 This is useful in cases where you would want a thresholding function
 with a smooth transition.
 \apiend
+
+\apiitem{float {\ce smooth_linearstep} (float edge0, float edge1, float x, float eps)}
+\indexapi{smooth_linearstep()}
+\NEW % 1.7
+This function is strictly linear between ${\mathit edge0}+{\mathit eps}$ and ${\mathit edge1}-{\mathit eps}$
+but smoothly ramps to 0 between ${\mathit edge0}-{\mathit eps}$ and ${\mathit edge0}+{\mathit eps}$
+and smoothly ramps to 1 between ${\mathit edge1}-{\mathit eps}$ and ${\mathit edge1}+{\mathit eps}$.
+It is 0 when $x \le {\mathit edge0}-{\mathit eps}$, and 1 if $x \ge {\mathit edge1}+{\mathit eps}$,
+and performs a linear
+interpolation between 0 and 1 when ${\mathit edge0} < x < {\mathit edge1}$.
+\apiend
+
 
 %\section{Noise functions}
 %\label{sec:stdlib:noise}

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -419,6 +419,25 @@ normal step (normal edge, normal x) BUILTIN;
 float step (float edge, float x) BUILTIN;
 float smoothstep (float edge0, float edge1, float x) BUILTIN;
 
+float linearstep (float edge0, float edge1, float x) {
+    float xclamped = clamp (x, edge0, edge1);
+    return (xclamped - edge0) / (edge1 - edge0);
+}
+
+float smooth_linearstep (float edge0, float edge1, float x_, float eps_) {
+    float rampup (float x, float r) { return 0.5/r * x*x; }
+    float width_inv = 1.0 / (edge1 - edge0);
+    float eps = eps_ * width_inv;
+    float x = (x_ - edge0) * width_inv;
+    float result;
+    if      (x < -eps)    result = 0;
+    else if (x < eps)     result = rampup (x+eps, 2.0*eps);
+    else if (x < 1.0-eps) result = x;
+    else if (x < 1.0+eps) result = 1.0 - rampup (1.0+eps - x, 2.0*eps);
+    else                  result = 1;
+    return result;
+}
+
 float aastep (float edge, float s, float dedge, float ds) {
     // Box filtered AA step
     float width = fabs(dedge) + fabs(ds);


### PR DESCRIPTION
`linearstep(edge0, edge1, x)` linearly interpolates from 0 to 1 as x goes from edge0 to edge1.

Here is a picture of `linearstep(0,1,x)`:

![linearstep](https://cloud.githubusercontent.com/assets/504179/10401074/72ed7432-6e71-11e5-9c04-85552a6cb5ee.png)

-----

`smooth_linearstep(edge0, edge1, x, eps)` is exactly linear (identical to linearstep) on [edge0+eps,edge1-eps] but has smooth ramp on and off between [edge0-eps,edge0+eps] and [edge1-eps,edge1+eps].

Below, linearstep(0,1,x) is blue, smoothstep(0,1,x) is green, smooth_linearstep(0,1,x,0.1) is red:

![smoothlinearstep](https://cloud.githubusercontent.com/assets/504179/10401099/91cef0b0-6e71-11e5-811b-5821bdd9c490.png)

`smooth_linearstep` has some interesting properties:
* It is exactly linear in much of its domain, unlike `smoothstep` which is always curvy.
* Its slope is 1 in the linear range, exactly matching `linearstep`, unlike `smoothstep` which is "steeper" than linear interpolation.
* But it does this be having its tails extend slightly beyond the edge0 and edge1 values.
