### PR TITLE
Remove has_userdata method from RendererServices

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -198,9 +198,6 @@ public:
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type,
                                ShaderGlobals *sg, void *val) = 0;
 
-    /// Does the current object have the named user-data associated with it?
-    virtual bool has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg) = 0;
-
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
     virtual TextureHandle * get_texture_handle (ustring filename);

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -187,9 +187,6 @@ public:
                                ShaderGlobals *sg, void *val) {
         return false;   // FIXME?
     }
-    virtual bool has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg) {
-        return false;   // FIXME?
-    }
 };
 
 

--- a/src/testrender/simplerend.cpp
+++ b/src/testrender/simplerend.cpp
@@ -280,15 +280,6 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
 }
 
 
-
-bool
-SimpleRenderer::has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg)
-{
-    return false;
-}
-
-
-
 bool
 SimpleRenderer::get_camera_resolution (ShaderGlobals *sg, bool derivs, ustring object,
                                     TypeDesc type, ustring name, void *val)

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -66,7 +66,6 @@ public:
                                 TypeDesc type, ustring name, void *val);
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type, 
                                ShaderGlobals *sg, void *val);
-    virtual bool has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg);
 
     // Super simple camera and display parameters.  Many options not
     // available, no motion blur, etc.

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -387,15 +387,6 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
 }
 
 
-
-bool
-SimpleRenderer::has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg)
-{
-    return false;
-}
-
-
-
 bool
 SimpleRenderer::get_camera_resolution (ShaderGlobals *sg, bool derivs, ustring object,
                                     TypeDesc type, ustring name, void *val)

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -69,7 +69,6 @@ public:
                                 TypeDesc type, ustring name, void *val);
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type, 
                                ShaderGlobals *sg, void *val);
-    virtual bool has_userdata (ustring name, TypeDesc type, ShaderGlobals *sg);
 
     // Super simple camera and display parameters.  Many options not
     // available, no motion blur, etc.


### PR DESCRIPTION
None of the internals of OSL ever call this method