### PR TITLE
Use llvm::getLazyBitcodeModule in newer LLVM.

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -170,7 +170,7 @@ public:
     void setup_optimization_passes (int optlevel);
 
     /// Run the optimization passes.
-    void do_optimize ();
+    void do_optimize (std::string *err = nullptr);
 
     /// Retrieve a callable pointer to the JITed version of a function.
     /// This will JIT the function if it hasn't already done so. Be sure


### PR DESCRIPTION
Using `llvm::getLazyBitcodeModule` instead of `llvm::parseBitcodeFile` seems to provide a significant speed bump. The comment about why `parseBitcodeFile ` was used seems no longer valid.

I've only tested on OS X, so if it still is an issue on other platforms could one try the steps mentioned on line `519`?
