### PR TITLE
Improve aliasing of params with simple init ops.

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -862,6 +862,12 @@ RuntimeOptimizer::simplify_params ()
             // if it's a simple assignment from a global whose value is
             // not reassigned later, we can just alias it, and if we're
             // lucky that may eliminate all uses of the parameter.
+
+            // First, trim init ops in case nops have accumulated
+            while (s->has_init_ops() && op(s->initbegin()).opname() == u_nop)
+                s->initbegin (s->initbegin()+1);
+            while (s->has_init_ops() && op(s->initend()-1).opname() == u_nop)
+                s->initend (s->initend()-1);
             if (s->initbegin() == s->initend()-1) {  // just one op
                 Opcode &op (inst()->ops()[s->initbegin()]);
                 if (op.opname() == u_assign) {
@@ -3035,7 +3041,7 @@ RuntimeOptimizer::run ()
     // Optimize each layer again, from last to first (because some
     // optimizations are only apparent when the subsequent shaders have
     // been simplified).
-    for (int layer = nlayers-2;  layer >= 0;  --layer) {
+    for (int layer = nlayers-1;  layer >= 0;  --layer) {
         set_inst (layer);
         if (! inst()->unused())
             optimize_instance ();


### PR DESCRIPTION
Params that needed init ops, but the initialization was just a single assignment, could be "aliased" to the thing they were assigned to (a constant or a global or another param). It was identifying this by basically asking "does this param's init ops consist of just one op, and is it 'assign'?"

But... maybe the initialization started out as several ops, and runtime optimization whittled it down to just one assignment -- it might look like multiple ops, but all but one are 'nop'.

So now we "trim" the init ops of any leading or trailing nop instructions, before doing this test. And it catches some more cases that can be simplified!

As a real-world example, consider:

    param s = u * scale + offset

Where scale and offset are also parameters.  This initially compiled to:

     tmp1 = u * scale
     s = tmp1 + offset

If at runtime, parameter scale==1 and offset==0, this will get optimized to

     nop
     s = u

which is really just saying s is an alias for u, but this is the case that fails because the test on the untrimmed ops will say "it's 2 ops, forget it".