### PR TITLE
Add ways to test OSL version:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-err-struct-array-init oslc-err-struct-dup
             oslc-warn-commainit
             oslc-variadic-macro
+            oslc-version
             oslinfo-arrayparams oslinfo-colorctrfloat
             oslinfo-metadata oslinfo-noparams
             osl-imageio

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -62,7 +62,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
 \date{{\large Date: 6 Feb 2017 \\
- (with corrections, 11 Apr 2017)
+ (with corrections, 28 Apr 2017)
 }
 \bigskip
 \bigskip
@@ -4793,6 +4793,7 @@ wish to make queryable.
 \hline
 {\bf Name} & {\bf Type} & {\bf Description} \\
 \hline
+{\cf "osl:version\"}          & {\cf int}       & Major*10000 + Minor*100 + patch. \\
 {\cf "shader:shadername"}     & {\cf string}    & Name of the shader master. \\
 {\cf "shader:layername"}      & {\cf string}    & Name of the layer instance. \\
 {\cf "shader:groupname"}      & {\cf string}    & Name of the shader group. \\

--- a/src/include/OSL/oslversion.h.in
+++ b/src/include/OSL/oslversion.h.in
@@ -40,6 +40,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //     for compiled shaders.
 // These are all independent, though loosely coupled.
 
+// Version of the language:
+#define @PROJ_NAME@_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+#define @PROJ_NAME@_VERSION_MINOR @PROJECT_VERSION_MINOR@
+#define @PROJ_NAME@_VERSION_PATCH @PROJECT_VERSION_PATCH@
+#define @PROJ_NAME@_VERSION (10000 * @PROJ_NAME@_VERSION_MAJOR + \
+                               100 * @PROJ_NAME@_VERSION_MINOR + \
+                                     @PROJ_NAME@_VERSION_PATCH)
+
 // Version of this library:
 #define OSL_LIBRARY_VERSION_MAJOR @OSL_LIBRARY_VERSION_MAJOR@
 #define OSL_LIBRARY_VERSION_MINOR @OSL_LIBRARY_VERSION_MINOR@

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -208,6 +208,14 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
                 ctx.get_language() | boost::wave::support_option_variadics);
         ctx.set_language (lang);
 
+        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_MAJOR=%d",
+                                                  OSL_LIBRARY_VERSION_MAJOR).c_str());
+        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_MINOR=%d",
+                                                  OSL_LIBRARY_VERSION_MINOR).c_str());
+        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_PATCH=%d",
+                                                  OSL_LIBRARY_VERSION_PATCH).c_str());
+        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION=%d",
+                                                  OSL_LIBRARY_VERSION_CODE).c_str());
         for (size_t i = 0; i < defines.size(); ++i) {
             if (defines[i][1] == 'D')
                 ctx.add_macro_definition (defines[i].c_str()+2);
@@ -345,6 +353,14 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     clang::PreprocessorOptions &preprocOpts = inst.getPreprocessorOpts();
     preprocOpts.UsePredefines = 0;
+    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_MAJOR=%d",
+                                             OSL_LIBRARY_VERSION_MAJOR).c_str());
+    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_MINOR=%d",
+                                             OSL_LIBRARY_VERSION_MINOR).c_str());
+    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_PATCH=%d",
+                                             OSL_LIBRARY_VERSION_PATCH).c_str());
+    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION=%d",
+                                             OSL_LIBRARY_VERSION_CODE).c_str());
     for (auto&& d : defines) {
         if (d[1] == 'D')
             preprocOpts.addMacroDef (d.c_str()+2);

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2243,7 +2243,11 @@ DECLFOLDER(constfold_getattribute)
     bool found = false;
 
     // Check global things first
-    if (attr_name == "shader:shadername" && attr_type == TypeDesc::TypeString) {
+    if (attr_name == "osl:version" && attr_type == TypeDesc::TypeInt) {
+        int *val = (int *)(char *)buf;
+        *val = OSL_VERSION;
+        found = true;
+    } else if (attr_name == "shader:shadername" && attr_type == TypeDesc::TypeString) {
         ustring *up = (ustring *)(char *)buf;
         *up = ustring(rop.inst()->shadername());
         found = true;

--- a/src/testrender/simplerend.cpp
+++ b/src/testrender/simplerend.cpp
@@ -50,6 +50,7 @@ SimpleRenderer::SimpleRenderer ()
                    0.1f, 1000.0f, 256, 256);
 
     // Set up getters
+    m_attr_getters[ustring("osl:version")] = &SimpleRenderer::get_osl_version;
     m_attr_getters[ustring("camera:resolution")] = &SimpleRenderer::get_camera_resolution;
     m_attr_getters[ustring("camera:projection")] = &SimpleRenderer::get_camera_projection;
     m_attr_getters[ustring("camera:pixelaspect")] = &SimpleRenderer::get_camera_pixelaspect;
@@ -275,6 +276,18 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
         return true;
     }
 
+    return false;
+}
+
+
+bool
+SimpleRenderer::get_osl_version (ShaderGlobals *sg, bool derivs, ustring object,
+                                    TypeDesc type, ustring name, void *val)
+{
+    if (type == TypeDesc::TypeInt) {
+        ((int *)val)[0] = OSL_VERSION;
+        return true;
+    }
     return false;
 }
 

--- a/src/testrender/simplerend.h
+++ b/src/testrender/simplerend.h
@@ -99,6 +99,8 @@ private:
     AttrGetterMap m_attr_getters;
 
     // Attribute getters
+    bool get_osl_version (ShaderGlobals *sg, bool derivs, ustring object,
+                         TypeDesc type, ustring name, void *val);
     bool get_camera_resolution (ShaderGlobals *sg, bool derivs, ustring object,
                          TypeDesc type, ustring name, void *val);
     bool get_camera_projection (ShaderGlobals *sg, bool derivs, ustring object,

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -150,6 +150,7 @@ SimpleRenderer::SimpleRenderer ()
                    0.1f, 1000.0f, 256, 256);
 
     // Set up getters
+    m_attr_getters[ustring("osl:version")] = &SimpleRenderer::get_osl_version;
     m_attr_getters[ustring("camera:resolution")] = &SimpleRenderer::get_camera_resolution;
     m_attr_getters[ustring("camera:projection")] = &SimpleRenderer::get_camera_projection;
     m_attr_getters[ustring("camera:pixelaspect")] = &SimpleRenderer::get_camera_pixelaspect;
@@ -383,6 +384,18 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
         return true;
     }
 
+    return false;
+}
+
+
+bool
+SimpleRenderer::get_osl_version (ShaderGlobals *sg, bool derivs, ustring object,
+                                    TypeDesc type, ustring name, void *val)
+{
+    if (type == TypeDesc::TypeInt) {
+        ((int *)val)[0] = OSL_VERSION;
+        return true;
+    }
     return false;
 }
 

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -102,6 +102,8 @@ private:
     AttrGetterMap m_attr_getters;
 
     // Attribute getters
+    bool get_osl_version (ShaderGlobals *sg, bool derivs, ustring object,
+                         TypeDesc type, ustring name, void *val);
     bool get_camera_resolution (ShaderGlobals *sg, bool derivs, ustring object,
                          TypeDesc type, ustring name, void *val);
     bool get_camera_projection (ShaderGlobals *sg, bool derivs, ustring object,

--- a/testsuite/oslc-version/ref/out.txt
+++ b/testsuite/oslc-version/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled test.osl -> test.oso
+Test versions:
+OK!
+

--- a/testsuite/oslc-version/run.py
+++ b/testsuite/oslc-version/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command += testshade ("test")

--- a/testsuite/oslc-version/test.osl
+++ b/testsuite/oslc-version/test.osl
@@ -1,0 +1,21 @@
+
+shader test ()
+{
+    int ok = 1;
+    printf ("Test versions:\n");
+    int version = 0;
+    getattribute ("osl:version", version);
+    if (version != OSL_VERSION) {
+        printf ("OSL_VERSION and attribute \"osl:version\" DO NOT MATCH!\n");
+        ok = 0;
+    }
+    if (version != OSL_VERSION_MAJOR*10000+OSL_VERSION_MINOR*100+OSL_VERSION_PATCH) {
+        printf ("OSL_VERSION and (maj*10000+min*100+patch) DO NOT MATCH!\n");
+        ok = 0;
+    }
+    if (ok)
+        printf ("OK!\n");
+    // printf ("Version = %d\n", version);
+    // printf ("VERSION = %d\n", OSL_VERSION);
+}
+


### PR DESCRIPTION
* C++: define OSL_VERSION (10900 for 1.9.0), OSL_VERSION_MAJOR,
  OSL_VERSION_MINOR, OSL_VERSION_PATCH.

* osl source at compile time: oslc now pre-defines OSL_VERSION,
  OSL_VERSION_MAJOR, OSL_VERSION_MINOR, OSL_VERSION_PATCH.

* osl runtime now supports getattribute("osl:version"), which also
  get properly constant folded.

Note that this means that renderers ought to make sure their
implementation of RendererServices::get_attribute detects requests for
"osl:version" and in that case retrieve the integer value of
OSL_VERSION. But in practice, you will only notice a renderer's failure
to do this if you turn off runtime optimization and the constant folding
of the attribute doesn't occur.

