### PR TITLE
Fix clang assertion / linkage error

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -16,9 +16,6 @@ ifeq ($(SP_OS), rhel7)
     NINJA := ninja
     MY_CMAKE_FLAGS += -DCMAKE_MAKE_PROGRAM=${NINJA}
 
-    # Temporary bug fix, having problems with clang cpp, revert to Boost wave.
-    USE_BOOST_WAVE ?= 1
-
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
     LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/spinux1/llvm_3.5


### PR DESCRIPTION
On some systems, sometimes, when linking against LLVM <= 3.5 and using
clang internals for C preprocessing, we've seen assertions coming from
llvm::cl::OptionCategory::registerCategory, which we aren't even
intentionally using.

This email explains the issue:

 http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20140203/203968.html

Seems pointless to fight what appears to be an awkward mis-design in
older LLVM. The problem was fixed some time between 3.5 and 3.9.

So let's sweep it under the rug by falling back to boost wave when using
older LLVM.