### PR TITLE
More robust finding of stdosl.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,10 @@ install:
     - export OIIOMAKEFLAGS="$OIIOMAKEFLAGS -j2 DEBUG= USE_PYTHON=0 OIIO_BUILD_TESTS=0"
     - src/build-scripts/build_openimageio.bash
     - export OPENIMAGEIOHOME=$PWD/OpenImageIO/dist/$OIIOPLATFORM
+    - export PATH=$OPENIMAGEIOHOME/bin:$PATH
     - export DYLD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$DYLD_LIBRARY_PATH
     - export LD_LIBRARY_PATH=$OPENIMAGEIOHOME/lib:$LD_LIBRARY_PATH
-    - export PATH=$OPENIMAGEIOHOME/bin:$PATH
+    - export PYTHONPATH=$OPENIMAGEIOHOME/python:$PYTHONPATH
     - if [ $TRAVIS_OS_NAME == linux ] ; then
           export BUILD_FLAGS="$BUILD_FLAGS LLVM_STATIC=1" ;
           export TEST_FLAGS="-E broken\|render-cornell\|render-oren-nayar\|render-veachmis\|render-ward" ;
@@ -82,10 +83,6 @@ install:
 script:
     - make VERBOSE=1 $BUILD_FLAGS cmakesetup
     - make -j2 $BUILD_FLAGS
-    - export OSLHOME=$PWD/dist/$PLATFORM
-    - export DYLD_LIBRARY_PATH=$OSLHOME/lib:$DYLD_LIBRARY_PATH 
-    - export LD_LIBRARY_PATH=$OSLHOME/lib:$LD_LIBRARY_PATH
-    - export PYTHONPATH=$OSLHOME/python:$OPENIMAGEIOHOME/python:$PYTHONPATH
     - export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
     - make $BUILD_FLAGS test
 

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -66,36 +66,6 @@ usage ()
 
 
 
-// Guess the path for stdosl.h. Try ../shaders, if this is oslc, that's
-// where you'd expect it to be.
-static std::string
-stdoslpath ()
-{
-    std::string program = OIIO::Sysutil::this_program_path ();
-    if (program.size()) {
-        std::string path (program);  // our program
-        path = OIIO::Filesystem::parent_path(path);  // the bin dir of our program
-        path = OIIO::Filesystem::parent_path(path);  // now the parent dir
-        std::string savepath = path;
-        // We search two spots: ../../lib/osl/include, and ../shaders
-        path = savepath + "/lib/osl/include";
-        if (OIIO::Filesystem::exists (path)) {
-            path = path + "/stdosl.h";
-            if (OIIO::Filesystem::exists (path))
-                return path;
-        }
-        path = savepath + "/shaders";
-        if (OIIO::Filesystem::exists (path)) {
-            path = path + "/stdosl.h";
-            if (OIIO::Filesystem::exists (path))
-                return path;
-        }
-    }
-    return std::string();
-}
-
-
-
 namespace { // anonymous
 
 // Subclass ErrorHandler because we want our messages to appear somewhat
@@ -177,7 +147,7 @@ main (int argc, const char *argv[])
         }
         else {
             OSLCompiler compiler (&default_oslc_error_handler);
-            bool ok = compiler.compile (argv[a], args, stdoslpath());
+            bool ok = compiler.compile (argv[a], args);
             if (ok) {
                 if (!quiet)
                     std::cout << "Compiled " << argv[a] << " -> " 


### PR DESCRIPTION
There was a discrepancy in how stdosl.h is searched for, among the different ways that compiles are triggered (osl from command line, versus OSLCompiler from file, versus OSLCompiler from buffer). This patch unifies them, and expands with additional heuristics for finding the file.

Also falling out of this is that the build and test scripts are now much more robust to the user not setting $OSLHOME -- a top-level 'make test' will find it all in the build itself. Also, it fixes some cases where osl.imageio.so can't find stdosl.h, and thus would appear inexplicably broken.