### PR TITLE
Support OSLQuery from a given bytecode

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -97,6 +97,14 @@ public:
     bool open (string_view shadername,
                string_view searchpath = string_view());
 
+    /// Get info on the shader from it's compiled bytecode.  Return
+    /// true for success, false if the shader could not be found or
+    /// opened properly.
+    /// Meant to be called from an app which caches bytecodes from
+    /// it's own side and wants to get shader info on runtime without
+    /// creating a temporary file.
+    bool open_bytecode (string_view buffer);
+
     /// Meant to be called at runtime from an app with a full ShadingSystem,
     /// fill out an OSLQuery structure for the given layer of the group.
     /// This is much faster than using open() to read it from an oso file on

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -306,5 +306,12 @@ OSLQuery::open (string_view shadername,
     return ok;
 }
 
+bool
+OSLQuery::open_bytecode (string_view buffer)
+{
+    OSOReaderQuery oso (*this);
+    bool ok = oso.parse_memory (buffer);
+    return ok;
+}
 
 OSL_NAMESPACE_EXIT


### PR DESCRIPTION
This is handy feature to have for applications which has OSL in-memory bytecode
cache but still needs to run OSLQuery on such shaders without creating temporary
files on the disk.

Currently only explicit query.open_bytecode() call is supported, this is because
it's not really possible to distinguish filepath from memory buffer being passed
to the constructor.