### PR TITLE
Fix some subtle bugs in the recent improved basic block alias analysis.

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -685,6 +685,7 @@ public:
     void renderer_output (bool v) { m_renderer_output = v; }
 
     bool is_constant () const { return symtype() == SymTypeConst; }
+    bool is_temp () const { return symtype() == SymTypeTemp; }
 
     /// Stream output
     std::ostream& print (std::ostream& out, int maxvals=100000000) const;


### PR DESCRIPTION
* The temporary coalescing has always relied on the assumption that temp
  lifetimes can simply be compared for overlap in their min/max
  instruction numbers, and this is only possible if their lifetime
  doesn't cross a loop boundary. As long as temporaries are restricted
  to live within one basic block, this is safe -- and they do so as a
  natural consequence of how they are created and used. EXCEPT that as a
  result of the new analysis, their values could end up being used
  outside their original basic blocks, and then could be inappropriate
  coalesced. Oops.

  The easy fix for this one is that when we save and restore the alias
  list, we exclude temporaries from the copy. The fix is in the
  implementation of copy_block_aliases.

* There are a couple circumstances in which code transformations call
  block_unalias() to say that a block-local symbol alias is no longer
  valid. The implementation just looks up that alias and removes it from
  the list. EXCEPT... now there is not just one list, but also the ones
  in the outer recursive scope. Oops.

  The fix here is that we keep track of a stack of such scopes, and
  bock_unalias walks up the stack and removes the alias from callers as
  well.

There are a couple minor odds and ends, mostly slight renames and
comments and clarifications.