### PR TITLE
Windows fix for lexer

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -41,6 +41,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %option noyywrap
 %option nounput noinput
 
+/* never-interactive fixes a Windows compatibility problem where the
+ * lexer emits isatty calls that don't exist.
+ */
+%option never-interactive
+
  /* Option 'prefix' creates a C++ lexer with the given prefix, so that
   * we can link with other flex-generated lexers in the same application
   * without name conflicts.

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -42,6 +42,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %option noyywrap
 %option nounput noinput
 
+/* never-interactive fixes a Windows compatibility problem where the
+ * lexer emits isatty calls that don't exist.
+ */
+%option never-interactive
+
  /* Option 'prefix' creates a C++ lexer with the given prefix, so that
   * we can link with other flex-generated lexers in the same application
   * without name conflicts.


### PR DESCRIPTION
Option "never-interactive" prevents flex from emitting calls to isatty,
which is not always present on Windows. This is fine because we never
use the lexer in interactive mode anyway.