### PR TITLE
Fix oslc incorrectly emitting init ops for constructor color(float).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,7 +550,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-warn-commainit
             oslc-variadic-macro
-            oslinfo-arrayparams oslinfo-metadata oslinfo-noparams
+            oslinfo-arrayparams oslinfo-colorctrfloat
+            oslinfo-metadata oslinfo-noparams
             osl-imageio
             printf-whole-array
             raytype reparam

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -675,12 +675,15 @@ ASTvariable_declaration::param_one_default_literal (const Symbol *sym,
                 val = val->next();
                 completed = false;
             }
+            bool one_arg = (val && ! val->nextptr());
             for (int c = 0;  c < 3;  ++c) {
                 if (val.get())
                     ++nargs;
                 if (val.get() && val->nodetype() == ASTNode::literal_node) {
                     f[c] = ((ASTliteral *)val.get())->floatval ();
                     val = val->next();
+                } else if (c > 0 && one_arg) {
+                    f[c] = f[0];
                 } else {
                     f[c] = 0;
                     completed = false;

--- a/testsuite/oslinfo-colorctrfloat/ref/out.txt
+++ b/testsuite/oslinfo-colorctrfloat/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled test.osl -> test.oso
+shader "test"
+    "foo" "color"
+		Default value: [ 0.1 0.2 0.3 ]
+    "bar" "color"
+		Default value: [ 0.75 0.75 0.75 ]

--- a/testsuite/oslinfo-colorctrfloat/run.py
+++ b/testsuite/oslinfo-colorctrfloat/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python 
+
+command = oslinfo("-v test")

--- a/testsuite/oslinfo-colorctrfloat/test.osl
+++ b/testsuite/oslinfo-colorctrfloat/test.osl
@@ -1,0 +1,5 @@
+shader test (color foo=color(0.1, 0.2, 0.3),
+             color bar=color(0.75))
+{
+    printf ("foo=%f, bar=%f\n", foo, bar);
+}


### PR DESCRIPTION
We're talking about a construct like:

    shader foo (color c = color(1), ...)

It got it right if it was

    color c = color(1,1,1)

In both cases, it properly reduced the default value to a static constant
value, but the bug was that it ALSO (unnecessarily) had extra init ops
for that parameter. That would be eliminated in runtime optimization, the
shader certainly ran correctly, but it threw off oslinfo, which figures
that if init ops are present, it can't figure out what the default values
were.