### PR TITLE
[bug fix] Allow compiling against Boost v1.61 and above

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -52,6 +52,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  define OSL_CPLUSPLUS_VERSION  3 /* presume C++03 */
 #endif
 
+// Boost v1.61 uses std::mutex instead of boost::mutex
+// This forces the use of boost::mutex which compiles
+#define BOOST_NO_CXX11_HDR_MUTEX 1
+
 // Symbol export defines
 #include "export.h"
 


### PR DESCRIPTION
This patch can be applied to RB-1.7 branch directly with no modifications.

New versions of Boost use std::mutex when using a cpp11 compatible
compiler.

FILE: boost_1_60_0/boost/pool/detail/mutex.hpp
#if !defined(BOOST_HAS_THREADS) || defined(BOOST_NO_MT) || defined(BOOST_POOL_NO_MT)
  typedef null_mutex default_mutex;
#else
  typedef boost::mutex default_mutex;
#endif

Was changed to:

FILE: boost_1_61_0/boost/pool/detail/mutex.hpp
#if !defined(BOOST_HAS_THREADS) || defined(BOOST_NO_MT) || defined(BOOST_POOL_NO_MT)
  typedef null_mutex default_mutex;
#else
#if defined (BOOST_NO_CXX11_HDR_MUTEX)
  typedef boost::mutex default_mutex;
#else
  typedef std::mutex default_mutex;
#endif
#endif

The Boost Wave functions use default_mutex, so defining
BOOST_NO_CXX11_HDR_MUTEX allos the old method of boost::mutex
to be used, which is what OSL was originally written to use.

TODO: Allow files to be linked against std::mutex if using
a cpp11 compatible compiler.

Closes bug 648