### PR TITLE
More robust handling of exceptions to "useless op elision."

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -169,7 +169,7 @@ struct OpDescriptor {
         : name(n), llvmgen(ll), folder(fold), simple_assign(simple), flags(flags)
     {}
 
-    enum FlagValues { None=0, Tex=1 };
+    enum FlagValues { None=0, Tex=1, SideEffects=2 };
 };
 
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1193,12 +1193,13 @@ RuntimeOptimizer::use_stale_sym (int sym)
 
 
 bool
-RuntimeOptimizer::is_simple_assign (Opcode &op)
+RuntimeOptimizer::is_simple_assign (Opcode &op, const OpDescriptor *opd)
 {
     // Simple only if arg0 is the only write, and is write only.
     if (op.argwrite_bits() != 1 || op.argread(0))
         return false;
-    const OpDescriptor *opd = shadingsys().op_descriptor (op.opname());
+    if (! opd)
+        opd = shadingsys().op_descriptor (op.opname());
     if (!opd || !opd->simple_assign)
         return false;   // reject all other known non-simple assignments
     // Make sure the result isn't also read
@@ -2129,9 +2130,11 @@ RuntimeOptimizer::optimize_ops (int beginop, int endop,
             if (op->argread(i))
                 use_stale_sym (oparg(*op,i));
         }
+
+        const OpDescriptor *opd = shadingsys().op_descriptor (op->opname());
         // If it's a simple assignment and the lvalue is "stale", go
         // back and eliminate its last assignment.
-        if (is_simple_assign(*op))
+        if (is_simple_assign(*op, opd))
             simple_sym_assign (oparg (*op, 0), opnum);
         // Make sure there's room for several more symbols, so that we
         // can add a few consts if we need to, without worrying about
@@ -2140,7 +2143,6 @@ RuntimeOptimizer::optimize_ops (int beginop, int endop,
         // For various ops that we know how to effectively
         // constant-fold, dispatch to the appropriate routine.
         if (optimize() >= 2 && m_opt_constant_fold) {
-            const OpDescriptor *opd = shadingsys().op_descriptor (op->opname());
             if (opd && opd->folder) {
                 int c = (*opd->folder) (*this, opnum);
                 if (c) {
@@ -2161,7 +2163,8 @@ RuntimeOptimizer::optimize_ops (int beginop, int endop,
         // Now we handle assignments.
         if (optimize() >= 2 && op->opname() == u_assign && m_opt_assign)
             changed += optimize_assignment (*op, opnum);
-        if (optimize() >= 2 && m_opt_elide_useless_ops)
+        if (optimize() >= 2 && m_opt_elide_useless_ops && opd
+            && !(opd->flags & OpDescriptor::SideEffects))
             changed += useless_op_elision (*op, opnum);
         if (m_stop_optimizing)
             break;

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -244,7 +244,8 @@ public:
 
     /// Is the op a "simple" assignment (arg 0 completely overwritten,
     /// no side effects or funny business)?
-    bool is_simple_assign (Opcode &op);
+    /// Optional OpDescriptor is passed to save an extra lookup.
+    bool is_simple_assign (Opcode &op, const OpDescriptor *opd=NULL);
 
     /// Called when symbol sym is "simply" assigned at the given op.  An
     /// assignment is considered simple if it completely overwrites the

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -780,6 +780,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
                                                   constfold_##fold, simp, flag);
 #define OP(name,ll,fold,simp,flag) OP2(name,name,ll,fold,simp,flag)
 #define TEX OpDescriptor::Tex
+#define SIDE OpDescriptor::SideEffects
 
     // name          llvmgen              folder         simple     flags
     OP (aassign,     aassign,             aassign,       false,     0);
@@ -832,7 +833,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (eq,          compare_op,          eq,            true,      0);
     OP (erf,         generic,             erf,           true,      0);
     OP (erfc,        generic,             erfc,          true,      0);
-    OP (error,       printf,              none,          false,     0);
+    OP (error,       printf,              none,          false,     SIDE);
     OP (exit,        return,              none,          false,     0);
     OP (exp,         generic,             exp,           true,      0);
     OP (exp2,        generic,             exp2,          true,      0);
@@ -887,9 +888,9 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (pointcloud_search, pointcloud_search, pointcloud_search,
                                                          false,     TEX);
     OP (pointcloud_get, pointcloud_get,   pointcloud_get,false,     TEX);
-    OP (pointcloud_write, pointcloud_write, none,        false,     0);
+    OP (pointcloud_write, pointcloud_write, none,        false,     SIDE);
     OP (pow,         generic,             pow,           true,      0);
-    OP (printf,      printf,              none,          false,     0);
+    OP (printf,      printf,              none,          false,     SIDE);
     OP (psnoise,     noise,               noise,         true,      0);
     OP (radians,     generic,             radians,       true,      0);
     OP (raytype,     raytype,             raytype,       true,      0);
@@ -898,7 +899,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (return,      return,              none,          false,     0);
     OP (round,       generic,             none,          true,      0);
     OP (select,      select,              select,        true,      0);
-    OP (setmessage,  setmessage,          setmessage,    false,     0);
+    OP (setmessage,  setmessage,          setmessage,    false,     SIDE);
     OP (shl,         bitwise_binary_op,   none,          true,      0);
     OP (shr,         bitwise_binary_op,   none,          true,      0);
     OP (sign,        generic,             none,          true,      0);
@@ -925,7 +926,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (tanh,        generic,             none,          true,      0);
     OP (texture,     texture,             texture,       true,      TEX);
     OP (texture3d,   texture3d,           none,          true,      TEX);
-    OP (trace,       trace,               none,          false,     0);
+    OP (trace,       trace,               none,          false,     SIDE);
     OP (transform,   transform,           transform,     true,      0);
     OP (transformn,  transform,           transform,     true,      0);
     OP (transformv,  transform,           transform,     true,      0);
@@ -933,12 +934,13 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (trunc,       generic,             none,          true,      0);
     OP (useparam,    useparam,            useparam,      false,     0);
     OP (vector,      construct_triple,    triple,        true,      0);
-    OP (warning,     printf,              warning,       false,     0);
+    OP (warning,     printf,              warning,       false,     SIDE);
     OP (wavelength_color, blackbody,      none,          true,      0);
     OP (while,       loop_op,             none,          false,     0);
     OP (xor,         bitwise_binary_op,   xor,           true,      0);
 #undef OP
 #undef TEX
+#undef SIDE
 }
 
 


### PR DESCRIPTION
OSL's runtime optimizer tries to eliminate operations whose results are never used (people don't write shaders like this, but as we optimize and rewrite the shader's ops, many ops may reveal themselves as having no effect).

But, we don't do this with built-ins that have no written arguments at all (such as printf or setmessage), because it figures that having no immediate outputs means it's there purely for the side effects.

But -- OH NO! -- it turns out that trace() is an exception to the rule. It has a writeable output (the return value), but it ALSO has an important side effect (it sets up trade state that may later be queried by getmessage("trace")). So if you wrote a trace call and did not assign its return value to something that got used, the trace call might be eliminated entirely, which would totally bork your later getmessage queries about that traced probe ray.

So sorry.

This fix formalizes the notion that certain ops have important stateful side effects, and it will not apply the "useless op elision" optimization to those instructions.