### PR TITLE
New getattribute queries for shader, layer, and group name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,7 @@ macro ( TESTSUITE )
         # test, which we don't bother testing unoptimized.
         if (NOT _testname MATCHES "^render" AND
             NOT _testname MATCHES "^oslinfo" AND
+            NOT _testname MATCHES "^getattribute-shader" AND
             NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
           set (_env TESTSHADE_OPT=0 OPENIMAGEIOHOME=${OPENIMAGEIOHOME})
           add_test ( NAME ${_testname}
@@ -537,7 +538,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             draw_string
             error-dupes exit exponential
             function-earlyreturn function-simple function-outputelem
-            geomath getattribute-camera getsymbol-nonheap gettextureinfo
+            geomath getattribute-camera getattribute-shader
+            getsymbol-nonheap gettextureinfo
             group-outputs groupstring
             hex hyperb
             ieee_fp if incdec initops intbits isconnected isconstant

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -62,7 +62,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
 \date{{\large Date: 14 Jan, 2016 \\
- (with corrections, 5 Jul 2016)
+ (with corrections, 27 Sep 2016)
 }
 \bigskip
 \bigskip
@@ -4763,7 +4763,21 @@ Tables giving ``standardized'' names for different kinds of attributes may
 be found below. All renderers are expected to use the same names for these
 attributes, but are free to choose any names for additional attributes they
 wish to make queryable.
+
 \apiend
+
+\begin{table}[htbp]
+\caption{Names of standard attributes that may be retrieved.}\label{tab:cameraattributes}
+\begin{tabular}{|p{1.8in}|p{0.6in}|p{2.8in}|}
+\hline
+{\bf Name} & {\bf Type} & {\bf Description} \\
+\hline
+{\cf "shader:shadername"}     & {\cf string}    & Name of the shader master. \\
+{\cf "shader:layername"}      & {\cf string}    & Name of the layer instance. \\
+{\cf "shader:groupname"}      & {\cf string}    & Name of the shader group. \\
+\hline
+\end{tabular}
+\end{table}
 
 \begin{table}[htbp]
 \caption{Names of standard camera attributes that may be retrieved.

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1286,6 +1286,10 @@ ShadingSystemImpl::attribute (ShaderGroup *group, string_view name,
         group->m_exec_repeat = *(const int *)val;
         return true;
     }
+    if (name == "groupname" && type == TypeDesc::TypeString) {
+        group->name (ustring(((const char **)val)[0]));
+        return true;
+    }
     return false;
 }
 
@@ -3135,8 +3139,8 @@ osl_uninit_check (long long typedesc_, void *vals_,
     if (uninit) {
         ctx->error ("Detected possible use of uninitialized value in %s %s at %s:%d (group %s, layer %d %s, shader %s, op %d '%s', arg %d)",
                     typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
-                    groupname ? groupname: "<unnamed group>",
-                    layer, layername ? layername : "<unnamed layer>",
+                    (groupname && groupname[0]) ? groupname: "<unnamed group>",
+                    layer, (layername && layername[0]) ? layername : "<unnamed layer>",
                     shadername, opnum, USTR(opname), argnum);
     }
 }
@@ -3155,7 +3159,7 @@ osl_range_check (int indexvalue, int length, const char *symname,
                     " (group %s, layer %d %s, shader %s)",
                     indexvalue, USTR(symname), length-1,
                     USTR(sourcefile), sourceline,
-                    groupname ? groupname : "<unnamed group>", layer,
+                    (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
                     (layername && layername[0]) ? layername : "<unnamed layer>",
                     USTR(shadername));
         if (indexvalue >= length)

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -326,7 +326,7 @@ void parse_scene() {
             if (commands.size())
                 group = shadingsys->ShaderGroupBegin (name, shadertype, commands);
             else
-                group = shadingsys->ShaderGroupBegin();
+                group = shadingsys->ShaderGroupBegin (name);
             ParamStorage<1024> store; // scratch space to hold parameters until they are read by Shader()
             for (pugi::xml_node gnode = node.first_child(); gnode; gnode = gnode.next_sibling()) {
                 if (strcmp(gnode.name(), "Parameter") == 0) {

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1001,7 +1001,7 @@ test_shade (int argc, const char *argv[])
     // to be processed at the end.  Bear with us.
     
     // Start the shader group and grab a reference to it.
-    shadergroup = shadingsys->ShaderGroupBegin ();
+    shadergroup = shadingsys->ShaderGroupBegin (groupname);
 
     // Get the command line arguments.  That will set up all the shader
     // instances and their parameters for the group.
@@ -1011,6 +1011,8 @@ test_shade (int argc, const char *argv[])
         std::cerr << "ERROR: Invalid shader group. Exiting testshade.\n";
         return EXIT_FAILURE;
     }
+
+    shadingsys->attribute (shadergroup.get(), "groupname", groupname);
 
     // Now set up the connections
     for (size_t i = 0;  i < connections.size();  i += 4) {

--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 0 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 0 'assign', arg 1)
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 1 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 , shader test, op 2 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 1 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 2 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 3 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 3 'assign', arg 1)
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 , shader test, op 4 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 , shader test, op 5 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 4 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 <unnamed layer>, shader test, op 5 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/getattribute-shader/ref/out.txt
+++ b/testsuite/getattribute-shader/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled test.osl -> test.oso
+shader name: test
+layer name:  Cake
+group name:  Beatles
+

--- a/testsuite/getattribute-shader/run.py
+++ b/testsuite/getattribute-shader/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+# Simple test on a grid texture
+command = testshade("-groupname Beatles -layer Cake test")

--- a/testsuite/getattribute-shader/test.osl
+++ b/testsuite/getattribute-shader/test.osl
@@ -1,0 +1,16 @@
+
+
+shader
+test ()
+{
+    string shadername = "unknown";
+    string layername  = "unknown";
+    string groupname  = "unknown";
+    getattribute ("shader:shadername", shadername);
+    getattribute ("shader:layername", layername);
+    getattribute ("shader:groupname", groupname);
+
+    printf ("shader name: %s\n", shadername);
+    printf ("layer name:  %s\n", layername);
+    printf ("group name:  %s\n", groupname);
+}


### PR DESCRIPTION
    getattribute ("shader:shadername", dst)
    getattribute ("shader:layername", dst)
    getattribute ("shader:groupname", dst)

And of course they constant fold, so there is no runtime cost.

Beware: the layer names could be screwy if you are using the duplicate
instance merging optimization. If you are depending on layer names for
debugging, you may want to turn off just that optimization (set
ShadingSystem attribute "opt_merge_instances" to 0) while debugging.
