### PR TITLE
OSL optimization: much better tracking of basic block aliases.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -145,6 +145,7 @@ public:
     ///         opt_peephole, opt_coalesce_temps, opt_assign, opt_mix
     ///         opt_merge_instances, opt_merge_instance_with_userdata,
     ///         opt_fold_getattribute, opt_middleman, opt_texture_handle
+    ///         opt_seed_bblock_aliases
     ///    int opt_passes         Number of optimization passes per layer (10)
     ///    int llvm_optimize      Which of several LLVM optimize strategies (0)
     ///    int llvm_debug         Set LLVM extra debug level (0)

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -733,6 +733,7 @@ private:
     bool m_opt_fold_getattribute;         ///< Constant-fold getattribute()?
     bool m_opt_middleman;                 ///< Middle-man optimization?
     bool m_opt_texture_handle;            ///< Use texture handles?
+    bool m_opt_seed_bblock_aliases;       ///< Turn on basic block alias seeds
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!
     int m_opt_passes;                     ///< Opt passes per layer
     int m_llvm_optimize;                  ///< OSL optimization strategy
@@ -1112,7 +1113,8 @@ public:
     Symbol *argsymbol (int argnum) { return symbol(arg(argnum)); }
     const OpcodeVec & ops () const { return m_instops; }
     OpcodeVec & ops () { return m_instops; }
-
+    const Opcode & op (int opnum) const { return ops()[opnum]; }
+    Opcode & op (int opnum) { return ops()[opnum]; }
     SymbolVec &symbols () { return m_instsymbols; }
     const SymbolVec &symbols () const { return m_instsymbols; }
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -648,6 +648,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_opt_merge_instances(1), m_opt_merge_instances_with_userdata(true),
       m_opt_fold_getattribute(true),
       m_opt_middleman(true), m_opt_texture_handle(true),
+      m_opt_seed_bblock_aliases(true),
       m_optimize_nondebug(false),
       m_opt_passes(10),
       m_llvm_optimize(0),
@@ -1052,6 +1053,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_SET ("opt_middleman", int, m_opt_middleman);
     ATTR_SET ("opt_texture_handle", int, m_opt_texture_handle);
+    ATTR_SET ("opt_seed_bblock_aliases", int, m_opt_seed_bblock_aliases);
     ATTR_SET ("opt_passes", int, m_opt_passes);
     ATTR_SET ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
@@ -1154,6 +1156,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("opt_fold_getattribute", int, m_opt_fold_getattribute);
     ATTR_DECODE ("opt_middleman", int, m_opt_middleman);
     ATTR_DECODE ("opt_texture_handle", int, m_opt_texture_handle);
+    ATTR_DECODE ("opt_seed_bblock_aliases", int, m_opt_seed_bblock_aliases);
     ATTR_DECODE ("opt_passes", int, m_opt_passes);
     ATTR_DECODE ("optimize_nondebug", int, m_optimize_nondebug);
     ATTR_DECODE ("llvm_optimize", int, m_llvm_optimize);


### PR DESCRIPTION
OSL's runtime optimizer tracks "value aliases" (one variable being set to be the same as another, or a constant), such as a=1, b=u. So then in subsequent use, if it sees c=a*d, it knows that can simplify to c=d (because a==1) and e = b-u can simplify to e=0 (because b and u hold the same value).  When a symbol's value is altered, of course the alias is removed from the active list. Also, we clear the list when we begin a new basic block (any contiguous series of instructions with strictly sequential control flow), because we don't know what values are held by variables at breaks of control flow.

However... there are a couple special (but common) cases where we know that even though an instruction is the target of a jump and therefore the beginning of a new basic block, we need not throw out all the prior information we have learned. For example,

    // start of basic block 0
    a = 0;
    if (u < 0.5) {
        // start of basic block 1
        t = a;
    } else {
        // start of basic block 2
        t = u;
    }
    // start of basic block 3
    z = a;

We can observe that basic blocks 1 and 2 can ONLY run immediately after block 0 finishes, and therefore they (each, separately) ought to be able to inherit whatever value aliases were known at the end of block 0.

Also, at the start of block 3, although it cannot be certain what is in t (because it was written inside the body of the 'if'), we SHOULD be able to still know that 'a', which was not modified by either branch of the 'if', should still have the value it started with before the conditional.

And similarly, we can make some deductions about aliases when we descend into function calls (remember that all function calls are inlined in OSL, though they still look like distinct basic blocks).

And also loops! Although loops are tricky because they may be entered from EITHER the preceding block, or from already having executed the loop body, so it's important that the body only be seeded with the prior aliases after they have been scrubbed of any aliases involving symbols that are modified in the loop.

Careful tracking of this information turns out to make the value alias tracking much more effective, because it doesn't have to throw out everything it knows at the start of every new basic block. This provides much more information for the runtime optimizer to bring to bear for further code simplifications.

I'm seeing pretty substantial reductions in the number of post-optimized instructions and symbols, as reported by the stats. Often this translates to improvements in runtime, but is extremely dependent on the shaders.  It will never take longer, but sometimes it is not noticeably faster.  But for other complex scenes, I'm seeing as much as 10% of overall render time improvement! I look forward to hearng how much this improves times across a wider range of scenes that people try.

Just in case I botched this, I've added a global ShadingSystem attribute "opt_seed_bblock_aliases" which can be set to 0 to disable this new optimization. I hope it won't be needed, but it's there to disable this specific feature in cases where we suspect that it's behaving incorrectly.