### PR TITLE
isconstant(expr) returns 1 if the expression can be turned into a constant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,7 +491,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             function-earlyreturn function-simple function-outputelem
             geomath getattribute-camera getsymbol-nonheap gettextureinfo
             group-outputs groupstring
-            hyperb ieee_fp if incdec initops intbits isconnected
+            hyperb ieee_fp if incdec initops intbits isconnected isconstant
             layers layers-Ciassign layers-entry layers-lazy
             layers-nonlazycopy layers-repeatedoutputs
             linearstep

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4905,6 +4905,17 @@ so {\cf isconnected()} applied to a function parameter will depend on
 what was passed in as the actual parameter.
 \apiend
 
+\apiitem{int {\ce isconstant} (\emph{type} expr)}
+\indexapi{isconstant()}
+Returns {\cf 1} if the expression can, at runtime (knowing the values of all
+the shader group's parameter values and connections), be discerned to be
+reducible to a constant value, otherwise returns {\cf 0}.
+
+This is primarily a debugging aid for advanced shader writers to verify
+their assumptions about what expressions can end up being constant-folded
+by the runtime optimizer.
+\apiend
+
 
 \section{Dictionary Lookups}
 \label{sec:stdlib:dictionaries}

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1238,6 +1238,7 @@ static const char * builtin_func_args [] = {
     "getmessage", "is?", "is?[]", "iss?", "iss?[]", "!rw", NULL,
     "gettextureinfo", "iss?", "iss?[]", "!rw", NULL,  // FIXME -- further checking?
     "isconnected", "i?", NULL,
+    "isconstant", "i?", NULL,
     "noise", GNOISE_ARGS, NOISE_ARGS, "!deriv", NULL,
     "pnoise", PGNOISE_ARGS, PNOISE_ARGS, "!deriv", NULL,
     "pointcloud_search", "ispfi.", "ispfii.", "!rw", NULL,

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2725,6 +2725,21 @@ DECLFOLDER(constfold_deriv)
 
 
 
+DECLFOLDER(constfold_isconstant)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
+    // If at this point we know it's a constant, it's certainly a constant,
+    // so we can constant fold it. Note that if it's not known to be a
+    // constant at this point, that doesn't mean we won't detect it to be
+    // constant after further optimization, so we never fold this to 0.
+    if (A.is_constant()) {
+        rop.turn_into_assign_one (op, "isconstant => 1");
+        return 1;
+    }
+    return 0;
+}
+
 
 }; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3583,6 +3583,19 @@ LLVMGEN (llvm_gen_luminance)
 
 
 
+LLVMGEN (llvm_gen_isconstant)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    ASSERT (op.nargs() == 2);
+    Symbol &Result (*rop.opargsym (op, 0));
+    ASSERT (Result.typespec().is_int());
+    Symbol &A (*rop.opargsym (op, 1));
+    rop.llvm_store_value (rop.ll.constant(A.is_constant() ? 1 : 0), Result);
+    return true;
+}
+
+
+
 LLVMGEN (llvm_gen_functioncall)
 {
     Opcode &op (rop.inst()->ops()[opnum]);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -847,6 +847,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (if,          if,                  if,            false,     0);
     OP (inversesqrt, generic,             inversesqrt,   true,      0);
     OP (isconnected, generic,             none,          true,      0);
+    OP (isconstant,  isconstant,          isconstant,    true,      0);
     OP (isfinite,    generic,             none,          true,      0);
     OP (isinf,       generic,             none,          true,      0);
     OP (isnan,       generic,             none,          true,      0);

--- a/testsuite/isconstant/ref/out.txt
+++ b/testsuite/isconstant/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled test.osl -> test.oso
+Is param A const? 1
+Is 2*A const? 1
+Is noise(P) const? 0
+

--- a/testsuite/isconstant/run.py
+++ b/testsuite/isconstant/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+command = testshade("test")
+

--- a/testsuite/isconstant/test.osl
+++ b/testsuite/isconstant/test.osl
@@ -1,0 +1,8 @@
+
+
+shader test (float A = 1)
+{
+    printf ("Is param A const? %d\n", isconstant(A));
+    printf ("Is 2*A const? %d\n", isconstant(2*A));
+    printf ("Is noise(P) const? %d\n", isconstant(noise(P)));
+}


### PR DESCRIPTION
isconstant(expr) returns 1 if the expression can be turned into a constant
at runtime (with full knowledge of the shader group's parameters values and
connections).

This is primarily a debugging aid for advanced shader writers to verify
their assumptions about what expressions can end up being constant-folded
by the runtime optimizer. Also an aid for me in debugging that the runtime
optimizer is behaving as I expect.