### PR TITLE
Struct constructors work like built-in type constructors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-notfunc
             oslc-err-outputparamvararray oslc-err-paramdefault
-            oslc-err-struct-array-init oslc-err-struct-dup
+            oslc-err-struct-array-init oslc-err-struct-ctr
+            oslc-err-struct-dup
             oslc-warn-commainit
             oslc-variadic-macro
             oslc-version

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -62,7 +62,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
 \date{{\large Date: 6 Feb 2017 \\
- (with corrections, 28 Apr 2017)
+ (with corrections, 12 May 2017)
 }
 \bigskip
 \bigskip
@@ -2068,14 +2068,37 @@ using the `dot' operator.  The syntax for declaring and using structures
 is similar to C or C++:
 
 \begin{code}
-    struct Ray {                   // Define a structure type
-        point pos;
-        vector dir;
+    struct RGBA {                    // Define a structure type
+        color rgb;
+        float alpha;
     };
 
-    Ray r;                         // Declare a structure
-    r.pos = point (1, 0, 0);       // Assign to one field
-    point p = r.pos;               // Read from a structure field
+    RGBA col;                        // Declare a structure
+    r.rgb = color (1, 0, 0);         // Assign to one field
+    color c = r.rgb;                 // Read from a structure field
+
+    RGBA b = { color(.1,.2,.3), 1 }; // Member-by-member initialization
+\end{code}
+
+You can use ``constructor expressions'' for a your struct types much like
+you can construct built-in types like \color or \point:
+
+\vspace{10pt}
+\hspace{0.25in} \emph{struct\_name ( first\_member\_value, ... )}
+\vspace{10pt}
+
+\noindent For example,
+
+\begin{code}
+    RGBA c = RGBA(col,alpha);        // Constructor syntax
+
+    RGBA add (RGBA a, RGBA b)
+    {
+        return RGBA (a.rgb+b.rgb, a.a+b.a);   // return expression
+    }
+
+    // pass constructor expression as a parameter:
+    RGBA d = add (c, RGBA(color(.3,.4,.5), 0));
 \end{code}
 
 It is permitted to have a structure field that is an array, as well as to
@@ -2089,8 +2112,8 @@ arrays).
         float b[4];       // Ok: struct may contain an array
     };
 
-    Ray rays[4];          // Ok: Array of structures
-    rays[0].pos = 0;
+    RGBA vals[4];         // Ok: Array of structures
+    vals[0].a = 0;
 
     A d[5];               // NO: Array of structures that contain arrays
 \end{code}

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -998,6 +998,9 @@ ASTfunction_call::ASTfunction_call (OSLCompilerImpl *comp, ustring name,
         // find the things that almost matched and offer suggestions.
         return;
     }
+    if (is_struct_ctr()) {
+        return;  // It's a struct constructor
+    }
     if (m_sym->symtype() != SymTypeFunction) {
         error ("'%s' is not a function", name.c_str());
         m_sym = NULL;

--- a/testsuite/oslc-err-struct-ctr/ref/out.txt
+++ b/testsuite/oslc-err-struct-ctr/ref/out.txt
@@ -1,0 +1,7 @@
+test.osl:10: error: Cannot initialize structure 'A' with a scalar value
+test.osl:13: error: Constructor for 'rgba' has the wrong number of arguments (expected 2, got 1)
+test.osl:16: error: Constructor for 'rgba' has the wrong number of arguments (expected 2, got 3)
+test.osl:16: error: Too many initializers for 'struct rgba this'
+test.osl:19: error: Can't assign 'string' to 'color this.rgb'
+test.osl:19: error: Can't assign 'string' to 'float this.a'
+FAILED test.osl

--- a/testsuite/oslc-err-struct-ctr/run.py
+++ b/testsuite/oslc-err-struct-ctr/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-struct-ctr/test.osl
+++ b/testsuite/oslc-err-struct-ctr/test.osl
@@ -1,0 +1,20 @@
+struct rgba {
+   color rgb;
+   float a;
+};
+
+
+shader test ()
+{
+    // wrong entire type
+    rgba A = 1;
+
+    // not enough args
+    rgba B = rgba(1);
+
+    // too many args
+    rgba C = rgba (color(1,1,1), 0, 1);
+
+    // wrong type of args
+    rgba D = rgba ("foo", "bar");
+}

--- a/testsuite/struct/ref/out.txt
+++ b/testsuite/struct/ref/out.txt
@@ -2,6 +2,8 @@ Compiled test.osl -> test.oso
 test struct
 a == { 3.14159, 42, [0 1 2], foobar }
 
+constructed x == { 6.28319, 21, [1 2 3], constructed }
+
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
@@ -26,6 +28,8 @@ Varying:
 after a.p=P, a == { 310.5, 42, [0 0 1], foobar }
 test struct
 a == { 3.14159, 42, [0 1 2], foobar }
+
+constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
 
@@ -52,6 +56,8 @@ after a.p=P, a == { 310.5, 42, [1 0 1], foobar }
 test struct
 a == { 3.14159, 42, [0 1 2], foobar }
 
+constructed x == { 6.28319, 21, [1 2 3], constructed }
+
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
@@ -76,6 +82,8 @@ Varying:
 after a.p=P, a == { 310.5, 42, [0 1 1], foobar }
 test struct
 a == { 3.14159, 42, [0 1 2], foobar }
+
+constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
 

--- a/testsuite/struct/test.osl
+++ b/testsuite/struct/test.osl
@@ -53,6 +53,13 @@ test (
     // Structure selection
     printf ("a == { %g, %i, [%g], %s }\n", a.f, a.i, a.p, a.s);
 
+    // Test struct construction
+    {
+        Astruct x = Astruct (M_PI*2, 21, point(1,2,3), "constructed");
+        printf ("\n");
+        printf ("constructed x == { %g, %i, [%g], %s }\n", x.f, x.i, x.p, x.s);
+    }
+
     // Make sure it came in ok as a param
     printf ("\n");
     printf ("struct param:  aparam == { %g, %i, [%g], %s }\n",


### PR DESCRIPTION
You know how you can have an expression for a built-in type like color?

    foo = color(1,1,1)

or

    void func (color c) { ...}
    func (color(1,1,1);

It was really awkward to do this with structs.

So with this patch, for every struct, you can construct it by name
with a function-call-like syntax, where the arguments must be the same
types as the data members of the struct, in order.

For example:

    struct RGBA {
        color rgb;
        float a;
    };

    RGBA x = RGBA(color(1,1,1), 1);

    void func (RGBA x) { ... }
    func (RGBA(Cblah,alpha));

You don't need to explicitly declare the constructor like in C++, it
just exists.

