### PR TITLE
More boost removal

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include <boost/intrusive_ptr.hpp>
 #include <OpenImageIO/refcnt.h>
 
 #include "OSL/oslcomp.h"
@@ -55,7 +54,7 @@ class TypeSpec;
 ///
 class ASTNode : public OIIO::RefCnt {
 public:
-    typedef boost::intrusive_ptr<ASTNode> ref;  ///< Ref-counted pointer to an ASTNode
+    typedef OIIO::intrusive_ptr<ASTNode> ref;  ///< Ref-counted pointer to an ASTNode
 
     /// List of all the types of AST nodes.
     ///

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -816,7 +816,7 @@ ASTNode::check_arglist (const char *funcname, ASTNode::ref arg,
             return true;
         if (*formals == '.') {  // Special case for token/value pairs
             // FIXME -- require that the tokens be string literals
-            if (arg->typespec().is_string() && arg->next() != NULL) {
+            if (arg->typespec().is_string() && arg->next()) {
                 arg = arg->next();
                 continue;
             }

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -591,7 +591,7 @@ ShadingSystemImpl::loadshader (string_view cname)
     }
     OIIO::Timer timer;
     bool ok = oso.parse_file (filename);
-    ShaderMaster::ref r = ok ? oso.master() : NULL;
+    ShaderMaster::ref r = ok ? oso.master() : nullptr;
     m_shader_masters[name] = r;
     double loadtime = timer();
     {
@@ -644,7 +644,7 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
     OSOReaderToMaster reader (*this);
     OIIO::Timer timer;
     bool ok = reader.parse_memory (buffer);
-    ShaderMaster::ref r = ok ? reader.master() : NULL;
+    ShaderMaster::ref r = ok ? reader.master() : nullptr;
     m_shader_masters[name] = r;
     double loadtime = timer();
     {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -38,7 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 
 #include <boost/regex_fwd.hpp>
-#include <boost/intrusive_ptr.hpp>
 #include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
 #include <OpenImageIO/ustring.h>
@@ -338,7 +337,7 @@ inline void stlfree (T &v)
 /// individual instances of the shader.
 class ShaderMaster : public RefCnt {
 public:
-    typedef boost::intrusive_ptr<ShaderMaster> ref;
+    typedef OIIO::intrusive_ptr<ShaderMaster> ref;
     ShaderMaster (ShadingSystemImpl &shadingsys) : m_shadingsys(shadingsys) { }
     ~ShaderMaster ();
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -45,8 +45,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <OpenImageIO/pugixml.hpp>
 #endif
 
-#include <boost/thread.hpp>
-
 #include "OSL/oslexec.h"
 #include "simplerend.h"
 #include "raytracer.h"
@@ -633,7 +631,7 @@ int main (int argc, const char *argv[]) {
     // validate options
     if (aa < 1) aa = 1;
     if (num_threads < 1)
-        num_threads = boost::thread::hardware_concurrency();
+        num_threads = std::thread::hardware_concurrency();
 
     // prepare background importance table (if requested)
     if (backgroundResolution > 0 && backgroundShaderID >= 0) {
@@ -659,9 +657,9 @@ int main (int argc, const char *argv[]) {
     // Create shared counter to iterate over one scanline at a time
     Counter scanline_counter(errhandler, yres, "Rendering");
     // launch a scanline worker for each thread
-    boost::thread_group workers;
+    OIIO::thread_group workers;
     for (int i = 0; i < num_threads; i++)
-        workers.add_thread(new boost::thread(scanline_worker, std::ref(scanline_counter), std::ref(pixels)));
+        workers.add_thread(new std::thread (scanline_worker, std::ref(scanline_counter), std::ref(pixels)));
     workers.join_all();
 
     // Write image to disk

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -33,14 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <cmath>
 
-#include <boost/thread.hpp>
-
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/timer.h>
 
@@ -1081,7 +1080,7 @@ test_shade (int argc, const char *argv[])
         test_group_attributes (shadergroup.get());
 
     if (num_threads < 1)
-        num_threads = boost::thread::hardware_concurrency();
+        num_threads = OIIO::Sysutil::hardware_concurrency();
 
     double setuptime = timer.lap ();
 
@@ -1102,7 +1101,7 @@ test_shade (int argc, const char *argv[])
             shade_region (shadergroup.get(), roi, save);
 #else
             OIIO::ImageBufAlgo::parallel_image (
-                    boost::bind (shade_region, shadergroup.get(), _1, save),
+                    std::bind (shade_region, shadergroup.get(), std::placeholders::_1, save),
                     roi, num_threads);
 #endif
         }


### PR DESCRIPTION
New changes in this patch:

* boost::intrusive_ptr -> OIIO::intrusive_ptr (we could've done this a while back probably, but it's trivial now that we've bumped master's minimum OIIO version)

* boost thread, bind -> std + OIIO thread utils

After this patch is applied, our ONLY direct boost use in OSL is:
* boost::wave (for oslc's C preprocessor)
* boost's flat_map and flat_set containers (header only, fast)
* boost's thread-specific pointer (very handy, and equivalent is not yet in std::thread)
* boost::regex (only because std::regex is incompletely implemented prior to gcc 4.9, so we'll remove this next year if VFXPlatform moves to gcc 4.9 or beyond)

That's getting pretty minimal, and none of it is in the public APIs.
