### PR TITLE
Testsuite organization overhaul -- no more src or ref in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,11 +445,15 @@ add_subdirectory (src/doc)
 #########################################################################
 # Testing
 
-# Make a copy of the testsuite into the build area
-if (DEFINED CMAKE_VERSION AND NOT CMAKE_VERSION VERSION_LESS 2.8)
-    file (COPY "${PROJECT_SOURCE_DIR}/testsuite"
-          DESTINATION "${CMAKE_BINARY_DIR}")
-endif()
+# Make a build/platform/testsuite directory, and copy the master runtest.py
+# there. The rest is up to the tests themselves.
+file (MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/testsuite")
+add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        "${CMAKE_SOURCE_DIR}/testsuite/runtest.py"
+                        "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
+                    MAIN_DEPENDENCY "${CMAKE_SOURCE_DIR}/testsuite/runtest.py")
+add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
 
 macro ( TESTSUITE )
     parse_arguments (_ats "LABEL" "" ${ARGN})
@@ -460,6 +464,7 @@ macro ( TESTSUITE )
     endif ()
     # Add the tests if all is well.
     foreach (_testname ${_ats_DEFAULT_ARGS})
+        set (_testsrcdir "${CMAKE_SOURCE_DIR}/testsuite/${_testname}")
         set (_testdir "${CMAKE_BINARY_DIR}/testsuite/${_testname}")
         if (_ats_LABEL MATCHES "broken")
             set (_testname "${_testname}-broken")
@@ -475,11 +480,13 @@ macro ( TESTSUITE )
             message (STATUS "TEST ${_testname}: ${CMAKE_BINARY_DIR}/testsuite/runtest.py ${_testdir} ${_extra_test_args}")
         endif ()
 
+        file (MAKE_DIRECTORY "${_testdir}")
+
         # Run the test unoptimized, unless it's a "render_*" or "oslinfo_*"
         # test, which we don't bother testing unoptimized.
         if (NOT _testname MATCHES "^render" AND
             NOT _testname MATCHES "^oslinfo" AND
-            NOT EXISTS "${_testdir}/OPTIMIZEONLY")
+            NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
           set (_env TESTSHADE_OPT=0 OPENIMAGEIOHOME=${OPENIMAGEIOHOME})
           add_test ( NAME ${_testname}
                      COMMAND env ${_env} ${_runtest} )

--- a/testsuite/pointcloud-fold/run.py
+++ b/testsuite/pointcloud-fold/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-command += testshade("-param radius 1000.0 rdcloud")
+command += testshade("-param radius 1000.0 -param filename data/cloud.geo rdcloud")

--- a/testsuite/texture-derivs/run.py
+++ b/testsuite/texture-derivs/run.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-command += testshade("-g 128 128 --center -od uint8 -o Cout out.tif -o dx dx.tif -o dy dy.tif -param scale 128.0 test")
+command += testshade("-g 128 128 --center -od uint8 -o Cout out.tif -o dx dx.tif -o dy dy.tif -param scale 128.0 -param filename data/ramp.exr test")
 outputs = [ "out.txt", "out.tif", "dx.tif", "dy.tif" ]

--- a/testsuite/unknown-instruction/ref/out.txt
+++ b/testsuite/unknown-instruction/ref/out.txt
@@ -1,4 +1,4 @@
 ERROR: Parsing shader "test": instruction "blahblah" is not known. Maybe compiled with a too-new oslc?
-ERROR: Unable to read "test.oso"
-ERROR: Could not find shader "test"
+ERROR: Unable to read "data/test.oso"
+ERROR: Could not find shader "data/test"
 

--- a/testsuite/unknown-instruction/run.py
+++ b/testsuite/unknown-instruction/run.py
@@ -2,4 +2,4 @@
 
 # Test what happens when an oso file contains an unknown instruction
 
-command = testshade("test")
+command = testshade("data/test")

--- a/testsuite/vararray-deserialize/run.py
+++ b/testsuite/vararray-deserialize/run.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python 
 
-command += testshade("-group serial.oslgroup")
+command += testshade("-group data/serial.oslgroup")


### PR DESCRIPTION
The old way was that when CMake runs for the first time (when it builds your make or ninja files), it copies everything from testsuite/ into build/PLATFORM/testsuite/, and then when you run tests, it uses all the info (source data, scripts, and reference output) in the build area.

That was fine usually, but if you were developing or modifying a test itself, it was a big PITA, because changing something in testsuite/mytest would not be reflected in the build/PLATFORM/testsuite/mytest that had already been copied. It was the source of many frustrations and errors. And beware modifying something in the build area and then blowing it away, not remembering to copy it to the source testsuite/ area.

This overhaul NO LONGER COPIES source data or reference output en masse to build at all. Instead, a combination of selective copies (usually just .osl files), links and references to the canonical files are used to make the build area only the temporary location of test output itself. This sure does make everything easier.