### PR TITLE
Move TypeSpec::string and c_str from symtab.cpp to typespec.cpp

### DIFF
--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -42,40 +42,6 @@ namespace pvt {   // OSL::pvt
 
 
 std::string
-TypeSpec::string () const
-{
-    std::string str;
-    if (is_closure() || is_closure_array()) {
-        str += "closure color";
-        if (is_unsized_array())
-            str += "[]";
-        else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-    }
-    else if (structure() > 0) {
-        str += Strutil::format ("struct %d", structure());
-        if (is_unsized_array())
-            str += "[]";
-        else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-    } else {
-        str += simpletype().c_str();
-    }
-    return str;
-}
-
-
-
-const char *
-TypeSpec::c_str () const
-{
-    ustring s (this->string());
-    return s.c_str ();
-}
-
-
-
-std::string
 Symbol::mangled () const
 {
     // FIXME: De-alias

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -64,6 +64,40 @@ TypeSpec::TypeSpec (const char *name, int structid, int arraylen)
 
 
 
+std::string
+TypeSpec::string () const
+{
+    std::string str;
+    if (is_closure() || is_closure_array()) {
+        str += "closure color";
+        if (is_unsized_array())
+            str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
+    }
+    else if (structure() > 0) {
+        str += Strutil::format ("struct %d", structure());
+        if (is_unsized_array())
+            str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
+    } else {
+        str += simpletype().c_str();
+    }
+    return str;
+}
+
+
+
+const char *
+TypeSpec::c_str () const
+{
+    ustring s (this->string());
+    return s.c_str ();
+}
+
+
+
 int
 TypeSpec::structure_id (const char *name, bool add)
 {


### PR DESCRIPTION
Just moving these methods from one file to another, so they live with the rest of the methods for the TypeSpec class.
