### PR TITLE
Revision of the logic behind lifetime analysis inside loops.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -333,6 +333,10 @@ ASTvariable_declaration::ASTvariable_declaration (OSLCompilerImpl *comp,
     }
     SymType symtype = isparam ? (isoutput ? SymTypeOutputParam : SymTypeParam)
                               : SymTypeLocal;
+    // Sneaky debugging aid: a local that starts with "__debug_tmp__"
+    // gets declared as a temp. Don't do this on purpose!!!
+    if (symtype == SymTypeLocal && Strutil::starts_with (name, "__debug_tmp__"))
+        symtype = SymTypeTemp;
     m_sym = new Symbol (name, type, symtype, this);
     if (! m_ismetadata)
         oslcompiler->symtab().insert (m_sym);

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -302,7 +302,8 @@ public:
 
     static void track_variable_lifetimes (const OpcodeVec &ircode,
                                           const SymbolPtrVec &opargs,
-                                          const SymbolPtrVec &allsyms);
+                                          const SymbolPtrVec &allsyms,
+                                          std::vector<int> *bblock_ids=NULL);
     static void coalesce_temporaries (SymbolPtrVec &symtab);
 
     const std::string main_filename () const { return m_main_filename; }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1544,7 +1544,7 @@ ShadingSystemImpl::getstats (int level) const
     }
 
     std::string opt;
-#define BOOLOPT(name) if (m_##name) opt += #name " "
+#define BOOLOPT(name) opt += Strutil::format(#name "=%d ", m_##name)
 #define INTOPT(name) opt += Strutil::format(#name "=%d ", m_##name)
 #define STROPT(name) if (m_##name.size()) opt += Strutil::format(#name "=\"%s\" ", m_##name)
     INTOPT (optimize);


### PR DESCRIPTION
A subtle optimization bug was traced to this, and now I'm fully at Stage 6 ("how did that ever work?"). I think that the test we had before did not catch all the cases, and applied only to declared local variables, which I can't even fathom why I thought was not going to cause trouble.

I think that to be safe, the correct rule is that any symbol that is modified before or inside a loop, and read inside or after the loop, needs to have its lifetime extended to the full body of the loop, because it needs to preserve its value for possible additional iterations of that loop and NOT be optimized away or coalesced with another symbol in a way that would botch this.

As an important exception, there is the case of a temporary or local that is written strictly before being read, and whose entire lifetime resides within one basic block -- those DON'T need to have their lifetimes ballooned up to the whole loop. (That is, indeed, the case for most temp variables, which is probably why the non-inclusion of temps before was asymptomatic. But there are cases where it's an issue, including temps that hold computed expressions that are passed as parameters to functions, when those functions contain loops within which the parameter is used.) We can only detect this case when we happen to have the basic block information already computed, which we don't always, so we make that an optional argument to track_variable_lifetimes.
