### PR TITLE
Change isconnected() to reveal down-connections

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4899,7 +4899,10 @@ from the ``front'' or the ``outside'' of a closed object.
 \apiitem{int {\ce isconnected} (\emph{type} parameter)}
 \indexapi{isconnected()}
 Returns {\cf 1} if the argument is a shader parameter and is connected
-to an earlier layer in the shader group, otherwise returns {\cf 0}.
+to an earlier layer in the shader group, 
+{\cf 2} if the argument is a shader output parameter connected
+to a later layer in the shader group, {\cf 3} if connected to both
+earlier and later layers, otherwise returns {\cf 0}.
 Remember that function arguments in OSL are always pass-by-reference,
 so {\cf isconnected()} applied to a function parameter will depend on
 what was passed in as the actual parameter.

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2353,10 +2353,9 @@ RuntimeOptimizer::resolve_isconnected ()
                 ASSERT (fieldsymid >= 0);
                 s = inst()->symbol(fieldsymid);
             }
-            if (s->connected())
-                turn_into_assign_one (op, "resolve isconnected() [1]");
-            else
-                turn_into_assign_zero (op, "resolve isconnected() [0]");
+            int val = (s->connected() ? 1 : 0) + (s->connected_down() ? 2 : 0);
+            turn_into_assign (op, add_constant(TypeDesc::TypeInt, &val),
+                              "resolve isconnected()");
         }
     }
 }

--- a/testsuite/isconnected/ref/out.txt
+++ b/testsuite/isconnected/ref/out.txt
@@ -2,10 +2,19 @@ Compiled test.osl -> test.oso
 Compiled upstream.osl -> upstream.oso
 Connect upstream.out to downstream.a
 Connect upstream.struct1 to downstream.mystruct1
-a is connected
-b is not connected
-mystruct1 is connected
-mystruct1.x is connected
-mystruct2 is not connected
-mystruct2.x is not connected
+Upstream:
+out connected: 2  (value=0.5)
+notout connected: 0  (value=10)
+struct1 connected: 2  (value=10)
+struct1.x connected: 2  (value=3)
+struct2 connected: 0  (value=3)
+struct2.x connected: 0  (value=5)
+a=0.5
+Downstream:
+a connected: 1  (value=0.5)
+b connected: 0  (value=0)
+mystruct1 connected: 1  (value=0)
+mystruct1.x connected: 1  (value=3)
+mystruct2 connected: 0  (value=3)
+mystruct2.x connected: 0  (value=0)
 

--- a/testsuite/isconnected/test.osl
+++ b/testsuite/isconnected/test.osl
@@ -2,13 +2,15 @@
 
 void status (float variable, string name)
 {
-    printf ("%s %s connected\n", name, isconnected(variable) ? "is" : "is not");
+    printf ("%s connected: %d  (value=%g)\n",
+            name, isconnected(variable), variable);
 }
 
 
 void status (MyStruct variable, string name)
 {
-    printf ("%s %s connected\n", name, isconnected(variable) ? "is" : "is not");
+    printf ("%s connected: %d  (value=%g)\n",
+            name, isconnected(variable), variable);
     status (variable.x, concat(name, ".x"));
 }
 
@@ -17,6 +19,8 @@ shader test (float a = 0, float b = 0,
              MyStruct mystruct1 = {0,0},
              MyStruct mystruct2 = {0,0})
 {
+    printf ("a=%g\n", a);   // force retrieval/execution of upstream layer
+    printf ("Downstream:\n");
     status (a, "a");
     status (b, "b");
     status (mystruct1, "mystruct1");

--- a/testsuite/isconnected/upstream.osl
+++ b/testsuite/isconnected/upstream.osl
@@ -1,8 +1,35 @@
 #include "mystruct.h"
 
-shader upstream (output float out = 0, output MyStruct struct1 = {0,0})
+void status (float variable, string name)
 {
-    out = 1;
+    printf ("%s connected: %d  (value=%g)\n",
+            name, isconnected(variable), variable);
+}
+
+
+void status (MyStruct variable, string name)
+{
+    printf ("%s connected: %d  (value=%g)\n",
+            name, isconnected(variable), variable);
+    status (variable.x, concat(name, ".x"));
+}
+
+
+shader upstream (output float out = 0,
+                 output float notout = 0,
+                 output MyStruct struct1 = {0,0},
+                 output MyStruct struct2 = {0,0})
+{
+    out = noise(P);
+    notout = 10;
     struct1.x = 3;
     struct1.y = 4;
+    struct2.x = 5;
+    struct2.y = 6;
+
+    printf ("Upstream:\n");
+    status (out, "out");
+    status (notout, "notout");
+    status (struct1, "struct1");
+    status (struct2, "struct2");
 }


### PR DESCRIPTION
Old: isconnected(param) returns 1 if the param is connected to an upstream
layer, otherwise 0.

New: isconnected(param) returns 1 if the param is connected to an upstream
layer, 2 if connected to a downstream layer, 3 if both, 0 if neither.