### PR TITLE
Record oslc options in comment in the oso file

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -418,7 +418,7 @@ OSLCompilerImpl::compile (string_view filename,
             ASSERT (m_osofile == NULL);
             m_osofile = &oso_output;
 
-            write_oso_file (m_output_filename);
+            write_oso_file (m_output_filename, OIIO::Strutil::join(options," "));
             ASSERT (m_osofile == NULL);
         }
 
@@ -504,7 +504,7 @@ OSLCompilerImpl::compile_buffer (string_view sourcecode,
             ASSERT (m_osofile == NULL);
             m_osofile = &oso_output;
 
-            write_oso_file (m_output_filename);
+            write_oso_file (m_output_filename, OIIO::Strutil::join(options," "));
             osobuffer = oso_output.str();
             ASSERT (m_osofile == NULL);
         }
@@ -740,12 +740,14 @@ OSLCompilerImpl::write_oso_symbol (const Symbol *sym)
 
 
 void
-OSLCompilerImpl::write_oso_file (const std::string &outfilename)
+OSLCompilerImpl::write_oso_file (const std::string &outfilename,
+                                 string_view options)
 {
     ASSERT (m_osofile != NULL && m_osofile->good());
     oso ("OpenShadingLanguage %d.%02d\n",
          OSO_FILE_VERSION_MAJOR, OSO_FILE_VERSION_MINOR);
     oso ("# Compiled by oslc %s\n", OSL_LIBRARY_VERSION_STRING);
+    oso ("# options: %s\n", options);
 
     ASTshader_declaration *shaderdecl = shader_decl();
     oso ("%s %s", shaderdecl->shadertypename(), 

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -312,7 +312,7 @@ private:
     void initialize_globals ();
     void initialize_builtin_funcs ();
     std::string default_output_filename ();
-    void write_oso_file (const std::string &outfilename);
+    void write_oso_file (const std::string &outfilename, string_view options);
     void write_oso_const_value (const ConstantSymbol *sym) const;
     void write_oso_symbol (const Symbol *sym);
     void write_oso_metadata (const ASTNode *metanode) const;


### PR DESCRIPTION
Makes debugging a little easier for me, I don't need to wonder what command line options (defines or include directories, etc.) were used.
