### PR TITLE
Travis cleanup, and use ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,30 +41,39 @@ cache:
     ccache: true
     apt: true
     directories:
-    - $HOME/.ccache
+      - $HOME/.ccache
 
 before_install:
-    - if [ $TRAVIS_OS_NAME == osx ] ; then export PLATFORM=macosx ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export PLATFORM=linux64 ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then
+          export PLATFORM=macosx ;
+          sysctl machdep.cpu.features ;
+      elif [ $TRAVIS_OS_NAME == linux ] ; then
+          export PLATFORM=linux64 ;
+          cat /proc/cpuinfo ;
+      fi
     - echo "Build platform name is $PLATFORM"
-    - if [ $TRAVIS_OS_NAME == osx ] ; then sysctl machdep.cpu.features ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then cat /proc/cpuinfo ; fi
 
 install:
     - if [ "$CXX" == "g++" ]; then export CXX="g++-${WHICHGCC}" ; fi
-    - if [ $TRAVIS_OS_NAME == osx ] ; then src/build-scripts/install_homebrew_deps.bash ; fi
-    - if [ $TRAVIS_OS_NAME == osx ] ; then export LLVM_DIRECTORY=/usr/local/Cellar/llvm34/3.4.2/lib/llvm-3.4 ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then src/build-scripts/build_openexr.bash ; fi
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export ILMBASE_HOME=$PWD/openexr-install ; export OPENEXR_HOME=$PWD/openexr-install ; fi
+    - if [ $TRAVIS_OS_NAME == osx ] ; then
+          src/build-scripts/install_homebrew_deps.bash ;
+          export LLVM_DIRECTORY=/usr/local/Cellar/llvm34/3.4.2/lib/llvm-3.4 ;
+      elif [ $TRAVIS_OS_NAME == linux ] ; then
+          src/build-scripts/build_openexr.bash ;
+          export ILMBASE_HOME=$PWD/openexr-install ;
+          export OPENEXR_HOME=$PWD/openexr-install ;
+      fi
     - export OIIOMAKEFLAGS="$OIIOMAKEFLAGS -j2"
     - src/build-scripts/build_openimageio.bash
     - export OPENIMAGEIOHOME=$PWD/OpenImageIO/dist/$PLATFORM
     - export DYLD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$DYLD_LIBRARY_PATH
     - export LD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$LD_LIBRARY_PATH
     - export PATH=$OPENIMAGEIOHOME/bin:$PATH
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export BUILD_FLAGS="$BUILD_FLAGS LLVM_STATIC=1" ; fi
-    # Linux only, can't make these test work. Exclude for now and return later.
-    - if [ $TRAVIS_OS_NAME == linux ] ; then export TEST_FLAGS="-E broken\|render-cornell\|render-oren-nayar\|render-veachmis\|render-ward" ; fi
+    - if [ $TRAVIS_OS_NAME == linux ] ; then
+          export BUILD_FLAGS="$BUILD_FLAGS LLVM_STATIC=1" ;
+          export TEST_FLAGS="-E broken\|render-cornell\|render-oren-nayar\|render-veachmis\|render-ward" ;
+      fi
+    # ^^^ Linux only, can't make these test work. Exclude for now and return later. ;
 
 # before_script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
           src/build-scripts/install_homebrew_deps.bash ;
           export LLVM_DIRECTORY=/usr/local/Cellar/llvm34/3.4.2/lib/llvm-3.4 ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
-          src/build-scripts/build_openexr.bash ;
+          CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_HOME=$PWD/openexr-install ;
           export OPENEXR_HOME=$PWD/openexr-install ;
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ message (STATUS "CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}")
 
 # Figure out which compiler we're using
 if (CMAKE_COMPILER_IS_GNUCC)
-    execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpversion
+    execute_process (COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                      OUTPUT_VARIABLE GCC_VERSION
                      OUTPUT_STRIP_TRAILING_WHITESPACE)
     if (VERBOSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ endif ()
 # gcc specific options
 if (CMAKE_COMPILER_IS_GNUCC AND (NOT CMAKE_COMPILER_IS_CLANG))
     if (NOT ${GCC_VERSION} VERSION_LESS 4.8)
+        add_definitions ("-Wno-error=strict-overflow")
         # suppress a warning that Boost::Python hits in g++ 4.8
         add_definitions ("-Wno-error=unused-local-typedefs")
         add_definitions ("-Wno-unused-local-typedefs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,13 @@ if (EXISTS "/usr/lib/libc++.dylib")
     set (OSL_SYSTEM_HAS_LIBCPP ON)
 endif ()
 
+# Use ccache if found
+find_program (CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property (GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif ()
+
 
 set (VERBOSE OFF CACHE BOOL "Print lots of messages while compiling")
 set (OSL_BUILD_TESTS ON CACHE BOOL "Build the unit tests, testshade, testrender")

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -19,12 +19,11 @@ brew update >/dev/null
 echo ""
 echo "Before my brew installs:"
 brew list --versions
+brew install ccache
 brew install flex bison
 brew install ilmbase openexr
 brew install boost-python
 brew install opencolorio partio
-#brew install homebrew/science/hdf5 --with-threadsafe
-#brew install field3d
 brew install freetype libraw libpng webp
 brew install llvm34
 #brew install homebrew/science/hdf5 --with-threadsafe
@@ -32,6 +31,3 @@ brew install llvm34
 echo ""
 echo "After brew installs:"
 brew list --versions
-
-echo "testing llvm:"
-ls -R /usr/local/Cellar/llvm34


### PR DESCRIPTION
Same changes as https://github.com/OpenImageIO/oiio/pull/1274

Last night's web surfing discovery: 5 lines added to CMakeLists.txt that causes it to use ccache if it's installed on the system. Cuts Travis builds by half, and will also speed up any other users building OSL who doesn't take steps on their own to use cmake.

Is there a downside? Does anybody feel like they are likely to have cmake installed but want specifically NOT to use it, and need a switch to turn this off? Or is "use cmake if they have it" good enough?

Also some cleanup and reformatting after discovering that in the .travis.yml file I can split commands over several lines, makes it more readable.