### PR TITLE
Relax the strict typing of ShadingSystem::Parameter()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslinfo-arrayparams oslinfo-colorctrfloat
             oslinfo-metadata oslinfo-noparams
             osl-imageio
+            paramval-floatpromotion
             printf-whole-array
             raytype raytype-specialized reparam
             render-background render-bumptest

--- a/testsuite/paramval-floatpromotion/ref/out.txt
+++ b/testsuite/paramval-floatpromotion/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled test.osl -> test.oso
+a=10 10 10
+p=42 21 7
+

--- a/testsuite/paramval-floatpromotion/run.py
+++ b/testsuite/paramval-floatpromotion/run.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+# Here we have a parameter 'a' that's a color, and we are passing just
+# a float, and a parameter 'p' that's a point but we're passing a vector.
+# Thexe used to be errors, but now we want to accept it.
+# Test to make sure it works.
+
+command = testshade("--param a 10.0 -param:type=vector p 42,21,7 test")

--- a/testsuite/paramval-floatpromotion/test.osl
+++ b/testsuite/paramval-floatpromotion/test.osl
@@ -1,0 +1,6 @@
+shader test (color a = color(.1,.2,.3),
+             point p = point(1,2,3))
+{
+    printf ("a=%g\n", a);
+    printf ("p=%g\n", p);
+}


### PR DESCRIPTION
SS::Parameter(), which is used to pass parameter instance values,
is very strict about the types matching exactly. I'm loosening it
somewhat -- by allowing the user to pass a float as the
instance value of a triple (color, point, etc.), and to pass one triple
when a different was the declared parameter. This makes it have similar
flexibility to that afforded by ConnectParameters, and I can't think of
a good reason why one should be any stricter than the other.

