### PR TITLE
Disallow quoted strings from spanning lines (just like you can't in C).

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -70,11 +70,8 @@ FLT2            {DIGIT}*\.{DIGIT}+{E}?
 FLT3            {DIGIT}+{E}
 FLT             {FLT1}|{FLT2}|{FLT3}
  /* string literal */
-STR     \"(\\.|[^\\"])*\"
-STRDUMMY \"(\\.|[^\\"])*\"
- /* Dumb note: STRDUMMY is just to fix my syntax highlighting in emacs,
-  * which is thrown off by the odd number of quotes!
-  */
+STR     \"(\\.|[^\\"\n])*\"
+        /* " This extra quote fixes emacs syntax highlighting on this file */
  /* Identifier: alphanumeric, may contain digits after the first character */
 IDENT           ({ALPHA}|[_])({ALPHA}|{DIGIT}|[_])*
  /* C preprocessor (cpp) directives */


### PR DESCRIPTION
This was never intentionally allowed; it was just a bug in the lexer's
regex describing a quoted string. The compiler would accept it silently,
but in the process forget the line count and botch subsequent error
messages.