### PR TITLE
Allow shaders to be accidentally specified with trailing .oso

### DIFF
--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -566,6 +566,8 @@ OSOReaderToMaster::instruction_end ()
 ShaderMaster::ref
 ShadingSystemImpl::loadshader (string_view cname)
 {
+    if (Strutil::ends_with (cname, ".oso"))
+        cname.remove_suffix (4);   // strip superfluous .oso
     if (! cname.size()) {
         error ("Attempt to load shader with empty name \"\".");
         return NULL;


### PR DESCRIPTION
One way you could bump into this is if you

    testshade ... test.oso

it would complain about the shader not being found.
