### PR TITLE
oslc better err reporting for use of non-function symbol as function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,7 +563,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul
             oslc-err-format oslc-err-intoverflow
-            oslc-err-noreturn oslc-err-outputparamvararray oslc-err-paramdefault
+            oslc-err-noreturn oslc-err-notfunc
+            oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-warn-commainit
             oslc-variadic-macro

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -935,6 +935,7 @@ ASTfunction_call::ASTfunction_call (OSLCompilerImpl *comp, ustring name,
     }
     if (m_sym->symtype() != SymTypeFunction) {
         error ("'%s' is not a function", name.c_str());
+        m_sym = NULL;
         return;
     }
 }

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1201,8 +1201,12 @@ ASTfunction_call::typecheck (TypeSpec expected)
         actualargs += arg->typespec().string();
     }
 
-    error ("No matching function call to '%s (%s)'\n    Candidates are:\n%s", 
-           m_name.c_str(), actualargs.c_str(), choices.c_str());
+    if (choices.size())
+        error ("No matching function call to '%s (%s)'\n    Candidates are:\n%s",
+               m_name.c_str(), actualargs.c_str(), choices.c_str());
+    else
+        error ("No matching function call to '%s (%s)'",
+               m_name.c_str(), actualargs.c_str());
     return TypeSpec();
 }
 

--- a/testsuite/oslc-err-notfunc/ref/out.txt
+++ b/testsuite/oslc-err-notfunc/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:2: error: 'cos' is not a function
+test.osl:2: error: No matching function call to 'cos (int)'
+FAILED test.osl

--- a/testsuite/oslc-err-notfunc/run.py
+++ b/testsuite/oslc-err-notfunc/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-notfunc/test.osl
+++ b/testsuite/oslc-err-notfunc/test.osl
@@ -1,0 +1,9 @@
+void mybug (float cos) {
+    cos(1);  // inner scope cos is not a function
+}
+
+
+shader test ()
+{
+}
+


### PR DESCRIPTION
See the new testsuite example. This crashed oslc before!
Fix it up to not crash (by marking the unfound function's symbol as NULL),
and also improve the resulting error message.

Fixes #681