### PR TITLE
Restrict find_program LLVM to LLVM_DIRECTORY

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -180,9 +180,9 @@ endif()
 
 # try to find llvm-config, with a specific version if specified
 if(LLVM_DIRECTORY)
-  FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION} HINTS "${LLVM_DIRECTORY}/bin" NO_CMAKE_PATH)
+  FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION} HINTS "${LLVM_DIRECTORY}/bin" NO_DEFAULT_PATH)
   if(NOT LLVM_CONFIG)
-    FIND_PROGRAM(LLVM_CONFIG llvm-config HINTS "${LLVM_DIRECTORY}/bin" NO_CMAKE_PATH)
+    FIND_PROGRAM(LLVM_CONFIG llvm-config HINTS "${LLVM_DIRECTORY}/bin" NO_DEFAULT_PATH)
   endif()
 else()
   FIND_PROGRAM(LLVM_CONFIG llvm-config-${LLVM_VERSION})


### PR DESCRIPTION
Hey there,

when building Blender on Debian testing, I stumbled over this.

LLVM can be installed on a system without clang.
So, if LLVM_DIRECTORY pointed to a locally installed llvm/clang version but the system had LLVM installed without Clang, until now the script would find the system LLVM and no Clang and the build would fail.
However, since LLVM is globally searched for if the hinted attempts fail, it should not hurt to only search in the hinted paths, would it?

And a question: Why is *llvm-config* (lines 194-207) only called if LLVM_DIRECTORY was not set?

Cheers,
Stefan