### PR TITLE
Warn for common misstep of forgetting constructor name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-dup
+            oslc-warn-commainit
             oslc-variadic-macro
             oslinfo-arrayparams oslinfo-metadata oslinfo-noparams
             osl-imageio

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -122,6 +122,19 @@ ASTvariable_declaration::typecheck (TypeSpec expected)
 
     typecheck_initlist (init, m_typespec, m_name.c_str());
 
+    // Warning to catch confusing comma operator in variable initializers.
+    // One place this comes up is when somebody forgets the proper syntax
+    // for constructors, for example
+    //     color x = (a, b, c);   // Sets x to (c,c,c)!
+    // when they really meant
+    //     color x = color(a, b, c);
+    if (init->nodetype() == comma_operator_node && !typespec().is_closure() &&
+        (typespec().is_triple() || typespec().is_matrix())) {
+        warning ("Comma operator is very confusing here. "
+                 "Did you mean to use a constructor: %s = %s(...)?",
+                 m_name.c_str(), typespec().c_str());
+    }
+
     return m_typespec;
 }
 
@@ -430,6 +443,19 @@ ASTassign_expression::typecheck (TypeSpec expected)
         error ("Cannot assign '%s' to '%s'", type_c_str(et), type_c_str(vt));
         // FIXME - can we print the variable in question?
         return TypeSpec();
+    }
+
+    // Warning to catch confusing comma operator in assignment.
+    // One place this comes up is when somebody forgets the proper syntax
+    // for constructors, for example
+    //     color x = (a, b, c);   // Sets x to (c,c,c)!
+    // when they really meant
+    //     color x = color(a, b, c);
+    if (expr()->nodetype() == comma_operator_node && !vt.is_closure() &&
+        (vt.is_triple() || vt.is_matrix())) {
+        warning ("Comma operator is very confusing here. "
+                 "Did you mean to use a constructor: = %s(...)?",
+                 vt.c_str());
     }
 
     return m_typespec = vt;

--- a/testsuite/oslc-warn-commainit/ref/out.txt
+++ b/testsuite/oslc-warn-commainit/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:3: warning: Comma operator is very confusing here. Did you mean to use a constructor: x = vector(...)?
+test.osl:4: warning: Comma operator is very confusing here. Did you mean to use a constructor: = color(...)?
+Compiled test.osl -> test.oso

--- a/testsuite/oslc-warn-commainit/run.py
+++ b/testsuite/oslc-warn-commainit/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic

--- a/testsuite/oslc-warn-commainit/test.osl
+++ b/testsuite/oslc-warn-commainit/test.osl
@@ -1,0 +1,5 @@
+shader test ( output color Cout = 0 )
+{
+    vector x = (1, 2, 3);
+    Cout = (u, v, 0);
+}


### PR DESCRIPTION
    shader test ( output color Cout = 0 )
    {
        vector x = (1, 2, 3);
    }

See where this goes wrong? This code will make x be (3,3,3).  If you
don't know why, think about how the comma operator works in C, C++, and
related languages.

The user almost certainly meant

    vector x = vector (1, 2, 3);

With this change, the original (buggy) code will get the following
warning output:

    test.osl:3: warning: Comma operator is very confusing here. Did you mean to use a constructor: x = vector(...)?