### PR TITLE
Fix OSX build problems on TravisCI, support make INSTALL_PREFIX=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ script:
     - make VERBOSE=1 $BUILD_FLAGS cmakesetup
     - make -j2 $BUILD_FLAGS
     - export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
+    - export OSLHOME=$PWD/dist/$PLATFORM
+    - export OIIO_LIBRARY_PATH=$OSLHOME/lib:${OIIO_LIBRARY_PATH}
     - make $BUILD_FLAGS test
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ message (STATUS "CMake version is ${CMAKE_VERSION}")
 cmake_policy (SET CMP0017 NEW)  # Prefer files from the CMake module directory when including from there.
 cmake_policy (SET CMP0025 NEW)  # Detect AppleClang for new CMake
 cmake_policy (SET CMP0046 OLD)  # Don't error on non-existent dependency in add_dependencies.
-cmake_policy (SET CMP0042 OLD)  # Don't enable MACOSX_RPATH by default
 set (CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 
 # Deprecated names
@@ -34,7 +33,8 @@ set (OSO_FILE_VERSION_MINOR 0)
 if (VERBOSE)
     message (STATUS "Project source dir = ${PROJECT_SOURCE_DIR}")
 endif ()
-message (STATUS "Project build dir = ${CMAKE_BINARY_DIR}")
+message (STATUS "Project build dir   = ${CMAKE_BINARY_DIR}")
+message (STATUS "Project install dir = ${CMAKE_INSTALL_PREFIX}")
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message (FATAL_ERROR "Not allowed to run in-source build!")

--- a/src/build-scripts/build_openimageio.bash
+++ b/src/build-scripts/build_openimageio.bash
@@ -2,16 +2,20 @@
 
 # Install OpenImageIO
 
+OIIOREPO=${OIIOREPO:=OpenImageIO/oiio}
 OIIOBRANCH=${OIIOBRANCH:=master}
 OIIOINSTALLDIR=${OIIOINSTALLDIR:=${PWD}/OpenImageIO}
 
 if [ ! -e $OIIOINSTALLDIR ] ; then
-    git clone https://github.com/OpenImageIO/oiio.git $OIIOINSTALLDIR
+    git clone https://github.com/${OIIOREPO} $OIIOINSTALLDIR
 fi
 
-( cd $OIIOINSTALLDIR ; git fetch --all -p && git checkout $OIIOBRANCH --force ; make nuke )
-( cd $OIIOINSTALLDIR ; make ${OIIOMAKEFLAGS} VERBOSE=1 cmakesetup )
-( cd $OIIOINSTALLDIR ; make ${OIIOMAKEFLAGS} )
+cd $OIIOINSTALLDIR
+git fetch --all -p
+git checkout $OIIOBRANCH --force
+make nuke
+make ${OIIOMAKEFLAGS} VERBOSE=1 cmakesetup
+make ${OIIOMAKEFLAGS}
 
 echo "OIIOINSTALLDIR $OIIOINSTALLDIR"
 ls -R $OIIOINSTALLDIR/dist

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -24,7 +24,7 @@ brew install flex bison
 brew install ilmbase openexr
 #brew install boost-python
 brew install opencolorio partio
-#brew install freetype libpng
+brew install freetype libpng
 brew install llvm${LLVMBREWVER}
 #brew install homebrew/science/hdf5 --with-threadsafe
 #brew install field3d webp ffmpeg openjpeg opencv

--- a/src/cmake/install.cmake
+++ b/src/cmake/install.cmake
@@ -59,6 +59,7 @@ set (INSTALL_FONTS OFF CACHE BOOL "Install default fonts")
 
 ###########################################################################
 # Rpath handling at the install step
+set (MACOSX_RPATH ON)
 if (CMAKE_SKIP_RPATH)
     # We need to disallow the user from truly setting CMAKE_SKIP_RPATH, since
     # we want to run the generated executables from the build tree in order to
@@ -87,7 +88,6 @@ endif ()
 set (CMAKE_SKIP_BUILD_RPATH  FALSE)
 # When building, don't use the install RPATH already (but later on when installing)
 set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
 
 
 


### PR DESCRIPTION
Our TravisCI builds on OSX have been failing for a while and I finally
got a chance to track down the issues.

1. Slight adjustment to ensure that on OSX the rpath is set correctly.
(At least I think it's more "correct" now. Seems to fix some things.)

2. Make sure that on Travis we install the homebrew freetype package,
which is needed for the texture-udim test.

3. Make sure OIIO_LIBRARY_PATH is set to help the osl-imageio test, which
needs to find the osl plugin for OIIO.

4. Also simultaneously depends on a change to OIIO (analogous to the first
item here) to adjust its RPATH behavior slightly on OSX.

None of these things should affect non-OSX builds.

Also, as was recently done to OIIO, add to the wrapper Makefile the
ability to set INSTALL_PREFIX, which is passed along to cmake as
CMAKE_INSTALL_PREFIX. It defaults to the usual of ./dist/PLATFORM, but
this lets you override to, for example, instruct the build to put the
full installed files in another location. You could always do this if
invoking cmake directly, but it was tricky for those who preferred to
use the make wrapper.