### PR TITLE
oslc: Add error detection of duplicate functions in the same scope.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             operator-overloading
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul oslc-err-field
-            oslc-err-format oslc-err-intoverflow
+            oslc-err-format oslc-err-funcredef oslc-err-intoverflow
             oslc-err-noreturn oslc-err-notfunc
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -248,24 +248,15 @@ protected:
 
     /// Flatten a list of nodes (headed by A) into a vector of node refs
     /// (vec).
-    static void list_to_vec (const ref &A, std::vector<ref> &vec) {
-        vec.clear ();
-        for (ref node = A; node; node = node->next())
-            vec.push_back (node);
-    }
+    static void list_to_vec (const ref &A, std::vector<ref> &vec);
 
     /// Turn a vector of node refs into a list of nodes, returning its
     /// head.
-    static ref vec_to_list (std::vector<ref> &vec) {
-        if (vec.size()) {
-            for (size_t i = 0;  i < vec.size()-1;  ++i)
-                vec[i]->m_next = vec[i+1];
-            vec[vec.size()-1]->m_next = NULL;
-            return vec[0];
-        } else {
-            return ref();
-        }
-    }
+    static ref vec_to_list (std::vector<ref> &vec);
+
+    /// Generate a comma-separated string of data types of the list headed
+    /// by node (for example, "float, int, string").
+    static std::string list_to_types_string (const ASTNode *node);
 
     /// Return the number of child nodes.
     ///
@@ -420,7 +411,8 @@ class ASTfunction_declaration : public ASTNode
 {
 public:
     ASTfunction_declaration (OSLCompilerImpl *comp, TypeSpec type, ustring name,
-                             ASTNode *form, ASTNode *stmts, ASTNode *meta=NULL);
+                             ASTNode *form, ASTNode *stmts, ASTNode *meta=NULL,
+                             int sourceline_start=-1);
     const char *nodetypename () const { return "function_declaration"; }
     const char *childname (size_t i) const;
     void print (std::ostream &out, int indentlevel=0) const;

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -194,11 +194,12 @@ shader_or_function_declaration
                         f = new ASTfunction_declaration (oslcompiler,
                                                          typespec_stack.top(),
                                                          ustring($2), $7 /*formals*/,
-                                                         $11 /*statements*/);
+                                                         $11 /*statements*/,
+                                                         NULL /*metadata*/,
+                                                         @2.first_line);
                         oslcompiler->remember_function_decl (f);
                         f->add_meta (concat($4, $10));
                         $$ = f;
-                        $$->sourceline (@2.first_line);
                         typespec_stack.pop ();
                     } else {
                         // Shader declaration

--- a/src/shaders/color2.h
+++ b/src/shaders/color2.h
@@ -181,18 +181,6 @@ color2 clamp(color2 c, float minval, float maxval)
     return clamp(c, color2(minval, minval), color2(maxval, maxval));
 }
 
-color2 pow(color2 base, color2 power)
-{
-    return color2(pow(base.r, power.r),
-                  pow(base.a, power.a));
-}
-
-color2 pow(color2 base, float power)
-{
-    return color2(pow(base.r, power),
-                  pow(base.a, power));
-}
-
 color2 max(color2 a, color2 b)
 {
     return color2(max(a.r, b.r),

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -60,6 +60,7 @@
     color  name (color x) BUILTIN;              \
     float  name (float x) BUILTIN;
 
+// Declare name (T,T) for T in {triples,float}
 #define PERCOMP2(name)                          \
     normal name (normal x, normal y) BUILTIN;   \
     vector name (vector x, vector y) BUILTIN;   \
@@ -67,13 +68,12 @@
     color  name (color x, color y) BUILTIN;     \
     float  name (float x, float y) BUILTIN;
 
+// Declare name(T,float) for T in {triples}
 #define PERCOMP2F(name)                         \
     normal name (normal x, float y) BUILTIN;    \
     vector name (vector x, float y) BUILTIN;    \
     point  name (point x, float y) BUILTIN;     \
-    color  name (color x, float y) BUILTIN;     \
-    float  name (float x, float y) BUILTIN;
-
+    color  name (color x, float y) BUILTIN;
 
 // Basic math
 normal degrees (normal x) { return x*(180.0/M_PI); }

--- a/testsuite/oslc-err-funcredef/ref/out.txt
+++ b/testsuite/oslc-err-funcredef/ref/out.txt
@@ -1,0 +1,2 @@
+test.osl:1: warning: Function 'point abs (point)' declared twice in the same scope
+Compiled test.osl -> test.oso

--- a/testsuite/oslc-err-funcredef/run.py
+++ b/testsuite/oslc-err-funcredef/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-funcredef/test.osl
+++ b/testsuite/oslc-err-funcredef/test.osl
@@ -1,0 +1,12 @@
+point abs (point p)
+{
+    printf ("Alternate abs!\n");
+    return point (abs(p[0]), abs(p[1]), abs(p[2]));
+}
+
+
+shader test()
+{
+    printf ("abs(P)= %g\n", abs(P));
+}
+


### PR DESCRIPTION
Previously, if you for some reason defined two identical functions in
the same scope (including redefining a "built-in" function exactly in
the outermost scope), it would just silently accept it, and then you
wouldn't be sure which one would actually end up getting called.

Now it's an outright error.

