### PR TITLE
Allow optimization of shader groups with known raytype bits.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslinfo-metadata oslinfo-noparams
             osl-imageio
             printf-whole-array
-            raytype reparam
+            raytype raytype-specialized reparam
             render-background render-bumptest
             render-cornell render-furnace-diffuse
             render-microfacet render-oren-nayar render-veachmis render-ward

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -294,6 +294,7 @@ public:
     ///                                  until the shader actually runs.
     ///   int num_renderer_outputs   Number of named renderer outputs.
     ///   string renderer_outputs[]  List of renderer outputs.
+    ///   int raytype_queries        Bit field of all possible rayquery
     ///   int num_entry_layers       Number of named entry point layers.
     ///   string entry_layers[]      List of entry point layers.
     ///   string pickle              Retrieves a serialized representation
@@ -554,7 +555,16 @@ public:
     int raytype_bit (ustring name);
 
     /// Ensure that the group has been optimized and JITed.
+    /// Ensure that the group has been optimized and JITed.
     void optimize_group (ShaderGroup *group);
+
+    /// Ensure that the group has been optimized and JITed. The raytypes_on
+    /// gives a bitfield describing which ray flags are known to be 1, and
+    /// raytypes_off describes which ray flags are known to be 0. Bits that
+    /// are not set in either set of flags are not known to the optimizer,
+    /// and will be determined strictly at execution time.
+    void optimize_group (ShaderGroup *group, int raytypes_on,
+                         int raytypes_off);
 
     /// If option "greedyjit" was set, this call will trigger all
     /// shader groups that have not yet been compiled to do so with the

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2792,5 +2792,27 @@ DECLFOLDER(constfold_isconstant)
 }
 
 
+
+DECLFOLDER(constfold_raytype)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    Symbol& Name = *rop.opargsym (op, 1);
+    DASSERT (Name.typespec().is_string());
+    if (! Name.is_constant())
+        return 0;   // Can't optimize non-constant raytype name
+
+    int bit = rop.shadingsys().raytype_bit (*(ustring *)Name.data());
+    if (bit & rop.raytypes_on()) {
+        rop.turn_into_assign_one (op, "raytype => 1");
+        return 1;
+    }
+    if (bit & rop.raytypes_off()) {
+        rop.turn_into_assign_zero (op, "raytype => 0");
+        return 1;
+    }
+    return 0;  // indeterminite until execution time
+}
+
+
 }; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -671,7 +671,7 @@ ShaderGroup::ShaderGroup (string_view name)
   : m_optimized(0), m_does_nothing(false),
     m_llvm_groupdata_size(0), m_num_entry_layers(0),
     m_llvm_compiled_version(NULL),
-    m_name(name), m_exec_repeat(1)
+    m_name(name), m_exec_repeat(1), m_raytype_queries(-1)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;
@@ -685,7 +685,7 @@ ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
     m_llvm_groupdata_size(0), m_num_entry_layers(g.m_num_entry_layers),
     m_llvm_compiled_version(NULL),
     m_layers(g.m_layers),
-    m_name(name), m_exec_repeat(1)
+    m_name(name), m_exec_repeat(1), m_raytype_queries(-1)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -182,6 +182,20 @@ ShaderMaster::resolve_syms ()
         oparg_ptrs.push_back (symbol (a));
     OSLCompilerImpl::track_variable_lifetimes (m_ops, oparg_ptrs, allsymptrs);
 
+    // Figure out which ray types are queried
+    m_raytype_queries = 0;
+    BOOST_FOREACH (const Opcode& op, m_ops) {
+        if (op.opname() == Strings::raytype) {
+            int bit = -1;   // could be any
+            const Symbol *Name (symbol(m_args[op.firstarg()+1]));
+            if (Name->is_constant())
+                if (int b = shadingsys().raytype_bit (*(ustring *)Name->data()))
+                    bit = b;
+            m_raytype_queries |= bit;
+        }
+    }
+    // std::cout << shadername() << " has raytypes bits " << m_raytype_queries << "\n";
+
     // Adjust statistics
     size_t opmem = vectorbytes (m_ops);
     size_t argmem = vectorbytes (m_args);

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -107,6 +107,7 @@ namespace Strings {
     extern ustring end, useparam;
     extern ustring uninitialized_string;
     extern ustring unull;
+    extern ustring raytype;
 }; // namespace Strings
 
 
@@ -379,6 +380,8 @@ public:
 
     int num_params () const { return m_lastparam - m_firstparam; }
 
+    int raytype_queries () const { return m_raytype_queries; }
+
 private:
     ShadingSystemImpl &m_shadingsys;    ///< Back-ptr to the shading system
     ShaderType m_shadertype;            ///< Type of shader
@@ -396,6 +399,7 @@ private:
     std::vector<ustring> m_sconsts;     ///< string constant values
     int m_firstparam, m_lastparam;      ///< Subset of symbols that are params
     int m_maincodebegin, m_maincodeend; ///< Main shader code range
+    int m_raytype_queries;              ///< Bitmask of raytypes queried
 
     friend class OSOReaderToMaster;
     friend class ShaderInstance;
@@ -581,7 +585,8 @@ public:
     /// The group is set and won't be changed again; take advantage of
     /// this by optimizing the code knowing all our instance parameters
     /// (at least the ones that can't be overridden by the geometry).
-    void optimize_group (ShaderGroup &group);
+    void optimize_group (ShaderGroup &group,
+                         int raytypes_on=0, int raytypes_off=0);
 
     /// After doing all optimization and code JIT, we can clean up by
     /// deleting the instances' code and arguments, and paring their
@@ -1458,6 +1463,8 @@ public:
                                   : is_last_layer(layer);
     }
 
+    int raytype_queries () const { return m_raytype_queries; }
+
 private:
     // Put all the things that are read-only (after optimization) and
     // needed on every shade execution at the front of the struct, as much
@@ -1472,7 +1479,8 @@ private:
     std::vector<RunLLVMGroupFunc> m_llvm_compiled_layers;
     std::vector<ShaderInstanceRef> m_layers;
     ustring m_name;
-    int m_exec_repeat;              ///< How many times to execute group
+    int m_exec_repeat;               ///< How many times to execute group
+    int m_raytype_queries;           ///< Bitmask of raytypes queried
     mutable mutex m_mutex;           ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -124,7 +124,8 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_pass(0),
       m_next_newconst(0), m_next_newtemp(0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
-      m_stop_optimizing(false)
+      m_stop_optimizing(false),
+      m_raytypes_on(0), m_raytypes_off(0)
 {
     memset (&m_shaderglobals, 0, sizeof(ShaderGlobals));
     m_shaderglobals.context = shadingcontext();

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -72,6 +72,15 @@ public:
 
     virtual void set_debug ();
 
+    /// Optionally set which ray types are known to be on or off (0 means
+    /// not known at optimize time).
+    void set_raytypes (int raytypes_on, int raytypes_off) {
+        m_raytypes_on  = raytypes_on;
+        m_raytypes_off = raytypes_off;
+    }
+    int raytypes_on ()  const { return m_raytypes_on; }
+    int raytypes_off () const { return m_raytypes_off; }
+
     /// Optimize one layer of a group, given what we know about its
     /// instance variables and connections.
     void optimize_instance ();
@@ -438,6 +447,8 @@ private:
     double m_stat_opt_locking_time;       ///<   locking time
     double m_stat_specialization_time;    ///<   specialization time
     bool m_stop_optimizing;           ///< for debugging
+    int m_raytypes_on;                ///< Ray types known to be on
+    int m_raytypes_off;               ///< Ray types known to be off
 
     // Persistant data shared between layers
     bool m_unknown_message_sent;      ///< Somebody did a non-const setmessage

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -92,6 +92,7 @@ static ErrorHandler errhandler;
 static int iters = 1;
 static std::string raytype = "camera";
 static int raytype_bit = 0;
+static bool raytype_opt = false;
 static std::string extraoptions;
 static SimpleRenderer rend;  // RendererServices
 static OSL::Matrix44 Mshad;  // "shader" space to "common" space matrix
@@ -463,6 +464,7 @@ getargs (int argc, const char *argv[])
                 "--archivegroup %s", &archivegroup,
                         "Archive the group to a given filename",
                 "--raytype %s", &raytype, "Set the raytype",
+                "--raytype_opt", &raytype_opt, "Specify ray type mask for optimization",
                 "--iters %d", &iters, "Number of iterations",
                 "-O0", &O0, "Do no runtime shader optimization",
                 "-O1", &O1, "Do a little runtime shader optimization",
@@ -652,6 +654,9 @@ setup_output_images (ShadingSystem *shadingsys,
     // not to actually run the shader.
     ShaderGlobals sg;
     setup_shaderglobals (sg, shadingsys, 0, 0);
+
+    if (raytype_opt)
+        shadingsys->optimize_group (shadergroup.get(), raytype_bit, ~raytype_bit);
     shadingsys->execute (ctx, *shadergroup, sg, false);
 
     if (entryoutputs.size()) {
@@ -848,7 +853,9 @@ test_group_attributes (ShaderGroup *group)
         if (unk)
             std::cout << "    and unknown attributes\n";
     }
-
+    int raytype_queries = 0;
+    shadingsys->getattribute (group, "raytype_queries", raytype_queries);
+    std::cout << "raytype() query mask: " << raytype_queries << "\n";
 }
 
 

--- a/testsuite/raytype-specialized/ref/out.txt
+++ b/testsuite/raytype-specialized/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled test.osl -> test.oso
+camera? 0
+glossy? 1
+diffuse? 0
+

--- a/testsuite/raytype-specialized/run.py
+++ b/testsuite/raytype-specialized/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("--raytype glossy --raytype_opt test")

--- a/testsuite/raytype-specialized/test.osl
+++ b/testsuite/raytype-specialized/test.osl
@@ -1,0 +1,6 @@
+shader test ()
+{
+    printf ("camera? %d\n", raytype("camera"));
+    printf ("glossy? %d\n", raytype("glossy"));
+    printf ("diffuse? %d\n", raytype("diffuse"));
+}


### PR DESCRIPTION
A new ShadingSystem::optimize_group() method takes bit fields describing
which ray types are known to be true and known to be false (not being
specified in either means it's indeterminite at optimize time, will only
be known at execution time).

When compiled in this manner, the runtime optimizer will constant-fold
calls to raytype(name) when the name matches those in the "in" and "out"
lists you have supplied.

This allows an app to specialize a shader for particular ray types (such
as a highly optimized version just for shadow rays).

There is also a new group attribute query "raytype_queries", which reveals
the bit pattern of any raytype() calls mde by any of the shaders within
the group.

As an example, the basic logic for specializing shadow shades and non-shadow
shades looks like this:

    // Make the shader group, however you want
    ShaderGroupRef group = shadingsys->ShaderGroupBegin ("groupname", ...);
    ...
    ShaderGroupEnd ();

    // A second reference-counted shader group starts just referring to the
    // same group.
    ShaderGroupRef group_shad = group;

    // Figure out if the shader group contains any raytype("shadow") queries.
    int rayqueries = 0;
    shadingsys->getattribute (group.get(), "raytype_queries", rayqueries);

    std::string serialized;
    int shadowbit = raytypebit(ustring("shadow"));
    if (rayqueries & shadowbit) {
        // The shader group asks (or might ask) for raytype("shadow"). Let's
        // assume it has different behavior for shadow rays and specialize.
        // First, make another group from the same serialized description.
        shadingsys->getattribute (group.get(), "pickle", serialized);
        group_shad = shadingsys->ShaderGroupBegin ("groupname", "surface", serialized);
        ShaderGroupEnd ();
        // Now specialize the shadow-specific group for shadow rays only:
        shadingsys->optimize_group (group_shad.get(),
                                    shadowbit,   /* ray types on: shadow */
                                    ~shadowbit); /* ray types off: everything else */
        // And specialize the original group for anything but shadow rays:
        shadingsys->optimize_group (group_shad.get(),
                                    0,           /* ray types on -- anything */
                                    shadowbit);  /* ray types off -- shadow */
    } else {
        // The shader group definitely does not check for raytype("shadow"), so
        // there's no point in specializing. Just stick to one version of the
        // shader. It will compile automatically in a generic way whenever we
        // first call shadingsys->execute () with that group. We don't need to
        // do anything special.
    }

    ... shading time: ...
    if (it's a shadow ray)
        shadingsys->execute (context, *group_shad, shaderglobals);
    else /* not a shadow ray */
        shadingsys->execute (context, *group, shaderglobals);

The bad news is that it takes a bit more memory (you're making extra
shader groups) and more time to compile (you're optimizing twice for
many shaders). Nonetheless, I'm finding that I come out ahead.

On my production tests, I'm seeing between 2% and 15% speedup -- very
dependent on the scene, as well as the structure of your shaders. YMMV.

The whole scheme assumes that your shaders take significant shortcuts for
shadow rays, based on explicitly using "if (raytype("shadow")) ...".