### PR TITLE
A collection of optimizer debugging aids

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -143,6 +143,7 @@ public:
     ///         opt_peephole, opt_coalesce_temps, opt_assign, opt_mix
     ///         opt_merge_instances, opt_merge_instance_with_userdata,
     ///         opt_fold_getattribute, opt_middleman, opt_texture_handle
+    ///    int opt_passes         Number of optimization passes per layer (10)
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Set LLVM extra debug level (0)
     ///    int llvm_debug_layers  Extra printfs upon entering and leaving

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -312,7 +312,14 @@ public:
     ///
     void llvm_zero_derivs (const Symbol &sym, llvm::Value *count);
 
+    /// Generate a debugging printf at shader execution time.
     void llvm_gen_debug_printf (const std::string &message);
+
+    /// Generate a warning message at shader execution time.
+    void llvm_gen_warning (const std::string &message);
+
+    /// Generate an error message at shader execution time.
+    void llvm_gen_error (const std::string &message);
 
     /// Generate code to call the given layer.  If 'unconditional' is
     /// true, call it without even testing if the layer has already been

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -107,6 +107,24 @@ BackendLLVM::llvm_gen_debug_printf (const std::string &message)
                       ll.constant(s));
 }
 
+    
+
+void
+BackendLLVM::llvm_gen_warning (const std::string &message)
+{
+    ll.call_function ("osl_warning", sg_void_ptr(), ll.constant("%s\n"),
+                      ll.constant(message));
+}
+
+
+
+void
+BackendLLVM::llvm_gen_error (const std::string &message)
+{
+    ll.call_function ("osl_error", sg_void_ptr(), ll.constant("%s\n"),
+                      ll.constant(message));
+}
+
 
 
 void

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3062,8 +3062,10 @@ LLVMGEN (llvm_gen_closure)
 
     const ClosureRegistry::ClosureEntry * clentry = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-        rop.shadingcontext()->error ("Closure '%s' is not supported by the current renderer, called from (%s:%d)",
-                                closure_name.c_str(), op.sourcefile().c_str(), op.sourceline());
+        rop.shadingcontext()->error ("Closure '%s' is not supported by the current renderer, called from %s:%d in shader \"%s\", layer %d \"%s\", group \"%s\"",
+                                     closure_name, op.sourcefile(), op.sourceline(),
+                                     rop.inst()->shadername(), rop.layer(),
+                                     rop.inst()->layername(), rop.group().name());
         return false;
     }
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3080,10 +3080,10 @@ LLVMGEN (llvm_gen_closure)
 
     const ClosureRegistry::ClosureEntry * clentry = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-        rop.shadingcontext()->error ("Closure '%s' is not supported by the current renderer, called from %s:%d in shader \"%s\", layer %d \"%s\", group \"%s\"",
+        rop.llvm_gen_error (Strutil::format("Closure '%s' is not supported by the current renderer, called from %s:%d in shader \"%s\", layer %d \"%s\", group \"%s\"",
                                      closure_name, op.sourcefile(), op.sourceline(),
                                      rop.inst()->shadername(), rop.layer(),
-                                     rop.inst()->layername(), rop.group().name());
+                                     rop.inst()->layername(), rop.group().name()));
         return false;
     }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1017,7 +1017,7 @@ BackendLLVM::run ()
     m_layer_remap.resize (nlayers, -1);
     m_num_used_layers = 0;
     if (debug() >= 1)
-        std::cout << "\nLayers used:\n";
+        std::cout << "\nLayers used: (group " << group().name() << ")\n";
     for (int layer = 0;  layer < nlayers;  ++layer) {
         // Skip unused or empty layers, unless they are callable entry
         // points.
@@ -1026,7 +1026,7 @@ BackendLLVM::run ()
         if (inst->entry_layer() || is_single_entry ||
             (! inst->unused() && !inst->empty_instance())) {
             if (debug() >= 1)
-                std::cout << "  " << layer << "\n";
+                std::cout << "  " << layer << ' ' << inst->layername() << "\n";
             m_layer_remap[layer] = m_num_used_layers++;
         }
     }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -557,6 +557,7 @@ public:
     int llvm_debug_layers () const { return m_llvm_debug_layers; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
     bool opt_texture_handle () const { return m_opt_texture_handle; }
+    int opt_passes() const { return m_opt_passes; }
     int max_warnings_per_thread() const { return m_max_warnings_per_thread; }
     bool countlayerexecs() const { return m_countlayerexecs; }
     bool lazy_userdata () const { return m_lazy_userdata; }
@@ -731,6 +732,7 @@ private:
     bool m_opt_middleman;                 ///< Middle-man optimization?
     bool m_opt_texture_handle;            ///< Use texture handles?
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!
+    int m_opt_passes;                     ///< Opt passes per layer
     int m_llvm_optimize;                  ///< OSL optimization strategy
     int m_debug;                          ///< Debugging output
     int m_llvm_debug;                     ///< More LLVM debugging output

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2067,12 +2067,13 @@ RuntimeOptimizer::optimize_instance ()
 
     // Try to fold constants.  We take several passes, until we get to
     // the point that not much is improving.  It rarely goes beyond 3-4
-    // passes, but we have a hard cutoff at 10 just to be sure we don't
+    // passes, but we have a hard cutoff just to be sure we don't
     // ever get into an infinite loop from an unforseen cycle where we
     // end up inadvertently transforming A => B => A => etc.
     int totalchanged = 0;
     int reallydone = 0;   // Force a few passes after we think we're done
-    for (m_pass = 0;  m_pass < 10;  ++m_pass) {
+    int npasses = shadingsys().opt_passes();
+    for (m_pass = 0;  m_pass < npasses;  ++m_pass) {
 
         // Once we've made one pass (and therefore called
         // mark_outgoing_connections), we may notice that the layer is

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -139,6 +139,11 @@ public:
     /// of instructions that were altered.
     int turn_into_nop (int begin, int end, string_view why=NULL);
 
+    void debug_opt (int opbegin, int opend, string_view message);
+    void debug_turn_into (const Opcode &op, int numops,
+                          string_view newop, int newarg0,
+                          int newarg1, int newarg2, string_view why);
+
     void simplify_params ();
 
     void find_params_holding_globals ();

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -647,6 +647,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_opt_fold_getattribute(true),
       m_opt_middleman(true), m_opt_texture_handle(true),
       m_optimize_nondebug(false),
+      m_opt_passes(10),
       m_llvm_optimize(0),
       m_debug(0), m_llvm_debug(0), m_llvm_debug_layers(0),
       m_commonspace_synonym("world"),
@@ -1048,6 +1049,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_SET ("opt_middleman", int, m_opt_middleman);
     ATTR_SET ("opt_texture_handle", int, m_opt_texture_handle);
+    ATTR_SET ("opt_passes", int, m_opt_passes);
     ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
@@ -1148,6 +1150,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_DECODE ("opt_middleman", int, m_opt_middleman);
     ATTR_DECODE ("opt_texture_handle", int, m_opt_texture_handle);
+    ATTR_DECODE ("opt_passes", int, m_opt_passes);
     ATTR_DECODE ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_DECODE ("llvm_optimize", int, m_llvm_optimize);
     ATTR_DECODE ("debug", int, m_debug);
@@ -1567,6 +1570,7 @@ ShadingSystemImpl::getstats (int level) const
     BOOLOPT (opt_fold_getattribute);
     BOOLOPT (opt_middleman);
     BOOLOPT (opt_texture_handle);
+    INTOPT  (opt_passes);
     STROPT (debug_groupname);
     STROPT (debug_layername);
     STROPT (archive_groupname);


### PR DESCRIPTION
1. Instead of hard-coding 10 passes over each layer when optimizing, let it be a SS attribute. (This is for me, I don't expect or want users to mess with it.)

2. Improved optimizer debugging messages -- refactored in a way that made it easier to have the little "I changed instruction FOO to instruction BAR because ..." debug messages to note which shader file and line that corresponds to.

3. Make an easy way for the JITer to insert code that will generate a runtime error or warning.

4. When encountering a request to make a closure that the renderer doesn't know about, instead of being a JIT-time error, do the thing from (3) above to make it a shader runtime error, which of course will only trigger if it actually tries to execute that line. This removes some spurious error messages in certain circumstances where we make closures obsolete but still want to run old shaders that reference them.


