### PR TITLE
Use clang's C preprocessor as alternative to Boost Wave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ addons:
       - cmake-data
       - gcc-4.8
       - g++-4.8
-      - gcc-6
-      - g++-6
       - libboost1.55-all-dev
       - libtiff4-dev
       #- llvm-3.9-dev
@@ -115,21 +113,37 @@ matrix:
       - os: linux
         compiler: gcc
         env: DEBUG=1
-      - os: osx
-        compiler: clang
-        env: DEBUG=1
+      # - os: osx
+      #   compiler: clang
+      #   env: DEBUG=1
     # Test against the older release branch of OIIO (all the other tests
     # are against OIIO master).
       - os: linux
         compiler: gcc
         env: OIIOBRANCH=release USE_CPP11=1
-      - os: osx
-        compiler: clang
-        env: OIIOBRANCH=release USE_CPP11=1
+      # - os: osx
+      #   compiler: clang
+      #   env: OIIOBRANCH=release USE_CPP11=1
     # Make sure the older LLVM still works
       - os: linux
         compiler: gcc
         env: LLVM_VERSION=3.5.2
+    # Linux only: test gcc 4.9
+      - os: linux
+        compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-4.9', 'cmake', 'cmake-data', 'libboost1.55-all-dev', 'libtiff4-dev' ]
+        env: WHICHGCC=4.9
+    # Linux only: test gcc 5
+      - os: linux
+        compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-5', 'cmake', 'cmake-data', 'libboost1.55-all-dev', 'libtiff4-dev' ]
+        env: WHICHGCC=5
     # Linux only: test gcc 6 (catch new warnings hot off the presses) and
     # also use a higher SIMD level, avx and f16c, to make sure all is well.
     # TravisCI's OSX images don't yet support avx/f16c, so we only do this
@@ -137,7 +151,19 @@ matrix:
     # into separate tests.
       - os: linux
         compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-6', 'cmake', 'cmake-data', 'libboost1.55-all-dev', 'libtiff4-dev' ]
         env: WHICHGCC=6 USE_SIMD=avx,f16c
+    # Test new gcc against older LLVM
+      - os: linux
+        compiler: gcc
+        addons:
+          apt:
+            sources: [ 'ubuntu-toolchain-r-test', 'boost-latest', 'george-edison55-precise-backports' ]
+            packages: [ 'g++-6', 'cmake', 'cmake-data', 'libboost1.55-all-dev', 'libtiff4-dev' ]
+        env: WHICHGCC=6 USE_SIMD=avx,f16c LLVM_VERSION=3.5.2
     # One more, just for the heck of it, turn all SIMD off.  I guess this
     # should/could be both platforms, but in the interest of making the
     # tests go faster, don't bother doing it on OSX.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set (OSL_NO_DEFAULT_TEXTURESYSTEM OFF CACHE BOOL "Do not use create a raw OIIO::
 set (OSL_BUILD_PLUGINS ON CACHE BOOL "Bool OSL plugins, for example OIIO plugin")
 set (USE_CCACHE ON CACHE BOOL "Use ccache if found")
 set (CODECOV OFF CACHE BOOL "Build code coverage tests")
+option (USE_BOOST_WAVE "Use Boost Wave for C preprocessor (alternative is to use clang)" OFF)
 
 # Use ccache if found
 find_program (CCACHE_FOUND ccache)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,13 @@ OSL currently compiles and runs cleanly on Linux, Mac OS X, and Windows.
 Dependencies
 ------------
 
-OSL requires the following dependencies:
+OSL requires the following dependencies or tools:
+
+* A suitable C++11 compiler to build OSL itself, which may be any of:
+   - GCC 4.8.5 or newer
+   - Clang 3.4 or newer
+   - Microsoft Visual Studio 2015 or newer
+   - Intel C++ compiler icc version 13 (?) or newer
 
 * [OpenImageIO](http://openimageio.org) 1.7 or newer
 
@@ -36,10 +42,18 @@ OSL requires the following dependencies:
    JIT may be important for interactive applications). We anticipate that
    future OSL releases will improve JIT performance and then drop support
    for the older LLVM versions.
+
+   Optionally, if Clang libraries are installed alongside LLVM, OSL will
+   in most circumstances use Clang's internals for C-style preprocessing of
+   OSL source. If not found, it will fall back on Boost Wave (but on many
+   platforms, that requires that Boost has been built in C++11 mode).
+
 * [Boost](www.boost.org) 1.55 or newer.
 * [Imath/OpenEXR](http://openexr.com/downloads.html)
 * [Flex](https://github.com/westes/flex)
 * [GNU Bison](https://www.gnu.org/software/bison/)
+* [PugiXML](http://pugixml.org/)
+
 
 
 Build process

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ ifneq (${USE_LLVM_BITCODE},)
 MY_CMAKE_FLAGS += -DUSE_LLVM_BITCODE:BOOL=${USE_LLVM_BITCODE}
 endif
 
+ifneq (${USE_BOOST_WAVE},)
+MY_CMAKE_FLAGS += -DUSE_BOOST_WAVE:BOOL=${USE_BOOST_WAVE}
+endif
+
 ifneq (${NAMESPACE},)
 MY_CMAKE_FLAGS += -DOSL_NAMESPACE:STRING=${NAMESPACE}
 endif
@@ -347,10 +351,11 @@ help:
 	@echo "      LLVM_NAMESPACE=xx        Specify custom LLVM namespace"
 	@echo "      LLVM_STATIC=1            Use static LLVM libraries"
 	@echo "      USE_LLVM_BITCODE=0       Don't generate embedded LLVM bitcode"
+	@echo "      USE_BOOST_WAVE=1         Force boost wave rather than clang preprocessor"
 	@echo "  OSL build-time options:"
 	@echo "      NAMESPACE=name           Wrap OSL APIs in another namespace"
 	@echo "      USE_FAST_MATH=1          Use faster, but less accurate math (set to 0 for libm defaults)"
-	@echo "      OSL_BUILD_TESTS=0        Skip building the unit tests, testshade, testrender"
+	@echo "      OSL_BUILD_TESTS=0        Don't build unit tests, testshade, testrender"
 	@echo "      USE_SIMD=arch            Build with SIMD support (choices: 0, sse2, sse3,"
 	@echo "                                  ssse3, sse4.1, sse4.2, f16c,"
 	@echo "                                  comma-separated ok)"

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -91,10 +91,12 @@ else ifeq (${platform}, macosx)
     # clang from the site-specific places we have installed them.
     ifeq (${COMPILER}, gcc5)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/usr/local/bin/gcc-5 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-5
+           -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER}, gcc6)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/usr/local/bin/gcc-6 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-6
+           -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6
+        USE_LIBCPLUSPLUS := 0
     else ifeq (${COMPILER},clang35)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang-3.5 -DCMAKE_CXX_COMPILER=clang++-3.5
     else ifeq (${COMPILER},clang38)

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -8,6 +8,8 @@
 #  LLVM_SYSTEM_LIBRARIES - additional libraries needed by LLVM
 #  LLVM_DIRECTORY   - If not already set, the root of the LLVM install
 #  LLVM_LIB_DIR     - where to find llvm libs
+#  CLANG_LIBRARIES  - list of libraries for clang components (optional,
+#                        those may not be found)
 #
 # The following input symbols may be used to help guide the search:
 #  LLVM_DIRECTORY   - the root of the LLVM installation (if custom)
@@ -66,6 +68,19 @@ find_library ( LLVM_MCJIT_LIBRARY
                NAMES LLVMMCJIT
                PATHS ${LLVM_LIB_DIR})
 
+
+foreach (COMPONENT clangFrontend clangDriver clangSerialization
+                   clangParse clangSema clangAnalysis clangAST clangBasic
+                   clangEdit clangLex)
+    find_library ( _CLANG_${COMPONENT}_LIBRARY
+                  NAMES ${COMPONENT}
+                  PATHS ${LLVM_LIB_DIR})
+    if (_CLANG_${COMPONENT}_LIBRARY)
+        list (APPEND CLANG_LIBRARIES ${_CLANG_${COMPONENT}_LIBRARY})
+    endif ()
+endforeach ()
+
+
 # if (NOT LLVM_LIBRARY)
 #     execute_process (COMMAND ${LLVM_CONFIG} --libfiles engine
 #                      OUTPUT_VARIABLE LLVM_LIBRARIES
@@ -100,11 +115,12 @@ find_package_handle_standard_args (LLVM
 if (LLVM_FOUND)
     message (STATUS "LLVM version  = ${LLVM_VERSION}")
     if (NOT LLVM_FIND_QUIETLY)
-        message (STATUS "LLVM dir       = ${LLVM_DIRECTORY}")
-        message (STATUS "LLVM includes  = ${LLVM_INCLUDES}")
-        message (STATUS "LLVM lib dir   = ${LLVM_LIB_DIR}")
-        message (STATUS "LLVM libraries = ${LLVM_LIBRARIES}")
-        message (STATUS "LLVM sys libs  = ${LLVM_SYSTEM_LIBRARIES}")
+        message (STATUS "LLVM dir        = ${LLVM_DIRECTORY}")
+        message (STATUS "LLVM includes   = ${LLVM_INCLUDES}")
+        message (STATUS "LLVM lib dir    = ${LLVM_LIB_DIR}")
+        message (STATUS "LLVM libraries  = ${LLVM_LIBRARIES}")
+        message (STATUS "LLVM sys libs   = ${LLVM_SYSTEM_LIBRARIES}")
+        message (STATUS "Clang libraries = ${CLANG_LIBRARIES}")
     endif ()
 else()
     message (STATUS "LLVM not found. Specify LLVM_DIRECTORY to locate it.")

--- a/src/include/OSL/oslversion.h.in
+++ b/src/include/OSL/oslversion.h.in
@@ -81,10 +81,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef OSL_NAMESPACE
 // Macros to use in each file to enter and exit the right name spaces.
 #define OSL_NAMESPACE_ENTER namespace OSL_NAMESPACE { namespace OSL {
-#define OSL_NAMESPACE_EXIT }; }; using namespace OSL_NAMESPACE;
+#define OSL_NAMESPACE_EXIT } } using namespace OSL_NAMESPACE;
 #else
 #define OSL_NAMESPACE_ENTER namespace OSL {
-#define OSL_NAMESPACE_EXIT };
+#define OSL_NAMESPACE_EXIT }
 #endif
 
 #define OSL_BUILD_CPP11 1 /* Always build for C++ >= 11 */

--- a/src/liboslcomp/CMakeLists.txt
+++ b/src/liboslcomp/CMakeLists.txt
@@ -21,7 +21,9 @@ else ()
 endif ()
 
 TARGET_LINK_LIBRARIES ( oslcomp ${OPENIMAGEIO_LIBRARIES} ${ILMBASE_LIBRARIES}
-                       ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+                       ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
+                       ${CLANG_LIBRARIES} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
+                       ${LLVM_SYSTEM_LIBRARIES})
 
 INSTALL ( TARGETS oslcomp RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib )
 

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -37,16 +37,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "oslcomp_pvt.h"
 
-#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/platform.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/thread.h>
 
-#include <boost/wave.hpp>
-#include <boost/wave/cpplexer/cpp_lex_token.hpp>
-#include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
+#ifndef USE_BOOST_WAVE
+# define USE_BOOST_WAVE 0
+#endif
+#if USE_BOOST_WAVE
+# include <boost/wave.hpp>
+# include <boost/wave/cpplexer/cpp_lex_token.hpp>
+# include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
+#else
+# if !defined(__STDC_CONSTANT_MACROS)
+#   define __STDC_CONSTANT_MACROS 1
+# endif
+# include <clang/Frontend/CompilerInstance.h>
+# include <clang/Frontend/TextDiagnosticPrinter.h>
+# include <clang/Frontend/Utils.h>
+# include <clang/Basic/TargetInfo.h>
+# include <clang/Lex/PreprocessorOptions.h>
+# include <llvm/Support/ToolOutputFile.h>
+# include <llvm/Support/Host.h>
+# include <llvm/Support/MemoryBuffer.h>
+# include <llvm/Support/raw_ostream.h>
+#endif
 
 
 OSL_NAMESPACE_ENTER
@@ -195,6 +213,8 @@ OSLCompilerImpl::preprocess_file (const std::string &filename,
 
 
 
+#if USE_BOOST_WAVE
+
 bool
 OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
                                     const std::string &filename,
@@ -286,6 +306,110 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     return true;
 }
+
+
+#else /* LLVM: vvvvvvvvvv */
+
+bool
+OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
+                                    const std::string &filename,
+                                    const std::string &stdoslpath,
+                                    const std::vector<std::string> &defines,
+                                    const std::vector<std::string> &includepaths,
+                                    std::string &result)
+{
+    std::string instring;
+    if (!stdoslpath.empty())
+        instring = OIIO::Strutil::format("#include \"%s\"\n", stdoslpath);
+    else
+        instring = "\n";
+    instring += buffer;
+    std::unique_ptr<llvm::MemoryBuffer> mbuf (llvm::MemoryBuffer::getMemBuffer(instring, filename));
+
+    clang::CompilerInstance inst;
+
+#if 1
+    inst.createDiagnostics();
+#else
+    // I think these are unnecessary?
+    llvm::raw_fd_ostream stderrRaw(2, false);
+    clang::DiagnosticOptions *diagOptions = new clang::DiagnosticOptions();
+    clang::TextDiagnosticPrinter *diagPrinter =
+        new clang::TextDiagnosticPrinter(stderrRaw, diagOptions);
+    llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagIDs(new clang::DiagnosticIDs);
+    clang::DiagnosticsEngine *diagEngine =
+        new clang::DiagnosticsEngine(diagIDs, diagOptions, diagPrinter);
+    inst.setDiagnostics(diagEngine);
+#endif
+
+#if OSL_LLVM_VERSION <= 34
+    clang::TargetOptions &targetopts = inst.getTargetOpts();
+    targetopts.Triple = llvm::sys::getDefaultTargetTriple();
+    clang::TargetInfo *target =
+        clang::TargetInfo::CreateTargetInfo(inst.getDiagnostics(), &targetopts);
+#else // LLVM 3.5+
+    const std::shared_ptr<clang::TargetOptions> &targetopts =
+          std::make_shared<clang::TargetOptions>(inst.getTargetOpts());
+    targetopts->Triple = llvm::sys::getDefaultTargetTriple();
+    clang::TargetInfo *target =
+        clang::TargetInfo::CreateTargetInfo(inst.getDiagnostics(), targetopts);
+#endif
+
+    inst.setTarget(target);
+
+    inst.createFileManager();
+    inst.createSourceManager(inst.getFileManager());
+#if OSL_LLVM_VERSION <= 35
+    clang::FrontendInputFile inputFile(mbuf.release(), clang::IK_None);
+    inst.InitializeSourceManager(inputFile);
+#else
+    clang::SourceManager &sm = inst.getSourceManager();
+    sm.setMainFileID (sm.createFileID(std::move(mbuf), clang::SrcMgr::C_User));
+#endif
+
+    inst.getPreprocessorOutputOpts().ShowCPP = 1;
+    inst.getPreprocessorOutputOpts().ShowMacros = 0;
+
+    clang::HeaderSearchOptions &headerOpts = inst.getHeaderSearchOpts();
+    headerOpts.UseBuiltinIncludes = 0;
+    headerOpts.UseStandardSystemIncludes = 0;
+    headerOpts.UseStandardCXXIncludes = 0;
+    std::string directory = OIIO::Filesystem::parent_path(filename);
+    if (directory.empty())
+        directory = OIIO::Filesystem::current_path();
+    headerOpts.AddPath (directory, clang::frontend::Angled, false, true);
+    for (auto&& inc : includepaths) {
+        headerOpts.AddPath (inc, clang::frontend::Angled,
+                            false /* not a framework */,
+                            true /* ignore sys root */);
+    }
+
+    clang::PreprocessorOptions &preprocOpts = inst.getPreprocessorOpts();
+    preprocOpts.UsePredefines = 0;
+    for (auto&& d : defines) {
+        if (d[1] == 'D')
+            preprocOpts.addMacroDef (d.c_str()+2);
+        else if (d[1] == 'U')
+            preprocOpts.addMacroUndef (d.c_str()+2);
+    }
+
+    inst.getLangOpts().LineComment = 1;
+
+#if OSL_LLVM_VERSION >= 35
+    inst.createPreprocessor(clang::TU_Prefix);
+#else
+    inst.createPreprocessor();
+#endif
+
+    llvm::raw_string_ostream ostream(result);
+    // diagPrinter->BeginSourceFile (inst.getLangOpts(), &inst.getPreprocessor());
+    clang::DoPrintPreprocessedInput (inst.getPreprocessor(),
+                                     &ostream, inst.getPreprocessorOutputOpts());
+    // diagPrinter->EndSourceFile ();
+    return true;
+}
+
+#endif
 
 
 

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -151,6 +151,7 @@ TARGET_LINK_LIBRARIES ( oslexec
                         ${PUGIXML_LIBRARIES}
                         ${PARTIO_LIBRARIES} ${ZLIB_LIBRARIES}
                         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
+                        ${CLANG_LIBRARIES}
                         ${LLVM_LIBRARY} ${LLVM_MCJIT_LIBRARY}
                         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
                         ${LLVM_SYSTEM_LIBRARIES})


### PR DESCRIPTION
Boost Wave is a bit of a pain, in particular it can have problems if compiling OSL with C++11 (as is mandatory now in master) but link against a Boost that was compiled without the C++11 options.

At Chris Kulla's suggestion, we can switch to using the C preprocessing faciliies from clang's internals. Ordinarily, LLVM/clang would be much to painful to add just for this, but since we're already tied to LLVM as a dependency, it's really no additional burden.

So here we are. There's a build time cmake option USE_BOOST_WAVE, which defaults to off, but if problems are discovered with the clang cpp, that gives is a Plan B. Eventually, when we're completely confident in the way I've done it with clang, we may remove the Wave option entirely.

This is not 100% working. It seems to work fine if you are using clang as your compiler, or if you are using gcc 4.8.x, or if you are building against LLVM 3.4/3.5.  But the combination of using gcc >= 4.9 to compile and linking against LLVM >= 3.9 is resulting in crashes with complaints about double-freeing something. Surely it's our error, making a mistake about who owns what allocation or something, but I'm not sure what's wrong and I'm tired of holding up this patch for all the people and cases that it can help. So for now, for the combinations that don't run properly, it automatically falls back to using Boost Wave. We will remove this special case as soon as we figure out why it's failing in that case. (As stated earlier, you can also force use of boost wave with USE_BOOST_WAVE=1.)

Also made some changes to the Travis build matrix to cover various cases of combinations of compiler and LLVM version.