### PR TITLE
Debugging option 'llvm_debug_ops' adds a printf before running each op

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -149,6 +149,8 @@ public:
     ///    int llvm_debug         Set LLVM extra debug level (0)
     ///    int llvm_debug_layers  Extra printfs upon entering and leaving
     ///                              layer functions.
+    ///    int llvm_debug_ops     Extra printfs for each OSL op (helpful
+    ///                              for devs to find crashes)
     ///    int max_local_mem_KB   Error if shader group needs more than this
     ///                              much local storage to execute (1024K)
     ///    string debug_groupname Name of shader group -- debug only this one

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -391,6 +391,8 @@ public:
     void llvm_generate_debugnan (const Opcode &op);
     /// Check for uninitialized values in all read-from arguments to the op
     void llvm_generate_debug_uninit (const Opcode &op);
+    /// Print debugging line for the op
+    void llvm_generate_debug_op_printf (const Opcode &op);
 
     llvm::Function *layer_func () const { return ll.current_function(); }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -629,6 +629,18 @@ BackendLLVM::llvm_generate_debug_uninit (const Opcode &op)
 
 
 
+void
+BackendLLVM::llvm_generate_debug_op_printf (const Opcode &op)
+{
+    std::ostringstream msg;
+    msg << op.sourcefile() << ':' << op.sourceline() << ' ' << op.opname();
+    for (int i = 0;  i < op.nargs();  ++i)
+        msg << ' ' << opargsym (op, i)->mangled();
+    llvm_gen_debug_printf (msg.str());
+}
+
+
+
 bool
 BackendLLVM::build_llvm_code (int beginop, int endop, llvm::BasicBlock *bb)
 {
@@ -641,6 +653,8 @@ BackendLLVM::build_llvm_code (int beginop, int endop, llvm::BasicBlock *bb)
         if (opd && opd->llvmgen) {
             if (shadingsys().debug_uninit() /* debug uninitialized vals */)
                 llvm_generate_debug_uninit (op);
+            if (shadingsys().llvm_debug_ops())
+                llvm_generate_debug_op_printf (op);
             bool ok = (*opd->llvmgen) (*this, opnum);
             if (! ok)
                 return false;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -564,6 +564,7 @@ public:
     int llvm_optimize () const { return m_llvm_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
     int llvm_debug_layers () const { return m_llvm_debug_layers; }
+    int llvm_debug_ops () const { return m_llvm_debug_ops; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
     bool opt_texture_handle () const { return m_opt_texture_handle; }
     int opt_passes() const { return m_opt_passes; }
@@ -755,6 +756,7 @@ private:
     int m_debug;                          ///< Debugging output
     int m_llvm_debug;                     ///< More LLVM debugging output
     int m_llvm_debug_layers;              ///< Add layer enter/exit printfs
+    int m_llvm_debug_ops;                 ///< Add printfs to every op
     ustring m_debug_groupname;            ///< Name of sole group to debug
     ustring m_debug_layername;            ///< Name of sole layer to debug
     ustring m_opt_layername;              ///< Name of sole layer to optimize

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -650,7 +650,8 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_optimize_nondebug(false),
       m_opt_passes(10),
       m_llvm_optimize(0),
-      m_debug(0), m_llvm_debug(0), m_llvm_debug_layers(0),
+      m_debug(0), m_llvm_debug(0),
+      m_llvm_debug_layers(0), m_llvm_debug_ops(0),
       m_commonspace_synonym("world"),
       m_colorspace("Rec709"),
       m_max_local_mem_KB(2048),
@@ -1067,6 +1068,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("llvm_optimize", int, m_llvm_optimize);
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
     ATTR_SET ("llvm_debug_layers", int, m_llvm_debug_layers);
+    ATTR_SET ("llvm_debug_ops", int, m_llvm_debug_ops);
     ATTR_SET ("strict_messages", int, m_strict_messages);
     ATTR_SET ("range_checking", int, m_range_checking);
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
@@ -1175,6 +1177,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("debug", int, m_debug);
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
     ATTR_DECODE ("llvm_debug_layers", int, m_llvm_debug_layers);
+    ATTR_DECODE ("llvm_debug_ops", int, m_llvm_debug_ops);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
     ATTR_DECODE ("range_checking", int, m_range_checking);
     ATTR_DECODE ("unknown_coordsys_error", int, m_unknown_coordsys_error);
@@ -1586,6 +1589,7 @@ ShadingSystemImpl::getstats (int level) const
     INTOPT (profile);
     INTOPT (llvm_debug);
     BOOLOPT (llvm_debug_layers);
+    BOOLOPT (llvm_debug_ops);
     BOOLOPT (lazylayers);
     BOOLOPT (lazyglobals);
     BOOLOPT (lazyunconnected);


### PR DESCRIPTION
This can be helpful to OSL's developers for certain debugging tasks.
