### PR TITLE
Eliminate varargs from OSLCompilerImpl and ASTNode

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenEXR/ImathMatrix.h>
 
 // All the things we need from OpenImageIO
-#include <OpenImageIO/version.h>
+#include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/errorhandler.h>
 #include <OpenImageIO/texture.h>
 #include <OpenImageIO/typedesc.h>

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -26,7 +26,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <cstdarg>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -113,25 +112,27 @@ ASTNode::ASTNode (NodeType nodetype, OSLCompilerImpl *compiler, int op,
 
 
 void
-ASTNode::error (const char *format, ...)
+ASTNode::error_impl (string_view msg) const
 {
-    va_list ap;
-    va_start (ap, format);
-    std::string errmsg = format ? Strutil::vformat (format, ap) : "syntax error";
-    va_end (ap);
-    m_compiler->error (sourcefile(), sourceline(), "%s", errmsg.c_str());
+#if OIIO_VERSION >= 10803
+    m_compiler->error (sourcefile(), sourceline(), "%s", msg);
+#else
+    // DEPRECATED -- delete when minimum OIIO is at least 1.8
+    m_compiler->error (sourcefile(), sourceline(), "%s", msg.c_str());
+#endif
 }
 
 
 
 void
-ASTNode::warning (const char *format, ...)
+ASTNode::warning_impl (string_view msg) const
 {
-    va_list ap;
-    va_start (ap, format);
-    std::string errmsg = format ? Strutil::vformat (format, ap) : "unknown warning";
-    va_end (ap);
-    m_compiler->warning (sourcefile(), sourceline(), "%s", errmsg.c_str());
+#if OIIO_VERSION >= 10803
+    m_compiler->warning (sourcefile(), sourceline(), "%s", msg);
+#else
+    // DEPRECATED -- delete when minimum OIIO is at least 1.8
+    m_compiler->warning (sourcefile(), sourceline(), "%s", msg.c_str());
+#endif
 }
 
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -179,9 +179,28 @@ public:
 
     void sourceline (int line) { m_sourceline = line; }
 
-    // FIXME - some day, replace this with TinyFormat-based version.
-    void error (const char *format, ...);
-    void warning (const char *format, ...);
+    template<typename... Args>
+    void error (string_view format, const Args&... args) const
+    {
+        DASSERT (format.size());
+#if OIIO_VERSION >= 10803
+        error_impl (OIIO::Strutil::format (format, args...));
+#else /* DEPRECATE when OIIO minimum is at least 1.8 */
+        error_impl (OIIO::Strutil::format (format.c_str(), args...));
+#endif
+    }
+
+    /// Warning reporting
+    template<typename... Args>
+    void warning (string_view format, const Args&... args) const
+    {
+        DASSERT (format.size());
+#if OIIO_VERSION >= 10803
+        warning_impl (OIIO::Strutil::format (format, args...));
+#else /* DEPRECATE when OIIO minimum is at least 1.8 */
+        warning_impl (OIIO::Strutil::format (format.c_str(), args...));
+#endif
+    }
 
     bool is_lvalue () const { return m_is_lvalue; }
 
@@ -319,6 +338,9 @@ protected:
                                 Symbol *arrayindex,
                                 bool copywholearrays, int intindex,
                                 bool paraminit);
+
+    void error_impl (string_view msg) const;
+    void warning_impl (string_view msg) const;
 
 protected:
     NodeType m_nodetype;          ///< Type of node this is

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <streambuf>
 #include <cstdio>
 #include <cerrno>
-#include <cstdarg>
 
 #include "oslcomp_pvt.h"
 
@@ -146,40 +145,6 @@ OSLCompilerImpl::OSLCompilerImpl (ErrorHandler *errhandler)
 OSLCompilerImpl::~OSLCompilerImpl ()
 {
     delete m_derivsym;
-}
-
-
-
-void
-OSLCompilerImpl::error (ustring filename, int line, const char *format, ...) const
-{
-    va_list ap;
-    va_start (ap, format);
-    std::string errmsg = format ? OIIO::Strutil::vformat (format, ap) : "syntax error";
-    if (filename.c_str())
-        m_errhandler->error ("%s:%d: error: %s",
-                             filename.c_str(), line, errmsg.c_str());
-    else
-        m_errhandler->error ("error: %s", errmsg.c_str());
-
-    va_end (ap);
-    m_err = true;
-}
-
-
-
-void
-OSLCompilerImpl::warning (ustring filename, int line, const char *format, ...) const
-{
-    va_list ap;
-    va_start (ap, format);
-    std::string errmsg = format ? OIIO::Strutil::vformat (format, ap) : "";
-    if (filename.c_str())
-        m_errhandler->error ("%s:%d: warning: %s",
-                             filename.c_str(), line, errmsg.c_str());
-    else
-        m_errhandler->error ("warning: %s", errmsg.c_str());
-    va_end (ap);
 }
 
 

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -99,12 +99,47 @@ public:
     ErrorHandler &errhandler () const { return *m_errhandler; }
 
     /// Error reporting
-    ///
-    void error (ustring filename, int line, const char *format, ...) const;
+    template<typename... Args>
+    void error (string_view filename, int line,
+                string_view format, const Args&... args) const
+    {
+        ASSERT (format.size());
+#if OIIO_VERSION >= 10804
+        std::string msg = OIIO::Strutil::format (format, args...);
+        if (filename.size())
+            m_errhandler->error ("%s:%d: error: %s", filename, line, msg);
+        else
+            m_errhandler->error ("error: %s", msg);
+#else /* Deprecate when the OIIO minimum is 1.8 */
+        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
+        if (filename.size())
+            m_errhandler->error ("%s:%d: error: %s", filename.c_str(), line, msg.c_str());
+        else
+            m_errhandler->error ("error: %s", msg.c_str());
+#endif
+        m_err = true;
+    }
 
     /// Warning reporting
-    ///
-    void warning (ustring filename, int line, const char *format, ...) const;
+    template<typename... Args>
+    void warning (string_view filename, int line,
+                  string_view format, const Args&... args) const
+    {
+        ASSERT (format.size());
+#if OIIO_VERSION >= 10804
+        std::string msg = OIIO::Strutil::format (format, args...);
+        if (filename.size())
+            m_errhandler->warning ("%s:%d: warning: %s", filename, line, msg);
+        else
+            m_errhandler->warning ("warning: %s", msg);
+#else /* Deprecate when the OIIO minimum is 1.8 */
+        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
+        if (filename.size())
+            m_errhandler->warning ("%s:%d: warning: %s", filename.c_str(), line, msg.c_str());
+        else
+            m_errhandler->warning ("warning: %s", msg.c_str());
+#endif
+    }
 
     /// Have we hit an error?
     ///


### PR DESCRIPTION
Use type-safe variadic templates instead.

The implementation details get cleaner if you have a sufficiently new OIIO, so there are a couple `#if`s
for now, but eventually the old path can be removed.

Not a pressing issue, just some cleanup I finally got around to.
