### PR TITLE
Include file fixes after recent OIIO change that split atomic.h & thread.h

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -96,6 +96,7 @@ CPLUSCOMMENT    \/\/.*\n
 #include <vector>
 #include <string>
 
+#include <OpenImageIO/thread.h>
 #include "oslcomp_pvt.h"
 
 using namespace OSL;

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/thread.h>
 
 #include "OSL/oslcomp.h"
 #include "OSL/oslexec.h"

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/timer.h>
+#include <OpenImageIO/thread.h>
 
 #ifdef USE_EXTERNAL_PUGIXML
 # include <pugixml.hpp>


### PR DESCRIPTION
OpenImageIO/refcnt.h no longer includes all of thread.h
