### PR TITLE
SS and group options "exec_repeat" can cause shader execution to repeat.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -96,6 +96,7 @@ public:
     ///    int profile            Perform some rudimentary profiling (0)
     ///    int no_noise           Replace noise with constant value. (0)
     ///    int no_pointcloud      Skip pointcloud lookups. (0)
+    ///    int exec_repeat        How many times to run each group (1).
     /// 2. Attributes that should be set by applications/renderers that
     /// incorporate OSL:
     ///    string commonspace     Name of "common" coord system ("world")
@@ -189,6 +190,7 @@ public:
     ///                                 callable entry points. They won't
     ///                                 be elided, but nor will they be
     ///                                 called unconditionally.
+    ///    int exec_repeat            How many times to run the group (1).
     ///
     bool attribute (ShaderGroup *group, string_view name,
                     TypeDesc type, const void *val);

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -671,7 +671,7 @@ ShaderGroup::ShaderGroup (string_view name)
   : m_optimized(0), m_does_nothing(false),
     m_llvm_groupdata_size(0), m_num_entry_layers(0),
     m_llvm_compiled_version(NULL),
-    m_name(name)
+    m_name(name), m_exec_repeat(1)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;
@@ -685,7 +685,7 @@ ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
     m_llvm_groupdata_size(0), m_num_entry_layers(g.m_num_entry_layers),
     m_llvm_compiled_version(NULL),
     m_layers(g.m_layers),
-    m_name(name)
+    m_name(name), m_exec_repeat(1)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -763,6 +763,7 @@ private:
     bool m_buffer_printf;                 ///< Buffer/batch printf output?
     bool m_no_noise;                      ///< Substitute trivial noise calls
     bool m_no_pointcloud;                 ///< Substitute trivial pointcloud calls
+    int m_exec_repeat;                   ///< How many times to execute group
 
     // Derived/cached calculations from options:
     Color3 m_Red, m_Green, m_Blue;        ///< Color primaries (xyY)
@@ -1468,6 +1469,7 @@ private:
     std::vector<RunLLVMGroupFunc> m_llvm_compiled_layers;
     std::vector<ShaderInstanceRef> m_layers;
     ustring m_name;
+    int m_exec_repeat;              ///< How many times to execute group
     mutable mutex m_mutex;           ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -444,6 +444,7 @@ getargs (int argc, const char *argv[])
                 "--path %s", &shaderpath, "Specify oso search path",
                 "-g %d %d", &xres, &yres, "Make an X x Y grid of shading points",
                 "-res %d %d", &xres, &yres, "", // synonym for -g
+                "--options %s", &extraoptions, "Set extra OSL options",
                 "-o %L %L", &outputvars, &outputfiles,
                         "Output (variable, filename)",
                 "-od %s", &dataformatname, "Set the output data format to one of: "
@@ -471,7 +472,6 @@ getargs (int argc, const char *argv[])
                 "--center", &pixelcenters, "Shade at output pixel 'centers' rather than corners",
                 "--debugnan", &debugnan, "Turn on 'debug_nan' mode",
                 "--debuguninit", &debug_uninit, "Turn on 'debug_uninit' mode",
-                "--options %s", &extraoptions, "Set extra OSL options",
                 "--groupoutputs", &use_group_outputs, "Specify group outputs, not global outputs",
                 "--oslquery", &do_oslquery, "Test OSLQuery at runtime",
                 "--inbuffer", &inbuffer, "Compile osl source from and to buffer",


### PR DESCRIPTION
The default is 1, which is the old behavior: each call to
ShadingSystem::execute() will run the shader group once.

How is this useful? Suppose you have a very complicated app like a
renderer, and you're curious how much total time is attributable to the
actual execution of the shader. Each individual shader execution may be
so quick that putting timers around the calls may throw off the overall
time of the app (it takes time to retrieve the time, so by measuring
you are changing the timing characteristics; Heisenberg would
be proud).

So you set exec_repeat to 2, running each shader TWICE per call to
execute(). If you time this and compare it to shading the usual 1 time
per execution, the difference should be the total time spent shading for
an ordinary run. (But NOT including texture I/O time, since the "first
shade" will include any I/O that is triggered by needing non-resident
tiles, which will then already be resident for the "second shade." But
the OIIO TextureSystem stats should also tell you the amount of I/O
time).

Setting exec_repeat=0 will skip texture execution. I'm not sure how that's
helpful, since it changes appearance, duh.

You can set the exec_repeat for the whole ShadingSystem, and also override
it for individual groups.

Beware that a few things with side effects (printf, error calls, and
pointcloud_write) may change overall rendering behavior by doing them
multiple times. But everything else should be safe and yield the same
rendered results, if I've done this all correctly.