### PR TITLE
testshade improvements

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -101,8 +101,8 @@ static ShaderGroupRef shadergroup;
 static std::string archivegroup;
 static int exprcount = 0;
 static bool shadingsys_options_set = false;
-static float sscale = 1, tscale = 1;
-static float soffset = 0, toffset = 0;
+static float uscale = 1, vscale = 1;
+static float uoffset = 0, voffset = 0;
 
 
 
@@ -496,8 +496,10 @@ getargs (int argc, const char *argv[])
                 "--shadeimage", &use_shade_image, "Use shade_image utility",
                 "--noshadeimage %!", &use_shade_image, "Don't use shade_image utility",
                 "--expr %@ %s", &specify_expr, NULL, "Specify an OSL expression to evaluate",
-                "--offsetst %f %f", &soffset, &toffset, "Offset s & t texture coordinates (default: 0 0)",
-                "--scalest %f %f", &sscale, &tscale, "Scale s & t texture lookups (default: 1, 1)",
+                "--offsetuv %f %f", &uoffset, &voffset, "Offset s & t texture coordinates (default: 0 0)",
+                "--offsetst %f %f", &uoffset, &voffset, "", // old name
+                "--scaleuv %f %f", &uscale, &vscale, "Scale s & t texture lookups (default: 1, 1)",
+                "--scalest %f %f", &uscale, &vscale, "", // old name
                 "--userdata_isconnected", &userdata_isconnected, "Consider lockgeom=0 to be isconnected()",
                 "-v", &verbose, "Verbose output",
                 NULL);
@@ -587,17 +589,17 @@ setup_shaderglobals (ShaderGlobals &sg, ShadingSystem *shadingsys,
     if (pixelcenters) {
         // Our patch is like an "image" with shading samples at the
         // centers of each pixel.
-        sg.u = sscale * (float)(x+0.5f) / xres + soffset;
-        sg.v = tscale * (float)(y+0.5f) / yres + toffset;
-        sg.dudx = sscale / xres;
-        sg.dvdy = tscale / yres;
+        sg.u = uscale * (float)(x+0.5f) / xres + uoffset;
+        sg.v = vscale * (float)(y+0.5f) / yres + voffset;
+        sg.dudx = uscale / xres;
+        sg.dvdy = vscale / yres;
     } else {
         // Our patch is like a Reyes grid of points, with the border
         // samples being exactly on u,v == 0 or 1.
-        sg.u = sscale * ((xres == 1) ? 0.5f : (float) x / (xres - 1)) + soffset;
-        sg.v = tscale * ((yres == 1) ? 0.5f : (float) y / (yres - 1)) + toffset;
-        sg.dudx = sscale / std::max (1, xres-1);
-        sg.dvdy = tscale / std::max (1, yres-1);
+        sg.u = uscale * ((xres == 1) ? 0.5f : (float) x / (xres - 1)) + uoffset;
+        sg.v = vscale * ((yres == 1) ? 0.5f : (float) y / (yres - 1)) + voffset;
+        sg.dudx = uscale / std::max (1, xres-1);
+        sg.dvdy = vscale / std::max (1, yres-1);
     }
 
     // Assume that position P is simply (u,v,1), that makes the patch lie

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -465,8 +465,9 @@ getargs (int argc, const char *argv[])
                 "--texoptions %s", &texoptions, "Set extra TextureSystem options",
                 "-o %L %L", &outputvars, &outputfiles,
                         "Output (variable, filename)",
-                "-od %s", &dataformatname, "Set the output data format to one of: "
+                "-d %s", &dataformatname, "Set the output data format to one of: "
                         "uint8, half, float",
+                "-od %s", &dataformatname, "", // old name
                 "--print", &print_outputs, "Print values of all -o outputs to console instead of saving images",
                 "--groupname %s", &groupname, "Set shader group name",
                 "--layer %s", &layername, "Set next layer name",

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1153,6 +1153,7 @@ test_shade (int argc, const char *argv[])
             }
         }
     }
+    double runtime = timer.lap();
 
     if (outputfiles.size() == 0)
         std::cout << "\n";
@@ -1187,10 +1188,11 @@ test_shade (int argc, const char *argv[])
 
     // Print some debugging info
     if (debug || runstats || profile) {
-        double runtime = timer.lap();
+        double writetime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup: " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";
         std::cout << "Run  : " << OIIO::Strutil::timeintervalformat (runtime,2) << "\n";
+        std::cout << "Write: " << OIIO::Strutil::timeintervalformat (writetime,2) << "\n";
         std::cout << "\n";
         std::cout << shadingsys->getstats (5) << "\n";
         OIIO::TextureSystem *texturesys = shadingsys->texturesys();

--- a/testsuite/texture-udim/run.py
+++ b/testsuite/texture-udim/run.py
@@ -7,5 +7,5 @@ command += oiiotool ("-pattern constant:color=.1,.1,.5 256x256 3 -text:size=50:x
 
 # Purposely only create two of the four UDIM textures
 
-command += testshade("-g 128 128 --center -scalest 2 2 -od uint8 -o Cout out.tif test")
+command += testshade("-g 128 128 --center -scaleuv 2 2 -od uint8 -o Cout out.tif test")
 outputs = [ "out.txt", "out.tif" ]


### PR DESCRIPTION
A grab-bag of minor testshade improvements:

* Rename command line arguments `--scalest` and `--offsetst` to `--scaleuv` and `--offsetuv`, since what they do is change the u,v range, had nothing to do with anything named "s" or "t". (For compatibility, the old names also still work, but are no longer documented and are considered deprecated.)

* New option `--print` sends to the console the value of all saved outputs. This is useful if you are trying to unit-test or directly inspect the outputs of a shader, without needing 'printf' calls in the shader. Though it's probably not helpful to do this when using -g to produce big output images -- too much console output to be useful.

* When `-o` is outputting to a JPEG, GIF, or PNG file, automatically convert the linear shader output to the sRGB color space required of those file types. That makes it easier to use testshade to produce output images that are "web ready" without a separate color correction step.

* `--runstats` is more careful about not including the time of writing output images in the statistic of shader runtime.

* Change the `-od` option to be called `-d` to match the equivalent option in oiiotool and maketx. I'm not sure why it was ever `-od`, that's weird. Maybe at some point I thought `-d` was going to be something else, maybe debug. Anyway, for compatibility, the `-od` will still work, but it's considered deprecated and is no longer documented.
