### PR TITLE
Fix OSL compiler assert when indexing into closure type

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -480,7 +480,8 @@ ASTindex::ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index)
             expr->nodetype() == structselect_node);
     if (expr->typespec().is_array())       // array dereference
         m_typespec = expr->typespec().elementtype();
-    else if (expr->typespec().is_triple()) // component access
+    else if (!expr->typespec().is_closure() &&
+             expr->typespec().is_triple()) // component access
         m_typespec = TypeDesc::FLOAT;
     else {
         error ("indexing into non-array or non-component type");


### PR DESCRIPTION
Minor issue, when compiling this shader with `oslc` or an application embedding the OSL compiler it crashes:
```
shader test()
{
    closure color A;
    A[0] = 0;
}
```

```
src/include/osl_pvt.h:314: failed assertion '! is_closure() && "Don't call this if it could be a closure"'
```

From: https://developer.blender.org/T49016