### PR TITLE
Fix oslnoise link errors when building static OSL libraries.

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -28,12 +28,10 @@ if (NOT BUILDSTATIC)
 endif ()
 
 # oslnoise symbols used in oslexec
-if (NOT BUILDSTATIC)
-    LIST(APPEND liboslexec_srcs
-        ../liboslnoise/gabornoise.cpp
-        ../liboslnoise/simplexnoise.cpp
-        )
-endif ()
+LIST(APPEND liboslexec_srcs
+   ../liboslnoise/gabornoise.cpp
+   ../liboslnoise/simplexnoise.cpp
+   )
 
 # oslquery symbols used in oslexec
 if (NOT BUILDSTATIC)


### PR DESCRIPTION
With static libraries the indirect dependency is not picked up automatically, so explicitly add it to `testshade` and `testrender`.