### PR TITLE
For stdosl.h funcs marked builtin, auto-detect funny read-write cases.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -260,10 +260,18 @@ ASTfunction_declaration::add_meta (ASTNode *meta)
         Symbol *metasym = metavar->sym();
         if (metasym->name() == "builtin") {
             m_is_builtin = true;
-            if (func()->typespec().is_closure()) // It is a builtin closure
+            if (func()->typespec().is_closure())  { // It is a builtin closure
                 // Force keyword arguments at the end
                 func()->argcodes(ustring(std::string(func()->argcodes().c_str()) + "."));
-
+            }
+            // For built-in functions, if any of the params are output,
+            // also automatically mark it as readwrite_special_case.
+            for (ASTNode *f = formals().get(); f; f = f->nextptr()) {
+                ASSERT (f->nodetype() == variable_declaration_node);
+                ASTvariable_declaration *v = (ASTvariable_declaration *)f;
+                if (v->is_output())
+                    func()->readwrite_special_case (true);
+            }
         }
         else if (metasym->name() == "derivs")
             func()->takes_derivs (true);

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -52,7 +52,6 @@
 // Declaration of built-in functions and closures
 #define BUILTIN [[ int builtin = 1 ]]
 #define BUILTIN_DERIV [[ int builtin = 1, int deriv = 1 ]]
-#define BUILTIN_NONSTANDARD_RW [[ int builtin = 1, int rw = 1 ]]
 
 #define PERCOMP1(name)                          \
     normal name (normal x) BUILTIN;             \
@@ -531,7 +530,7 @@ int iscameraray () { return raytype("camera"); }
 int isdiffuseray () { return raytype("diffuse"); }
 int isglossyray () { return raytype("glossy"); }
 int isshadowray () { return raytype("shadow"); }
-int getmatrix (string fromspace, string tospace, output matrix M) BUILTIN_NONSTANDARD_RW;
+int getmatrix (string fromspace, string tospace, output matrix M) BUILTIN;
 int getmatrix (string fromspace, output matrix M) {
     return getmatrix (fromspace, "common", M);
 }


### PR DESCRIPTION
As Chris points out in #618, the fact that params are marked as output
is all we need to know that function's parameters are not all read-only
(duh). That seems a little more foolproof than requiring a separate notation
in stdosl.h.
