### PR TITLE
Typo bug transpose() vs transposed().

### DIFF
--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -642,14 +642,14 @@ OSL_SHADEOP void osl_transformn_vmv(void *result, void* M_, void* v_)
 {
    const Vec3 &v = VEC(v_);
    const Matrix44 &M = MAT(M_);
-   M.inverse().transpose().multDirMatrix (v, VEC(result));
+   M.inverse().transposed().multDirMatrix (v, VEC(result));
 }
 
 OSL_SHADEOP void osl_transformn_dvmdv(void *result, void* M_, void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
    const Matrix44    &M = MAT(M_);
-   multDirMatrix (M.inverse().transpose(), v, DVEC(result));
+   multDirMatrix (M.inverse().transposed(), v, DVEC(result));
 }
 
 

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -227,13 +227,13 @@ inline void osl_transformv_dvmdv(void *result, const Matrix44 &M, void* v_)
 inline void osl_transformn_vmv(void *result, const Matrix44 &M, void* v_)
 {
    const Vec3 &v = VEC(v_);
-   M.inverse().transpose().multDirMatrix (v, VEC(result));
+   M.inverse().transposed().multDirMatrix (v, VEC(result));
 }
 
 inline void osl_transformn_dvmdv(void *result, const Matrix44 &M, void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
-   multDirMatrix (M.inverse().transpose(), v, DVEC(result));
+   multDirMatrix (M.inverse().transposed(), v, DVEC(result));
 }
 
 


### PR DESCRIPTION
Imath::M44f.transpose() transposes in place and returns the ref,
whereas transposed() returns the transpose without altering the original.

Not a symptomatic bug because we only did this on the result of an
inverse(), which was a temporary, so didn't hurt to mess with it in place.
But better to correct this code to properly reflect our intent.
