### PR TITLE
LLVM-related refactoring

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -86,10 +86,6 @@ public:
     void debug (int d) { m_debug = d; }
     int debug () const { return m_debug; }
 
-    /// Use MCJIT?
-    void mcjit (int on) { m_mcjit = on; }
-    int mcjit () const { return m_mcjit; }
-
     /// Return a reference to the current context.
     llvm::LLVMContext &context () const { return *m_llvm_context; }
 
@@ -514,7 +510,6 @@ private:
 
 
     int m_debug;
-    int m_mcjit;
     PerThreadInfo *m_thread;
     llvm::LLVMContext *m_llvm_context;
     llvm::Module *m_llvm_module;

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -52,15 +52,10 @@ namespace llvm {
   class Value;
   template<bool preserveNames, typename T, typename Inserter> class IRBuilder;
   template<bool preserveNames> class IRBuilderDefaultInserter;
-#if OSL_LLVM_VERSION >= 34
   namespace legacy {
     class FunctionPassManager;
     class PassManager;
   }
-#else
-  class FunctionPassManager;
-  class PassManager;
-#endif
 }
 
 
@@ -526,13 +521,8 @@ private:
     IRBuilder *m_builder;
     OSL_Dummy_JITMemoryManager *m_llvm_jitmm;
     llvm::Function *m_current_function;
-#if OSL_LLVM_VERSION >= 34
     llvm::legacy::PassManager *m_llvm_module_passes;
     llvm::legacy::FunctionPassManager *m_llvm_func_passes;
-#else
-    llvm::PassManager *m_llvm_module_passes;
-    llvm::FunctionPassManager *m_llvm_func_passes;
-#endif
     llvm::ExecutionEngine *m_llvm_exec;
     std::vector<llvm::BasicBlock *> m_return_block;     // stack for func call
     std::vector<llvm::BasicBlock *> m_loop_after_block; // stack for break

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -142,7 +142,6 @@ public:
     ///    int llvm_debug         Set LLVM extra debug level (0)
     ///    int llvm_debug_layers  Extra printfs upon entering and leaving
     ///                              layer functions.
-    ///    int llvm_mcjit         Use LLVM MCJIT if available (0).
     ///    int max_local_mem_KB   Error if shader group needs more than this
     ///                              much local storage to execute (1024K)
     ///    string debug_groupname Name of shader group -- debug only this one

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -97,9 +97,6 @@ BackendLLVM::BackendLLVM (ShadingSystemImpl &shadingsys,
     // getcwd inside LLVM. Oy.
     check_cwd (shadingsys);
 #endif
-    int mcjit = 0;
-    if (shadingsys.getattribute ("llvm_mcjit", TypeDesc::INT, &mcjit))
-        ll.mcjit (mcjit);
 }
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -714,7 +714,6 @@ private:
     bool m_unknown_coordsys_error;        ///< Error to use unknown xform name?
     bool m_connection_error;              ///< Error for ConnectShaders to fail?
     bool m_greedyjit;                     ///< JIT as much as we can?
-    bool m_llvm_mcjit;                    ///< Use MCJIT if available?
     bool m_countlayerexecs;               ///< Count number of layer execs?
     int m_max_warnings_per_thread;        ///< How many warnings to display per thread before giving up?
     int m_profile;                        ///< Level of profiling of shader execution

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -618,7 +618,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_lockgeom_default (true), m_strict_messages(true),
       m_range_checking(true),
       m_unknown_coordsys_error(true), m_connection_error(true),
-      m_greedyjit(false), m_llvm_mcjit(false), m_countlayerexecs(false),
+      m_greedyjit(false), m_countlayerexecs(false),
       m_max_warnings_per_thread(100),
       m_profile(0),
       m_optimize(2),
@@ -1048,7 +1048,6 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_SET ("connection_error", int, m_connection_error);
     ATTR_SET ("greedyjit", int, m_greedyjit);
-    ATTR_SET ("llvm_mcjit", int, m_llvm_mcjit);
     ATTR_SET ("countlayerexecs", int, m_countlayerexecs);
     ATTR_SET ("max_warnings_per_thread", int, m_max_warnings_per_thread);
     ATTR_SET ("max_local_mem_KB", int, m_max_local_mem_KB);
@@ -1152,7 +1151,6 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_DECODE ("connection_error", int, m_connection_error);
     ATTR_DECODE ("greedyjit", int, m_greedyjit);
-    ATTR_DECODE ("llvm_mcjit", int, m_llvm_mcjit);
     ATTR_DECODE ("countlayerexecs", int, m_countlayerexecs);
     ATTR_DECODE ("max_warnings_per_thread", int, m_max_warnings_per_thread);
     ATTR_DECODE_STRING ("commonspace", m_commonspace_synonym);
@@ -1546,7 +1544,6 @@ ShadingSystemImpl::getstats (int level) const
     BOOLOPT (lockgeom_default);
     BOOLOPT (range_checking);
     BOOLOPT (greedyjit);
-    BOOLOPT (llvm_mcjit);
     BOOLOPT (countlayerexecs);
     BOOLOPT (opt_simplify_param);
     BOOLOPT (opt_constant_fold);


### PR DESCRIPTION
I'm in the middle of a concerted effort to bring us into a more modern era of LLVM versions. This set of patches is not a complete solution, but contains several intermediate steps in that direction.

* Remove all support for LLVM 3.3 and earlier. This gets rid of lots of confusing `#if` clauses and simplifies the structure of the code. Henceforth, LLVM 3.4 will be the minimal version we support for OSL 1.8.

* A number of changes that allow us to build cleanly against LLVM 3.6. Although it correctly runs the llvmutil_test unit test, it fails all the testsuite tests involving OSL itself (against LLVM 3.6). But at least it compiles.

* Remove runtime selection of MCJIT for LLVM versions that support both MCJIT and old JIT. This simplifies the logic in some places, by cleanly dividing LLVM 3.4/3.5 + old JIT, versus LLVM 3.6+ with MCJIT and no old JIT.

What this nets us is a simplification of code that will make the next steps easier. As of now (in master), we fully support and work properly with LLVM 3.4 and 3.5, and the next task will be to get some later version (maybe 3.6, or we may skip all the way to 3.7+ORC JIT, we'll see) fully working.

This whole discussion is about OSL master (what will some day be 1.8). The production release (OSL 1.7) will continue to work with LLVM 3.2 and 3.3 (though please note that I have not personally tested with either for quite some time, though I also have not purposely changed anything that would cause them to break).
