### PR TITLE
Better runtime optimization of some matrix constructors.

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -110,6 +110,7 @@ public:
     int add_constant (float c) { return add_constant(TypeDesc::TypeFloat, &c); }
     int add_constant (int c) { return add_constant(TypeDesc::TypeInt, &c); }
     int add_constant (ustring s) { return add_constant(TypeDesc::TypeString, &s); }
+    int add_constant (const Matrix44 &c) { return add_constant(TypeDesc::TypeMatrix, &c); }
 
     /// Create a new temporary variable of the given type, return its index.
     int add_temp (const TypeSpec &type);


### PR DESCRIPTION
matrix(spaceA,spaceB) already optimized to a constant matrix if spaceA and spaceB were both constant names and did not refer to motion-blurred transformations.

New case: if spaceA and spaceB alias to the same symbol, then we know this is the identiy matrix, even if they are not known constant values, and even if they refer to a motion-blurred space.

matrix(float0, float1, ... float15) already turned into a constant matrix if all the values were constant.

New case: matrix(float0) can be turned into a constant matrix if its value is constant (it's usually 1, but it doesn't have to be).