### PR TITLE
Travis-CI setup for OSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,105 @@
+# .travis.yml for OSL
+
+language: cpp
+sudo: false
+compiler:
+    - clang
+    - gcc
+os:
+    - linux
+    - osx
+#osx_image: xcode7
+dist: trusty
+
+# Do a default build (C++03, sse2), an sse4.2 build, and a C++11 build.
+# Also try with both gcc 4.8 and 4.9 (on Linux; on OSX these will be
+# excluded).
+env:
+    matrix:
+      - WHICHGCC=4.8 OIIOBRANCH=master BUILD_FLAGS=""
+      - WHICHGCC=4.8 OIIOBRANCH=master BUILD_FLAGS="USE_CPP=1"
+      - WHICHGCC=4.9 OIIOBRANCH=master BUILD_FLAGS=""
+      # - WHICHGCC=4.8 OIIOBRANCH=release BUILD_FLAGS=""
+
+# Add-ons: specify apt packages for Linux
+addons:
+  apt: 
+   sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+   packages:
+      - gcc-4.8
+      - g++-4.8
+      - gcc-4.9
+      - g++-4.9
+      - libboost1.55-all-dev
+      - libtiff4-dev
+      - llvm3.4
+      - clang-3.4
+
+cache:
+    ccache: true
+    apt: true
+    directories:
+    - $HOME/.ccache
+
+before_install:
+    - if [ $TRAVIS_OS_NAME == osx ] ; then export PLATFORM=macosx ; fi
+    - if [ $TRAVIS_OS_NAME == linux ] ; then export PLATFORM=linux64 ; fi
+    - echo "Build platform name is $PLATFORM"
+    - if [ $TRAVIS_OS_NAME == osx ] ; then sysctl machdep.cpu.features ; fi
+    - if [ $TRAVIS_OS_NAME == linux ] ; then cat /proc/cpuinfo ; fi
+
+install:
+    - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then src/build-scripts/install_homebrew_deps.bash ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then export LLVM_DIRECTORY=/usr/local/Cellar/llvm34/3.4.2/lib/llvm-3.4 ; fi
+    - if [ $TRAVIS_OS_NAME == linux ] ; then src/build-scripts/build_openexr.bash ; fi
+    - if [ $TRAVIS_OS_NAME == linux ] ; then export ILMBASE_HOME=$PWD/openexr-install ; export OPENEXR_HOME=$PWD/openexr-install ; fi
+    - export OIIOMAKEFLAGS="$OIIOMAKEFLAGS -j2"
+    - src/build-scripts/build_openimageio.bash
+    - export OPENIMAGEIOHOME=$PWD/OpenImageIO/dist/$PLATFORM
+    - export DYLD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$DYLD_LIBRARY_PATH
+    - export LD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$LD_LIBRARY_PATH
+    - export PATH=$OPENIMAGEIOHOME/bin:$PATH
+    - if [ $TRAVIS_OS_NAME == linux ] ; then export BUILD_FLAGS="$BUILD_FLAGS LLVM_STATIC=1" ; fi
+    # Linux only, can't make these test work. Exclude for now and return later.
+    - if [ $TRAVIS_OS_NAME == linux ] ; then export TEST_FLAGS="-E broken\|render-cornell\|render-oren-nayar\|render-veachmis\|render-ward" ; fi
+
+# before_script:
+
+script:
+    - make VERBOSE=1 $BUILD_FLAGS cmakesetup
+    - make -j2 $BUILD_FLAGS
+    - export OSLHOME=$PWD/dist/$PLATFORM
+    - export DYLD_LIBRARY_PATH=$OSLHOME/lib:$DYLD_LIBRARY_PATH 
+    - export LD_LIBRARY_PATH=$OSLHOME/lib:$LD_LIBRARY_PATH
+    - make $BUILD_FLAGS test
+
+
+# after_success:
+
+after_failure:
+# FIXME: find failed logs, stash them or send them to lg?
+
+#branches:
+#  only:
+#    - master
+#    - /^v\d+\./
+
+matrix:
+    exclude:
+      - os: osx
+        compiler: gcc
+      - os: linux
+        compiler: clang
+      - os: osx
+        compiler: clang
+        env: WHICHGCC=4.9 OIIOBRANCH=master BUILD_FLAGS=""
+
+notifications:
+    email:
+#        recipients:
+#            - 
+        on_success: change
+        on_failure: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,9 @@ if (CMAKE_COMPILER_IS_GNUCC AND (NOT CMAKE_COMPILER_IS_CLANG))
         add_definitions ("-Wno-error=unused-local-typedefs")
         add_definitions ("-Wno-unused-local-typedefs")
     endif ()
+    if (NOT ${GCC_VERSION} VERSION_LESS 4.5)
+        add_definitions ("-Wno-unused-result")
+    endif ()
 endif ()
 
 
@@ -512,7 +515,6 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-variadic-macro
             oslinfo-arrayparams oslinfo-metadata oslinfo-noparams
             osl-imageio
-            pointcloud pointcloud-fold
             printf-whole-array
             raytype reparam
             render-background render-bumptest
@@ -524,7 +526,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             struct-with-array struct-within-struct
             ternary
             testshade-expr
-            texture-alpha texture-blur texture-derivs texture-field3d
+            texture-alpha texture-blur texture-derivs
             texture-firstchannel texture-interp 
             texture-missingcolor texture-simple
             texture-smallderivs texture-swirl
@@ -535,7 +537,20 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             vararray-deserialize vararray-param
             vecctr vector
             wavelength_color xml )
+
+# Only run field3d-related tests if the local OIIO was built with f3d support.
+EXECUTE_PROCESS ( COMMAND ${OPENIMAGEIO_BIN}/oiiotool --help
+                  OUTPUT_VARIABLE oiiotool_help )
+if (oiiotool_help MATCHES "field3d")
+    TESTSUITE ( texture-field3d )
+endif()
+
+# Only run pointcloud tests if Partio is found
+if (PARTIO_FOUND)
+    TESTSUITE ( pointcloud pointcloud-fold )
 endif ()
+
+endif (OSL_BUILD_TESTS)
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ dist : cmakeinstall
 # 'make test' does a full build and then runs all tests
 test: cmake
 	${CMAKE} -E cmake_echo_color --switch=$(COLOR) --cyan "Running tests ${TEST_FLAGS}..."
-	( cd ${build_dir} ; ctest --force-new-ctest-process ${TEST_FLAGS} -E broken )
+	( cd ${build_dir} ; ctest --force-new-ctest-process -E broken ${TEST_FLAGS} )
 
 # 'make testall' does a full build and then runs all tests (even the ones
 # that are expected to fail on some platforms)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+README for Open Shading Language
+================================
+
+Build status:
+
+[![Build Status](https://travis-ci.org/lgritz/OpenShadingLanguage.svg?branch=master)](https://travis-ci.org/lgritz/OpenShadingLanguage)
+
 Table of contents
 ------------------
 

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# The Linux VM used by Travis has OpenEXR 1.x. We really want 2.x.
+
+EXRINSTALLDIR=${EXRINSTALLDIR:=${PWD}/openexr-install}
+EXRVERSION=${EXRVERSION:=2.2.0}
+echo "EXR install dir will be: ${EXRINSTALLDIR}"
+
+if [ ! -e ${EXRINSTALLDIR} ] ; then
+    mkdir ${EXRINSTALLDIR}
+fi
+
+# Clone OpenEXR project (including IlmBase) from GitHub and build
+if [ ! -e ./openexr ] ; then
+    git clone -b v${EXRVERSION} https://github.com/openexr/openexr.git ./openexr
+    pushd ./openexr/IlmBase
+    ./bootstrap && ./configure --prefix=${EXRINSTALLDIR} && make && make install
+    cd ../OpenEXR
+    ./bootstrap ; ./configure --prefix=${EXRINSTALLDIR} --with-ilmbase-prefix=${EXRINSTALLDIR} --disable-ilmbasetest && make && make install
+    popd
+fi
+
+ls -R ${EXRINSTALLDIR}
+
+#echo "listing .."
+#ls ..
+

--- a/src/build-scripts/build_openimageio.bash
+++ b/src/build-scripts/build_openimageio.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Install OpenImageIO
+
+OIIOBRANCH=${OIIOBRANCH:=master}
+OIIOINSTALLDIR=${OIIOINSTALLDIR:=${PWD}/OpenImageIO}
+
+if [ ! -e $OIIOINSTALLDIR ] ; then
+    git clone https://github.com/OpenImageIO/oiio.git $OIIOINSTALLDIR
+fi
+
+( cd $OIIOINSTALLDIR ; git fetch --all -p && git checkout $OIIOBRANCH --force ; make nuke )
+( cd $OIIOINSTALLDIR ; make ${OIIOMAKEFLAGS} VERBOSE=1 cmakesetup )
+( cd $OIIOINSTALLDIR ; make ${OIIOMAKEFLAGS} )
+
+echo "OIIOINSTALLDIR $OIIOINSTALLDIR"
+ls -R $OIIOINSTALLDIR/dist

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script, which assumes it is runnign on a Mac OSX with Homebrew
+# installed, does a "brew install" in all packages reasonably needed by
+# OIIO.
+
+if [ `uname` != "Darwin" ] ; then
+    echo "Don't run this script unless you are on Mac OSX"
+    exit 1
+fi
+
+if [ `which brew` == "" ] ; then
+    echo "You need to install Homebrew before running this script."
+    echo "See http://brew.sh"
+    exit 1
+fi
+
+brew update >/dev/null
+echo ""
+echo "Before my brew installs:"
+brew list --versions
+brew install flex bison
+brew install ilmbase openexr
+brew install boost-python
+brew install opencolorio partio
+#brew install homebrew/science/hdf5 --with-threadsafe
+#brew install field3d
+brew install freetype libraw libpng webp
+brew install llvm34
+#brew install homebrew/science/hdf5 --with-threadsafe
+#brew install field3d webp ffmpeg openjpeg opencv
+echo ""
+echo "After brew installs:"
+brew list --versions
+
+echo "testing llvm:"
+ls -R /usr/local/Cellar/llvm34

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -199,20 +199,27 @@ endif ()
 find_library ( LLVM_LIBRARY
                NAMES LLVM-${LLVM_VERSION}
                PATHS ${LLVM_LIB_DIR})
+find_library ( LLVM_MCJIT_LIBRARY
+               NAMES LLVMMCJIT
+               PATHS ${LLVM_LIB_DIR})
+execute_process (COMMAND ${LLVM_CONFIG} --ldflags
+                 OUTPUT_VARIABLE LLVM_LDFLAGS
+                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# if (NOT LLVM_LIBRARY)
+#     execute_process (COMMAND ${LLVM_CONFIG} --libfiles engine
+#                      OUTPUT_VARIABLE LLVM_LIBRARIES
+#                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+# endif ()
+
 if (NOT LLVM_FIND_QUIETLY)
     message (STATUS "LLVM version  = ${LLVM_VERSION}")
     message (STATUS "LLVM dir      = ${LLVM_DIRECTORY}")
-endif ()
-
-find_library ( LLVM_MCJIT_LIBRARY
-                   NAMES LLVMMCJIT
-                   PATHS ${LLVM_LIB_DIR})
-
-if (NOT LLVM_FIND_QUIETLY)
     message (STATUS "LLVM includes = ${LLVM_INCLUDES}")
     message (STATUS "LLVM library  = ${LLVM_LIBRARY}")
     message (STATUS "LLVM MCJIT library  = ${LLVM_MCJIT_LIBRARY}")
     message (STATUS "LLVM lib dir  = ${LLVM_LIB_DIR}")
+    message (STATUS "LLVM libraries = ${LLVM_LIBRARIES}")
 endif ()
 
 # shared llvm library may not be available, this is not an error if we use LLVM_STATIC.

--- a/src/cmake/oiio.cmake
+++ b/src/cmake/oiio.cmake
@@ -23,12 +23,17 @@ find_path ( OPENIMAGEIO_INCLUDES
             NAMES OpenImageIO/imageio.h
             HINTS ${OPENIMAGEIOHOME}
             PATH_SUFFIXES include )
-IF (OPENIMAGEIO_INCLUDES AND OPENIMAGEIO_LIBRARY )
+find_program ( OPENIMAGEIO_BIN
+               NAMES oiiotool
+               HINTS ${OPENIMAGEIOHOME}
+               PATH_SUFFIXES bin )
+if (NOT OpenImageIO_FIND_QUIETLY)
+    MESSAGE ( STATUS "OpenImageIO includes = ${OPENIMAGEIO_INCLUDES}" )
+    MESSAGE ( STATUS "OpenImageIO library = ${OPENIMAGEIO_LIBRARY}" )
+    MESSAGE ( STATUS "OpenImageIO bin = ${OPENIMAGEIO_BIN}" )
+endif ()
+IF ( OPENIMAGEIO_INCLUDES AND OPENIMAGEIO_LIBRARY )
     SET ( OPENIMAGEIO_FOUND TRUE )
-    if (NOT OpenImageIO_FIND_QUIETLY)
-        MESSAGE ( STATUS "OpenImageIO includes = ${OPENIMAGEIO_INCLUDES}" )
-        MESSAGE ( STATUS "OpenImageIO library = ${OPENIMAGEIO_LIBRARY}" )
-    endif ()
 ELSE ()
     MESSAGE ( FATAL_ERROR "OpenImageIO not found" )
 ENDIF ()

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -145,7 +145,9 @@ TARGET_LINK_LIBRARIES ( oslexec
                         ${OPENIMAGEIO_LIBRARY} ${PUGIXML_LIBRARIES}
                         ${PARTIO_LIBRARIES} ${ZLIB_LIBRARIES}
                         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
-                        ${LLVM_LIBRARY} ${LLVM_MCJIT_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES})
+                        ${LLVM_LIBRARY} ${LLVM_MCJIT_LIBRARY}
+                        ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
+                        ${EXTRA_OSLEXEC_LIBRARIES})
 ADD_DEPENDENCIES (oslexec "${CMAKE_CURRENT_SOURCE_DIR}/liboslexec.map")
 LINK_ILMBASE ( oslexec )
 
@@ -154,12 +156,12 @@ INSTALL ( TARGETS oslexec RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIV
 # Unit tests
 if (OSL_BUILD_TESTS)
     add_executable (accum_test accum_test.cpp)
-    target_link_libraries ( accum_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES} )
+    target_link_libraries ( accum_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${EXTRA_OSLEXEC_LIBRARIES} )
     link_ilmbase (accum_test)
     add_test (unit_accum "${CMAKE_BINARY_DIR}/src/liboslexec/accum_test")
 
     add_executable (llvmutil_test llvmutil_test.cpp)
-    target_link_libraries ( llvmutil_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} ${EXTRA_OSLEXEC_LIBRARIES} )
+    target_link_libraries ( llvmutil_test oslexec oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${EXTRA_OSLEXEC_LIBRARIES} )
     link_ilmbase (llvmutil_test)
     add_test (unit_llvmutil "${CMAKE_BINARY_DIR}/src/liboslexec/llvmutil_test")
 endif ()

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -12,7 +12,7 @@ else ()
     ADD_LIBRARY ( "libtestshade" SHARED ${testshade_srcs} )
 endif ()
 
-TARGET_LINK_LIBRARIES (libtestshade oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${LLVM_LIBRARY} )
+TARGET_LINK_LIBRARIES (libtestshade oslexec oslcomp oslquery ${OPENIMAGEIO_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
 SET_TARGET_PROPERTIES (libtestshade PROPERTIES PREFIX "")
 
 INSTALL ( TARGETS libtestshade RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Modeled after what I did recently for OIIO. Henceforth, all pull requests and pushes to the main OSL repo will cause builds to be kicked off for OSX and Linux, with a few different build options each. When somebody makes a PR, even before merging we can be reasonably certain it doesn't break the build, yay.

It's not 100% finished, but it's working and useful. The biggest unresolved issue is that I have to manually exclude 4 tests (out of almost 300) that don't match their output images exactly (and I'm sure are fine), and I haven't yet figured out how to recover the files it generates so I can commit it as an alternate reference image. But I'll sweep that under the rug for now and come back to it.
