### PR TITLE
Don't test or set "layer ran bits" on last layer.

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1433,12 +1433,16 @@ public:
 
     int num_entry_layers () const { return m_num_entry_layers; }
 
+    bool is_last_layer (int layer) const {
+        return layer == nlayers()-1;
+    }
+
     /// Is the given layer an entry point? It is if explicitly tagged as
     /// such, or if no layers are so tagged then the last layer is the one
     /// entry.
     bool is_entry_layer (int layer) const {
         return num_entry_layers() ? m_layers[layer]->entry_layer()
-                                  : (layer == nlayers()-1);
+                                  : is_last_layer(layer);
     }
 
 private:


### PR DESCRIPTION
This shouldn't change any behavior. It's just removing some pointless code that checks if a layer has been run before, but there's no need to do that on the root layer which by definition is run exactly once.

Also be sure that the entry point doesn't use the "fast" calling convention.

This is just some stuff I noticed in the process of scrutinizing the code we were generating.
