### PR TITLE
Add OSL_LLVM_PREFIX option for prefixing names of functions invoked by LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ if (OSL_NAMESPACE)
 endif ()
 message(STATUS "Setting Namespace to: ${OSL_NAMESPACE}")
 
+if (OSL_LLVM_PREFIX)
+    add_definitions ("-DOSL_LLVM_PREFIX=${OSL_LLVM_PREFIX}")
+endif ()
+message(STATUS "Setting OSL LLVM prefix to: ${OSL_LLVM_PREFIX}")
+
 include (util_macros)
 include (externalpackages)
 include (flexbison)

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ ifneq (${NAMESPACE},)
 MY_CMAKE_FLAGS += -DOSL_NAMESPACE:STRING=${NAMESPACE}
 endif
 
+ifneq (${OSL_LLVM_PREFIX},)
+MY_CMAKE_FLAGS += -DOSL_LLVM_PREFIX:STRING=${OSL_LLVM_PREFIX}
+endif
+
 ifneq (${HIDE_SYMBOLS},)
 MY_CMAKE_FLAGS += -DHIDE_SYMBOLS:BOOL=${HIDE_SYMBOLS}
 endif
@@ -359,6 +363,7 @@ help:
 	@echo "      USE_BOOST_WAVE=1         Force boost wave rather than clang preprocessor"
 	@echo "  OSL build-time options:"
 	@echo "      NAMESPACE=name           Wrap OSL APIs in another namespace"
+	@echo "      OSL_LLVM_PREFIX=prefix   Apply prefix to names of OSL functions invoked by LLVM"
 	@echo "      USE_FAST_MATH=1          Use faster, but less accurate math (set to 0 for libm defaults)"
 	@echo "      OSL_BUILD_TESTS=0        Don't build unit tests, testshade, testrender"
 	@echo "      USE_SIMD=arch            Build with SIMD support (choices: 0, sse2, sse3,"

--- a/src/include/OSL/oslversion.h.in
+++ b/src/include/OSL/oslversion.h.in
@@ -87,6 +87,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OSL_NAMESPACE_EXIT }
 #endif
 
+// When the C++ API is wrapped in a namespace using OSL_NAMESPACE above, it may
+// also be desirable to ensure that the C free functions invoked by LLVM are
+// disambiguated as well. This can be enabled by providing a string value for
+// OSL_LLVM_PREFIX. This string will be prefixed to all free functions that may
+// be invoked via LLVM so that the right version of OSL API finds the right
+// version of the free function. If no prefix is supplied, we use an empty one.
+#ifndef OSL_LLVM_PREFIX
+#define OSL_LLVM_PREFIX
+#endif
+
+// These "internal" macros are not intended to be used anywhere other than as
+// part of the "public" OSL_LLVM_ macros below. The indirection is necessary to
+// ensure that OSL_LLVM_PREFIX is properly expanded to its value and is not
+// string-ified literally.
+#define __INTERNAL__STRINGIFY(token) #token
+#define __INTERNAL__STRINGIFY_INDIRECT(token) __INTERNAL__STRINGIFY(token)
+#define __INTERNAL__ADD_PREFIX_TO_TOKEN(prefix, token) prefix ## token
+#define __INTERNAL__ADD_PREFIX_TO_TOKEN_INDIRECT(prefix, token) __INTERNAL__ADD_PREFIX_TO_TOKEN(prefix, token)
+#define __INTERNAL__ADD_PREFIX_TO_OP(prefix, opname, signature) prefix ## osl_ ## opname ## signature
+#define __INTERNAL__ADD_PREFIX_TO_OP_INDIRECT(prefix, opname, signature) __INTERNAL__ADD_PREFIX_TO_OP(prefix, opname, signature)
+
+#define OSL_LLVM_PREFIX_AS_STRING __INTERNAL__STRINGIFY_INDIRECT(OSL_LLVM_PREFIX)
+#define OSL_LLVM_PREFIXED_STRING(stringarg) OSL_LLVM_PREFIX_AS_STRING stringarg
+#define OSL_LLVM_PREFIXED_TOKEN_AS_STRING(token) OSL_LLVM_PREFIX_AS_STRING #token
+#define OSL_LLVM_PREFIXED_TOKEN(token) __INTERNAL__ADD_PREFIX_TO_TOKEN_INDIRECT(OSL_LLVM_PREFIX, token)
+#define OSL_LLVM_OP_TOKEN(opname, signature) __INTERNAL__ADD_PREFIX_TO_OP_INDIRECT(OSL_LLVM_PREFIX, opname, signature)
+
+
 #define OSL_BUILD_CPP11 1 /* Always build for C++ >= 11 */
 // OSL_BUILD_CPP14 will be 1 if this OSL was built using C++14
 #cmakedefine01 OSL_BUILD_CPP14

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -375,7 +375,7 @@ ShadingContext::osl_get_attribute (ShaderGlobals *sg, void *objdata,
 
 
 OSL_SHADEOP void
-osl_incr_layers_executed (ShaderGlobals *sg)
+OSL_LLVM_PREFIXED_TOKEN(osl_incr_layers_executed) (ShaderGlobals *sg)
 {
     ShadingContext *ctx = (ShadingContext *)sg->context;
     ctx->incr_layers_executed ();

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -455,7 +455,9 @@ ShadingContext::free_dict_resources ()
 
 
 
-OSL_SHADEOP int osl_dict_find_iis (void *sg_, int nodeID, void *query)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_dict_find_iis) (void *sg_,
+                                                            int nodeID,
+                                                            void *query)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     return sg->context->dict_find (nodeID, USTR(query));
@@ -463,7 +465,9 @@ OSL_SHADEOP int osl_dict_find_iis (void *sg_, int nodeID, void *query)
 
 
 
-OSL_SHADEOP int osl_dict_find_iss (void *sg_, void *dictionary, void *query)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_dict_find_iss) (void *sg_,
+                                                            void *dictionary,
+                                                            void *query)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     return sg->context->dict_find (USTR(dictionary), USTR(query));
@@ -471,7 +475,7 @@ OSL_SHADEOP int osl_dict_find_iss (void *sg_, void *dictionary, void *query)
 
 
 
-OSL_SHADEOP int osl_dict_next (void *sg_, int nodeID)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_dict_next) (void *sg_, int nodeID)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     return sg->context->dict_next (nodeID);
@@ -479,8 +483,11 @@ OSL_SHADEOP int osl_dict_next (void *sg_, int nodeID)
 
 
 
-OSL_SHADEOP int osl_dict_value (void *sg_, int nodeID, void *attribname,
-                               long long type, void *data)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_dict_value) (void *sg_,
+                                                         int nodeID,
+                                                         void *attribname,
+                                                         long long type,
+                                                         void *data)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     return sg->context->dict_value (nodeID, USTR(attribname), TYPEDESC(type), data);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -39,8 +39,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../liboslcomp/oslcomp_pvt.h"
 #include "backendllvm.h"
 
-// Create extrenal declarations for all built-in funcs we may call from LLVM
-#define DECL(name,signature) extern "C" void name();
+// Create external declarations for all built-in funcs we may call from LLVM
+#define DECL(name,signature) extern "C" void OSL_LLVM_PREFIXED_TOKEN(name)();
 #include "builtindecl.h"
 #undef DECL
 
@@ -152,8 +152,8 @@ initialize_llvm_helper_function_map ()
     if (llvm_helper_function_map_initialized)
         return;
 #define DECL(name,signature) \
-    llvm_helper_function_map[#name] = HelperFuncRecord(signature,name); \
-    external_function_names.push_back (#name);
+    llvm_helper_function_map[OSL_LLVM_PREFIXED_TOKEN_AS_STRING(name)] = HelperFuncRecord(signature,OSL_LLVM_PREFIXED_TOKEN(name)); \
+    external_function_names.push_back (OSL_LLVM_PREFIXED_TOKEN_AS_STRING(name));
 #include "builtindecl.h"
 #undef DECL
 
@@ -1100,7 +1100,9 @@ BackendLLVM::run ()
         if (f && group().is_entry_layer(layer))
             entry_function_names.push_back (ll.func_name(f));
     }
-    ll.internalize_module_functions ("osl_", external_function_names, entry_function_names);
+    ll.internalize_module_functions (OSL_LLVM_PREFIXED_STRING("osl_"),
+                                     external_function_names,
+                                     entry_function_names);
 
     // Optimize the LLVM IR unless it's a do-nothing group.
     if (! group().does_nothing())

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1275,9 +1275,11 @@ LLVM_Util::call_function (llvm::Value *func, llvm::Value **args, int nargs)
 llvm::Value *
 LLVM_Util::call_function (const char *name, llvm::Value **args, int nargs)
 {
-    llvm::Function *func = module()->getFunction (name);
+    std::string func_name(OSL_LLVM_PREFIX_AS_STRING);
+    func_name += name;
+    llvm::Function *func = module()->getFunction (func_name.c_str());
     if (! func)
-        std::cerr << "Couldn't find function " << name << "\n";
+        std::cerr << "Couldn't find function " << func_name << "\n";
     return call_function (func, args, nargs);
 }
 

--- a/src/liboslexec/opclosure.cpp
+++ b/src/liboslexec/opclosure.cpp
@@ -39,8 +39,9 @@ namespace pvt {
 
 
 OSL_SHADEOP const ClosureColor *
-osl_add_closure_closure (ShaderGlobals *sg,
-                         const ClosureColor *a, const ClosureColor *b)
+OSL_LLVM_PREFIXED_TOKEN(osl_add_closure_closure) (ShaderGlobals *sg,
+                                                  const ClosureColor *a,
+                                                  const ClosureColor *b)
 {
     if (a == NULL) return b;
     if (b == NULL) return a;
@@ -49,7 +50,9 @@ osl_add_closure_closure (ShaderGlobals *sg,
 
 
 OSL_SHADEOP const ClosureColor *
-osl_mul_closure_color (ShaderGlobals *sg, ClosureColor *a, const Color3 *w)
+OSL_LLVM_PREFIXED_TOKEN(osl_mul_closure_color) (ShaderGlobals *sg,
+                                                ClosureColor *a,
+                                                const Color3 *w)
 {
     if (a == NULL) return NULL;
     if (w->x == 0.0f &&
@@ -63,7 +66,9 @@ osl_mul_closure_color (ShaderGlobals *sg, ClosureColor *a, const Color3 *w)
 
 
 OSL_SHADEOP const ClosureColor *
-osl_mul_closure_float (ShaderGlobals *sg, ClosureColor *a, float w)
+OSL_LLVM_PREFIXED_TOKEN(osl_mul_closure_float) (ShaderGlobals *sg,
+                                                ClosureColor *a,
+                                                float w)
 {
     if (a == NULL) return NULL;
     if (w == 0.0f) return NULL;
@@ -73,7 +78,9 @@ osl_mul_closure_float (ShaderGlobals *sg, ClosureColor *a, float w)
 
 
 OSL_SHADEOP ClosureComponent *
-osl_allocate_closure_component (ShaderGlobals *sg, int id, int size)
+OSL_LLVM_PREFIXED_TOKEN(osl_allocate_closure_component) (ShaderGlobals *sg,
+                                                         int id,
+                                                         int size)
 {
     return sg->context->closure_component_allot(id, size, Color3(1.0f));
 }
@@ -81,7 +88,10 @@ osl_allocate_closure_component (ShaderGlobals *sg, int id, int size)
 
 
 OSL_SHADEOP ClosureColor *
-osl_allocate_weighted_closure_component (ShaderGlobals *sg, int id, int size, const Color3 *w)
+OSL_LLVM_PREFIXED_TOKEN(osl_allocate_weighted_closure_component) (ShaderGlobals *sg,
+                                                                  int id,
+                                                                  int size,
+                                                                  const Color3 *w)
 {
     if (w->x == 0.0f && w->y == 0.0f && w->z == 0.0f)
         return NULL;
@@ -89,7 +99,8 @@ osl_allocate_weighted_closure_component (ShaderGlobals *sg, int id, int size, co
 }
 
 OSL_SHADEOP const char *
-osl_closure_to_string (ShaderGlobals *sg, ClosureColor *c)
+OSL_LLVM_PREFIXED_TOKEN(osl_closure_to_string) (ShaderGlobals *sg,
+                                                ClosureColor *c)
 {
     // Special case for printing closures
     std::stringstream stream;

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -493,7 +493,9 @@ ShadingSystemImpl::blackbody_rgb (float T)
 
 
 
-OSL_SHADEOP void osl_blackbody_vf (void *sg, void *out, float temp)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_blackbody_vf) (void *sg,
+                                                            void *out,
+                                                            float temp)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     *(Color3 *)out = ctx->shadingsys().blackbody_rgb (temp);
@@ -501,7 +503,9 @@ OSL_SHADEOP void osl_blackbody_vf (void *sg, void *out, float temp)
 
 
 
-OSL_SHADEOP void osl_wavelength_color_vf (void *sg, void *out, float lambda)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_wavelength_color_vf) (void *sg,
+                                                                   void *out,
+                                                                   float lambda)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     Color3 rgb = ctx->shadingsys().XYZ_to_RGB (wavelength_color_XYZ (lambda));
@@ -514,7 +518,9 @@ OSL_SHADEOP void osl_wavelength_color_vf (void *sg, void *out, float lambda)
 
 
 
-OSL_SHADEOP void osl_luminance_fv (void *sg, void *out, void *c)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_luminance_fv) (void *sg,
+                                                            void *out,
+                                                            void *c)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     ((float *)out)[0] = ctx->shadingsys().luminance (((const Color3 *)c)[0]);
@@ -522,7 +528,9 @@ OSL_SHADEOP void osl_luminance_fv (void *sg, void *out, void *c)
 
 
 
-OSL_SHADEOP void osl_luminance_dfdv (void *sg, void *out, void *c)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_luminance_dfdv) (void *sg,
+                                                              void *out,
+                                                              void *c)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     ((float *)out)[0] = ctx->shadingsys().luminance (((const Color3 *)c)[0]);
@@ -533,7 +541,9 @@ OSL_SHADEOP void osl_luminance_dfdv (void *sg, void *out, void *c)
 
 
 OSL_SHADEOP void
-osl_prepend_color_from (void *sg, void *c_, const char *from)
+OSL_LLVM_PREFIXED_TOKEN(osl_prepend_color_from) (void *sg,
+                                                 void *c_,
+                                                 const char *from)
 {
     ShadingContext *ctx (((ShaderGlobals *)sg)->context);
     Color3 &c (*(Color3*)c_);

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -53,19 +53,19 @@ namespace pvt {
 // Matrix ops
 
 OSL_SHADEOP void
-osl_mul_mm (void *r, void *a, void *b)
+OSL_LLVM_PREFIXED_TOKEN(osl_mul_mm) (void *r, void *a, void *b)
 {
     MAT(r) = MAT(a) * MAT(b);
 }
 
 OSL_SHADEOP void
-osl_mul_mf (void *r, void *a, float b)
+OSL_LLVM_PREFIXED_TOKEN(osl_mul_mf) (void *r, void *a, float b)
 {
     MAT(r) = MAT(a) * b;
 }
 
 OSL_SHADEOP void
-osl_mul_m_ff (void *r, float a, float b)
+OSL_LLVM_PREFIXED_TOKEN(osl_mul_m_ff) (void *r, float a, float b)
 {
     float f = a * b;
     MAT(r) = Matrix44 (f,0,0,0, 0,f,0,0, 0,0,f,0, 0,0,0,f);
@@ -74,25 +74,25 @@ osl_mul_m_ff (void *r, float a, float b)
 
 
 OSL_SHADEOP void
-osl_div_mm (void *r, void *a, void *b)
+OSL_LLVM_PREFIXED_TOKEN(osl_div_mm) (void *r, void *a, void *b)
 {
     MAT(r) = MAT(a) * MAT(b).inverse();
 }
 
 OSL_SHADEOP void
-osl_div_mf (void *r, void *a, float b)
+OSL_LLVM_PREFIXED_TOKEN(osl_div_mf) (void *r, void *a, float b)
 {
     MAT(r) = MAT(a) * (1.0f/b);
 }
 
 OSL_SHADEOP void
-osl_div_fm (void *r, float a, void *b)
+OSL_LLVM_PREFIXED_TOKEN(osl_div_fm) (void *r, float a, void *b)
 {
     MAT(r) = a * MAT(b).inverse();
 }
 
 OSL_SHADEOP void
-osl_div_m_ff (void *r, float a, float b)
+OSL_LLVM_PREFIXED_TOKEN(osl_div_m_ff) (void *r, float a, float b)
 {
     float f = (b == 0) ? 0.0f : (a / b);
     MAT(r) = Matrix44 (f,0,0,0, 0,f,0,0, 0,0,f,0, 0,0,0,f);
@@ -101,7 +101,7 @@ osl_div_m_ff (void *r, float a, float b)
 
 
 OSL_SHADEOP void
-osl_transpose_mm (void *r, void *m)
+OSL_LLVM_PREFIXED_TOKEN(osl_transpose_mm) (void *r, void *m)
 {
     MAT(r) = MAT(m).transposed();
 }
@@ -109,7 +109,7 @@ osl_transpose_mm (void *r, void *m)
 
 
 OSL_SHADEOP int
-osl_get_matrix (void *sg_, void *r, const char *from)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_matrix) (void *sg_, void *r, const char *from)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     ShadingContext *ctx = (ShadingContext *)sg->context;
@@ -139,7 +139,9 @@ osl_get_matrix (void *sg_, void *r, const char *from)
 
 
 OSL_SHADEOP int
-osl_get_inverse_matrix (void *sg_, void *r, const char *to)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_inverse_matrix) (void *sg_,
+                                                 void *r,
+                                                 const char *to)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     ShadingContext *ctx = (ShadingContext *)sg->context;
@@ -169,10 +171,14 @@ osl_get_inverse_matrix (void *sg_, void *r, const char *to)
 
 
 OSL_SHADEOP int
-osl_prepend_matrix_from (void *sg, void *r, const char *from)
+OSL_LLVM_PREFIXED_TOKEN(osl_prepend_matrix_from) (void *sg,
+                                                  void *r,
+                                                  const char *from)
 {
     Matrix44 m;
-    bool ok = osl_get_matrix ((ShaderGlobals *)sg, &m, from);
+    bool ok = OSL_LLVM_PREFIXED_TOKEN(osl_get_matrix) ((ShaderGlobals *)sg,
+                                                       &m,
+                                                       from);
     if (ok)
         MAT(r) = m * MAT(r);
     else {
@@ -186,11 +192,18 @@ osl_prepend_matrix_from (void *sg, void *r, const char *from)
 
 
 OSL_SHADEOP int
-osl_get_from_to_matrix (void *sg, void *r, const char *from, const char *to)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_from_to_matrix) (void *sg,
+                                                 void *r,
+                                                 const char *from,
+                                                 const char *to)
 {
     Matrix44 Mfrom, Mto;
-    int ok = osl_get_matrix ((ShaderGlobals *)sg, &Mfrom, from);
-    ok &= osl_get_inverse_matrix ((ShaderGlobals *)sg, &Mto, to);
+    int ok = OSL_LLVM_PREFIXED_TOKEN(osl_get_matrix) ((ShaderGlobals *)sg,
+                                                      &Mfrom,
+                                                      from);
+    ok &= OSL_LLVM_PREFIXED_TOKEN(osl_get_inverse_matrix) ((ShaderGlobals *)sg,
+                                                           &Mto,
+                                                           to);
     MAT(r) = Mfrom * Mto;
     return ok;
 }
@@ -198,39 +211,51 @@ osl_get_from_to_matrix (void *sg, void *r, const char *from, const char *to)
 
 
 // point = M * point
-inline void osl_transform_vmv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transform_vmv)(void *result,
+                                                       const Matrix44 &M,
+                                                       void* v_)
 {
    const Vec3 &v = VEC(v_);
    robust_multVecMatrix (M, v, VEC(result));
 }
 
-inline void osl_transform_dvmdv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transform_dvmdv)(void *result,
+                                                         const Matrix44 &M,
+                                                         void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
    robust_multVecMatrix (M, v, DVEC(result));
 }
 
 // vector = M * vector
-inline void osl_transformv_vmv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transformv_vmv)(void *result,
+                                                        const Matrix44 &M,
+                                                        void* v_)
 {
    const Vec3 &v = VEC(v_);
    M.multDirMatrix (v, VEC(result));
 }
 
-inline void osl_transformv_dvmdv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transformv_dvmdv)(void *result,
+                                                          const Matrix44 &M,
+                                                          void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
    multDirMatrix (M, v, DVEC(result));
 }
 
 // normal = M * normal
-inline void osl_transformn_vmv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transformn_vmv)(void *result,
+                                                        const Matrix44 &M,
+                                                        void* v_)
 {
    const Vec3 &v = VEC(v_);
    M.inverse().transposed().multDirMatrix (v, VEC(result));
 }
 
-inline void osl_transformn_dvmdv(void *result, const Matrix44 &M, void* v_)
+inline void OSL_LLVM_PREFIXED_TOKEN(osl_transformn_dvmdv)(void *result,
+                                                          const Matrix44 &M,
+                                                          void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
    multDirMatrix (M.inverse().transposed(), v, DVEC(result));
@@ -239,9 +264,14 @@ inline void osl_transformn_dvmdv(void *result, const Matrix44 &M, void* v_)
 
 
 OSL_SHADEOP int
-osl_transform_triple (void *sg_, void *Pin, int Pin_derivs,
-                      void *Pout, int Pout_derivs,
-                      void *from, void *to, int vectype)
+OSL_LLVM_PREFIXED_TOKEN(osl_transform_triple) (void *sg_,
+                                               void *Pin,
+                                               int Pin_derivs,
+                                               void *Pout,
+                                               int Pout_derivs,
+                                               void *from,
+                                               void *to,
+                                               int vectype)
 {
     static ustring u_common ("common");
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
@@ -249,28 +279,34 @@ osl_transform_triple (void *sg_, void *Pin, int Pin_derivs,
     int ok;
     Pin_derivs &= Pout_derivs;   // ignore derivs if output doesn't need it
     if (USTR(from) == u_common)
-        ok = osl_get_inverse_matrix (sg, &M, (const char *)to);
+        ok = OSL_LLVM_PREFIXED_TOKEN(osl_get_inverse_matrix) (sg,
+                                                              &M,
+                                                              (const char *)to);
     else if (USTR(to) == u_common)
-        ok = osl_get_matrix (sg, &M, (const char *)from);
+        ok = OSL_LLVM_PREFIXED_TOKEN(osl_get_matrix) (sg,
+                                                      &M,
+                                                      (const char *)from);
     else
-        ok = osl_get_from_to_matrix (sg, &M, (const char *)from,
-                                     (const char *)to);
+        ok = OSL_LLVM_PREFIXED_TOKEN(osl_get_from_to_matrix) (sg,
+                                                              &M,
+                                                              (const char *)from,
+                                                              (const char *)to);
     if (ok) {
         if (vectype == TypeDesc::POINT) {
             if (Pin_derivs)
-                osl_transform_dvmdv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transform_dvmdv)(Pout, M, Pin);
             else
-                osl_transform_vmv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transform_vmv)(Pout, M, Pin);
         } else if (vectype == TypeDesc::VECTOR) {
             if (Pin_derivs)
-                osl_transformv_dvmdv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transformv_dvmdv)(Pout, M, Pin);
             else
-                osl_transformv_vmv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transformv_vmv)(Pout, M, Pin);
         } else if (vectype == TypeDesc::NORMAL) {
             if (Pin_derivs)
-                osl_transformn_dvmdv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transformn_dvmdv)(Pout, M, Pin);
             else
-                osl_transformn_vmv(Pout, M, Pin);
+                OSL_LLVM_PREFIXED_TOKEN(osl_transformn_vmv)(Pout, M, Pin);
         }
         else ASSERT(0);
     } else {
@@ -290,10 +326,14 @@ osl_transform_triple (void *sg_, void *Pin, int Pin_derivs,
 
 
 OSL_SHADEOP int
-osl_transform_triple_nonlinear (void *sg_, void *Pin, int Pin_derivs,
-                                void *Pout, int Pout_derivs,
-                                void *from, void *to,
-                                int vectype)
+OSL_LLVM_PREFIXED_TOKEN(osl_transform_triple_nonlinear) (void *sg_,
+                                                         void *Pin,
+                                                         int Pin_derivs,
+                                                         void *Pout,
+                                                         int Pout_derivs,
+                                                         void *from,
+                                                         void *to,
+                                                         int vectype)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     RendererServices *rend = sg->renderer;
@@ -316,8 +356,14 @@ osl_transform_triple_nonlinear (void *sg_, void *Pin, int Pin_derivs,
     }
 
     // Renderer couldn't or wouldn't transform directly
-    return osl_transform_triple (sg, Pin, Pin_derivs, Pout, Pout_derivs,
-                                 from, to, vectype);
+    return OSL_LLVM_PREFIXED_TOKEN(osl_transform_triple) (sg,
+                                                          Pin,
+                                                          Pin_derivs,
+                                                          Pout,
+                                                          Pout_derivs,
+                                                          from,
+                                                          to,
+                                                          vectype);
 }
 
 
@@ -357,7 +403,7 @@ inline F det4x4(const Imath::Matrix44<F> &m)
 }
 
 OSL_SHADEOP float
-osl_determinant_fm (void *m)
+OSL_LLVM_PREFIXED_TOKEN(osl_determinant_fm) (void *m)
 {
     return det4x4 (MAT(m));
 }

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -51,7 +51,13 @@ namespace pvt {
 
 
 OSL_SHADEOP void
-osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val, int layeridx, const char* sourcefile_, int sourceline)
+OSL_LLVM_PREFIXED_TOKEN(osl_setmessage) (ShaderGlobals *sg,
+                                         const char *name_,
+                                         long long type_,
+                                         void *val,
+                                         int layeridx,
+                                         const char* sourcefile_,
+                                         int sourceline)
 {
     const ustring &name (USTR(name_));
     const ustring &sourcefile (USTR(sourcefile_));
@@ -94,9 +100,15 @@ osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val
 
 
 OSL_SHADEOP int
-osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
-                long long type_, void *val, int derivs,
-                int layeridx, const char* sourcefile_, int sourceline)
+OSL_LLVM_PREFIXED_TOKEN(osl_getmessage) (ShaderGlobals *sg,
+                                         const char *source_,
+                                         const char *name_,
+                                         long long type_,
+                                         void *val,
+                                         int derivs,
+                                         int layeridx,
+                                         const char* sourcefile_,
+                                         int sourceline)
 {
     const ustring &source (USTR(source_));
     const ustring &name (USTR(name_));

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -94,28 +94,28 @@ void test_perlin(int d) {
 
 
 #define NOISE_IMPL(opname,implname)                                     \
-OSL_SHADEOP float osl_ ##opname## _ff (float x) {                       \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _ff) (float x) {            \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, x);                                                        \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fff (float x, float y) {             \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fff) (float x, float y) {  \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, x, y);                                                     \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fv (char *x) {                       \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fv) (char *x) {            \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, VEC(x));                                                   \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fvf (char *x, float y) {             \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fvf) (char *x, float y) {  \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, VEC(x), y);                                                \
@@ -123,22 +123,22 @@ OSL_SHADEOP float osl_ ##opname## _fvf (char *x, float y) {             \
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vf (char *r, float x) {               \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vf) (char *r, float x) {    \
     implname impl;                                                      \
     impl (VEC(r), x);                                                   \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vff (char *r, float x, float y) {     \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vff) (char *r, float x, float y) { \
     implname impl;                                                      \
     impl (VEC(r), x, y);                                                \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vv (char *r, char *x) {               \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vv) (char *r, char *x) {    \
     implname impl;                                                      \
     impl (VEC(r), VEC(x));                                              \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vvf (char *r, char *x, float y) {     \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vvf) (char *r, char *x, float y) { \
     implname impl;                                                      \
     impl (VEC(r), VEC(x), y);                                           \
 }
@@ -148,83 +148,83 @@ OSL_SHADEOP void osl_ ##opname## _vvf (char *r, char *x, float y) {     \
 
 
 #define NOISE_IMPL_DERIV(opname,implname)                               \
-OSL_SHADEOP void osl_ ##opname## _dfdf (char *r, char *x) {             \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdf) (char *r, char *x) {  \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x));                                        \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdfdf (char *r, char *x, char *y) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdfdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x), DFLOAT(y));                             \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdff (char *r, char *x, float y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdff) (char *r, char *x, float y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x), Dual2<float>(y));                       \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dffdf (char *r, float x, char *y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dffdf) (char *r, float x, char *y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), Dual2<float>(x), DFLOAT(y));                       \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdv (char *r, char *x) {             \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdv) (char *r, char *x) {  \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x));                                          \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvdf (char *r, char *x, char *y) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x), DFLOAT(y));                               \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvf (char *r, char *x, float y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvf) (char *r, char *x, float y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x), Dual2<float>(y));                         \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfvdf (char *r, char *x, char *y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfvdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DFLOAT(r), Dual2<Vec3>(VEC(x)), DFLOAT(y));                   \
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdf (char *r, char *x) {             \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdf) (char *r, char *x) {  \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x));                                          \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdfdf (char *r, char *x, char *y) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdfdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x), DFLOAT(y));                               \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdff (char *r, char *x, float y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdff) (char *r, char *x, float y) { \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x), Dual2<float>(y));                         \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvfdf (char *r, float x, char *y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvfdf) (char *r, float x, char *y) { \
     implname impl;                                                      \
     impl (DVEC(r), Dual2<float>(x), DFLOAT(y));                         \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdv (char *r, char *x) {             \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdv) (char *r, char *x) {  \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x));                                            \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvdf (char *r, char *x, char *y) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x), DFLOAT(y));                                 \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvf (char *r, char *x, float y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvf) (char *r, char *x, float y) { \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x), Dual2<float>(y));                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvvdf (char *r, char *x, char *y) {   \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvvdf) (char *r, char *x, char *y) { \
     implname impl;                                                      \
     impl (DVEC(r), Dual2<Vec3>(VEC(x)), DFLOAT(y));                     \
 }
@@ -233,43 +233,43 @@ OSL_SHADEOP void osl_ ##opname## _dvvdf (char *r, char *x, char *y) {   \
 
 
 #define NOISE_IMPL_DERIV_OPT(opname,implname)                           \
-OSL_SHADEOP void osl_ ##opname## _dfdf (char *name, char *r, char *x, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdf) (char *name, char *r, char *x, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DFLOAT(x), (ShaderGlobals *)sg, (NoiseParams *)opt);                                   \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdfdf (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdfdf) (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DFLOAT(x), DFLOAT(y), (ShaderGlobals *)sg, (NoiseParams *)opt);                        \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdv (char *name, char *r, char *x, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdv) (char *name, char *r, char *x, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DVEC(x), (ShaderGlobals *)sg, (NoiseParams *)opt);                                     \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvdf (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvdf) (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DVEC(x), DFLOAT(y), (ShaderGlobals *)sg, (NoiseParams *)opt);                          \
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdf (char *name, char *r, char *x, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdf) (char *name, char *r, char *x, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DFLOAT(x), (ShaderGlobals *)sg, (NoiseParams *)opt);                                     \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdfdf (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdfdf) (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DFLOAT(x), DFLOAT(y), (ShaderGlobals *)sg, (NoiseParams *)opt);                                     \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdv (char *name, char *r, char *x, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdv) (char *name, char *r, char *x, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DVEC(x), (ShaderGlobals *)sg, (NoiseParams *)opt);                                       \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvdf (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvdf) (char *name, char *r, char *x, char *y, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DVEC(x), DFLOAT(y), (ShaderGlobals *)sg, (NoiseParams *)opt);                            \
 }
@@ -290,28 +290,28 @@ NOISE_IMPL_DERIV (usimplexnoise, USimplexNoise)
 
 
 #define PNOISE_IMPL(opname,implname)                                    \
-    OSL_SHADEOP float osl_ ##opname## _fff (float x, float px) {        \
+    OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fff) (float x, float px) { \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, x, px);                                                    \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fffff (float x, float y, float px, float py) { \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fffff) (float x, float y, float px, float py) { \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, x, y, px, py);                                             \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fvv (char *x, char *px) {            \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fvv) (char *x, char *px) { \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, VEC(x), VEC(px));                                          \
     return r;                                                           \
 }                                                                       \
                                                                         \
-OSL_SHADEOP float osl_ ##opname## _fvfvf (char *x, float y, char *px, float py) { \
+OSL_SHADEOP float OSL_LLVM_OP_TOKEN(opname, _fvfvf) (char *x, float y, char *px, float py) { \
     implname impl;                                                      \
     float r;                                                            \
     impl (r, VEC(x), y, VEC(px), py);                                   \
@@ -319,22 +319,22 @@ OSL_SHADEOP float osl_ ##opname## _fvfvf (char *x, float y, char *px, float py) 
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vff (char *r, float x, float px) {    \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vff) (char *r, float x, float px) { \
     implname impl;                                                      \
     impl (VEC(r), x, px);                                               \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vffff (char *r, float x, float y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vffff) (char *r, float x, float y, float px, float py) { \
     implname impl;                                                      \
     impl (VEC(r), x, y, px, py);                                        \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vvv (char *r, char *x, char *px) {    \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vvv) (char *r, char *x, char *px) { \
     implname impl;                                                      \
     impl (VEC(r), VEC(x), VEC(px));                                     \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _vvfvf (char *r, char *x, float y, char *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _vvfvf) (char *r, char *x, float y, char *px, float py) { \
     implname impl;                                                      \
     impl (VEC(r), VEC(x), y, VEC(px), py);                              \
 }
@@ -344,83 +344,83 @@ OSL_SHADEOP void osl_ ##opname## _vvfvf (char *r, char *x, float y, char *px, fl
 
 
 #define PNOISE_IMPL_DERIV(opname,implname)                              \
-OSL_SHADEOP void osl_ ##opname## _dfdff (char *r, char *x, float px) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdff) (char *r, char *x, float px) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x), px);                                    \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdfdfff (char *r, char *x, char *y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdfdfff) (char *r, char *x, char *y, float px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x), DFLOAT(y), px, py);                     \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdffff (char *r, char *x, float y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdffff) (char *r, char *x, float y, float px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DFLOAT(x), Dual2<float>(y), px, py);               \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dffdfff (char *r, float x, char *y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dffdfff) (char *r, float x, char *y, float px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), Dual2<float>(x), DFLOAT(y), px, py);               \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvv (char *r, char *x, char *px) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvv) (char *r, char *x, char *px) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x), VEC(px));                                 \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvdfvf (char *r, char *x, char *y, char *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvdfvf) (char *r, char *x, char *y, char *px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x), DFLOAT(y), VEC(px), py);                  \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvfvf (char *r, char *x, float y, char *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvfvf) (char *r, char *x, float y, char *px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), DVEC(x), Dual2<float>(y), VEC(px), py);            \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfvdfvf (char *r, char *x, char *y, char *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfvdfvf) (char *r, char *x, char *y, char *px, float py) { \
     implname impl;                                                      \
     impl (DFLOAT(r), Dual2<Vec3>(VEC(x)), DFLOAT(y), VEC(px), py);      \
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdff (char *r, char *x, float px) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdff) (char *r, char *x, float px) { \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x), px);                                      \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdfdfff (char *r, char *x, char *y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdfdfff) (char *r, char *x, char *y, float px, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x), DFLOAT(y), px, py);                       \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdffff (char *r, char *x, float y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdffff) (char *r, char *x, float y, float px, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), DFLOAT(x), Dual2<float>(y), px, py);                 \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvfdfff (char *r, float x, char *y, float px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvfdfff) (char *r, float x, char *y, float px, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), Dual2<float>(x), DFLOAT(y), px, py);                 \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvv (char *r, char *x, char *px) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvv) (char *r, char *x, char *px) { \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x), VEC(px));                                   \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvdfvf (char *r, char *x, char *y, char *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvdfvf) (char *r, char *x, char *y, char *px, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x), DFLOAT(y), VEC(px), py);                    \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvfvf (char *r, char *x, float y, float *px, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvfvf) (char *r, char *x, float y, float *px, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), DVEC(x), Dual2<float>(y), VEC(px), py);              \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvvdfvf (char *r, char *x, char *px, char *y, float py) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvvdfvf) (char *r, char *x, char *px, char *y, float py) { \
     implname impl;                                                      \
     impl (DVEC(r), Dual2<Vec3>(VEC(x)), DFLOAT(y), VEC(px), py);        \
 }
@@ -429,43 +429,43 @@ OSL_SHADEOP void osl_ ##opname## _dvvdfvf (char *r, char *x, char *px, char *y, 
 
 
 #define PNOISE_IMPL_DERIV_OPT(opname,implname)                          \
-OSL_SHADEOP void osl_ ##opname## _dfdff (char *name, char *r, char *x, float px, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdff) (char *name, char *r, char *x, float px, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DFLOAT(x), px, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdfdfff (char *name, char *r, char *x, char *y, float px, float py, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdfdfff) (char *name, char *r, char *x, char *y, float px, float py, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DFLOAT(x), DFLOAT(y), px, py, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvv (char *name, char *r, char *x, char *px, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvv) (char *name, char *r, char *x, char *px, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DVEC(x), VEC(px), (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dfdvdfvf (char *name, char *r, char *x, char *y, char *px, float py, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dfdvdfvf) (char *name, char *r, char *x, char *y, char *px, float py, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DFLOAT(r), DVEC(x), DFLOAT(y), VEC(px), py, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdff (char *name, char *r, char *x, float px, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdff) (char *name, char *r, char *x, float px, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DFLOAT(x), px, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdfdfff (char *name, char *r, char *x, char *y, float px, float py, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdfdfff) (char *name, char *r, char *x, char *y, float px, float py, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DFLOAT(x), DFLOAT(y), px, py, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvv (char *name, char *r, char *x, char *px, char *sg, char *opt) {  \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvv) (char *name, char *r, char *x, char *px, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DVEC(x), VEC(px), (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }                                                                       \
                                                                         \
-OSL_SHADEOP void osl_ ##opname## _dvdvdfvf (char *name, char *r, char *x, char *y, char *px, float py, char *sg, char *opt) { \
+OSL_SHADEOP void OSL_LLVM_OP_TOKEN(opname, _dvdvdfvf) (char *name, char *r, char *x, char *y, char *px, float py, char *sg, char *opt) { \
     implname impl;                                                      \
     impl (USTR(name), DVEC(r), DVEC(x), DFLOAT(y), VEC(px), py, (ShaderGlobals *)sg, (NoiseParams *)opt); \
 }
@@ -799,7 +799,7 @@ PNOISE_IMPL_DERIV_OPT (genericpnoise, GenericPNoise)
 // Utility: retrieve a pointer to the ShadingContext's noise params
 // struct, also re-initialize its contents.
 OSL_SHADEOP void *
-osl_get_noise_options (void *sg_)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_noise_options) (void *sg_)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     RendererServices::NoiseOpt *opt = sg->context->noise_options_ptr ();
@@ -810,7 +810,7 @@ osl_get_noise_options (void *sg_)
 
 
 OSL_SHADEOP void
-osl_noiseparams_set_anisotropic (void *opt, int a)
+OSL_LLVM_PREFIXED_TOKEN(osl_noiseparams_set_anisotropic) (void *opt, int a)
 {
     ((RendererServices::NoiseOpt *)opt)->anisotropic = a;
 }
@@ -818,7 +818,7 @@ osl_noiseparams_set_anisotropic (void *opt, int a)
 
 
 OSL_SHADEOP void
-osl_noiseparams_set_do_filter (void *opt, int a)
+OSL_LLVM_PREFIXED_TOKEN(osl_noiseparams_set_do_filter) (void *opt, int a)
 {
     ((RendererServices::NoiseOpt *)opt)->do_filter = a;
 }
@@ -826,7 +826,7 @@ osl_noiseparams_set_do_filter (void *opt, int a)
 
 
 OSL_SHADEOP void
-osl_noiseparams_set_direction (void *opt, void *dir)
+OSL_LLVM_PREFIXED_TOKEN(osl_noiseparams_set_direction) (void *opt, void *dir)
 {
     ((RendererServices::NoiseOpt *)opt)->direction = VEC(dir);
 }
@@ -834,7 +834,7 @@ osl_noiseparams_set_direction (void *opt, void *dir)
 
 
 OSL_SHADEOP void
-osl_noiseparams_set_bandwidth (void *opt, float b)
+OSL_LLVM_PREFIXED_TOKEN(osl_noiseparams_set_bandwidth) (void *opt, float b)
 {
     ((RendererServices::NoiseOpt *)opt)->bandwidth = b;
 }
@@ -842,7 +842,7 @@ osl_noiseparams_set_bandwidth (void *opt, float b)
 
 
 OSL_SHADEOP void
-osl_noiseparams_set_impulses (void *opt, float i)
+OSL_LLVM_PREFIXED_TOKEN(osl_noiseparams_set_impulses) (void *opt, float i)
 {
     ((RendererServices::NoiseOpt *)opt)->impulses = i;
 }
@@ -850,7 +850,7 @@ osl_noiseparams_set_impulses (void *opt, float i)
 
 
 OSL_SHADEOP void
-osl_count_noise (void *sg_)
+OSL_LLVM_PREFIXED_TOKEN(osl_count_noise) (void *sg_)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     sg->context->shadingsys().count_noise ();

--- a/src/liboslexec/opspline.cpp
+++ b/src/liboslexec/opspline.cpp
@@ -110,64 +110,96 @@ const Spline::SplineBasis *Spline::getSplineBasis(const ustring &basis_name)
 #define DFLOAT(x) (*(Dual2<Float> *)x)
 #define DVEC(x) (*(Dual2<Vec3> *)x)
 
-OSL_SHADEOP void  osl_spline_fff(void *out, const char *spline_, void *x, 
-                                 float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_fff)(void *out,
+                                                          const char *spline_,
+                                                          void *x,
+                                                          float *knots,
+                                                          int knot_count,
+                                                          int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<float, float, float, float, false>
       (spline, *(float *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dfdfdf(void *out, const char *spline_, void *x, 
-                                    float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dfdfdf)(void *out,
+                                                             const char *spline_,
+                                                             void *x,
+                                                             float *knots,
+                                                             int knot_count,
+                                                             int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, Dual2<float>, Dual2<float>, float, true>
       (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dffdf(void *out, const char *spline_, void *x, 
-                                   float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dffdf)(void *out,
+                                                            const char *spline_,
+                                                            void *x,
+                                                            float *knots,
+                                                            int knot_count,
+                                                            int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, float, Dual2<float>, float, true>
       (spline, DFLOAT(out), *(float *)x, knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dfdff(void *out, const char *spline_, void *x, 
-                                   float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dfdff)(void *out,
+                                                            const char *spline_,
+                                                            void *x,
+                                                            float *knots,
+                                                            int knot_count,
+                                                            int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<float>, Dual2<float>, float, float, false>
       (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_vfv(void *out, const char *spline_, void *x, 
-                                 Vec3 *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_vfv)(void *out,
+                                                          const char *spline_,
+                                                          void *x,
+                                                          Vec3 *knots,
+                                                          int knot_count,
+                                                          int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Vec3, float, Vec3, Vec3, false>
       (spline, *(Vec3 *)out, *(float *)x, knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dvdfv(void *out, const char *spline_, void *x, 
-                                   Vec3 *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dvdfv)(void *out,
+                                                            const char *spline_,
+                                                            void *x,
+                                                            Vec3 *knots,
+                                                            int knot_count,
+                                                            int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<Vec3>, Dual2<float>, Vec3, Vec3, false>
       (spline, DVEC(out), DFLOAT(x), knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dvfdv(void *out, const char *spline_, void *x, 
-                                    Vec3 *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dvfdv)(void *out,
+                                                            const char *spline_,
+                                                            void *x,
+                                                            Vec3 *knots,
+                                                            int knot_count,
+                                                            int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<Vec3>, float, Dual2<Vec3>, Vec3, true>
       (spline, DVEC(out), *(float *)x, knots, knot_count, knot_arraylen);
 }
 
-OSL_SHADEOP void  osl_spline_dvdfdv(void *out, const char *spline_, void *x, 
-                                    Vec3 *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void  OSL_LLVM_PREFIXED_TOKEN(osl_spline_dvdfdv)(void *out,
+                                                             const char *spline_,
+                                                             void *x,
+                                                             Vec3 *knots,
+                                                             int knot_count,
+                                                             int knot_arraylen)
 {
    const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
    Spline::spline_evaluate<Dual2<Vec3>, Dual2<float>, Dual2<Vec3>, Vec3, true>
@@ -176,35 +208,71 @@ OSL_SHADEOP void  osl_spline_dvdfdv(void *out, const char *spline_, void *x,
 
 
 
-OSL_SHADEOP void osl_splineinverse_fff(void *out, const char *spline_, void *x, 
-                                       float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_fff)(void *out,
+                                                                const char *spline_,
+                                                                void *x,
+                                                                float *knots,
+                                                                int knot_count,
+                                                                int knot_arraylen)
 {
     // Version with no derivs
     const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
-    Spline::spline_inverse<float> (spline, *(float *)out, *(float *)x, knots, knot_count, knot_arraylen);
+    Spline::spline_inverse<float> (spline,
+                                   *(float *)out,
+                                   *(float *)x,
+                                   knots,
+                                   knot_count,
+                                   knot_arraylen);
 }
 
-OSL_SHADEOP void osl_splineinverse_dfdff(void *out, const char *spline_, void *x, 
-                                         float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_dfdff)(void *out,
+                                                                  const char *spline_,
+                                                                  void *x,
+                                                                  float *knots,
+                                                                  int knot_count,
+                                                                  int knot_arraylen)
 {
     // x has derivs, so return derivs as well
     const Spline::SplineBasis *spline = Spline::getSplineBasis(USTR(spline_));
-    Spline::spline_inverse<Dual2<float> > (spline, DFLOAT(out), DFLOAT(x), knots, knot_count, knot_arraylen);
+    Spline::spline_inverse<Dual2<float> > (spline,
+                                           DFLOAT(out),
+                                           DFLOAT(x),
+                                           knots,
+                                           knot_count,
+                                           knot_arraylen);
 }
 
-OSL_SHADEOP void osl_splineinverse_dfdfdf(void *out, const char *spline_, void *x, 
-                                          float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_dfdfdf)(void *out,
+                                                                   const char *spline_,
+                                                                   void *x,
+                                                                   float *knots,
+                                                                   int knot_count,
+                                                                   int knot_arraylen)
 {
     // Ignore knot derivatives
-    osl_splineinverse_dfdff (out, spline_, x, knots, knot_count, knot_arraylen);
+    OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_dfdff) (out,
+                                                      spline_,
+                                                      x,
+                                                      knots,
+                                                      knot_count,
+                                                      knot_arraylen);
 }
 
-OSL_SHADEOP void osl_splineinverse_dffdf(void *out, const char *spline_, void *x, 
-                                         float *knots, int knot_count, int knot_arraylen)
+OSL_SHADEOP void OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_dffdf)(void *out,
+                                                                  const char *spline_,
+                                                                  void *x,
+                                                                  float *knots,
+                                                                  int knot_count,
+                                                                  int knot_arraylen)
 {
     // Ignore knot derivs
     float outtmp = 0;
-    osl_splineinverse_fff (&outtmp, spline_, x, knots, knot_count, knot_arraylen);
+    OSL_LLVM_PREFIXED_TOKEN(osl_splineinverse_fff) (&outtmp,
+                                                    spline_,
+                                                    x,
+                                                    knots,
+                                                    knot_count,
+                                                    knot_arraylen);
     DFLOAT(out) = outtmp;
 }
 

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -50,32 +50,33 @@ namespace pvt {
 
 // Only define 2-arg version of concat, sort it out upstream
 OSL_SHADEOP const char *
-osl_concat_sss (const char *s, const char *t)
+OSL_LLVM_PREFIXED_TOKEN(osl_concat_sss) (const char *s, const char *t)
 {
     return ustring::format("%s%s", s, t).c_str();
 }
 
 OSL_SHADEOP int
-osl_strlen_is (const char *s)
+OSL_LLVM_PREFIXED_TOKEN(osl_strlen_is) (const char *s)
 {
     return (int) USTR(s).length();
 }
 
 OSL_SHADEOP int
-osl_hash_is (const char *s)
+OSL_LLVM_PREFIXED_TOKEN(osl_hash_is) (const char *s)
 {
     return (int) USTR(s).hash();
 }
 
 OSL_SHADEOP int
-osl_getchar_isi (const char *str, int index)
+OSL_LLVM_PREFIXED_TOKEN(osl_getchar_isi) (const char *str, int index)
 {
     return str && unsigned(index) < USTR(str).length() ? str[index] : 0;
 }
 
 
-    OSL_SHADEOP int
-osl_startswith_iss (const char *s_, const char *substr_)
+OSL_SHADEOP int
+OSL_LLVM_PREFIXED_TOKEN(osl_startswith_iss) (const char *s_,
+                                             const char *substr_)
 {
     ustring substr (USTR(substr_));
     size_t substr_len = substr.length();
@@ -89,7 +90,7 @@ osl_startswith_iss (const char *s_, const char *substr_)
 }
 
 OSL_SHADEOP int
-osl_endswith_iss (const char *s_, const char *substr_)
+OSL_LLVM_PREFIXED_TOKEN(osl_endswith_iss) (const char *s_, const char *substr_)
 {
     ustring substr (USTR(substr_));
     size_t substr_len = substr.length();
@@ -103,19 +104,19 @@ osl_endswith_iss (const char *s_, const char *substr_)
 }
 
 OSL_SHADEOP int
-osl_stoi_is (const char *str)
+OSL_LLVM_PREFIXED_TOKEN(osl_stoi_is) (const char *str)
 {
     return str ? strtol(str, NULL, 10) : 0;
 }
 
 OSL_SHADEOP float
-osl_stof_fs (const char *str)
+OSL_LLVM_PREFIXED_TOKEN(osl_stof_fs) (const char *str)
 {
     return str ? (float)strtod(str, NULL) : 0.0f;
 }
 
 OSL_SHADEOP const char *
-osl_substr_ssii (const char *s_, int start, int length)
+OSL_LLVM_PREFIXED_TOKEN(osl_substr_ssii) (const char *s_, int start, int length)
 {
     ustring s (USTR(s_));
     int slen = int (s.length());
@@ -130,8 +131,12 @@ osl_substr_ssii (const char *s_, int start, int length)
 
 
 OSL_SHADEOP int
-osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
-                const char *pattern, int fullmatch)
+OSL_LLVM_PREFIXED_TOKEN(osl_regex_impl) (void *sg_,
+                                         const char *subject_,
+                                         void *results,
+                                         int nresults,
+                                         const char *pattern,
+                                         int fullmatch)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     ShadingContext *ctx = sg->context;
@@ -162,7 +167,7 @@ osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
 
 
 OSL_SHADEOP const char *
-osl_format (const char* format_str, ...)
+OSL_LLVM_PREFIXED_TOKEN(osl_format) (const char* format_str, ...)
 {
     va_list args;
     va_start (args, format_str);
@@ -173,7 +178,9 @@ osl_format (const char* format_str, ...)
 
 
 OSL_SHADEOP void
-osl_printf (ShaderGlobals *sg, const char* format_str, ...)
+OSL_LLVM_PREFIXED_TOKEN(osl_printf) (ShaderGlobals *sg,
+                                     const char* format_str,
+                                     ...)
 {
     va_list args;
     va_start (args, format_str);
@@ -189,7 +196,9 @@ osl_printf (ShaderGlobals *sg, const char* format_str, ...)
 
 
 OSL_SHADEOP void
-osl_error (ShaderGlobals *sg, const char* format_str, ...)
+OSL_LLVM_PREFIXED_TOKEN(osl_error) (ShaderGlobals *sg,
+                                    const char* format_str,
+                                    ...)
 {
     va_list args;
     va_start (args, format_str);
@@ -200,7 +209,9 @@ osl_error (ShaderGlobals *sg, const char* format_str, ...)
 
 
 OSL_SHADEOP void
-osl_warning (ShaderGlobals *sg, const char* format_str, ...)
+OSL_LLVM_PREFIXED_TOKEN(osl_warning) (ShaderGlobals *sg,
+                                      const char* format_str,
+                                      ...)
 {
     if (sg->context->allow_warnings()) {
         va_list args;
@@ -214,8 +225,11 @@ osl_warning (ShaderGlobals *sg, const char* format_str, ...)
 
 
 OSL_SHADEOP int
-osl_split (const char *str, ustring *results, const char *sep,
-           int maxsplit, int resultslen)
+OSL_LLVM_PREFIXED_TOKEN(osl_split) (const char *str,
+                                    ustring *results,
+                                    const char *sep,
+                                    int maxsplit,
+                                    int resultslen)
 {
     maxsplit = OIIO::clamp (maxsplit, 0, resultslen);
     std::vector<std::string> splits;

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -51,7 +51,7 @@ namespace pvt {
 // Utility: retrieve a pointer to the ShadingContext's texture options
 // struct, also re-initialize its contents.
 OSL_SHADEOP void *
-osl_get_texture_options (void *sg_)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_texture_options) (void *sg_)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     TextureOpt *opt = sg->context->texture_options_ptr ();
@@ -61,32 +61,32 @@ osl_get_texture_options (void *sg_)
 
 
 OSL_SHADEOP void
-osl_texture_set_firstchannel (void *opt, int x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_firstchannel) (void *opt, int x)
 {
     ((TextureOpt *)opt)->firstchannel = x;
 }
 
 
 OSL_SHADEOP void
-osl_texture_set_swrap (void *opt, const char *x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_swrap) (void *opt, const char *x)
 {
     ((TextureOpt *)opt)->swrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_twrap (void *opt, const char *x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_twrap) (void *opt, const char *x)
 {
     ((TextureOpt *)opt)->twrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_rwrap (void *opt, const char *x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_rwrap) (void *opt, const char *x)
 {
     ((TextureOpt *)opt)->rwrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_stwrap (void *opt, const char *x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_stwrap) (void *opt, const char *x)
 {
     TextureOpt::Wrap code = TextureOpt::decode_wrapmode(USTR(x));
     ((TextureOpt *)opt)->swrap = code;
@@ -94,88 +94,88 @@ osl_texture_set_stwrap (void *opt, const char *x)
 }
 
 OSL_SHADEOP void
-osl_texture_set_swrap_code (void *opt, int mode)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_swrap_code) (void *opt, int mode)
 {
     ((TextureOpt *)opt)->swrap = (TextureOpt::Wrap)mode;
 }
 
 OSL_SHADEOP void
-osl_texture_set_twrap_code (void *opt, int mode)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_twrap_code) (void *opt, int mode)
 {
     ((TextureOpt *)opt)->twrap = (TextureOpt::Wrap)mode;
 }
 
 OSL_SHADEOP void
-osl_texture_set_rwrap_code (void *opt, int mode)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_rwrap_code) (void *opt, int mode)
 {
     ((TextureOpt *)opt)->rwrap = (TextureOpt::Wrap)mode;
 }
 
 OSL_SHADEOP void
-osl_texture_set_stwrap_code (void *opt, int mode)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_stwrap_code) (void *opt, int mode)
 {
     ((TextureOpt *)opt)->swrap = (TextureOpt::Wrap)mode;
     ((TextureOpt *)opt)->twrap = (TextureOpt::Wrap)mode;
 }
 
 OSL_SHADEOP void
-osl_texture_set_sblur (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_sblur) (void *opt, float x)
 {
     ((TextureOpt *)opt)->sblur = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_tblur (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_tblur) (void *opt, float x)
 {
     ((TextureOpt *)opt)->tblur = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_rblur (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_rblur) (void *opt, float x)
 {
     ((TextureOpt *)opt)->rblur = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_stblur (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_stblur) (void *opt, float x)
 {
     ((TextureOpt *)opt)->sblur = x;
     ((TextureOpt *)opt)->tblur = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_swidth (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_swidth) (void *opt, float x)
 {
     ((TextureOpt *)opt)->swidth = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_twidth (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_twidth) (void *opt, float x)
 {
     ((TextureOpt *)opt)->twidth = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_rwidth (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_rwidth) (void *opt, float x)
 {
     ((TextureOpt *)opt)->rwidth = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_stwidth (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_stwidth) (void *opt, float x)
 {
     ((TextureOpt *)opt)->swidth = x;
     ((TextureOpt *)opt)->twidth = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_fill (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_fill) (void *opt, float x)
 {
     ((TextureOpt *)opt)->fill = x;
 }
 
 OSL_SHADEOP void
-osl_texture_set_time (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_time) (void *opt, float x)
 {
     ((TextureOpt *)opt)->time = x;
 }
@@ -201,7 +201,8 @@ tex_interp_to_code (ustring modename)
 }
 
 OSL_SHADEOP void
-osl_texture_set_interp (void *opt, const char *modename)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_interp) (void *opt,
+                                                 const char *modename)
 {
     int mode = tex_interp_to_code (USTR(modename));
     if (mode >= 0)
@@ -209,33 +210,36 @@ osl_texture_set_interp (void *opt, const char *modename)
 }
 
 OSL_SHADEOP void
-osl_texture_set_interp_code (void *opt, int mode)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_interp_code) (void *opt, int mode)
 {
     ((TextureOpt *)opt)->interpmode = (TextureOpt::InterpMode)mode;
 }
 
 OSL_SHADEOP void
-osl_texture_set_subimage (void *opt, int subimage)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_subimage) (void *opt, int subimage)
 {
     ((TextureOpt *)opt)->subimage = subimage;
 }
 
 
 OSL_SHADEOP void
-osl_texture_set_subimagename (void *opt, const char *subimagename)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_subimagename) (void *opt,
+                                                       const char *subimagename)
 {
     ((TextureOpt *)opt)->subimagename = USTR(subimagename);
 }
 
 OSL_SHADEOP void
-osl_texture_set_missingcolor_arena (void *opt, const void *missing)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_missingcolor_arena) (void *opt,
+                                                             const void *missing)
 {
     ((TextureOpt *)opt)->missingcolor = (const float *)missing;
 }
 
 OSL_SHADEOP void
-osl_texture_set_missingcolor_alpha (void *opt, int alphaindex,
-                                    float missingalpha)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture_set_missingcolor_alpha) (void *opt,
+                                                             int alphaindex,
+                                                             float missingalpha)
 {
     float *m = (float *)((TextureOpt *)opt)->missingcolor;
     if (m)
@@ -245,12 +249,12 @@ osl_texture_set_missingcolor_alpha (void *opt, int alphaindex,
 
 
 OSL_SHADEOP int
-osl_texture (void *sg_, const char *name, void *handle,
-             void *opt_, float s, float t,
-             float dsdx, float dtdx, float dsdy, float dtdy,
-             int chans, void *result, void *dresultdx, void *dresultdy,
-             void *alpha, void *dalphadx, void *dalphady,
-             ustring *errormessage)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture) (void *sg_, const char *name, void *handle,
+                                      void *opt_, float s, float t,
+                                      float dsdx, float dtdx, float dsdy, float dtdy,
+                                      int chans, void *result, void *dresultdx, void *dresultdy,
+                                      void *alpha, void *dalphadx, void *dalphady,
+                                      ustring *errormessage)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     TextureOpt *opt = (TextureOpt *)opt_;
@@ -293,14 +297,14 @@ osl_texture (void *sg_, const char *name, void *handle,
 
 
 OSL_SHADEOP int
-osl_texture3d (void *sg_, const char *name, void *handle,
-               void *opt_, void *P_,
-               void *dPdx_, void *dPdy_, void *dPdz_, int chans,
-               void *result, void *dresultdx,
-               void *dresultdy, void *dresultdz,
-               void *alpha, void *dalphadx,
-               void *dalphady, void *dalphadz,
-               ustring *errormessage)
+OSL_LLVM_PREFIXED_TOKEN(osl_texture3d) (void *sg_, const char *name, void *handle,
+                                        void *opt_, void *P_,
+                                        void *dPdx_, void *dPdy_, void *dPdz_, int chans,
+                                        void *result, void *dresultdx,
+                                        void *dresultdy, void *dresultdz,
+                                        void *alpha, void *dalphadx,
+                                        void *dalphady, void *dalphadz,
+                                        ustring *errormessage)
 {
     const Vec3 &P (*(Vec3 *)P_);
     const Vec3 &dPdx (*(Vec3 *)dPdx_);
@@ -354,12 +358,12 @@ osl_texture3d (void *sg_, const char *name, void *handle,
 
 
 OSL_SHADEOP int
-osl_environment (void *sg_, const char *name, void *handle,
-                 void *opt_, void *R_,
-                 void *dRdx_, void *dRdy_, int chans,
-                 void *result, void *dresultdx, void *dresultdy,
-                 void *alpha, void *dalphadx, void *dalphady,
-                 ustring *errormessage)
+OSL_LLVM_PREFIXED_TOKEN(osl_environment) (void *sg_, const char *name, void *handle,
+                                          void *opt_, void *R_,
+                                          void *dRdx_, void *dRdy_, int chans,
+                                          void *result, void *dresultdx, void *dresultdy,
+                                          void *alpha, void *dalphadx, void *dalphady,
+                                          ustring *errormessage)
 {
     const Vec3 &R (*(Vec3 *)R_);
     const Vec3 &dRdx (*(Vec3 *)dRdx_);
@@ -408,9 +412,9 @@ osl_environment (void *sg_, const char *name, void *handle,
 
 
 OSL_SHADEOP int
-osl_get_textureinfo (void *sg_, const char *name, void *handle,
-                     void *dataname,  int type,
-                     int arraylen, int aggregate, void *data)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_textureinfo) (void *sg_, const char *name, void *handle,
+                                              void *dataname,  int type,
+                                              int arraylen, int aggregate, void *data)
 {
     // recreate TypeDesc
     TypeDesc typedesc;
@@ -433,7 +437,7 @@ osl_get_textureinfo (void *sg_, const char *name, void *handle,
 // Utility: retrieve a pointer to the ShadingContext's trace options
 // struct, also re-initialize its contents.
 OSL_SHADEOP void *
-osl_get_trace_options (void *sg_)
+OSL_LLVM_PREFIXED_TOKEN(osl_get_trace_options) (void *sg_)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     RendererServices::TraceOpt *opt = sg->context->trace_options_ptr ();
@@ -442,34 +446,34 @@ osl_get_trace_options (void *sg_)
 }
 
 OSL_SHADEOP void
-osl_trace_set_mindist (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_trace_set_mindist) (void *opt, float x)
 {
     ((RendererServices::TraceOpt *)opt)->mindist = x;
 }
 
 OSL_SHADEOP void
-osl_trace_set_maxdist (void *opt, float x)
+OSL_LLVM_PREFIXED_TOKEN(osl_trace_set_maxdist) (void *opt, float x)
 {
     ((RendererServices::TraceOpt *)opt)->maxdist = x;
 }
 
 OSL_SHADEOP void
-osl_trace_set_shade (void *opt, int x)
+OSL_LLVM_PREFIXED_TOKEN(osl_trace_set_shade) (void *opt, int x)
 {
     ((RendererServices::TraceOpt *)opt)->shade = x;
 }
 
 
 OSL_SHADEOP void
-osl_trace_set_traceset (void *opt, const char *x)
+OSL_LLVM_PREFIXED_TOKEN(osl_trace_set_traceset) (void *opt, const char *x)
 {
     ((RendererServices::TraceOpt *)opt)->traceset = USTR(x);
 }
 
 
 OSL_SHADEOP int
-osl_trace (void *sg_, void *opt_, void *Pos_, void *dPosdx_, void *dPosdy_,
-           void *Dir_, void *dDirdx_, void *dDirdy_)
+OSL_LLVM_PREFIXED_TOKEN(osl_trace) (void *sg_, void *opt_, void *Pos_, void *dPosdx_, void *dPosdy_,
+                                    void *Dir_, void *dDirdx_, void *dDirdy_)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     RendererServices::TraceOpt *opt = (RendererServices::TraceOpt *)opt_;

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -443,9 +443,17 @@ RendererServices::pointcloud_write (ShaderGlobals *sg,
 
 
 OSL_SHADEOP int
-osl_pointcloud_search (ShaderGlobals *sg, const char *filename, void *center, float radius,
-                       int max_points, int sort, void *out_indices, void *out_distances, int derivs_offset,
-                       int nattrs, ...)
+OSL_LLVM_PREFIXED_TOKEN(osl_pointcloud_search) (ShaderGlobals *sg,
+                                                const char *filename,
+                                                void *center,
+                                                float radius,
+                                                int max_points,
+                                                int sort,
+                                                void *out_indices,
+                                                void *out_distances,
+                                                int derivs_offset,
+                                                int nattrs,
+                                                ...)
 {
     ShadingSystemImpl &shadingsys (sg->context->shadingsys());
     if (shadingsys.no_pointcloud()) // Debug mode to skip pointcloud expense
@@ -491,8 +499,13 @@ osl_pointcloud_search (ShaderGlobals *sg, const char *filename, void *center, fl
 
 
 OSL_SHADEOP int
-osl_pointcloud_get (ShaderGlobals *sg, const char *filename, void *in_indices, int count,
-                    const char *attr_name, long long attr_type, void *out_data)
+OSL_LLVM_PREFIXED_TOKEN(osl_pointcloud_get) (ShaderGlobals *sg,
+                                             const char *filename,
+                                             void *in_indices,
+                                             int count,
+                                             const char *attr_name,
+                                             long long attr_type,
+                                             void *out_data)
 {
     ShadingSystemImpl &shadingsys (sg->context->shadingsys());
     if (shadingsys.no_pointcloud()) // Debug mode to skip pointcloud expense
@@ -511,9 +524,13 @@ osl_pointcloud_get (ShaderGlobals *sg, const char *filename, void *in_indices, i
 
 
 OSL_SHADEOP void
-osl_pointcloud_write_helper (ustring *names, TypeDesc *types, void **values,
-                             int index, const char *name, long long type,
-                             void *val)
+OSL_LLVM_PREFIXED_TOKEN(osl_pointcloud_write_helper) (ustring *names,
+                                                      TypeDesc *types,
+                                                      void **values,
+                                                      int index,
+                                                      const char *name,
+                                                      long long type,
+                                                      void *val)
 {
     names[index] = USTR(name);
     types[index] = TYPEDESC(type);
@@ -523,9 +540,13 @@ osl_pointcloud_write_helper (ustring *names, TypeDesc *types, void **values,
 
 
 OSL_SHADEOP int
-osl_pointcloud_write (ShaderGlobals *sg, const char *filename, const Vec3 *pos,
-                      int nattribs, const ustring *names,
-                      const TypeDesc *types, const void **values)
+OSL_LLVM_PREFIXED_TOKEN(osl_pointcloud_write) (ShaderGlobals *sg,
+                                               const char *filename,
+                                               const Vec3 *pos,
+                                               int nattribs,
+                                               const ustring *names,
+                                               const TypeDesc *types,
+                                               const void **values)
 {
     ShadingSystemImpl &shadingsys (sg->context->shadingsys());
     if (shadingsys.no_pointcloud()) // Debug mode to skip pointcloud expense

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3079,10 +3079,10 @@ OSL::OSLQuery::init (const ShaderGroup *group, int layernum)
 // we are checking the entire contents of the symbol.  More restrictive
 // firstcheck,nchecks are used to check just one element of an array.
 OSL_SHADEOP void
-osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
-                  void *sg, const void *sourcefile, int sourceline,
-                  void *symbolname, int firstcheck, int nchecks,
-                  const void *opname)
+OSL_LLVM_PREFIXED_TOKEN(osl_naninf_check) (int ncomps, const void *vals_, int has_derivs,
+                                           void *sg, const void *sourcefile, int sourceline,
+                                           void *symbolname, int firstcheck, int nchecks,
+                                           const void *opname)
 {
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
     const float *vals = (const float *)vals_;
@@ -3112,12 +3112,12 @@ osl_naninf_check (int ncomps, const void *vals_, int has_derivs,
 // More restrictive firstcheck,nchecks are used to check just one
 // element of an array.
 OSL_SHADEOP void
-osl_uninit_check (long long typedesc_, void *vals_,
-                  void *sg, const void *sourcefile, int sourceline,
-                  const char *groupname, int layer, const char *layername,
-                  const char *shadername,
-                  int opnum, const char *opname, int argnum,
-                  void *symbolname, int firstcheck, int nchecks)
+OSL_LLVM_PREFIXED_TOKEN(osl_uninit_check) (long long typedesc_, void *vals_,
+                                           void *sg, const void *sourcefile, int sourceline,
+                                           const char *groupname, int layer, const char *layername,
+                                           const char *shadername,
+                                           int opnum, const char *opname, int argnum,
+                                           void *symbolname, int firstcheck, int nchecks)
 {
     TypeDesc typedesc = TYPEDESC(typedesc_);
     ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
@@ -3158,10 +3158,10 @@ osl_uninit_check (long long typedesc_, void *vals_,
 
 
 OSL_SHADEOP int
-osl_range_check (int indexvalue, int length, const char *symname,
-                 void *sg, const void *sourcefile, int sourceline,
-                 const char *groupname, int layer, const char *layername,
-                 const char *shadername)
+OSL_LLVM_PREFIXED_TOKEN(osl_range_check) (int indexvalue, int length, const char *symname,
+                                          void *sg, const void *sourcefile, int sourceline,
+                                          const char *groupname, int layer, const char *layername,
+                                          const char *shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
@@ -3183,7 +3183,8 @@ osl_range_check (int indexvalue, int length, const char *symname,
 
 
 // Asked if the raytype is a name we can't know until mid-shader.
-OSL_SHADEOP int osl_raytype_name (void *sg_, void *name)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_raytype_name) (void *sg_,
+                                                           void *name)
 {
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     int bit = sg->context->shadingsys().raytype_bit (USTR(name));
@@ -3191,14 +3192,14 @@ OSL_SHADEOP int osl_raytype_name (void *sg_, void *name)
 }
 
 
-OSL_SHADEOP int osl_get_attribute(void *sg_,
-                             int   dest_derivs,
-                             void *obj_name_,
-                             void *attr_name_,
-                             int   array_lookup,
-                             int   index,
-                             const void *attr_type,
-                             void *attr_dest)
+OSL_SHADEOP int OSL_LLVM_PREFIXED_TOKEN(osl_get_attribute)(void *sg_,
+                                                           int   dest_derivs,
+                                                           void *obj_name_,
+                                                           void *attr_name_,
+                                                           int   array_lookup,
+                                                           int   index,
+                                                           const void *attr_type,
+                                                           void *attr_dest)
 {
     ShaderGlobals *sg   = (ShaderGlobals *)sg_;
     const ustring &obj_name  = USTR(obj_name_);
@@ -3214,11 +3215,16 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
 
 
 OSL_SHADEOP int
-osl_bind_interpolated_param (void *sg_, const void *name, long long type,
-                             int userdata_has_derivs, void *userdata_data,
-                             int symbol_has_derivs, void *symbol_data,
-                             int symbol_data_size,
-                             char *userdata_initialized, int userdata_index)
+OSL_LLVM_PREFIXED_TOKEN(osl_bind_interpolated_param) (void *sg_,
+                                                      const void *name,
+                                                      long long type,
+                                                      int userdata_has_derivs,
+                                                      void *userdata_data,
+                                                      int symbol_has_derivs,
+                                                      void *symbol_data,
+                                                      int symbol_data_size,
+                                                      char *userdata_initialized,
+                                                      int userdata_index)
 {
     char status = *userdata_initialized;
     if (status == 0) {


### PR DESCRIPTION
When OSL_NAMESPACE is used to wrap the C++ API in a namespace, it may also
be desirable to ensure that the C free functions invoked by LLVM are
disambiguated as well. This can be enabled by providing a string value for
OSL_LLVM_PREFIX. This string will be prefixed to all free functions that may
be invoked via LLVM so that the right version of OSL API finds the right
version of the free function. If no prefix is supplied, an empty one is used.

This change adds an OSL_LLVM_PREFIX build option for make and cmake, and it
adds macros for prefixing C strings and tokens with that prefix, as well as
building op function names that include the prefix. It also wraps all existing
functions that get invoked via LLVM with these macros to ensure that they are
prefixed properly if OSL_LLVM_PREFIX is set.