### PR TITLE
Bug fix: matrix param initialized with matrix(space,1) left out init ops

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -711,6 +711,13 @@ ASTvariable_declaration::param_one_default_literal (const Symbol *sym,
             ASTNode::ref val = ctr->args();
             float f[16];
             int nargs = 0;
+            DASSERT (val.get());
+            bool has_space_name = false;
+            if (val->nodetype() == ASTNode::literal_node && val->typespec().is_string()) {
+                has_space_name = true;
+                val = val->next();
+                completed = false;
+            }
             for (int c = 0;  c < 16;  ++c) {
                 if (val.get())
                     ++nargs;

--- a/testsuite/matrix/ref/out.txt
+++ b/testsuite/matrix/ref/out.txt
@@ -3,6 +3,7 @@ Parameter initialization:
   matrixparam0  = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrixparam1  = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
   matrixparam1m = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrixparam1world = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
   matrix (0.1) = 0.1 0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0 0.1
   matrix (0.1, 0.2, 0.3, 0.4,  0.5, 0.6, 0.7, 0.8,  0.9, 1, 1.1, 1.2,  1.3, 1.4, 1.5, 1.6) 
@@ -20,6 +21,8 @@ testing with spaces:
   matrix ("shader", 0) = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrix ("shader", 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) 
 	= 0 0.70711 0 0 0 0.70711 0 0 0 0 1 0 0 0 0 1
+  matrix ("world", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrix ("common", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
 Testing matrix from-to construction:
   matrix ("common", "shader") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -0.70711 0.70711 0 1)
@@ -65,6 +68,7 @@ Parameter initialization:
   matrixparam0  = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrixparam1  = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
   matrixparam1m = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrixparam1world = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
   matrix (0.1) = 0.1 0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0 0.1
   matrix (0.1, 0.2, 0.3, 0.4,  0.5, 0.6, 0.7, 0.8,  0.9, 1, 1.1, 1.2,  1.3, 1.4, 1.5, 1.6) 
@@ -82,6 +86,8 @@ testing with spaces:
   matrix ("shader", 1) = 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
   matrix ("shader", 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) 
 	= 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
+  matrix ("world", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrix ("common", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
 Testing matrix from-to construction:
   matrix ("common", "shader") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -0.70711 0.70711 0 1)
@@ -126,6 +132,7 @@ Parameter initialization:
   matrixparam0  = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrixparam1  = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
   matrixparam1m = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrixparam1world = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
   matrix (0.1) = 0.1 0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0 0.1
   matrix (0.1, 0.2, 0.3, 0.4,  0.5, 0.6, 0.7, 0.8,  0.9, 1, 1.1, 1.2,  1.3, 1.4, 1.5, 1.6) 
@@ -143,6 +150,8 @@ testing with spaces:
   matrix ("shader", 0) = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrix ("shader", 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) 
 	= 0 0.70711 0 0 0 0.70711 0 0 0 0 1 0 0 0 0 1
+  matrix ("world", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrix ("common", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
 Testing matrix from-to construction:
   matrix ("common", "shader") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -0.70711 0.70711 0 1)
@@ -187,6 +196,7 @@ Parameter initialization:
   matrixparam0  = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
   matrixparam1  = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
   matrixparam1m = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrixparam1world = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
   matrix (0.1) = 0.1 0 0 0 0 0.1 0 0 0 0 0.1 0 0 0 0 0.1
   matrix (0.1, 0.2, 0.3, 0.4,  0.5, 0.6, 0.7, 0.8,  0.9, 1, 1.1, 1.2,  1.3, 1.4, 1.5, 1.6) 
@@ -204,6 +214,8 @@ testing with spaces:
   matrix ("shader", 1) = 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
   matrix ("shader", 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) 
 	= 0.70711 0.70711 0 0 -0.70711 0.70711 0 0 0 0 1 0 1 0 0 1
+  matrix ("world", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
+  matrix ("common", 1) = 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1
 
 Testing matrix from-to construction:
   matrix ("common", "shader") = (0.70711 -0.70711 0 0 0.70711 0.70711 0 0 0 0 1 0 -0.70711 0.70711 0 1)

--- a/testsuite/matrix/test.osl
+++ b/testsuite/matrix/test.osl
@@ -23,13 +23,15 @@ void matrix_fromto (string from, string to)
 shader
 test (matrix matrixparam0 = 0,
       matrix matrixparam1 = 1,
-      matrix matrixparam1m = matrix(1))
+      matrix matrixparam1m = matrix(1),
+      matrix matrixparam1world = matrix("world",1))
 {
     // Test parameter initialization
     printf ("Parameter initialization:\n");
     printf ("  matrixparam0  = %g\n", matrixparam0);
     printf ("  matrixparam1  = %g\n", matrixparam1);
     printf ("  matrixparam1m = %g\n", matrixparam1m);
+    printf ("  matrixparam1world = %g\n", matrixparam1world);
     printf ("\n");
 
     // Test matrix constructors
@@ -66,6 +68,14 @@ test (matrix matrixparam0 = 0,
                 a, pretty(matrix("shader",a)));
         printf ("  matrix (\"shader\", %.5g, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1) \n\t= %.5g\n",
                 a, pretty(matrix ("shader", a, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)));
+    }
+
+    // World and comomon space construction
+    {
+        matrix Mw = matrix ("world", 1);
+        matrix Mc = matrix ("common", 1);
+        printf ("  matrix (\"world\", 1) = %g\n", Mw);
+        printf ("  matrix (\"common\", 1) = %g\n", Mc);
     }
 
     // Test "from-to" matrix construction and getmatrix calls


### PR DESCRIPTION
When generating the static construction values, it needed to recognize
that case and set the "completed" flag to false, so that it would know
that it couldn't be constructed statically and needed init ops emitted
for that paramter.