### PR TITLE
More flexibility in pointcloud_search/get retrieval

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -4337,6 +4337,15 @@ Note that the named point cloud will be created, if it does not yet
 exist in memory, and that it will be initialized by reading a point
 cloud from disk, if there is one matching the name.
 
+Generally, the element type of the data arrays must match exactly the type
+of the point data attribute, or else you will get a runtime error. But there
+are two exceptions: (1) ``triple'' types (\color, \point, \vector, \normal)
+are considered interchangeable; and (2) it is legal to retrieve {\cf float}
+arrays (e.g., a point cloud attribute that is {\cf float[4]}) into a regular
+array of {\cf float}, and the results will simply be concatenated into the
+larger array (which must still be big enough, in total, to hold {\cf
+maxpoints} of the data type in the file).
+
 \noindent Example:
 
 \begin{code}
@@ -4370,10 +4379,20 @@ in the following example:
       int indices[10];
       int n = pointcloud_search ("particles.ptc", P, r, 10,
                                  "index", indices);
-      float temp[10];
+      float temp[10];         // presumed to be "float" attribute
+      float quaternions[40];  // presumed to be "float[4]" attribute
       int ok = pointcloud_get ("particles.ptc", indices, n,
-                               "temperature", temp);
+                               "temperature", temp,
+                               "quat", quaternions);
 \end{code}
+
+As with {\cf pointcloud_search}, the element type of the data array must
+either be equivalent to the point cloud attribute being retrieved, or else
+when retrieving {\cf float} arrays (e.g., a point cloud attribute
+that is {\cf float[4]}) into a regular array of {\cf float}, and the
+results will simply be concatenated into the larger array (which must
+still be big enough, in total, to hold {\cf maxpoints} of the data type
+in the file).
 \apiend
 
 

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2594,10 +2594,6 @@ DECLFOLDER(constfold_pointcloud_search)
             continue;
         void *const_data = NULL;
         TypeDesc const_valtype = value_types[i];
-        // How big should the constant arrays be?  Shrink to the size of
-        // the results if they are much smaller.
-        if (count < const_valtype.arraylen/2 && const_valtype.arraylen > 8)
-            const_valtype.arraylen = count;
         tmp.clear ();
         tmp.resize (const_valtype.size(), 0);
         const_data = &tmp[0];
@@ -2688,7 +2684,7 @@ DECLFOLDER(constfold_pointcloud_get)
     int ok = rop.renderer()->pointcloud_get (rop.shaderglobals(), filename,
                                              indices, count,
                                              *(ustring *)Attr_name.data(),
-                                             valtype.elementtype(), &data[0]);
+                                             valtype, &data[0]);
     rop.shadingsys().pointcloud_stats (0, 1, 0);
 
     rop.turn_into_assign (op, rop.add_constant (TypeDesc::TypeInt, &ok),

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -163,28 +163,66 @@ PartioType (TypeDesc t)
 
 
 
-inline bool
-compatiblePartioType (Partio::ParticleAttribute *received, int expected)
+// Helper: number of base values
+inline int
+basevals (TypeDesc t)
 {
-    return ((expected == Partio::VECTOR) &&
-            (received->type == expected || received->type == Partio::FLOAT) &&
-            received->count == 3) ||
-        (received->type == expected && received->count == 1);
+    return t.numelements() * int(t.aggregate);
 }
 
 
 
-inline const char *
-partioTypeString(Partio::ParticleAttribute *ptype)
+bool
+compatiblePartioType (TypeDesc partio_type, TypeDesc osl_element_type)
 {
+    // Matching types (treating all VEC3 aggregates as equivalent)...
+    if (equivalent (partio_type, osl_element_type))
+        return true;
+
+    // Consider arrays and aggregates as interchangeable, as long as the
+    // totals are the same.
+    if (partio_type.basetype == osl_element_type.basetype &&
+        basevals(partio_type) == basevals(osl_element_type))
+        return true;
+
+    // The Partio file may contain an array size that OSL can't exactly
+    // represent, for example the partio type may be float[4], and the
+    // OSL array will be float[] but the element type will be just float
+    // because OSL doesn't permit multi-dimensional arrays.
+    // Just allow it anyway and fill in the OSL array.
+    if (TypeDesc::BASETYPE(partio_type.basetype) == osl_element_type)
+        return true;
+
+    return false;
+}
+
+
+
+TypeDesc
+TypeDescOfPartioType (const Partio::ParticleAttribute *ptype)
+{
+    TypeDesc type;  // default to UNKNOWN
     switch (ptype->type) {
-    case Partio::INT:    return "int";
-    case Partio::FLOAT:  return "float";
-    case Partio::VECTOR: return "vector";
-    default:             return "none";
+    case Partio::INT:
+        type = TypeDesc::INT;
+        if (ptype->count > 1)
+            type.arraylen = ptype->count;
+        break;
+    case Partio::FLOAT:
+        type = TypeDesc::FLOAT;
+        if (ptype->count > 1)
+            type.arraylen = ptype->count;
+        break;
+    case Partio::VECTOR:
+        type = TypeDesc (TypeDesc::FLOAT, TypeDesc::VEC3, TypeDesc::NOSEMANTICS);
+        if (ptype->count != 3)
+            type = TypeDesc::UNKNOWN;  // Must be 3: punt
+        break;
+    default:
+        break;   // Any other future types -- return UNKNOWN
     }
+    return type;
 }
-
 
 #endif
 
@@ -308,50 +346,44 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
 
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_get: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_get: could not open \"%s\"", filename);
         return 0;
     }
 
     const Partio::ParticlesData *cloud = pc->read_access();
     if (cloud == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_get: could not open \"%s\"", filename.c_str());
+        sg->context->error ("pointcloud_get: could not open \"%s\"", filename);
         return 0;
     }
 
     // lookup the ParticleAttribute pointer needed for a query
     Partio::ParticleAttribute *attr = pc->m_attributes[attr_name].get();
     if (! attr) {
-        sg->context->error ("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name.c_str(), filename.c_str());
+        sg->context->error ("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name, filename);
         return 0;
     }
 
-    // Now make sure that types are compatible
+    // Type the partio file contains:
+    TypeDesc partio_type = TypeDescOfPartioType (attr);
+    // Type the OSL shader has provided in destination array:
     TypeDesc element_type = attr_type.elementtype ();
-    int attr_partio_type = 0;
-
-    // Convert the OSL (OIIO) type to the equivalent Partio type
-    if (element_type == TypeDesc::TypeFloat)
-        attr_partio_type = Partio::FLOAT;
-    else if (element_type == TypeDesc::TypeInt)
-        attr_partio_type = Partio::INT;
-    else if (element_type == TypeDesc::TypeColor  || element_type == TypeDesc::TypePoint ||
-             element_type == TypeDesc::TypeVector || element_type == TypeDesc::TypeNormal)
-        attr_partio_type = Partio::VECTOR;
-    else {
-        // error ("Unsupported attribute type %s for pointcloud query in attribute %s",
-        //       element_type.c_str(), attr_name.c_str());
-        return 0;
-    }
 
     // Finally check for some equivalent types like float3 and vector
-    if (!compatiblePartioType(attr, attr_partio_type)) {
-        sg->context->error ("Type of attribute \"%s\" : %s[%d] not compatible with OSL's %s in \"%s\" pointcloud",
-                    attr_name.c_str(), partioTypeString(attr), attr->count,
-                    element_type.c_str(), filename.c_str());
+    if (!compatiblePartioType(partio_type, element_type)) {
+        sg->context->error ("Type of attribute \"%s\" : %s not compatible with OSL's %s in \"%s\" pointcloud",
+                            attr_name, partio_type, element_type, filename);
         return 0;
     }
 
-    ASSERT (sizeof(size_t) == sizeof(Partio::ParticleIndex) &&
+    // For safety, clamp the count to the most that will fit in the output
+    int maxn = basevals(attr_type) / basevals(partio_type);
+    if (maxn < count) {
+        sg->context->error ("Point cloud attribute \"%s\" : %s with retrieval count %d will not fit in %s",
+                            attr_name, partio_type, count, attr_type);
+        count = maxn;
+    }
+
+    static_assert (sizeof(size_t) == sizeof(Partio::ParticleIndex),
             "Only will work if Partio ParticleIndex is the size of a size_t");
     // FIXME -- if anybody cares about an architecture in which that is not
     // the case, we can easily allocate local space to retrieve the indices,


### PR DESCRIPTION
In the default RendererServices implementation of retrieving data from
point clouds via Partio, there had to be an exact match between the
attribute type of the point cloud file (as understood by Partio) and the
element type of the OSL array used to store the retrieved data.

Because OSL doesn't support 2D arrays, that means that you could retrieve
only data of the main non-array OSL types: int, float, 3-float (color,
point, vector, normal etc.).

But we had somebody create a point cloud that stored float[4] to store
quaternions (don't ask), and then was unable to retrieve it from OSL,
because there is no float[4] type.

So the solution is that we are loosening the type matching tests.
Simply stated, it's willing to match either a float or a float[n] in the
point cloud, when retrieving into a float array in OSL. If it's a
float[n], it will just pack them contiguously into the OSL array of
floats, and it's up to the shader to know what's expected and to unpack
and interpret it properly. An error will be reported if there is not
enough room in the array provided.
