### PR TITLE
Fix memory leak of ASTNode's in osl compiler.

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -92,7 +92,7 @@ public:
     ASTNode (NodeType nodetype, OSLCompilerImpl *compiler, int op,
              ASTNode *a, ASTNode *b, ASTNode *c, ASTNode *d);
 
-    virtual ~ASTNode () { }
+    virtual ~ASTNode ();
 
     /// Print a text description of this node (and its children) to the
     /// console, for debugging.
@@ -400,7 +400,7 @@ public:
     FunctionSymbol *func () const { return (FunctionSymbol *)m_sym; }
 
     bool is_builtin () const { return m_is_builtin; }
-    void add_meta (ASTNode *meta);
+    void add_meta (ref meta);
 
 private:
     ustring m_name;
@@ -426,7 +426,7 @@ public:
     ref init () const { return child (0); }
     ref meta () const { return child (1); }
 
-    void add_meta (ASTNode *meta) {
+    void add_meta (ref meta) {
         while (nchildren() < 2)
             addchild (NULL);
         m_children[1] = meta;  // beware changing the order!

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -350,6 +350,13 @@ public:
 
     bool debug () const { return m_debug; }
 
+    /// As the compiler generates function declarations, we need to remember
+    /// them (with ref-counted pointers). They'll get freed automatically
+    /// when the compiler destructs.
+    void remember_function_decl (ASTfunction_declaration *f) {
+        m_func_decls.emplace_back (f);
+    }
+
 private:
     void initialize_globals ();
     void initialize_builtin_funcs ();
@@ -427,6 +434,7 @@ private:
     ErrorHandler *m_errhandler; ///< Error handler
     mutable bool m_err;       ///< Has an error occurred?
     SymbolTable m_symtab;     ///< Symbol table
+    std::vector<ASTNode::ref> m_func_decls; ///< Ref-counted function decls
     TypeSpec m_current_typespec;  ///< Currently-declared type
     bool m_current_output;        ///< Currently-declared output status
     bool m_verbose;           ///< Verbose mode

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -195,6 +195,7 @@ shader_or_function_declaration
                                                          typespec_stack.top(),
                                                          ustring($2), $7 /*formals*/,
                                                          $11 /*statements*/);
+                        oslcompiler->remember_function_decl (f);
                         f->add_meta (concat($4, $10));
                         $$ = f;
                         $$->sourceline (@2.first_line);
@@ -332,6 +333,7 @@ function_declaration
                     f = new ASTfunction_declaration (oslcompiler,
                                                      typespec_stack.top(),
                                                      ustring($2), $5, $8, NULL);
+                    oslcompiler->remember_function_decl (f);
                     f->add_meta ($7);
                     $$ = f;
                     typespec_stack.pop ();


### PR DESCRIPTION
Chris discovered that oslc was leaking ASTNode allocations, which was
interfering with some of his sanitizer runs.

Function declarations had the raw pointers squirreled away in the symbol
table without ever keeping a ref-counted version, so they were never
freed. So now we keep a vector of the ref-counted pointers for
ASTfunction_declaration in the OSLCompilerImpl, which all get freed when
the compiler destructs.

Quite independently, we were leaking the nodes associated with certain
metadata, they were just dropped on the floor by the add_meta() method,
which walked through what it was handed and used it to adjust things,
but never freed the pointers. This is fixed by changing add_meta to
force the raw pointers to be converted to ref-counted.

I added some code that for DEBUG builds only will track the construction
and destruction of ASTNodes, and upon program termination will print
messages if more nodes were created than destroyed.
