### PR TITLE
Make an option to have OSL isconnected() return 1 for userdata parameters

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -113,6 +113,9 @@ public:
     ///    int lazyunconnected    Run layers lazily even if they have no
     ///                              output connections (1). For debugging.
     ///    int lazy_userdata      Retrieve userdata lazily (0).
+    ///    int userdata_isconnected  Should lockgeom=0 params (that may
+    ///                              receive userdata) return true from
+    ///                              isconnected()? (0)
     ///    int greedyjit          Optimize and compile all shaders up front,
     ///                              versus only as needed (0).
     ///    int lockgeom           Default 'lockgeom' value for shader params

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -562,6 +562,7 @@ public:
     int max_warnings_per_thread() const { return m_max_warnings_per_thread; }
     bool countlayerexecs() const { return m_countlayerexecs; }
     bool lazy_userdata () const { return m_lazy_userdata; }
+    bool userdata_isconnected () const { return m_userdata_isconnected; }
 
     ustring commonspace_synonym () const { return m_commonspace_synonym; }
 
@@ -705,6 +706,7 @@ private:
     bool m_lazyglobals;                   ///< Run lazily even if globals write?
     bool m_lazyunconnected;               ///< Run lazily even if not connected?
     bool m_lazy_userdata;                 ///< Retrieve userdata lazily?
+    bool m_userdata_isconnected;          ///< Userdata params isconnected()?
     bool m_clearmemory;                   ///< Zero mem before running shader?
     bool m_debugnan;                      ///< Root out NaN's?
     bool m_debug_uninit;                  ///< Find use of uninitialized vars?

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2356,7 +2356,10 @@ RuntimeOptimizer::resolve_isconnected ()
                 ASSERT (fieldsymid >= 0);
                 s = inst()->symbol(fieldsymid);
             }
-            int val = (s->connected() ? 1 : 0) + (s->connected_down() ? 2 : 0);
+            bool upconnected = s->connected();
+            if (!s->lockgeom() && shadingsys().userdata_isconnected())
+                upconnected = true;
+            int val = (upconnected ? 1 : 0) + (s->connected_down() ? 2 : 0);
             turn_into_assign (op, add_constant(TypeDesc::TypeInt, &val),
                               "resolve isconnected()");
         }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -613,7 +613,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
     : m_renderer(renderer), m_texturesys(texturesystem), m_err(err),
       m_statslevel (0), m_lazylayers (true),
       m_lazyglobals (true), m_lazyunconnected(true),
-      m_lazy_userdata(false),
+      m_lazy_userdata(false), m_userdata_isconnected(false),
       m_clearmemory (false), m_debugnan (false), m_debug_uninit(false),
       m_lockgeom_default (true), m_strict_messages(true),
       m_range_checking(true),
@@ -1016,6 +1016,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("lazyglobals", int, m_lazyglobals);
     ATTR_SET ("lazyunconnected", int, m_lazyunconnected);
     ATTR_SET ("lazy_userdata", int, m_lazy_userdata);
+    ATTR_SET ("userdata_isconnected", int, m_userdata_isconnected);
     ATTR_SET ("clearmemory", int, m_clearmemory);
     ATTR_SET ("debug_nan", int, m_debugnan);
     ATTR_SET ("debugnan", int, m_debugnan);  // back-compatible alias
@@ -1118,6 +1119,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("lazyglobals", int, m_lazyglobals);
     ATTR_DECODE ("lazyunconnected", int, m_lazyunconnected);
     ATTR_DECODE ("lazy_userdata", int, m_lazy_userdata);
+    ATTR_DECODE ("userdata_isconnected", int, m_userdata_isconnected);
     ATTR_DECODE ("clearmemory", int, m_clearmemory);
     ATTR_DECODE ("debug_nan", int, m_debugnan);
     ATTR_DECODE ("debugnan", int, m_debugnan);  // back-compatible alias
@@ -1538,6 +1540,7 @@ ShadingSystemImpl::getstats (int level) const
     BOOLOPT (lazyglobals);
     BOOLOPT (lazyunconnected);
     BOOLOPT (lazy_userdata);
+    BOOLOPT (userdata_isconnected);
     BOOLOPT (clearmemory);
     BOOLOPT (debugnan);
     BOOLOPT (debug_uninit);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -78,6 +78,7 @@ static bool use_group_outputs = false;
 static bool do_oslquery = false;
 static bool inbuffer = false;
 static bool use_shade_image = false;
+static bool userdata_isconnected = false;
 static int xres = 1, yres = 1;
 static int num_threads = 0;
 static std::string groupname;
@@ -133,6 +134,7 @@ set_shadingsys_options ()
     shadingsys->attribute ("lockgeom", 1);
     shadingsys->attribute ("debug_nan", debugnan);
     shadingsys->attribute ("debug_uninit", debug_uninit);
+    shadingsys->attribute ("userdata_isconnected", userdata_isconnected);
     if (! shaderpath.empty())
         shadingsys->attribute ("searchpath:shader", shaderpath);
     shadingsys_options_set = true;
@@ -469,6 +471,7 @@ getargs (int argc, const char *argv[])
                 "--expr %@ %s", &specify_expr, NULL, "Specify an OSL expression to evaluate",
                 "--offsetst %f %f", &soffset, &toffset, "Offset s & t texture coordinates (default: 0 0)",
                 "--scalest %f %f", &sscale, &tscale, "Scale s & t texture lookups (default: 1, 1)",
+                "--userdata_isconnected", &userdata_isconnected, "Consider lockgeom=0 to be isconnected()",
                 "-v", &verbose, "Verbose output",
                 NULL);
     if (ap.parse(argc, argv) < 0 || (shadernames.empty() && groupspec.empty())) {

--- a/testsuite/isconnected/ref/out.txt
+++ b/testsuite/isconnected/ref/out.txt
@@ -13,6 +13,26 @@ a=0.5
 Downstream:
 a connected: 1  (value=0.5)
 b connected: 0  (value=0)
+c connected: 0  (value=0)
+mystruct1 connected: 1  (value=0)
+mystruct1.x connected: 1  (value=3)
+mystruct2 connected: 0  (value=3)
+mystruct2.x connected: 0  (value=0)
+
+Connect upstream.out to downstream.a
+Connect upstream.struct1 to downstream.mystruct1
+Upstream:
+out connected: 2  (value=0.5)
+notout connected: 0  (value=10)
+struct1 connected: 2  (value=10)
+struct1.x connected: 2  (value=3)
+struct2 connected: 0  (value=3)
+struct2.x connected: 0  (value=5)
+a=0.5
+Downstream:
+a connected: 1  (value=0.5)
+b connected: 0  (value=0)
+c connected: 1  (value=0)
 mystruct1 connected: 1  (value=0)
 mystruct1.x connected: 1  (value=3)
 mystruct2 connected: 0  (value=3)

--- a/testsuite/isconnected/run.py
+++ b/testsuite/isconnected/run.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 
-command = testshade("-g 1 1 --layer upstream upstream --layer downstream test " +
-                    "--connect upstream out downstream a " +
-                    "--connect upstream struct1 downstream mystruct1")
+command  = testshade("--layer upstream upstream --layer downstream test " +
+                     "--connect upstream out downstream a " +
+                     "--connect upstream struct1 downstream mystruct1")
+
+# Run again, this time considering userdata (lockgeom=0) parameters to be
+# isconnected(). This time, parameter c should look like a connection.
+command += testshade("--userdata_isconnected " +
+                     "--layer upstream upstream --layer downstream test " +
+                     "--connect upstream out downstream a " +
+                     "--connect upstream struct1 downstream mystruct1")

--- a/testsuite/isconnected/test.osl
+++ b/testsuite/isconnected/test.osl
@@ -16,6 +16,7 @@ void status (MyStruct variable, string name)
 
 
 shader test (float a = 0, float b = 0,
+             float c = 0 [[ int lockgeom=0 ]],
              MyStruct mystruct1 = {0,0},
              MyStruct mystruct2 = {0,0})
 {
@@ -23,6 +24,7 @@ shader test (float a = 0, float b = 0,
     printf ("Downstream:\n");
     status (a, "a");
     status (b, "b");
+    status (c, "c");
     status (mystruct1, "mystruct1");
     status (mystruct2, "mystruct2");
 }


### PR DESCRIPTION
This adds a new ShadingSystem attribute, "userdata_isconnected". The
default of 0 is the old/usual behavior that most applications want.
However, setting this attribute to 1 will cause the OSL built-in
function isconnected(paramname) to return 1 not only for connected
parameters, but also for parameters that may be bound to userdata
(i.e., those that have lockgeom=0).

The use case for this involves a renderer implementation that can mix
C++ and OSL nodes within a shading group. The outputs exported by the
C++ nodes propagate their values to the downstream OSL node via
get_userdata(), hijacking the mechanism that is generally used geometric
primitive variable interpolation. But from the point of view of the
downstream node, they should semantically appear to be a connection.