### PR TITLE
First stab at code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_install:
           cat /proc/cpuinfo ;
       fi
     - export OIIOPLATFORM=$PLATFORM
-    - if [ $DEBUG == 1 ] ; then export PLATFORM=${PLATFORM}.debug ; fi
+    - if [ "$DEBUG" == 1 ] ; then export PLATFORM=${PLATFORM}.debug ; fi
     - echo "Build platform name is $PLATFORM"
 
 install:
@@ -89,7 +89,8 @@ script:
     - make $BUILD_FLAGS test
 
 
-# after_success:
+after_success:
+    - if [ "$CODECOV" == 1 ]; then bash <(curl -s https://codecov.io/bash) ; fi
 
 after_failure:
 # FIXME: find failed logs, stash them or send them to lg?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ set (USE_SIMD "" CACHE STRING "Use SIMD directives (0, sse2, sse3, sse4.1, sse4.
 set (OSL_NO_DEFAULT_TEXTURESYSTEM OFF CACHE BOOL "Do not use create a raw OIIO::TextureSystem")
 set (OSL_BUILD_PLUGINS ON CACHE BOOL "Bool OSL plugins, for example OIIO plugin")
 set (USE_CCACHE ON CACHE BOOL "Use ccache if found")
+set (CODECOV OFF CACHE BOOL "Build code coverage tests")
 
 # Use ccache if found
 find_program (CCACHE_FOUND ccache)
@@ -287,6 +288,19 @@ endif ()
 if (USE_LIBCPLUSPLUS AND CMAKE_COMPILER_IS_CLANG)
     message (STATUS "Using libc++")
     add_definitions ("-stdlib=libc++")
+endif ()
+
+# Options common to gcc and clang
+if (CODECOV AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
+    message (STATUS "Compiling for code coverage analysis")
+    add_definitions ("-ftest-coverage -fprofile-arcs -O0 -DOSL_CODE_COVERAGE=1")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ftest-coverage -fprofile-arcs")
+    set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -ftest-coverage -fprofile-arcs")
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -ftest-coverage -fprofile-arcs")
+endif ()
+
+if (DEFINED ENV{TRAVIS})
+    add_definitions ("-DOSL_TRAVIS=1")
 endif ()
 
 set (OSL_SIMD_FLAGS "")


### PR DESCRIPTION
    make CODECOV=1
    make CODECOV=1 test

on a gcc/clang system will run the testsuite and generate a code coverage
report in build/$PLATFORM/cov/index.html

I'm not yet sure how we should use this. It's just for information and to help spot places in the code that aren't covered by the testsuite. But I do not think we should aim to get 100% coverage -- eliminating all the stragglers for every possible error case and early return would be so much labor that we'd never get any real work done. So take with a grain of salt and use wisely.