### PR TITLE
oslc bug -- getmatrix failed to note that the matrix argument is written

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -993,7 +993,8 @@ ASTfunction_call::typecheck_builtin_specialcase ()
             argwriteonly (1);
             argwriteonly (2);
         } else if (m_name == "getattribute" || m_name == "getmessage" ||
-                   m_name == "gettextureinfo" || m_name == "dict_value") {
+                   m_name == "gettextureinfo" || m_name == "getmatrix" ||
+                   m_name == "dict_value") {
             // these all write to their last argument
             argwriteonly ((int)listlength(args()));
         } else if (m_name == "pointcloud_get") {

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -435,6 +435,10 @@ OSOReaderToMaster::hint (string_view hintstring)
             m_master->m_ops.back().argread(i, *str == 'r' || *str =='W');
         }
         ASSERT(m_nargs == i);
+        // Fix old bug where oslc forgot to mark getmatrix last arg as write
+        static ustring getmatrix("getmatrix");
+        if (m_master->m_ops.back().opname() == getmatrix)
+            m_master->m_ops.back().argwrite(m_nargs-1, true);
     }
     if (extract_prefix(h, "%argderivs{")) {
         while (1) {

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -52,6 +52,7 @@
 // Declaration of built-in functions and closures
 #define BUILTIN [[ int builtin = 1 ]]
 #define BUILTIN_DERIV [[ int builtin = 1, int deriv = 1 ]]
+#define BUILTIN_NONSTANDARD_RW [[ int builtin = 1, int rw = 1 ]]
 
 #define PERCOMP1(name)                          \
     normal name (normal x) BUILTIN;             \
@@ -530,7 +531,7 @@ int iscameraray () { return raytype("camera"); }
 int isdiffuseray () { return raytype("diffuse"); }
 int isglossyray () { return raytype("glossy"); }
 int isshadowray () { return raytype("shadow"); }
-int getmatrix (string fromspace, string tospace, output matrix M) BUILTIN;
+int getmatrix (string fromspace, string tospace, output matrix M) BUILTIN_NONSTANDARD_RW;
 int getmatrix (string fromspace, output matrix M) {
     return getmatrix (fromspace, "common", M);
 }


### PR DESCRIPTION
This could lead to a cascade of optimization errors at runtime.
I have no idea why this never showed up as a problem before today.

In addition to fixing it on the oslc side, add a hacky fix to make sure    that old compiled shaders are retroactively fixed as they are loaded at    runtime.