### PR TITLE
C++11 and Boost changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Dependency and standards changes:
   OIIO 1.7 or newer. You may find that 1.6 is still ok, but we are not doing
   any work to ensure that.
 * CMake >= 3.2.2
+* Boost >= 1.55
 
 Language features:
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -82,10 +82,8 @@ if (NOT Boost_FIND_QUIETLY)
 endif ()
 
 if (NOT DEFINED Boost_ADDITIONAL_VERSIONS)
-  set (Boost_ADDITIONAL_VERSIONS "1.60" "1.59" "1.58" "1.57" "1.56"
-                                 "1.55" "1.54" "1.53" "1.52" "1.51" "1.50"
-                                 "1.49" "1.48" "1.47" "1.46" "1.45" "1.44"
-                                 "1.43" "1.43.0" "1.42" "1.42.0")
+  set (Boost_ADDITIONAL_VERSIONS "1.63" "1.62" "1.61" "1.60"
+                                 "1.59" "1.58" "1.57" "1.56" "1.55")
 endif ()
 if (LINKSTATIC)
     set (Boost_USE_STATIC_LIBS   ON)
@@ -96,8 +94,8 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem regex system thread wave)
-    find_package (Boost 1.42 REQUIRED
+    set (Boost_COMPONENTS regex system thread wave)
+    find_package (Boost 1.55 REQUIRED
                   COMPONENTS ${Boost_COMPONENTS}
                  )
 endif ()

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -30,8 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <iostream>
 
-#include <boost/foreach.hpp>
-
 #include "oslcomp_pvt.h"
 
 #include <OpenImageIO/dassert.h>
@@ -110,7 +108,7 @@ OSLCompilerImpl::insert_code (int opnum, const char *opname,
             }
         }
         // Adjust param init ranges
-        BOOST_FOREACH (Symbol *s, symtab()) {
+        for (auto&& s : symtab()) {
             if (s->symtype() == SymTypeParam ||
                   s->symtype() == SymTypeOutputParam) {
                 if (s->initbegin() > opnum)
@@ -197,7 +195,7 @@ OSLCompilerImpl::add_struct_fields (StructSpec *structspec,
 Symbol *
 OSLCompilerImpl::make_constant (ustring val)
 {
-    BOOST_FOREACH (ConstantSymbol *sym, m_const_syms) {
+    for (auto&& sym : m_const_syms) {
         if (sym->typespec().is_string() && sym->strval() == val)
             return sym;
     }
@@ -215,7 +213,7 @@ Symbol *
 OSLCompilerImpl::make_constant (TypeDesc type, const void *val)
 {
     size_t typesize = type.size();
-    BOOST_FOREACH (ConstantSymbol *sym, m_const_syms) {
+    for (auto&& sym : m_const_syms) {
         if (sym->typespec().simpletype() == type &&
               ! memcmp(val, sym->data(), typesize))
             return sym;
@@ -234,7 +232,7 @@ OSLCompilerImpl::make_constant (TypeDesc type, const void *val)
 Symbol *
 OSLCompilerImpl::make_constant (int val)
 {
-    BOOST_FOREACH (ConstantSymbol *sym, m_const_syms) {
+    for (auto&& sym : m_const_syms) {
         if (sym->typespec().is_int() && sym->intval() == val)
             return sym;
     }
@@ -251,7 +249,7 @@ OSLCompilerImpl::make_constant (int val)
 Symbol *
 OSLCompilerImpl::make_constant (float val)
 {
-    BOOST_FOREACH (ConstantSymbol *sym, m_const_syms) {
+    for (auto&& sym : m_const_syms) {
         if (sym->typespec().is_float() && sym->floatval() == val)
             return sym;
     }
@@ -269,7 +267,7 @@ Symbol *
 OSLCompilerImpl::make_constant (TypeDesc type, float x, float y, float z)
 {
     Vec3 val (x, y, z);
-    BOOST_FOREACH (ConstantSymbol *sym, m_const_syms) {
+    for (auto&& sym : m_const_syms) {
         if (sym->typespec().simpletype() == type && sym->vecval() == val)
             return sym;
     }
@@ -354,7 +352,7 @@ ASTNode::codegen (Symbol *dest)
 void
 ASTNode::codegen_children ()
 {
-    BOOST_FOREACH (ref &c, m_children) {
+    for (auto&& c : m_children) {
         codegen_list (c);
     }
 }
@@ -777,7 +775,7 @@ ASTvariable_declaration::param_default_literals (const Symbol *sym,
         // the node that defined its parameter (i.e., *this). Look in that
         // list for the initializer for this specific field.
         init = NULL;
-        BOOST_FOREACH (const NamedInit &n, m_struct_field_inits) {
+        for (auto&& n : m_struct_field_inits) {
             if (n.first == sym->name()) {
                 init = n.second;
                 break;

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -47,9 +47,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/wave.hpp>
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>
 #include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
-#if OIIO_VERSION < 10604
-#include <boost/filesystem.hpp>
-#endif
 
 
 OSL_NAMESPACE_ENTER
@@ -344,11 +341,7 @@ OSLCompilerImpl::compile (string_view filename,
 
     std::vector<std::string> defines;
     std::vector<std::string> includepaths;
-#if OIIO_VERSION >= 10604
     m_cwd = OIIO::Filesystem::current_path();
-#else
-    m_cwd = boost::filesystem::current_path().string();
-#endif
     m_main_filename = filename;
 
     // Determine where the installed shader include directory is, and
@@ -439,11 +432,7 @@ OSLCompilerImpl::compile_buffer (string_view sourcecode,
 {
     string_view filename ("<buffer>");
 
-#if OIIO_VERSION >= 10604
     m_cwd = OIIO::Filesystem::current_path();
-#else
-    m_cwd = boost::filesystem::current_path().string();
-#endif
     m_main_filename = filename;
 
     // Determine where the installed shader include directory is, and

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/dassert.h>
 namespace Strutil = OIIO::Strutil;
 
-#include <boost/foreach.hpp>
-
 
 OSL_NAMESPACE_ENTER
 
@@ -337,7 +335,7 @@ SymbolTable::print ()
     if (TypeSpec::struct_list().size()) {
         std::cout << "Structure table:\n";
         int structid = 1;
-        BOOST_FOREACH (std::shared_ptr<StructSpec> &s, TypeSpec::struct_list()) {
+        for (auto&& s : TypeSpec::struct_list()) {
             if (! s)
                 continue;
             std::cout << "    " << structid << ": struct " << s->mangled();
@@ -356,7 +354,7 @@ SymbolTable::print ()
     }
 
     std::cout << "Symbol table:\n";
-    BOOST_FOREACH (const Symbol *s, m_allsyms) {
+    for (auto&& s : m_allsyms) {
         if (s->is_structure())
             continue;
         std::cout << "\t" << s->mangled() << " : ";

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -31,8 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <stack>
 #include <memory>
-
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
@@ -203,7 +202,7 @@ private:
 ///
 class SymbolTable {
 public:
-    typedef boost::unordered_map<ustring, Symbol *,ustringHash> ScopeTable;
+    typedef std::unordered_map<ustring, Symbol *,ustringHash> ScopeTable;
     typedef std::vector<ScopeTable> ScopeTableStack;
     typedef SymbolPtrVec::iterator iterator;
     typedef SymbolPtrVec::const_iterator const_iterator;

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/strutil.h>
 namespace Strutil = OIIO::Strutil;
 
-#include <boost/foreach.hpp>
-
 
 OSL_NAMESPACE_ENTER
 
@@ -57,7 +55,7 @@ ASTNode::typecheck (TypeSpec expected)
 void
 ASTNode::typecheck_children (TypeSpec expected)
 {
-    BOOST_FOREACH (ref &c, m_children) {
+    for (auto&& c : m_children) {
         typecheck_list (c, expected);
     }
 }

--- a/src/liboslexec/automata.h
+++ b/src/liboslexec/automata.h
@@ -32,9 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <list>
 #include <vector>
-
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "OSL/oslconfig.h"
 
@@ -47,13 +46,13 @@ OSL_NAMESPACE_ENTER
 // General container for integer sets
 typedef std::set<int> IntSet; // probably faster to test for equality, unions and so
 
-typedef boost::unordered_set<ustring, ustringHash> SymbolSet;
+typedef std::unordered_set<ustring, ustringHash> SymbolSet;
 // This is for the transition table used in DfAutomata::State
-typedef boost::unordered_map<ustring, int, ustringHash> SymbolToInt;
+typedef std::unordered_map<ustring, int, ustringHash> SymbolToInt;
 // And this is for the transition table in NdfAutomata which
 // has several movements for each symbol
-typedef boost::unordered_map<ustring, IntSet, ustringHash> SymbolToIntList;
-typedef boost::unordered_map<int, int> HashIntInt;
+typedef std::unordered_map<ustring, IntSet, ustringHash> SymbolToIntList;
+typedef std::unordered_map<int, int> HashIntInt;
 
 // For the rules in the deterministic states, we don't need a real set
 // cause when converting from the NDF automata we will never find the same

--- a/src/liboslexec/constantpool.h
+++ b/src/liboslexec/constantpool.h
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 #include <list>
-#include <boost/foreach.hpp>
 
 #include <OpenImageIO/thread.h>
 
@@ -66,7 +65,7 @@ public:
     T * alloc (size_t n) {
         OIIO::lock_guard lock (m_mutex);
         // Check each block in the block list to see if it has enough space
-        BOOST_FOREACH (block_t &block, m_block_list) {
+        for (auto&& block : m_block_list) {
             size_t s = block.size();
             if ((s+n) <= block.capacity()) {
                 // Enough space in this block.  Use it.

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstdio>
 
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 
 #include <OpenImageIO/dassert.h>

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <cstdlib>
 #include <ctype.h>
+#include <unordered_map>
 
-#include <boost/unordered_map.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <OpenImageIO/dassert.h>
@@ -139,8 +139,8 @@ private:
             : document(d), node(n), next(0) { }
     };
 
-    typedef boost::unordered_map <Query, QueryResult, QueryHash> QueryMap;
-    typedef boost::unordered_map<ustring, int, ustringHash> DocMap;
+    typedef std::unordered_map <Query, QueryResult, QueryHash> QueryMap;
+    typedef std::unordered_map<ustring, int, ustringHash> DocMap;
 
     ShadingContext *m_context;  // back-pointer to shading context
 

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -33,9 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctype.h>
 #include <unordered_map>
 
-#include <boost/algorithm/string.hpp>
-
 #include <OpenImageIO/dassert.h>
+#include <OpenImageIO/strutil.h>
 
 #ifdef USE_EXTERNAL_PUGIXML
 # include <pugixml.hpp>
@@ -179,7 +178,7 @@ Dictionary::get_document_index (ustring dictionaryname)
         pugi::xml_document *doc = new pugi::xml_document;
         m_documents.push_back (doc);
         pugi::xml_parse_result parse_result;
-        if (boost::ends_with (dictionaryname.string(), ".xml")) {
+        if (Strutil::ends_with (dictionaryname.string(), ".xml")) {
             // xml file -- read it
             parse_result = doc->load_file (dictionaryname.c_str());
         } else {

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -31,8 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <algorithm>
 
-#include <boost/foreach.hpp>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/strutil.h>
 
@@ -222,7 +220,7 @@ ShaderInstance::parameters (const ParamValueList &params)
         m_instoverrides[i].dataoffset (sym->dataoffset());
     }
 
-    BOOST_FOREACH (const ParamValue &p, params) {
+    for (auto&& p : params) {
         if (p.name().size() == 0)
             continue;   // skip empty names
         int i = findparam (p.name());
@@ -409,7 +407,7 @@ ShaderInstance::evaluate_writes_globals_and_userdata_params ()
 {
     writes_globals (false);
     userdata_params (false);
-    BOOST_FOREACH (Symbol &s, symbols()) {
+    for (auto&& s : symbols()) {
         if (s.symtype() == SymTypeGlobal && s.everwritten())
             writes_globals (true);
         if ((s.symtype() == SymTypeParam || s.symtype() == SymTypeOutputParam)
@@ -425,7 +423,7 @@ ShaderInstance::evaluate_writes_globals_and_userdata_params ()
     // the symbol overrides. This is very important to get instance merging
     // working correctly.
     int p = 0;
-    BOOST_FOREACH (SymOverrideInfo &s, m_instoverrides) {
+    for (auto&& s : m_instoverrides) {
         if (! s.lockgeom())
             userdata_params (true);
         ++p;

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -27,8 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <cmath>
-
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/sysutil.h>
@@ -136,7 +135,7 @@ struct HelperFuncRecord {
         : argtypes(argtypes), function(function) {}
 };
 
-typedef boost::unordered_map<std::string,HelperFuncRecord> HelperFuncMap;
+typedef std::unordered_map<std::string,HelperFuncRecord> HelperFuncMap;
 HelperFuncMap llvm_helper_function_map;
 atomic_int llvm_helper_function_map_initialized (0);
 spin_mutex llvm_helper_function_map_mutex;

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -815,7 +815,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
     // Setup the symbols
     m_named_values.clear ();
     m_layers_already_run.clear ();
-    BOOST_FOREACH (Symbol &s, inst()->symbols()) {
+    for (auto&& s : inst()->symbols()) {
         // Skip constants -- we always inline scalar constants, and for
         // array constants we will just use the pointers to the copy of
         // the constant that belongs to the instance.

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -34,8 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "oslexec_pvt.h"
 #include "osoreader.h"
 
-#include <boost/algorithm/string.hpp>
-
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/timer.h>
@@ -369,7 +367,7 @@ readuntil (std::string &source, const std::string &stop, bool do_trim=false)
     std::string r (source, 0, e);
     source.erase (0, e == source.npos ? e : e+1);
     if (do_trim)
-        boost::trim (r);
+        r = Strutil::strip (r); // trim whitespace
     return r;
 }
 

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -97,7 +97,7 @@ private:
     int m_oso_major, m_oso_minor;     ///< oso file format version
     int m_sym_default_index;          ///< Next sym default value to fill in
     bool m_errors;                    ///< Did we hit any errors?
-    typedef boost::unordered_map<ustring,int,ustringHash> UstringIntMap;
+    typedef std::unordered_map<ustring,int,ustringHash> UstringIntMap;
     UstringIntMap m_symmap;           ///< map sym name to index
 };
 

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -32,8 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <limits>
 #include <sstream>
 
-#include <boost/foreach.hpp>
-
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
@@ -129,7 +127,7 @@ ShaderMaster::resolve_syms ()
     m_firstparam = -1;
     m_lastparam = -1;
     int i = 0;
-    BOOST_FOREACH (Symbol &s, m_symbols) {
+    for (auto&& s : m_symbols) {
         allsymptrs.push_back (&s);
         // Fix up the size of the symbol's data (for one point, not 
         // counting derivatives).
@@ -178,13 +176,13 @@ ShaderMaster::resolve_syms ()
     // Re-track variable lifetimes
     SymbolPtrVec oparg_ptrs;
     oparg_ptrs.reserve (m_args.size());
-    BOOST_FOREACH (int a, m_args)
+    for (auto&& a : m_args)
         oparg_ptrs.push_back (symbol (a));
     OSLCompilerImpl::track_variable_lifetimes (m_ops, oparg_ptrs, allsymptrs);
 
     // Figure out which ray types are queried
     m_raytype_queries = 0;
-    BOOST_FOREACH (const Opcode& op, m_ops) {
+    for (auto&& op : m_ops) {
         if (op.opname() == Strings::raytype) {
             int bit = -1;   // could be any
             const Symbol *Name (symbol(m_args[op.firstarg()+1]));

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -44,7 +44,7 @@ namespace pvt {
 
 #if 0 // only when testing the statistics of perlin noise to normalize the range
 
-#include <boost/random.hpp>
+#include <random>
 
 void test_perlin(int d) {
     HashScalar h;
@@ -53,17 +53,17 @@ void test_perlin(int d) {
     float noise_avg = 0;
     float noise_avg2 = 0;
     float noise_stddev;
-    boost::mt19937 rndgen;
-    boost::uniform_01<boost::mt19937, float> rnd(rndgen);
+    std::mt19937 rndgen;
+    std::uniform_real_distribution<float> rnd (0.0f, 1.0f);
     printf("Running perlin-%d noise test ...\n", d);
     const int n = 100000000;
     const float r = 1024;
     for (int i = 0; i < n; i++) {
         float noise;
-        float nx = rnd(); nx = (2 * nx - 1) * r;
-        float ny = rnd(); ny = (2 * ny - 1) * r;
-        float nz = rnd(); nz = (2 * nz - 1) * r;
-        float nw = rnd(); nw = (2 * nw - 1) * r;
+        float nx = rnd(rndgen); nx = (2 * nx - 1) * r;
+        float ny = rnd(rndgen); ny = (2 * ny - 1) * r;
+        float nz = rnd(rndgen); nz = (2 * nz - 1) * r;
+        float nw = rnd(rndgen); nw = (2 * nw - 1) * r;
         switch (d) {
             case 1: perlin(noise, h, nx); break;
             case 2: perlin(noise, h, nx, ny); break;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -935,10 +935,10 @@ typedef std::vector<Connection> ConnectionVec;
 ///        FOREACH_PARAM (Symbol &s, inst) { ... stuff with s... }
 ///
 #define FOREACH_PARAM(symboldecl,inst) \
-    BOOST_FOREACH (symboldecl, param_range(inst))
+    for (symboldecl : param_range(inst))
 
 #define FOREACH_SYM(symboldecl,inst) \
-    BOOST_FOREACH (symboldecl, sym_range(inst))
+    for (symboldecl : sym_range(inst))
 
 
 
@@ -1094,37 +1094,49 @@ public:
     int firstparam () const { return m_firstparam; }
     int lastparam () const { return m_lastparam; }
 
-    /// Return a begin/end Symbol* pair for the set of param symbols
-    /// that is suitable to pass as a range for BOOST_FOREACH.
-    friend std::pair<Symbol *,Symbol *> param_range (ShaderInstance *i) {
+    // Range type suitable for use with "range for"
+    template<typename T>   // T should be Symbol or const Symbol
+    struct SymRange {
+        SymRange () : m_begin(nullptr), m_end(nullptr) {}
+        SymRange (T *a, T *b) : m_begin(a), m_end(b) {}
+        T *begin () const { return m_begin; }
+        T *end () const { return m_end; }
+    private:
+        T* m_begin;
+        T* m_end;
+    };
+
+    /// Return a SymRange for the set of param symbols that is suitable to
+    /// pass as a "range for".
+    friend SymRange<Symbol> param_range (ShaderInstance *i) {
         if (i->m_instsymbols.size() == 0 || i->firstparam() == i->lastparam())
-            return std::pair<Symbol*,Symbol*> ((Symbol*)NULL, (Symbol*)NULL);
+            return SymRange<Symbol> ();
         else
-            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
-                                               &i->m_instsymbols[0] + i->lastparam());
+            return SymRange<Symbol> (&i->m_instsymbols[0] + i->firstparam(),
+                                     &i->m_instsymbols[0] + i->lastparam());
     }
 
-    friend std::pair<const Symbol *,const Symbol *> param_range (const ShaderInstance *i) {
+    friend SymRange<const Symbol> param_range (const ShaderInstance *i) {
         if (i->m_instsymbols.size() == 0 || i->firstparam() == i->lastparam())
-            return std::pair<const Symbol*,const Symbol*> ((const Symbol*)NULL, (const Symbol*)NULL);
+            return SymRange<const Symbol> ();
         else
-            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[0] + i->firstparam(),
-                                                           &i->m_instsymbols[0] + i->lastparam());
+            return SymRange<const Symbol> (&i->m_instsymbols[0] + i->firstparam(),
+                                           &i->m_instsymbols[0] + i->lastparam());
     }
 
-    friend std::pair<Symbol *,Symbol *> sym_range (ShaderInstance *i) {
+    friend SymRange<Symbol> sym_range (ShaderInstance *i) {
         if (i->m_instsymbols.size() == 0)
-            return std::pair<Symbol*,Symbol*> ((Symbol*)NULL, (Symbol*)NULL);
+            return SymRange<Symbol> ();
         else
-            return std::pair<Symbol*,Symbol*> (&i->m_instsymbols[0],
-                                               &i->m_instsymbols[0] + i->m_instsymbols.size());
+            return SymRange<Symbol> (&i->m_instsymbols[0],
+                                     &i->m_instsymbols[0] + i->m_instsymbols.size());
     }
-    friend std::pair<const Symbol *,const Symbol *> sym_range (const ShaderInstance *i) {
+    friend SymRange<const Symbol> sym_range (const ShaderInstance *i) {
         if (i->m_instsymbols.size() == 0)
-            return std::pair<const Symbol*,const Symbol*> ((const Symbol*)NULL, (const Symbol*)NULL);
+            return SymRange<const Symbol> ();
         else
-            return std::pair<const Symbol*,const Symbol*> (&i->m_instsymbols[0],
-                                               &i->m_instsymbols[0] + i->m_instsymbols.size());
+            return SymRange<const Symbol> (&i->m_instsymbols[0],
+                                           &i->m_instsymbols[0] + i->m_instsymbols.size());
     }
 
     int Psym () const { return m_Psym; }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -35,9 +35,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <list>
 #include <set>
+#include <unordered_map>
 
 #include <boost/regex_fwd.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
@@ -639,7 +639,7 @@ public:
 
     void optimize_all_groups (int nthreads=0, int mythread=0, int totalthreads=1);
 
-    typedef boost::unordered_map<ustring,OpDescriptor,ustringHash> OpDescriptorMap;
+    typedef std::unordered_map<ustring,OpDescriptor,ustringHash> OpDescriptorMap;
 
     /// Look up OpDescriptor for the named op, return NULL for unknown op.
     ///
@@ -1718,7 +1718,7 @@ private:
     mutable TextureSystem::Perthread *m_texture_thread_info; ///< Ptr to texture thread info
     ShaderGroup *m_group;               ///< Ptr to shader group
     std::vector<char> m_heap;           ///< Heap memory
-    typedef boost::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;
+    typedef std::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;
     RegexMap m_regex_map;               ///< Compiled regex's
     MessageList m_messages;             ///< Message blackboard
     int m_max_warnings;                 ///< To avoid processing too many warnings

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -32,7 +32,7 @@ using namespace OSL::pvt;
 
 #if USE_PARTIO
 #include <Partio.h>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #endif
 
 
@@ -47,7 +47,7 @@ public:
     ~PointCloud ();
     static PointCloud *get (ustring filename, bool write = false);
 
-    typedef boost::unordered_map<ustring, std::shared_ptr<Partio::ParticleAttribute>, ustringHash> AttributeMap;
+    typedef std::unordered_map<ustring, std::shared_ptr<Partio::ParticleAttribute>, ustringHash> AttributeMap;
     // N.B./FIXME(C++11): shared_ptr is probably overkill, but
     // scoped_ptr is not copyable and therefore can't be used in
     // standard containers.  When C++11 is uniquitous, unique_ptr is the
@@ -69,7 +69,7 @@ public:
 };
 
 
-typedef boost::unordered_map<ustring, std::shared_ptr<PointCloud>, ustringHash> PointCloudMap;
+typedef std::unordered_map<ustring, std::shared_ptr<PointCloud>, ustringHash> PointCloudMap;
 // See above note about shared_ptr vs unique_ptr.
 static PointCloudMap pointclouds;
 static spin_mutex pointcloudmap_mutex;

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -38,8 +38,6 @@ using namespace OSL::pvt;
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 
-#include <boost/algorithm/string.hpp>
-
 
 OSL_NAMESPACE_ENTER
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -418,7 +418,7 @@ private:
     ShaderGlobals m_shaderglobals;        ///< Dummy ShaderGlobals
 
     // Keep track of some things for the whole shader group:
-    typedef boost::unordered_map<ustring,ustring,ustringHash> ustringmap_t;
+    typedef std::unordered_map<ustring,ustring,ustringHash> ustringmap_t;
     std::vector<ustringmap_t> m_params_holding_globals;
                    ///< Which params of each layer really just hold globals
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -32,12 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <set>
 
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 104900
-# include <boost/container/flat_map.hpp>
-# include <boost/container/flat_set.hpp>
-# define USE_FLAT_MAP 1
-#endif
+#include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
+#define USE_FLAT_MAP 1
 
 #include "oslexec_pvt.h"
 using namespace OSL;

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -31,8 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <fstream>
 #include <cstdlib>
-
-#include <boost/bind.hpp>
+#include <functional>
 
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
@@ -72,10 +71,10 @@ shade_image (ShadingSystem &shadingsys, ShaderGroup &group,
     if (nthreads != 1 && roi.npixels() >= 64*64) {
         // Parallelize
         OIIO::ImageBufAlgo::parallel_image (
-            boost::bind (shade_image, boost::ref(shadingsys),
-                         boost::ref(group), defaultsg,
-                         boost::ref(buf), outputs, shadelocations,
-                         _1 /*roi*/, 1 /*nthreads*/),
+            std::bind (shade_image, std::ref(shadingsys),
+                         std::ref(group), defaultsg,
+                         std::ref(buf), outputs, shadelocations,
+                         std::placeholders::_1 /*roi*/, 1 /*nthreads*/),
             roi, nthreads);
         return true;
     }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <cstdlib>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
 
 #include "oslexec_pvt.h"

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 
 #include "oslexec_pvt.h"
@@ -1490,7 +1489,7 @@ ShadingSystemImpl::error (const std::string &msg) const
 {
     lock_guard guard (m_errmutex);
     int n = 0;
-    BOOST_FOREACH (std::string &s, m_errseen) {
+    for (auto&& s : m_errseen) {
         if (s == msg)
             return;
         ++n;
@@ -1508,7 +1507,7 @@ ShadingSystemImpl::warning (const std::string &msg) const
 {
     lock_guard guard (m_errmutex);
     int n = 0;
-    BOOST_FOREACH (std::string &s, m_warnseen) {
+    for (auto&& s : m_warnseen) {
         if (s == msg)
             return;
         ++n;
@@ -2645,25 +2644,25 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group,
 
     // Copy some info recorted by the RuntimeOptimizer into the group
     group.m_unknown_textures_needed = rop.m_unknown_textures_needed;
-    BOOST_FOREACH (ustring f, rop.m_textures_needed)
+    for (auto&& f : rop.m_textures_needed)
         group.m_textures_needed.push_back (f);
     group.m_unknown_closures_needed = rop.m_unknown_closures_needed;
-    BOOST_FOREACH (ustring f, rop.m_closures_needed)
+    for (auto&& f : rop.m_closures_needed)
         group.m_closures_needed.push_back (f);
-    BOOST_FOREACH (ustring f, rop.m_globals_needed)
+    for (auto&& f : rop.m_globals_needed)
         group.m_globals_needed.push_back (f);
     size_t num_userdata = rop.m_userdata_needed.size();
     group.m_userdata_names.reserve (num_userdata);
     group.m_userdata_types.reserve (num_userdata);
     group.m_userdata_offsets.resize (num_userdata, 0);
     group.m_userdata_derivs.reserve (num_userdata);
-    BOOST_FOREACH (const UserDataNeeded& n, rop.m_userdata_needed) {
+    for (auto&& n : rop.m_userdata_needed) {
         group.m_userdata_names.push_back (n.name);
         group.m_userdata_types.push_back (n.type);
         group.m_userdata_derivs.push_back (n.derivs);
     }
     group.m_unknown_attributes_needed = rop.m_unknown_attributes_needed;
-    BOOST_FOREACH (const AttributeNeeded &f, rop.m_attributes_needed) {
+    for (auto&& f : rop.m_attributes_needed) {
         group.m_attributes_needed.push_back (f.name);
         group.m_attribute_scopes.push_back (f.scope);
     }

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -33,8 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 
-#include <boost/scoped_ptr.hpp>
-
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
 #include <memory>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <OpenImageIO/ustring.h>
 #include "OSL/oslexec.h"
 
@@ -95,7 +95,7 @@ private:
     typedef bool (SimpleRenderer::*AttrGetter)(ShaderGlobals *sg, bool derivs,
                                                ustring object, TypeDesc type,
                                                ustring name, void *val);
-    typedef boost::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
+    typedef std::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include <boost/thread.hpp>
-#include <boost/ref.hpp>
 
 #include "OSL/oslexec.h"
 #include "simplerend.h"
@@ -662,7 +661,7 @@ int main (int argc, const char *argv[]) {
     // launch a scanline worker for each thread
     boost::thread_group workers;
     for (int i = 0; i < num_threads; i++)
-        workers.add_thread(new boost::thread(scanline_worker, boost::ref(scanline_counter), boost::ref(pixels)));
+        workers.add_thread(new boost::thread(scanline_worker, std::ref(scanline_counter), std::ref(pixels)));
     workers.join_all();
 
     // Write image to disk

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
 #include <memory>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <OpenImageIO/ustring.h>
 #include "OSL/oslexec.h"
 
@@ -98,7 +98,7 @@ private:
     typedef bool (SimpleRenderer::*AttrGetter)(ShaderGlobals *sg, bool derivs,
                                                ustring object, TypeDesc type,
                                                ustring name, void *val);
-    typedef boost::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
+    typedef std::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters


### PR DESCRIPTION
I've waited a long time for this flurry of adjustments to 'master', now that we are safely assuming a base of C++11 minimum, Boost minimum 1.55 per VFXPlatform's guidelines (as far back as CY2015), and also our stated intention for OSL master/1.9 to require a minimum OpenImageIO version of 1.7 (which is the current supported release, so seems safe).

In the process, a whole bunch of our Boost use disappears, in favor of C++11 std and modern OIIO wrappers:

* BOOST_FOREACH -> C++11 "range for"
* boost::unordered_map and unordered_set -> std
* boost string algorithms -> OIIO Strutil utilities
* boost::bind and ref -> std
* boost::filesystem -> OIIO Filesystem utilities
