### PR TITLE
Use boost::thread_specific_ptr, don't rely on it in OIIO namespace.

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <OpenImageIO/thread.h>
+#include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
 #include "OSL/oslconfig.h"
 #include "OSL/llvm_util.h"
@@ -124,7 +125,7 @@ namespace pvt {
 namespace {
 static OIIO::spin_mutex llvm_global_mutex;
 static bool setup_done = false;
-static OIIO::thread_specific_ptr<LLVM_Util::PerThreadInfo> perthread_infos;
+static boost::thread_specific_ptr<LLVM_Util::PerThreadInfo> perthread_infos;
 static std::vector<shared_ptr<llvm::JITMemoryManager> > jitmm_hold;
 };
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/regex_fwd.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/intrusive_ptr.hpp>
+#include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/thread.h>
@@ -62,7 +63,6 @@ using OIIO::mutex;
 using OIIO::lock_guard;
 using OIIO::spin_mutex;
 using OIIO::spin_lock;
-using OIIO::thread_specific_ptr;
 using OIIO::ustringHash;
 namespace Strutil = OIIO::Strutil;
 
@@ -767,7 +767,7 @@ private:
     ParamValueList m_pending_params;      ///< Pending Parameter() values
     ShaderGroupRef m_curgroup;            ///< Current shading attribute state
     mutable mutex m_mutex;                ///< Thread safety
-    mutable thread_specific_ptr<PerThreadInfo> m_perthread_info;
+    mutable boost::thread_specific_ptr<PerThreadInfo> m_perthread_info;
 
     // Stats
     atomic_int m_stat_shaders_loaded;     ///< Stat: shaders loaded

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
+#include <boost/thread.hpp>
 
 #include "oslexec_pvt.h"
 #include "OSL/genclosure.h"

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <cmath>
 
+#include <boost/thread.hpp>
+
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>


### PR DESCRIPTION
The reason for this is that I want to take the inclusion of boost::tsp out of the OIIO thread.h public header file. These are the only places in OIIO that we use it.
