### PR TITLE
C++11 compatibility clean-up

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -38,15 +38,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Detect if we're C++11.
 //
 // Note: oslversion.h defined OSL_BUILD_CPP11 to be 1 if OSL was built
-// using C++11. In contrast, OSL_USING_CPP11 defined below will be 1 if
-// we're compiling C++11 RIGHT NOW. These two things may be the same when
-// compiling OSL, but they may not be the same if another packages is
-// compiling against OSL and using these headers (OSL may be C++11 but the
-// client package may be older, or vice versa -- use these two symbols to
-// differentiate these cases, when important).
-#if (__cplusplus >= 201103L)
-#define OSL_USING_CPP11 1
-#define OSL_USING_CPLUSPLUS11 1 /* DEPRECATED */
+// using C++11. In contrast, OSL_CPLUSPLUS_VERSION defined below will be set
+// to the right number for the C++ standard being compiled RIGHT NOW. These
+// two things may be the same when compiling OSL, but they may not be the
+// same if another packages is compiling against OSL and using these headers
+// (OSL may be C++11 but the client package may be older, or vice versa --
+// use these two symbols to differentiate these cases, when important).
+#if (__cplusplus >= 201402L)
+#  define OSL_CPLUSPLUS_VERSION  14
+#elif (__cplusplus >= 201103L)
+#  define OSL_CPLUSPLUS_VERSION  11
+#else
+#  define OSL_CPLUSPLUS_VERSION  3 /* presume C++03 */
 #endif
 
 // Symbol export defines
@@ -63,11 +66,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/texture.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
+#include <OpenImageIO/platform.h>
 
 // Sort out smart pointers
-#ifdef OSL_USING_CPP11
+#if OSL_CPLUSPLUS_VERSION >= 11
 # include <memory>
-#else
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
 # include <boost/shared_ptr.hpp>
 #endif
 
@@ -118,10 +122,10 @@ using OIIO::ustringHash;
 using OIIO::string_view;
 
 // Sort out smart pointers
-#ifdef OSL_USING_CPP11
+#if OSL_CPLUSPLUS_VERSION >= 11
   using std::shared_ptr;
   using std::weak_ptr;
-#else
+#else /* FIXME(C++11): remove this after making C++11 the baseline */
   using boost::shared_ptr;
   using boost::weak_ptr;
 #endif


### PR DESCRIPTION
Use OSL_CPLUSPLUS_VERSION rather than OSL_USING_CPP11. The former is better for long-run distinguishing between 03, 11, 14, 17, and so on, whereas the latter is shortsightedly binary.
