### PR TITLE
Runtime optimization: seed block alias with initial value of output param

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -173,6 +173,10 @@ public:
     ///
     bool is_structure_array () const { return m_structure > 0 && is_array(); }
 
+    /// Is this typespec an array of structures?
+    ///
+    bool is_structure_based () const { return m_structure > 0; }
+
     /// Return the structure ID of this typespec, or 0 if it's not a
     /// struct.
     int structure () const { return m_structure; }


### PR DESCRIPTION
Occasionally, a shader will use the incoming value of an output
parameter, before it is overwritten. If that value can be decuded, go
ahead and make the alias so that we can further optimize operations
involving that param until it is written.