### PR TITLE
Remove direct reference to tinyformat in lieu of C++11 variadic templates

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -164,11 +164,18 @@ private:
     std::vector<Parameter> m_meta;     ///< Meta-data about the shader
     friend class pvt::OSOReaderQuery;
 
+#if OIIO_VERSION >= 10803
     /// Internal error reporting routine, with printf-like arguments.
-    /// void error (const char *message, ...) const
+    template<typename... Args>
+    inline void error (string_view fmt, const Args&... args) const {
+        append_error(OIIO::Strutil::format (fmt, args...));
+    }
+#else
+    // Fallback for older OIIO
     TINYFORMAT_WRAP_FORMAT (void, error, const,
-        std::ostringstream msg;, msg, append_error(msg.str());)
-    void append_error (string_view message) const {
+                            std::ostringstream msg;, msg, append_error(msg.str());)
+#endif
+    void append_error (const std::string& message) const {
         if (m_error.size())
             m_error += '\n';
         m_error += message;

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -843,7 +843,11 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename,
         // %argderivs documents which arguments have derivs taken of
         // them by the op.
         if (op->argtakesderivs_all()) {
+#if OIIO_VERSION >= 10803
             oso (" %%argderivs{");
+#else
+            oso (" %cargderivs{", '%');  // trick to work with older OIIO
+#endif
             int any = 0;
             for (int i = 0;  i < op->nargs();  ++i)
                 if (op->argtakesderivs(i)) {

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -323,8 +323,15 @@ private:
     void write_oso_const_value (const ConstantSymbol *sym) const;
     void write_oso_symbol (const Symbol *sym);
     void write_oso_metadata (const ASTNode *metanode) const;
-    // void oso (const char *fmt, ...) const;
+
+#if OIIO_VERSION >= 10803
+    template<typename... Args>
+    inline void oso (string_view fmt, const Args&... args) const {
+        (*m_osofile) << OIIO::Strutil::format (fmt, args...);
+    }
+#else
     TINYFORMAT_WRAP_FORMAT (void, oso, const, , (*m_osofile), )
+#endif
 
     void track_variable_lifetimes () {
         track_variable_lifetimes (m_ircode, m_opargs, symtab().allsyms());

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -501,7 +501,32 @@ public:
                       TypeDesc type, const void *val);
 
     // Internal error, warning, info, and message reporting routines that
-    // take printf-like arguments.  Based on Tinyformat.
+    // take printf-like arguments.
+#if OIIO_VERSION >= 10803
+    template<typename T1, typename... Args>
+    inline void error (string_view fmt, const T1& v1, const Args&... args) const {
+        error (Strutil::format (fmt, v1, args...));
+    }
+    void error (const std::string &message) const;
+
+    template<typename T1, typename... Args>
+    inline void warning (string_view fmt, const T1& v1, const Args&... args) const {
+        warning (Strutil::format (fmt, v1, args...));
+    }
+    void warning (const std::string &message) const;
+
+    template<typename T1, typename... Args>
+    inline void info (string_view fmt, const T1& v1, const Args&... args) const {
+        info (Strutil::format (fmt, v1, args...));
+    }
+    void info (const std::string &message) const;
+
+    template<typename T1, typename... Args>
+    inline void message (string_view fmt, const T1& v1, const Args&... args) const {
+        message (Strutil::format (fmt, v1, args...));
+    }
+    void message (const std::string &message) const;
+#else
     TINYFORMAT_WRAP_FORMAT (void, error, const,
                             std::ostringstream msg;, msg, error(msg.str());)
     TINYFORMAT_WRAP_FORMAT (void, warning, const,
@@ -510,13 +535,11 @@ public:
                             std::ostringstream msg;, msg, info(msg.str());)
     TINYFORMAT_WRAP_FORMAT (void, message, const,
                             std::ostringstream msg;, msg, message(msg.str());)
-
-    /// Error reporting routines that take a pre-formatted string only.
-    ///
     void error (const std::string &message) const;
     void warning (const std::string &message) const;
     void info (const std::string &message) const;
     void message (const std::string &message) const;
+#endif
 
     std::string getstats (int level=1) const;
 
@@ -1694,6 +1717,27 @@ public:
     // Process all the recorded errors, warnings, printfs
     void process_errors () const;
 
+#if OIIO_VERSION >= 10803
+    template<typename... Args>
+    inline void error (string_view fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_ERROR, Strutil::format (fmt, args...));
+    }
+
+    template<typename... Args>
+    inline void warning (string_view fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_WARNING, Strutil::format (fmt, args...));
+    }
+
+    template<typename... Args>
+    inline void info (string_view fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_INFO, Strutil::format (fmt, args...));
+    }
+
+    template<typename... Args>
+    inline void message (string_view fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_MESSAGE, Strutil::format (fmt, args...));
+    }
+#else
     TINYFORMAT_WRAP_FORMAT (void, error, const,
                             std::ostringstream msg;, msg,
                             record_error(ErrorHandler::EH_ERROR, msg.str());)
@@ -1706,6 +1750,7 @@ public:
     TINYFORMAT_WRAP_FORMAT (void, message, const,
                             std::ostringstream msg;, msg,
                             record_error(ErrorHandler::EH_MESSAGE, msg.str());)
+#endif
 
 private:
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -153,9 +153,17 @@ public:
     int turn_into_nop (int begin, int end, string_view why=NULL);
 
     void debug_opt_impl (string_view message) const;
+#if OIIO_VERSION >= 10803
+    template<typename... Args>
+    inline void debug_opt (string_view fmt, const Args&... args) const {
+        debug_opt_impl (Strutil::format (fmt, args...));
+    }
+#else
     TINYFORMAT_WRAP_FORMAT (void, debug_opt, const,
                             std::ostringstream msg;, msg,
                             debug_opt_impl(msg.str());)
+#endif
+
     void debug_opt_ops (int opbegin, int opend, string_view message) const;
     void debug_turn_into (const Opcode &op, int numops,
                           string_view newop, int newarg0,


### PR DESCRIPTION
Goes along with (and is necessary for) https://github.com/OpenImageIO/oiio/pull/1619

but this change should work fine with OIIO before this change as well.
