### PR TITLE
Use std::regex any time it is available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,27 @@ if (NOT USE_SIMD STREQUAL "")
     endif ()
 endif ()
 
+
+# Test for features
+if (NOT VERBOSE)
+    set (CMAKE_REQUIRED_QUIET 1)
+endif ()
+include (CMakePushCheckState)
+include (CheckCXXSourceRuns)
+
+check_cxx_source_runs("
+      #include <regex>
+      int main() {
+          return std::regex_match(\"abc\", std::regex(\"(a)(.*)\")) ? 0 : 1;
+      }"
+      USE_STD_REGEX)
+if (USE_STD_REGEX)
+    add_definitions (-DUSE_STD_REGEX)
+else ()
+    add_definitions (-DUSE_BOOST_REGEX)
+endif ()
+
+
 # Set the default namespace
 if (OSL_NAMESPACE)
     add_definitions ("-DOSL_NAMESPACE=${OSL_NAMESPACE}")

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -73,7 +73,7 @@ ifeq ($(SP_OS), rhel7)
 	-DBoost_VERSION=${CONSTRUCTED_BOOSTVERS} \
 	-DBoost_INCLUDE_DIRS=/usr/include/boost_${BOOSTVERSSP} \
 	-DBoost_LIBRARY_DIRS=/usr/lib64/boost_${BOOSTVERS} \
-	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_wave-gcc48-mt${BOOSTVERS_SUFFIX}.so"
+	-DBoost_LIBRARIES:STRING="/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_filesystem-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_regex-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_system-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_thread-gcc48-mt${BOOSTVERS_SUFFIX}.so;/usr/lib64/boost_${BOOSTVERSSP}/libspboost_${BOOSTVERS_PREFIX}_wave-gcc48-mt${BOOSTVERS_SUFFIX}.so"
 
     # end rhel7
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -72,10 +72,12 @@ if (BOOST_CUSTOM)
     # N.B. For a custom version, the caller had better set up the variables
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
-    set (Boost_COMPONENTS filesystem regex system thread wave)
+    set (Boost_COMPONENTS filesystem system thread wave)
+    if (NOT USE_STD_REGEX)
+        list (APPEND Boost_COMPONENTS regex)
+    endif ()
     find_package (Boost 1.55 REQUIRED
-                  COMPONENTS ${Boost_COMPONENTS}
-                 )
+                  COMPONENTS ${Boost_COMPONENTS})
 endif ()
 
 # On Linux, Boost 1.55 and higher seems to need to link against -lrt

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -30,8 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <cstdlib>
 
-#include <boost/regex.hpp>
-
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/sysutil.h>
 
@@ -1430,8 +1428,8 @@ DECLFOLDER(constfold_regex_search)
         DASSERT (Subj.typespec().is_string() && Reg.typespec().is_string());
         const ustring &s (*(ustring *)Subj.data());
         const ustring &r (*(ustring *)Reg.data());
-        boost::regex reg (r.string());
-        int result = boost::regex_search (s.string(), reg);
+        regex reg (r.string());
+        int result = regex_search (s.string(), reg);
         int cind = rop.add_constant (result);
         rop.turn_into_assign (op, cind, "const fold regex_search");
         return 1;

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -30,8 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstdio>
 
-#include <boost/regex.hpp>
-
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
@@ -61,9 +59,6 @@ ShadingContext::~ShadingContext ()
 {
     process_errors ();
     m_shadingsys.m_stat_contexts -= 1;
-    for (RegexMap::iterator it = m_regex_map.begin(); it != m_regex_map.end(); ++it) {
-      delete it->second;
-    }
     free_dict_resources ();
 }
 
@@ -301,14 +296,14 @@ ShadingContext::symbol_data (const Symbol &sym) const
 
 
 
-const boost::regex &
+const regex &
 ShadingContext::find_regex (ustring r)
 {
     RegexMap::const_iterator found = m_regex_map.find (r);
     if (found != m_regex_map.end())
         return *found->second;
     // otherwise, it wasn't found, add it
-    m_regex_map[r] = new boost::regex(r.c_str());
+    m_regex_map[r].reset (new regex(r.c_str()));
     m_shadingsys.m_stat_regexes += 1;
     // std::cerr << "Made new regex for " << r << "\n";
     return *m_regex_map[r];

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -41,7 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "oslexec_pvt.h"
 
-#include <boost/regex.hpp>
 
 #define USTR(cstr) (*((ustring *)&cstr))
 
@@ -137,12 +136,12 @@ osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     ShadingContext *ctx = sg->context;
     const std::string &subject (ustring::from_unique(subject_).string());
-    boost::match_results<std::string::const_iterator> mresults;
-    const boost::regex &regex (ctx->find_regex (USTR(pattern)));
+    match_results<std::string::const_iterator> mresults;
+    const regex &regex (ctx->find_regex (USTR(pattern)));
     if (nresults > 0) {
         std::string::const_iterator start = subject.begin();
-        int res = fullmatch ? boost::regex_match (subject, mresults, regex)
-                            : boost::regex_search (subject, mresults, regex);
+        int res = fullmatch ? regex_match (subject, mresults, regex)
+                            : regex_search (subject, mresults, regex);
         int *m = (int *)results;
         for (int r = 0;  r < nresults;  ++r) {
             if (r/2 < (int)mresults.size()) {
@@ -156,8 +155,8 @@ osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
         }
         return res;
     } else {
-        return fullmatch ? boost::regex_match (subject, regex)
-                         : boost::regex_search (subject, regex);
+        return fullmatch ? regex_match (subject, regex)
+                         : regex_search (subject, regex);
     }
 }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -37,13 +37,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <unordered_map>
 
-#include <boost/regex_fwd.hpp>
 #include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/refcnt.h>
+
+#ifdef USE_BOOST_REGEX
+# include <boost/regex.hpp>
+#else
+# include <regex>
+#endif
 
 #include "OSL/genclosure.h"
 #include "OSL/oslexec.h"
@@ -68,6 +73,19 @@ namespace Strutil = OIIO::Strutil;
 
 
 OSL_NAMESPACE_ENTER
+
+
+#ifdef USE_BOOST_REGEX
+  using boost::regex;
+  using boost::regex_search;
+  using boost::regex_match;
+  using boost::match_results;
+#else
+  using std::regex;
+  using std::regex_search;
+  using std::regex_match;
+  using std::match_results;
+#endif
 
 
 
@@ -1628,7 +1646,7 @@ public:
     /// Return a reference to a compiled regular expression for the
     /// given string, being careful to cache already-created ones so we
     /// aren't constantly compiling new ones.
-    const boost::regex & find_regex (ustring r);
+    const regex & find_regex (ustring r);
 
     /// Return a pointer to the shading group for this context.
     ///
@@ -1762,7 +1780,7 @@ private:
     mutable TextureSystem::Perthread *m_texture_thread_info; ///< Ptr to texture thread info
     ShaderGroup *m_group;               ///< Ptr to shader group
     std::vector<char> m_heap;           ///< Heap memory
-    typedef std::unordered_map<ustring, boost::regex*, ustringHash> RegexMap;
+    typedef std::unordered_map<ustring, std::unique_ptr<regex>, ustringHash> RegexMap;
     RegexMap m_regex_map;               ///< Compiled regex's
     MessageList m_messages;             ///< Message blackboard
     int m_max_warnings;                 ///< To avoid processing too many warnings


### PR DESCRIPTION
On the currently supported compilers, we believe the only time we
need to fall back to boost::regex is for g++ 4.8.x.

Also change the ShadingContext::m_regex_map to use unique_ptr<>
so that the allocated regexes free upon destruction without needing
an explicit loop and delete calls.