### PR TITLE
Use C++11 vector::emplace_back() where appropriate.

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -431,7 +431,7 @@ public:
     /// Append a new field (with type and name) to this struct.
     ///
     void add_field (const TypeSpec &type, ustring name) {
-        m_fields.push_back (FieldSpec (type, name));
+        m_fields.emplace_back(type, name);
     }
 
     /// The name of this struct (may not be unique across all scopes).

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -257,7 +257,7 @@ protected:
 
     /// Add a new node to the list of children.
     ///
-    void addchild (ASTNode *n) { m_children.push_back (n); }
+    void addchild (ASTNode *n) { m_children.emplace_back(n); }
 
     /// Call the print() method of all the children of this node.
     ///
@@ -428,7 +428,7 @@ public:
     Symbol *codegen_struct_initializers (ref init, Symbol *sym);
 
     void register_struct_init (ustring name, ASTNode *init) {
-        m_struct_field_inits.push_back (NamedInit (name, init));
+        m_struct_field_inits.emplace_back(name, init);
     }
 
 private:

--- a/src/liboslexec/accum.cpp
+++ b/src/liboslexec/accum.cpp
@@ -89,7 +89,7 @@ AccumAutomata::addRule(const char *pattern, int outidx, bool toalpha)
         delete e;
         return NULL;
     }
-    m_accumrules.push_back (AccumRule (outidx, toalpha));
+    m_accumrules.emplace_back(outidx, toalpha);
     // it is a list, so as long as we don't remove it from there, the pointer is valid
     void *rule = (void *)&(m_accumrules.back());
     m_rules.push_back (new lpexp::Rule (e, rule));

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -148,7 +148,7 @@ int main()
     // Create our fake testing AOV's
     std::vector<MyAov> aovs;
     for (int i = 0; i < naovs; ++i)
-        aovs.push_back (MyAov (test, i));
+        aovs.emplace_back(test, i);
 
     // Create the automata and add the rules
     AccumAutomata automata;

--- a/src/liboslexec/automata.cpp
+++ b/src/liboslexec/automata.cpp
@@ -545,7 +545,7 @@ StateSetRecord::ensureState(const IntSet &newstates, std::list<StateSetRecord::D
         getRulesFromSet(tstate, m_ndfautomata, newstates);
         m_key_to_dfstate[newkey] = tstate;
         // Add the discovery to the list so it will be explored
-        discovered.push_back(Discovery(tstate, newstates));
+        discovered.emplace_back(tstate, newstates);
         return tstate;
     }
 }

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -219,7 +219,7 @@ void
 ShadingContext::record_error (ErrorHandler::ErrCode code,
                               const std::string &text) const
 {
-    m_buffered_errors.push_back (ErrorItem(code,text));
+    m_buffered_errors.emplace_back(code,text);
     // If we aren't buffering, just process immediately
     if (! shadingsys().m_buffer_printf)
         process_errors ();

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -79,7 +79,7 @@ public:
     Dictionary (ShadingContext *ctx) : m_context(ctx)
     {
         // Create placeholder element 0 == 'not found'
-        m_nodes.push_back (Node(0, pugi::xml_node()));
+        m_nodes.emplace_back(0, pugi::xml_node());
     }
     ~Dictionary () {
         // Free all the documents.
@@ -238,7 +238,7 @@ Dictionary::dict_find (ustring dictionaryname, ustring query)
     int firstmatch = (int) m_nodes.size();
     int last = -1;
     for (int i = 0, e = (int)matches.size(); i < e;  ++i) {
-        m_nodes.push_back (Node (dindex, matches[i].node()));
+        m_nodes.emplace_back(dindex, matches[i].node());
         int nodeid = (int) m_nodes.size()-1;
         if (last < 0) {
             // If this is the first match, add a cache entry for it
@@ -285,7 +285,7 @@ Dictionary::dict_find (int nodeID, ustring query)
     int firstmatch = (int) m_nodes.size();
     int last = -1;
     for (int i = 0, e = (int)matches.size(); i < e;  ++i) {
-        m_nodes.push_back (Node (document, matches[i].node()));
+        m_nodes.emplace_back(document, matches[i].node());
         int nodeid = (int) m_nodes.size()-1;
         if (last < 0) {
             // If this is the first match, add a cache entry for it

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -388,7 +388,7 @@ ShaderInstance::add_connection (int srclayer, const ConnectedParam &srccon,
     }
 
     off_t oldmem = vectorbytes(m_connections);
-    m_connections.push_back (Connection (srclayer, srccon, dstcon));
+    m_connections.emplace_back(srclayer, srccon, dstcon);
 
     // adjust stats
     off_t mem = vectorbytes(m_connections) - oldmem;

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -231,7 +231,7 @@ void
 OSOReaderToMaster::add_param_default (const char *def, size_t offset, const Symbol& sym)
 {
   if (sym.typespec().is_unsized_array() && offset >= m_master->m_sdefaults.size())
-      m_master->m_sdefaults.push_back(ustring(def));
+      m_master->m_sdefaults.emplace_back(def);
   else
       m_master->m_sdefaults[offset] = ustring(def);
 }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1110,13 +1110,13 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
                 "ShaderGlobals.raytype is an int, max of 32 raytypes");
         m_raytypes.clear ();
         for (size_t i = 0;  i < type.numelements();  ++i)
-            m_raytypes.push_back (ustring(((const char **)val)[i]));
+            m_raytypes.emplace_back(((const char **)val)[i]);
         return true;
     }
     if (name == "renderer_outputs" && type.basetype == TypeDesc::STRING) {
         m_renderer_outputs.clear ();
         for (size_t i = 0;  i < type.numelements();  ++i)
-            m_renderer_outputs.push_back (ustring(((const char **)val)[i]));
+            m_renderer_outputs.emplace_back(((const char **)val)[i]);
         return true;
     }
     return false;
@@ -1281,7 +1281,7 @@ ShadingSystemImpl::attribute (ShaderGroup *group, string_view name,
     if (name == "renderer_outputs" && type.basetype == TypeDesc::STRING) {
         group->m_renderer_outputs.clear ();
         for (size_t i = 0;  i < type.numelements();  ++i)
-            group->m_renderer_outputs.push_back (ustring(((const char **)val)[i]));
+            group->m_renderer_outputs.emplace_back(((const char **)val)[i]);
         return true;
     }
     if (name == "entry_layers" && type.basetype == TypeDesc::STRING) {
@@ -1777,7 +1777,7 @@ ShadingSystemImpl::getstats (int level) const
             std::vector<GroupTimeVal> grouptimes;
             for (std::map<ustring,long long>::const_iterator m = m_group_profile_times.begin();
                  m != m_group_profile_times.end(); ++m) {
-                grouptimes.push_back (GroupTimeVal(m->first, m->second));
+                grouptimes.emplace_back(m->first, m->second);
             }
             std::sort (grouptimes.begin(), grouptimes.end(), group_time_compare());
             if (grouptimes.size() > 5)
@@ -2215,7 +2215,7 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
                     if (s.size() == 0)
                         break;
                 }
-                stringvals.push_back (ustring(s));
+                stringvals.emplace_back(s);
             }
             if (type.is_unsized_array()) {
                 // For unsized arrays, now set the size based on how many

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -139,7 +139,7 @@ OSOReaderQuery::symdefault (const char *def)
 {
     if (m_reading_param && m_query.nparams() > 0) {
         OSLQuery::Parameter &p (m_query.m_params[m_query.nparams()-1]);
-        p.sdefault.push_back (ustring(def));
+        p.sdefault.emplace_back(def);
         p.validdefault = true;
         m_default_values++;
     }
@@ -199,7 +199,7 @@ OSOReaderQuery::hint (string_view hintstring)
         if (p.type.basetype == TypeDesc::STRING) {
             string_view val;
             while (Strutil::parse_string (hintstring, val)) {
-                p.sdefault.push_back (ustring(val));
+                p.sdefault.emplace_back(val);
                 if (Strutil::parse_char (hintstring, '}'))
                     break;
                 Strutil::parse_char (hintstring, ',');
@@ -230,7 +230,7 @@ OSOReaderQuery::hint (string_view hintstring)
         while (1) {
             string_view ident = Strutil::parse_identifier (hintstring);
             if (ident.length()) {
-                param.fields.push_back (ustring(ident));
+                param.fields.emplace_back(ident);
                 Strutil::parse_char (hintstring, ',');
             } else {
                 break;

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -460,7 +460,7 @@ OSLInput::open (const std::string &name, ImageSpec &newspec,
             parse_res (args[i].second, m_topspec.tile_width, m_topspec.tile_height,
                        m_topspec.tile_depth);
         } else if (args[i].first == "OUTPUT") {
-            m_outputs.push_back (ustring(args[i].second));
+            m_outputs.emplace_back(args[i].second);
         } else if (args[i].first == "MIP") {
             m_mip = Strutil::from_string<int>(args[i].second);
         } else if (args[i].first.size() && args[i].second.size()) {
@@ -468,8 +468,8 @@ OSLInput::open (const std::string &name, ImageSpec &newspec,
         }
     }
     if (m_outputs.empty()) {
-        m_outputs.push_back (ustring("result"));
-        m_outputs.push_back (ustring("alpha"));
+        m_outputs.emplace_back("result");
+        m_outputs.emplace_back("alpha");
     }
 
     m_topspec.full_x = m_topspec.x;

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -163,17 +163,17 @@ main (int argc, const char *argv[])
                  ! strcmp (argv[a], "-O") || ! strcmp (argv[a], "-O0") ||
                  ! strcmp (argv[a], "-O1") || ! strcmp (argv[a], "-O2")) {
             // Valid command-line argument
-            args.push_back (argv[a]);
+            args.emplace_back(argv[a]);
             quiet |= (strcmp (argv[a], "-q") == 0);
         }
         else if (! strcmp (argv[a], "-o") && a < argc-1) {
-            args.push_back (argv[a]);
+            args.emplace_back(argv[a]);
             ++a;
-            args.push_back (argv[a]);
+            args.emplace_back(argv[a]);
         }
         else if (argv[a][0] == '-' &&
                  (argv[a][1] == 'D' || argv[a][1] == 'U' || argv[a][1] == 'I')) {
-            args.push_back (argv[a]);
+            args.emplace_back(argv[a]);
         }
         else {
             OSLCompiler compiler (&default_oslc_error_handler);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -676,7 +676,7 @@ setup_output_images (ShadingSystem *shadingsys,
     // For each output file specified on the command line...
     for (size_t i = 0;  i < outputfiles.size();  ++i) {
         // Make a ustring version of the output name, for fast manipulation
-        outputvarnames.push_back (ustring(outputvars[i]));
+        outputvarnames.emplace_back(outputvars[i]);
         // Start with a NULL ImageBuf pointer
         outputimgs.push_back (NULL);
 


### PR DESCRIPTION
Now that we have C++11 as a minimum, we can use this handy feature that
grows a vector by one slot (uninitialized) and the constructs a new
object in that location. In contrast, push_back() constructs the object
first, then grows the vector with a default constructed object, they
copies (or if you're lucky moves) the new object into the vector
position. Maybe the compiler will figure it all out, maybe not.  Using
emplace_back guarantees that there are no needless copies, moves, or
pointless constructions.

Thanks, clang-tidy, for making this a 5-minute change!