### PR TITLE
Fix bug comparing structure types with equivalent() -- false positive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             draw_string
             error-dupes exit exponential
             function-earlyreturn function-simple function-outputelem
+            function-overload-struct
             geomath getattribute-camera getattribute-shader
             getsymbol-nonheap gettextureinfo
             group-outputs groupstring

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -148,19 +148,22 @@ bool
 equivalent (const TypeSpec &a, const TypeSpec &b)
 {
     // The two complex types are equivalent if...
+    // they are actually identical (duh)
+    if (a == b)
+        return true;
+    // or if they are structs, and the structs are equivalent
+    if (a.is_structure() || b.is_structure())
+        return a.is_structure() && b.is_structure() &&
+               equivalent(a.structspec(), b.structspec());
+    // or if the underlying simple types are equivalent
     return
-        // they are actually identical (duh)
-        (a == b) ||
-        // or if the underlying simple types are equivalent
-        (((a.is_vectriple_based() && b.is_vectriple_based()) || equivalent(a.m_simple, b.m_simple))  &&
-         //     ... and either both or neither are closures
-         a.is_closure() == b.is_closure() &&
-         //     ... and, if arrays, they are the same length, or both unsized,
-         //         or one is unsized and the other isn't
-         (a.m_simple.arraylen == b.m_simple.arraylen || a.is_unsized_array() != b.is_unsized_array())) ||
-        // or if they are structs, and the structs are equivalent
-        (a.is_structure() && b.is_structure() &&
-         equivalent(a.structspec(), b.structspec()));
+        ((a.is_vectriple_based() && b.is_vectriple_based()) || equivalent(a.m_simple, b.m_simple))
+         // ... and either both or neither are closures
+         && a.is_closure() == b.is_closure()
+         // ... and, if arrays, they are the same length, or both unsized,
+         //     or one is unsized and the other isn't
+         && (a.m_simple.arraylen == b.m_simple.arraylen ||
+             a.is_unsized_array() != b.is_unsized_array());
 }
 
 

--- a/testsuite/function-overload-struct/ref/out.txt
+++ b/testsuite/function-overload-struct/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+c2_out = 0.3 0.3
+

--- a/testsuite/function-overload-struct/run.py
+++ b/testsuite/function-overload-struct/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("test")

--- a/testsuite/function-overload-struct/test.osl
+++ b/testsuite/function-overload-struct/test.osl
@@ -1,0 +1,36 @@
+struct color2
+{
+    float r;
+    float g;
+};
+
+struct color4
+{
+    color rgb;
+    float a;
+};
+
+
+color2 __operator__add__(color2 c1, color2 c2)
+{
+    return color2(c1.r + c2.r, c1.g + c2.g);
+}
+
+color4 __operator__add__(color4 c1, color4 c2)
+{
+    return color4(c1.rgb + c2.rgb, c1.a + c2.a);
+}
+
+
+shader test
+  (
+    color2 c2_in_1 = {.1, .1},
+    color2 c2_in_2 = {.2, .2},
+
+    output color2 c2_out = {0, 0},
+  )
+{
+    c2_out = c2_in_1 + c2_in_2;
+    printf ("c2_out = %g %g\n", c2_out.r, c2_out.g);
+}
+


### PR DESCRIPTION
It was incorrectly saying that two different structs matched! The
problem was a subtle issue of the ordering of clauses in a complex
comparison -- we need to test the structure case first, because the
other clause makes the assumption that the types are simple and not
structures and will have a false positive in that case. An important way
this could manifest is that if you had two overloaded functions whose
arguments were structs, say foo(structA) and foo(structB), it was not
able to correctly distinguish between them for type checking.
