### PR TITLE
Fix the handling of alignment for closure structs

### DIFF
--- a/src/include/OSL/genclosure.h
+++ b/src/include/OSL/genclosure.h
@@ -81,6 +81,6 @@ struct ClosureParam {
 #define CLOSURE_STRING_KEYPARAM(st, fld, key) \
     { TypeDesc::TypeString, (int)reckless_offsetof(st, fld), key, fieldsize(st, fld) }
 
-#define CLOSURE_FINISH_PARAM(st) { TypeDesc(), sizeof(st), NULL, 0 }
+#define CLOSURE_FINISH_PARAM(st) { TypeDesc(), sizeof(st), nullptr, alignof(st) }
 
 OSL_NAMESPACE_EXIT

--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -120,11 +120,11 @@ struct OSLEXECPUBLIC ClosureColor {
 /// whatever type of custom primitive component it actually is.
 struct OSLEXECPUBLIC ClosureComponent : public ClosureColor
 {
-    Vec3   w;        ///< Weight of this component
-    char   mem[4];   ///< Memory for the primitive
-                     ///  4 is the minimum, allocation
-                     ///  will be scaled to requirements
-                     ///  of the primitive
+    Vec3 w;                     ///< Weight of this component
+    alignas(void*) char mem[8]; ///< Memory for the primitive, 8 is the minimum, allocation will be
+                                ///  scaled to requirements of the registered closure struct.
+                                ///  Alignment is forced to a void* to match likely alignement requirements
+                                ///  of the user's structs.
 
     /// Handy method for getting the parameter memory as a void*.
     ///

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -542,8 +542,8 @@ public:
     std::string getstats (int level=1) const;
 
     void register_closure (string_view name, int id, const ClosureParam *params,
-                           PrepareClosureFunc prepare, SetupClosureFunc setup,
-                           int alignment = 1);
+                           PrepareClosureFunc prepare, SetupClosureFunc setup);
+
     /// Query either by name or id an existing closure. If name is non
     /// NULL it will use it for the search, otherwise id would be used
     /// and the name will be placed in name if successful. Also return


### PR DESCRIPTION
`ubsan` complained that our closure memory accesses were not properly aligned. The previous code wasn't tracking the actual `alignof` that the target struct wanted.

Due to how we pack the user's closure `struct` into the memory of `ClosureComponent`, we can't support arbitrary sizes. But I have at least added some error detection code to check that the user isn't trying to use a struct with wider than usual alignment requirements.

I've nuked the old `alignment` flag to `register_closure` because it wasn't working as intended and was somewhat hard to use (none of the example `test*` programs set it, nor did our renderer).