### PR TITLE
Use GCC attribute for the methods which are considered deprecated

### DIFF
--- a/src/include/OSL/oslcomp.h
+++ b/src/include/OSL/oslcomp.h
@@ -41,7 +41,7 @@ namespace pvt {
 
 class OSLCOMPPUBLIC OSLCompiler {
 public:
-    /// DEPRECATED -- it's ok to directly construct an OSLCompiler now.
+    OSL_DEPRECATED("It's ok to directly construct an OSLCompiler now")
     static OSLCompiler *create ();
 
     OSLCompiler (ErrorHandler *errhandler=NULL);

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -130,5 +130,18 @@ using OIIO::string_view;
   using boost::weak_ptr;
 #endif
 
+#ifndef __has_attribute
+#  define __has_attribute(x) 0
+#endif
+
+#if __cplusplus >= 201402L || (__cplusplus >= 201103L && __has_attribute(deprecated))
+#  define OSL_DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__)
+#  define OSL_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#  define OSL_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#  define OSL_DEPRECATED(msg)
+#endif
 
 OSL_NAMESPACE_EXIT

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -42,8 +42,10 @@ OSL_NAMESPACE_ENTER
 class RendererServices;
 class ShaderGroup;
 typedef shared_ptr<ShaderGroup> ShaderGroupRef;
-typedef ShaderGroup ShadingAttribState;       // DEPRECATED name
-typedef ShaderGroupRef ShadingAttribStateRef; // DEPRECATED name
+OSL_DEPRECATED("Use ShaderGroupRef instead")
+typedef ShaderGroup ShadingAttribState;
+OSL_DEPRECATED("Use ShaderGroupRef instead")
+typedef ShaderGroupRef ShadingAttribStateRef;
 struct ClosureParam;
 struct PerThreadInfo;
 class ShadingContext;
@@ -75,11 +77,12 @@ public:
                    ErrorHandler *err=NULL);
     ~ShadingSystem ();
 
-    /// DEPRECATED -- it's ok now to just construct a ShadingSystem.
+    OSL_DEPRECATED("It's ok now to just construct a ShadingSystem")
     static ShadingSystem *create (RendererServices *renderer=NULL,
                                   TextureSystem *texturesystem=NULL,
                                   ErrorHandler *err=NULL);
-    /// DEPRECATED -- it's ok now to just destroy a ShadingSystem.
+
+    OSL_DEPRECATED("It's ok now to just destroy a ShadingSystem")
     static void destroy (ShadingSystem *x);
 
     /// Set an attribute controlling the shading system.  Return true
@@ -445,8 +448,9 @@ public:
     /// setup, don't actually run the shader.
     bool execute (ShadingContext *ctx, ShaderGroup &group,
                   ShaderGlobals &globals, bool run=true);
+    OSL_DEPRECATED("Deprecated since 1.6")
     bool execute (ShadingContext &ctx, ShaderGroup &group,
-                  ShaderGlobals &globals, bool run=true); // DEPRECATED (1.6)
+                  ShaderGlobals &globals, bool run=true);
 
     /// Bind a shader group and globals to the context, in preparation to
     /// execute, including optimization and JIT of the group (if it has not

--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -156,7 +156,7 @@ public:
         return e;
     }
 
-    /// DEPRECATED(1.5) -- included for back compatibility
+    OSL_DEPRECATED("Deprecated since 1.5, included for back compatibility")
     std::string error (void) { return geterror(); }
 
 private:

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -182,7 +182,7 @@ shade_image (ShadingSystem &shadingsys, ShaderGroup &group,
         }
 
         // Actually run the shader for this point
-        shadingsys.execute (*ctx, group, sg);
+        shadingsys.execute (ctx, group, sg);
 
         // Save all the designated outputs.
         int chan = 0;

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -400,7 +400,7 @@ Vec3 eval_background(const Dual2<Vec3>& dir, ShadingContext* ctx) {
     sg.I = dir.val();
     sg.dIdx = dir.dx();
     sg.dIdy = dir.dy();
-    shadingsys->execute(*ctx, *shaders[backgroundShaderID], sg);
+    shadingsys->execute(ctx, *shaders[backgroundShaderID], sg);
     return process_background_closure(sg.Ci);
 }
 
@@ -436,7 +436,7 @@ Color3 subpixel_radiance(float x, float y, Sampler& sampler, ShadingContext* ctx
         if (shaderID < 0 || !shaders[shaderID]) break; // no shader attached? done
 
         // execute shader and process the resulting list of closures
-        shadingsys->execute (*ctx, *shaders[shaderID], sg);
+        shadingsys->execute (ctx, *shaders[shaderID], sg);
         ShadingResult result;
         bool last_bounce = b == max_bounces;
         process_closure(result, sg.Ci, last_bounce);
@@ -500,7 +500,7 @@ Color3 subpixel_radiance(float x, float y, Sampler& sampler, ShadingContext* ctx
                     ShaderGlobals light_sg;
                     globals_from_hit(light_sg, shadow_ray, shadow_dist, lid, false);
                     // execute the light shader (for emissive closures only)
-                    shadingsys->execute (*ctx, *shaders[shaderID], light_sg);
+                    shadingsys->execute (ctx, *shaders[shaderID], light_sg);
                     ShadingResult light_result;
                     process_closure(light_result, light_sg.Ci, true);
                     // accumulate contribution

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -640,7 +640,7 @@ setup_output_images (ShadingSystem *shadingsys,
     // not to actually run the shader.
     ShaderGlobals sg;
     setup_shaderglobals (sg, shadingsys, 0, 0);
-    shadingsys->execute (*ctx, *shadergroup, sg, false);
+    shadingsys->execute (ctx, *shadergroup, sg, false);
 
     if (entryoutputs.size()) {
         std::cout << "Entry outputs:";
@@ -886,7 +886,7 @@ shade_region (ShaderGroup *shadergroup, OIIO::ROI roi, bool save)
             // Actually run the shader for this point
             if (entrylayer_index.empty()) {
                 // Sole entry point for whole group, default behavior
-                shadingsys->execute (*ctx, *shadergroup, shaderglobals);
+                shadingsys->execute (ctx, *shadergroup, shaderglobals);
             } else {
                 // Explicit list of entries to call in order
                 shadingsys->execute_init (*ctx, *shadergroup, shaderglobals);


### PR DESCRIPTION
This helps applications to update their OSL API use earlier without need to
read full release or commit logs. Could also be handy to find use of methods
which are gonna to be deprecated in OSL itself.

Currently only GCC-like compilers are supported, but it's easy to support
more compilers when needed.

Applications which doesn't want this attribute to be used can define empty
OSL_DEPRECATED macros in the build system.

This commit also updates some internal use of API.