### PR TITLE
clang-tidy support and include file fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (OSL
          VERSION 1.9.0
          LANGUAGES CXX C)
 set (PROJ_NAME ${PROJECT_NAME})    # short name
+string (TOLOWER ${PROJ_NAME} PROJ_NAME_LOWER)  # short name lower case
 set (PROJECT_VERSION_RELEASE_TYPE "dev")   # "dev", "betaX", "RCY", ""
 set (${PROJECT_NAME}_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 set (PROJECT_COPYRIGHTYEARS "2008-2017")
@@ -123,7 +124,7 @@ include (install)          # installation options all implemented here
 include_directories (
     BEFORE
     "${CMAKE_SOURCE_DIR}/src/include"
-    "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}"
+    "${CMAKE_BINARY_DIR}/include"
   )
 
 
@@ -139,6 +140,7 @@ include (CTest)
 
 
 # Tell CMake to process the sub-directories
+add_subdirectory (src/include)
 add_subdirectory (src/liboslcomp)
 add_subdirectory (src/liboslquery)
 add_subdirectory (src/liboslexec)
@@ -157,7 +159,6 @@ if (OSL_BUILD_PLUGINS)
 add_subdirectory (src/osl.imageio)
 endif ()
 
-add_subdirectory (src/include)
 add_subdirectory (src/doc)
 
 

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,21 @@ ifneq (${SANITIZE},)
 MY_CMAKE_FLAGS += -DSANITIZE=${SANITIZE}
 endif
 
+ifneq (${CLANG_TIDY},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY:BOOL=1
+endif
+ifneq (${CLANG_TIDY_CHECKS},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_CHECKS:STRING=${CLANG_TIDY_CHECKS}
+endif
+ifneq (${CLANG_TIDY_ARGS},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_ARGS:STRING=${CLANG_TIDY_ARGS}
+endif
+ifneq (${CLANG_TIDY_FIX},)
+  MY_CMAKE_FLAGS += -DCLANG_TIDY_FIX:BOOL=${CLANG_TIDY_FIX}
+  MY_NINJA_FLAGS += -j 1
+  # N.B. when fixing, you don't want parallel jobs!
+endif
+
 #$(info MY_CMAKE_FLAGS = ${MY_CMAKE_FLAGS})
 #$(info MY_MAKE_FLAGS = ${MY_MAKE_FLAGS})
 
@@ -340,6 +355,8 @@ help:
 	@echo "      USE_CCACHE=0             Disable ccache (even if available)"
 	@echo "      CODECOV=1                Enable code coverage tests"
 	@echo "      SANITIZE=name1,...       Enablie sanitizers (address, leak, thread)"
+	@echo "      CLANG_TIDY=1             Run clang-tidy on all source (can be modified"
+	@echo "                                  by CLANG_TIDY_ARGS=... and CLANG_TIDY_FIX=1"
 	@echo "  Linking and libraries:"
 	@echo "      HIDE_SYMBOLS=1           Hide symbols not in the public API"
 	@echo "      BUILDSTATIC=1            Build static library instead of shared"
@@ -362,7 +379,7 @@ help:
 	@echo "      USE_FAST_MATH=1          Use faster, but less accurate math (set to 0 for libm defaults)"
 	@echo "      OSL_BUILD_TESTS=0        Don't build unit tests, testshade, testrender"
 	@echo "      USE_SIMD=arch            Build with SIMD support (choices: 0, sse2, sse3,"
-	@echo "                                  ssse3, sse4.1, sse4.2, f16c,"
+	@echo "                                  ssse3, sse4.1, sse4.2, f16c, avx, avx2"
 	@echo "                                  comma-separated ok)"
 	@echo "  make test, extra options:"
 	@echo "      TEST=regex               Run only tests matching the regex"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -17,6 +17,10 @@ option (BUILDSTATIC "Build static libraries instead of shared")
 option (LINKSTATIC  "Link with static external libraries when possible")
 option (CODECOV "Build code coverage tests")
 set (SANITIZE "" CACHE STRING "Build code using sanitizer (address, thread)")
+option (CLANG_TIDY "Enable clang-tidy" OFF)
+set (CLANG_TIDY_CHECKS "-*" CACHE STRING "clang-tidy checks to perform")
+set (CLANG_TIDY_ARGS "" CACHE STRING "clang-tidy args")
+option (CLANG_TIDY_FIX "Have clang-tidy fix source" OFF)
 
 
 # Figure out which compiler we're using
@@ -284,6 +288,18 @@ if (SANITIZE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG))
     add_definitions ("-D${PROJECT_NAME}_SANITIZE=1")
 endif ()
 
+# clang-tidy options
+if (CLANG_TIDY)
+    set (CMAKE_CXX_CLANG_TIDY "clang-tidy;-header-filter=(${PROJECT_NAME})|(${PROJ_NAME})|(${PROJ_NAME_LOWER})|(_pvt.h)")
+    if (CLANG_TIDY_ARGS)
+        set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};${CLANG_TIDY_ARGS}")
+    endif ()
+    if (CLANG_TIDY_FIX)
+        set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};-fix")
+    endif ()
+    set (CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY};-checks=${CLANG_TIDY_CHECKS}")
+    message (STATUS, "clang-tidy command line is: ${CMAKE_CXX_CLANG_TIDY}")
+endif ()
 
 if (EXTRA_CPP_ARGS)
     message (STATUS "Extra C++ args: ${EXTRA_CPP_ARGS}")
@@ -323,7 +339,6 @@ if (LINKSTATIC)
 else ()
     if (MSVC)
         add_definitions (-DBOOST_ALL_DYN_LINK)
-        # Necessary?  add_definitions (-DOPENEXR_DLL)
     endif ()
 endif ()
 

--- a/src/include/OSL/Imathx.h
+++ b/src/include/OSL/Imathx.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenEXR/ImathMatrix.h>
 #include <OpenEXR/ImathColor.h>
 
-#include "matrix22.h"
+#include <OSL/matrix22.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/include/OSL/accum.h
+++ b/src/include/OSL/accum.h
@@ -28,8 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "oslconfig.h"
-#include "optautomata.h"
+#include <OSL/oslconfig.h>
+#include <OSL/optautomata.h>
 #include <list>
 #include <stack>
 

--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -28,7 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "oslversion.h"
+#include <OSL/oslversion.h>
 #include <OpenImageIO/fmath.h>
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/dual_vec.h
+++ b/src/include/OSL/dual_vec.h
@@ -28,8 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "oslconfig.h"
-#include "dual.h"
+#include <OSL/oslconfig.h>
+#include <OSL/dual.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/genclosure.h
+++ b/src/include/OSL/genclosure.h
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <OpenImageIO/ustring.h>
-#include "oslconfig.h"
+#include <OSL/oslconfig.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -28,8 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "export.h"
-#include "oslversion.h"
+#include <OSL/export.h>
+#include <OSL/oslversion.h>
 
 #include <vector>
 

--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstring>
 #include <OpenImageIO/ustring.h>
-#include "oslconfig.h"
+#include <OSL/oslconfig.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/oslcomp.h
+++ b/src/include/OSL/oslcomp.h
@@ -28,7 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "oslconfig.h"
+#include <OSL/oslconfig.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -69,9 +69,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/platform.h>
 
 // Extensions to Imath
-#include "matrix22.h"
+#include <OSL/matrix22.h>
 
-#include "oslversion.h"
+#include <OSL/oslversion.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -30,9 +30,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 
-#include "OSL/oslconfig.h"
-#include "OSL/shaderglobals.h"
-#include "OSL/rendererservices.h"
+#include <OSL/oslconfig.h>
+#include <OSL/shaderglobals.h>
+#include <OSL/rendererservices.h>
 
 #include <OpenImageIO/refcnt.h>
 #include <OpenImageIO/ustring.h>

--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -42,7 +42,7 @@ Sony Pictures Imageworks terms, above.
 #include <string>
 #include <vector>
 
-#include "oslconfig.h"
+#include <OSL/oslconfig.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 
-#include "oslconfig.h"
+#include <OSL/oslconfig.h>
 
 #include <OpenImageIO/ustring.h>
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <OpenImageIO/dassert.h>
 
-#include "OSL/oslconfig.h"
+#include <OSL/oslconfig.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/refcnt.h>
 
-#include "OSL/oslcomp.h"
+#include <OSL/oslcomp.h>
 #include "symtab.h"
 
 

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -33,10 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <map>
 
-#include "OSL/oslcomp.h"
+#include <OSL/oslcomp.h>
 #include "ast.h"
 #include "symtab.h"
-#include "OSL/genclosure.h"
+#include <OSL/genclosure.h>
 
 
 extern int oslparse ();

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -115,7 +115,7 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
           ${LLVM_COMPILE_FLAGS}
           "-I${CMAKE_CURRENT_SOURCE_DIR}"
           "-I${CMAKE_SOURCE_DIR}/src/include"
-          "-I${CMAKE_BINARY_DIR}/include/OSL"
+          "-I${CMAKE_BINARY_DIR}/include"
           "-I${OPENIMAGEIO_INCLUDE_DIR}"
           "-I${ILMBASE_INCLUDE_DIR}"
           "-I${Boost_INCLUDE_DIRS}"

--- a/src/liboslexec/accum.cpp
+++ b/src/liboslexec/accum.cpp
@@ -26,8 +26,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "OSL/accum.h"
-#include "OSL/oslclosure.h"
+#include <OSL/accum.h>
+#include <OSL/oslclosure.h>
 #include "lpeparse.h"
 #include <OpenImageIO/dassert.h>
 

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -26,8 +26,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "OSL/accum.h"
-#include "OSL/oslclosure.h"
+#include <OSL/accum.h>
+#include <OSL/oslclosure.h>
 
 using namespace OSL;
 

--- a/src/liboslexec/automata.cpp
+++ b/src/liboslexec/automata.cpp
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "automata.h"
-#include "OSL/optautomata.h"
+#include <OSL/optautomata.h>
 #include <algorithm>
 #include <cstdio>
 

--- a/src/liboslexec/automata.h
+++ b/src/liboslexec/automata.h
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 #include <unordered_set>
 
-#include "OSL/oslconfig.h"
+#include <OSL/oslconfig.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -36,7 +36,7 @@ using namespace OSL;
 using namespace OSL::pvt;
 
 #include "runtimeoptimize.h"
-#include "OSL/llvm_util.h"
+#include <OSL/llvm_util.h>
 
 
 

--- a/src/liboslexec/closure.cpp
+++ b/src/liboslexec/closure.cpp
@@ -33,9 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/dassert.h>
 #include <OpenImageIO/sysutil.h>
 
-#include "OSL/oslconfig.h"
-#include "OSL/oslclosure.h"
-#include "OSL/genclosure.h"
+#include <OSL/oslconfig.h>
+#include <OSL/oslclosure.h>
+#include <OSL/genclosure.h>
 #include "oslexec_pvt.h"
 
 

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstdio>
 #include <cstdlib>
-#include <ctype.h>
+#include <cctype>
 #include <unordered_map>
 
 #include <OpenImageIO/dassert.h>

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/fmath.h>
 
 #include "oslexec_pvt.h"
-#include "OSL/genclosure.h"
+#include <OSL/genclosure.h>
 #include "backendllvm.h"
 
 using namespace OSL;

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -101,10 +101,10 @@ typedef long double max_align_t;
 #include <iostream>
 #include <cstddef>
 
-#include "OSL/oslconfig.h"
-#include "OSL/shaderglobals.h"
-#include "OSL/dual.h"
-#include "OSL/dual_vec.h"
+#include <OSL/oslconfig.h>
+#include <OSL/shaderglobals.h>
+#include <OSL/dual.h>
+#include <OSL/dual_vec.h>
 using namespace OSL;
 
 #include <OpenEXR/ImathFun.h>

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/thread.h>
 #include <boost/thread/tss.hpp>   /* for thread_specific_ptr */
 
-#include "OSL/oslconfig.h"
-#include "OSL/llvm_util.h"
+#include <OSL/oslconfig.h>
+#include <OSL/llvm_util.h>
 
 #if OSL_LLVM_VERSION < 34
 #error "LLVM minimum version required for OSL is 3.4"

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
-#include "OSL/llvm_util.h"
+#include <OSL/llvm_util.h>
 
 
 typedef int (*IntFuncOfTwoInts)(int,int);

--- a/src/liboslexec/lpeparse.cpp
+++ b/src/liboslexec/lpeparse.cpp
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "lpeparse.h"
-#include "OSL/oslclosure.h"
+#include <OSL/oslclosure.h>
 #include <OpenImageIO/dassert.h>
 
 

--- a/src/liboslexec/opclosure.cpp
+++ b/src/liboslexec/opclosure.cpp
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 
 #include "oslexec_pvt.h"
-#include "OSL/genclosure.h"
+#include <OSL/genclosure.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 
 #include "oslexec_pvt.h"
-#include "OSL/dual.h"
+#include <OSL/dual.h>
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
 using OIIO::expm1;

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 
 #include "oslexec_pvt.h"
-#include "OSL/dual.h"
-#include "OSL/dual_vec.h"
+#include <OSL/dual.h>
+#include <OSL/dual_vec.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -27,7 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "oslexec_pvt.h"
-#include "OSL/shaderglobals.h"
+#include <OSL/shaderglobals.h>
 
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/liboslexec/opspline.cpp
+++ b/src/liboslexec/opspline.cpp
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/fmath.h>
 
 #include "oslexec_pvt.h"
-#include "OSL/dual_vec.h"
+#include <OSL/dual_vec.h>
 #include "splineimpl.h"
 
 

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 
 #include "oslexec_pvt.h"
-#include "OSL/dual.h"
+#include <OSL/dual.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -50,9 +50,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <regex>
 #endif
 
-#include "OSL/genclosure.h"
-#include "OSL/oslexec.h"
-#include "OSL/oslclosure.h"
+#include <OSL/genclosure.h>
+#include <OSL/oslexec.h>
+#include <OSL/oslclosure.h>
 #include "osl_pvt.h"
 #include "constantpool.h"
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -34,9 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 
 #include "oslexec_pvt.h"
-#include "OSL/genclosure.h"
+#include <OSL/genclosure.h>
 #include "backendllvm.h"
-#include "OSL/oslquery.h"
+#include <OSL/oslquery.h>
 
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/dassert.h>

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstdio>
 
-#include "OSL/oslquery.h"
+#include <OSL/oslquery.h>
 #include "../liboslexec/osoreader.h"
 using namespace OSL;
 using namespace OSL::pvt;

--- a/src/liboslquery/querystub.cpp
+++ b/src/liboslquery/querystub.cpp
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// introducing dependencies to liboslexec (where the actual method
 /// is implemented)
 
-#include "OSL/oslquery.h"
+#include <OSL/oslquery.h>
 using namespace OSL;
 
 

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/imagebuf.h>
 
-#include "OSL/oslexec.h"
-#include "OSL/oslcomp.h"
+#include <OSL/oslexec.h>
+#include <OSL/oslcomp.h>
 
 using namespace OIIO;
 

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -37,8 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/thread.h>
 
-#include "OSL/oslcomp.h"
-#include "OSL/oslexec.h"
+#include <OSL/oslcomp.h>
+#include <OSL/oslexec.h>
 using namespace OSL;
 
 

--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -46,7 +46,7 @@ Sony Pictures Imageworks terms, above.
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/filesystem.h>
 
-#include "OSL/oslquery.h"
+#include <OSL/oslquery.h>
 using namespace OSL;
 
 

--- a/src/testrender/background.h
+++ b/src/testrender/background.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "OSL/dual_vec.h"
-#include "OSL/oslconfig.h"
+#include <OSL/dual_vec.h>
+#include <OSL/oslconfig.h>
 #include <algorithm> // upper_bound
 
 OSL_NAMESPACE_ENTER

--- a/src/testrender/optics.h
+++ b/src/testrender/optics.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "OSL/oslconfig.h"
+#include <OSL/oslconfig.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -2,8 +2,8 @@
 
 #include <OpenImageIO/fmath.h>
 
-#include "OSL/dual_vec.h"
-#include "OSL/oslconfig.h"
+#include <OSL/dual_vec.h>
+#include <OSL/oslconfig.h>
 #include <vector>
 
 OSL_NAMESPACE_ENTER

--- a/src/testrender/sampling.h
+++ b/src/testrender/sampling.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "OSL/oslconfig.h"
+#include <OSL/oslconfig.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>
 #include <algorithm>

--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -1,6 +1,6 @@
 #include "shading.h"
 #include "sampling.h"
-#include "OSL/genclosure.h"
+#include <OSL/genclosure.h>
 #include "optics.h"
 
 using namespace OSL;

--- a/src/testrender/shading.h
+++ b/src/testrender/shading.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "sampling.h"
-#include "OSL/dual_vec.h"
-#include "OSL/oslexec.h"
-#include "OSL/oslclosure.h"
-#include "OSL/oslconfig.h"
+#include <OSL/dual_vec.h>
+#include <OSL/oslexec.h>
+#include <OSL/oslclosure.h>
+#include <OSL/oslconfig.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <unordered_map>
 #include <OpenImageIO/ustring.h>
-#include "OSL/oslexec.h"
+#include <OSL/oslexec.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <OpenImageIO/pugixml.hpp>
 #endif
 
-#include "OSL/oslexec.h"
+#include <OSL/oslexec.h>
 #include "simplerend.h"
 #include "raytracer.h"
 #include "background.h"

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -27,8 +27,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
-#include "OSL/oslexec.h"
-#include "OSL/genclosure.h"
+#include <OSL/oslexec.h>
+#include <OSL/genclosure.h>
 #include "simplerend.h"
 using namespace OSL;
 

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <unordered_map>
 #include <OpenImageIO/ustring.h>
-#include "OSL/oslexec.h"
+#include <OSL/oslexec.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -43,9 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/timer.h>
 
-#include "OSL/oslexec.h"
-#include "OSL/oslcomp.h"
-#include "OSL/oslquery.h"
+#include <OSL/oslexec.h>
+#include <OSL/oslcomp.h>
+#include <OSL/oslquery.h>
 #include "simplerend.h"
 using namespace OSL;
 using OIIO::TypeDesc;


### PR DESCRIPTION
Similar to recent changes to OIIO:

* Build scripts modified to support easy running of clang-tidy.

* Minor fixes of deprecated C header includes, updated to proper C++ headers.

* Lots of fixes making a uniform approach to including headers within our own project. In particular, all public headers are included as <OSL/foo.h> and not as "OSL/foo.h" or "foo.h".
