### PR TITLE
ShadingSystem::convert_value, allow float[3] <--> triple conversion.

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -473,6 +473,7 @@ ShadingSystem::optimize_group (ShaderGroup *group,
 
 
 static TypeDesc TypeFloatArray2 (TypeDesc::FLOAT, 2);
+static TypeDesc TypeFloatArray3 (TypeDesc::FLOAT, 3);
 
 
 
@@ -532,6 +533,14 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
             return true;
         }
         return false; // Unsupported conversion
+    }
+
+    // float[3] -> triple
+    if ((srctype == TypeFloatArray3 && equivalent(dsttype, TypeDesc::TypePoint)) ||
+        (dsttype == TypeFloatArray3 && equivalent(srctype, TypeDesc::TypePoint))) {
+        if (dst && src)
+            memcpy (dst, src, dsttype.size());
+        return true;
     }
 
     // float[2] -> triple


### PR DESCRIPTION
This utility is used by renderers for getattribute and other
renderer-to-OSL data copying, and is meant to facilitate the
obvious set of copy conversions between slightly mismatched yet
sensible types.

Adding a clause that lets you retrieve a triple (point, color, etc.)
even if it was declared on the renderer side as float[3], and vice
versa.
