### PR TITLE
Add an API call to define raytypes_on and raytypes_off

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -557,15 +557,19 @@ public:
     /// data passed in via attribute("raytypes")).
     int raytype_bit (ustring name);
 
+    /// Configure the default raytypes to assume to be on (or off) at optimization
+    /// time for the given group. The raytypes_on gives a bitfield describing which
+    /// ray flags are known to be 1, and raytypes_off describes which ray flags are
+    /// known to be 0. Bits that are not set in either set of flags are not known
+    /// to the optimizer, and will be determined strictly at execution time.
+    void set_raytypes(ShaderGroup *group, int raytypes_on, int raytypes_off);
+
     /// Ensure that the group has been optimized and JITed.
     /// Ensure that the group has been optimized and JITed.
     void optimize_group (ShaderGroup *group);
 
-    /// Ensure that the group has been optimized and JITed. The raytypes_on
-    /// gives a bitfield describing which ray flags are known to be 1, and
-    /// raytypes_off describes which ray flags are known to be 0. Bits that
-    /// are not set in either set of flags are not known to the optimizer,
-    /// and will be determined strictly at execution time.
+    /// Ensure that the group has been optimized and JITed. This is a
+    /// convenience function that simply calls set_raytypes followed by optimize_group.
     void optimize_group (ShaderGroup *group, int raytypes_on,
                          int raytypes_off);
 

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -669,7 +669,7 @@ ShaderGroup::ShaderGroup (string_view name)
   : m_optimized(0), m_does_nothing(false),
     m_llvm_groupdata_size(0), m_num_entry_layers(0),
     m_llvm_compiled_version(NULL),
-    m_name(name), m_exec_repeat(1), m_raytype_queries(-1)
+    m_name(name), m_exec_repeat(1), m_raytype_queries(-1), m_raytypes_on(0), m_raytypes_off(0)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;
@@ -683,7 +683,7 @@ ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
     m_llvm_groupdata_size(0), m_num_entry_layers(g.m_num_entry_layers),
     m_llvm_compiled_version(NULL),
     m_layers(g.m_layers),
-    m_name(name), m_exec_repeat(1), m_raytype_queries(-1)
+    m_name(name), m_exec_repeat(1), m_raytype_queries(-1), m_raytypes_on(0), m_raytypes_off(0)
 {
     m_executions = 0;
     m_stat_total_shading_time_ticks = 0;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -630,8 +630,7 @@ public:
     /// The group is set and won't be changed again; take advantage of
     /// this by optimizing the code knowing all our instance parameters
     /// (at least the ones that can't be overridden by the geometry).
-    void optimize_group (ShaderGroup &group,
-                         int raytypes_on=0, int raytypes_off=0);
+    void optimize_group (ShaderGroup &group);
 
     /// After doing all optimization and code JIT, we can clean up by
     /// deleting the instances' code and arguments, and paring their
@@ -1523,6 +1522,15 @@ public:
 
     int raytype_queries () const { return m_raytype_queries; }
 
+    /// Optionally set which ray types are known to be on or off (0 means
+    /// not known at optimize time).
+    void set_raytypes (int raytypes_on, int raytypes_off) {
+        m_raytypes_on  = raytypes_on;
+        m_raytypes_off = raytypes_off;
+    }
+    int raytypes_on ()  const { return m_raytypes_on; }
+    int raytypes_off () const { return m_raytypes_off; }
+
 private:
     // Put all the things that are read-only (after optimization) and
     // needed on every shade execution at the front of the struct, as much
@@ -1539,6 +1547,8 @@ private:
     ustring m_name;
     int m_exec_repeat;               ///< How many times to execute group
     int m_raytype_queries;           ///< Bitmask of raytypes queried
+    int m_raytypes_on;               ///< Bitmask of raytypes we assume to be on
+    int m_raytypes_off;              ///< Bitmask of raytypes we assume to be off
     mutable mutex m_mutex;           ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -123,7 +123,7 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_next_newconst(0), m_next_newtemp(0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
       m_stop_optimizing(false),
-      m_raytypes_on(0), m_raytypes_off(0)
+      m_raytypes_on(group.raytypes_on()), m_raytypes_off(group.raytypes_off())
 {
     memset (&m_shaderglobals, 0, sizeof(ShaderGlobals));
     m_shaderglobals.context = shadingcontext();

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -444,11 +444,19 @@ ShadingSystem::archive_shadergroup (ShaderGroup *group, string_view filename)
 }
 
 
+void
+ShadingSystem::set_raytypes (ShaderGroup *group, int raytypes_on, int raytypes_off)
+{
+    DASSERT (group);
+    group->set_raytypes(raytypes_on, raytypes_off);
+}
+
 
 void
 ShadingSystem::optimize_group (ShaderGroup *group)
 {
-    optimize_group (group, 0, 0);   // No knowledge of the ray flags
+    DASSERT (group);
+    m_impl->optimize_group (*group);
 }
 
 
@@ -457,8 +465,10 @@ void
 ShadingSystem::optimize_group (ShaderGroup *group,
                                int raytypes_on, int raytypes_off)
 {
-    ASSERT (group);
-    m_impl->optimize_group (*group, raytypes_on, raytypes_off);
+    // convenience function for backwards compatibility
+    set_raytypes (group, raytypes_on, raytypes_off);
+    optimize_group (group);
+
 }
 
 
@@ -2606,8 +2616,7 @@ ShadingSystemImpl::group_post_jit_cleanup (ShaderGroup &group)
 
 
 void
-ShadingSystemImpl::optimize_group (ShaderGroup &group,
-                                   int raytypes_on, int raytypes_off)
+ShadingSystemImpl::optimize_group (ShaderGroup &group)
 {
     if (group.optimized())
         return;    // already optimized
@@ -2643,7 +2652,6 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group,
 
     ShadingContext *ctx = get_context ();
     RuntimeOptimizer rop (*this, group, ctx);
-    rop.set_raytypes (raytypes_on, raytypes_off);
     rop.run ();
 
     // Copy some info recorted by the RuntimeOptimizer into the group


### PR DESCRIPTION
This makes it possible to use this feature of the optimizer even when relying on lazy JIT of shader groups.