### PR TITLE
Fix missing faceforward() implementation

### DIFF
--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -202,8 +202,14 @@ float distance (point a, point b, point q)
 }
 normal normalize (normal v) BUILTIN;
 vector normalize (vector v) BUILTIN;
-vector faceforward (vector N, vector I, vector Nref) BUILTIN;
-vector faceforward (vector N, vector I) BUILTIN;
+vector faceforward (vector N, vector I, vector Nref)
+{
+    return (dot(I, Nref) > 0) ? -N : N;
+}
+vector faceforward (vector N, vector I)
+{
+    return faceforward(N, I, Ng);
+}
 vector reflect (vector I, vector N) { return I - 2*dot(N,I)*N; }
 vector refract (vector I, vector N, float eta) {
     float IdotN = dot (I, N);

--- a/testsuite/geomath/ref/out.txt
+++ b/testsuite/geomath/ref/out.txt
@@ -3,6 +3,8 @@ Compiled test.osl -> test.oso
    hypot (3, 4, 5) = 7.07107
    reflect (0.447214 -0.894427 0, 0 1 0) =  0.447214 0.894427 0
    reflect (0.447214 -0.894427 0, -1 0 0) =  -0.447214 -0.894427 0
+   faceforward (0 0 1, 0 -0.707107 -0.707107) =  0 0 1
+   faceforward (0 0 1, 0 -0.707107 -0.707107, 0 0 -1) =  0 0 -1
  testing total-internal reflection:
    refract (0.707107 -0.707107 0, 0 1 0, 1.42) =  0 0 0
    frensel:  Kr= 1  Kt = 0  R = 0.707107 0.707107 0  T = 0 0 0
@@ -23,6 +25,8 @@ Compiled test.osl -> test.oso
    hypot (3, 4, 5) = 7.07107
    reflect (0.447214 -0.894427 0, 0 1 0) =  0.447214 0.894427 0
    reflect (0.447214 -0.894427 0, -1 0 0) =  -0.447214 -0.894427 0
+   faceforward (0 0 1, 0 -0.707107 -0.707107) =  0 0 1
+   faceforward (0 0 1, 0 -0.707107 -0.707107, 0 0 -1) =  0 0 -1
  testing total-internal reflection:
    refract (0.707107 -0.707107 0, 0 1 0, 1.42) =  0 0 0
    frensel:  Kr= 1  Kt = 0  R = 0.707107 0.707107 0  T = 0 0 0
@@ -43,6 +47,8 @@ Compiled test.osl -> test.oso
    hypot (3, 4, 5) = 7.07107
    reflect (0.447214 -0.894427 0, 0 1 0) =  0.447214 0.894427 0
    reflect (0.447214 -0.894427 0, -1 0 0) =  -0.447214 -0.894427 0
+   faceforward (0 0 1, 0 -0.707107 -0.707107) =  0 0 1
+   faceforward (0 0 1, 0 -0.707107 -0.707107, 0 0 -1) =  0 0 -1
  testing total-internal reflection:
    refract (0.707107 -0.707107 0, 0 1 0, 1.42) =  0 0 0
    frensel:  Kr= 1  Kt = 0  R = 0.707107 0.707107 0  T = 0 0 0
@@ -63,6 +69,8 @@ Compiled test.osl -> test.oso
    hypot (3, 4, 5) = 7.07107
    reflect (0.447214 -0.894427 0, 0 1 0) =  0.447214 0.894427 0
    reflect (0.447214 -0.894427 0, -1 0 0) =  -0.447214 -0.894427 0
+   faceforward (0 0 1, 0 -0.707107 -0.707107) =  0 0 1
+   faceforward (0 0 1, 0 -0.707107 -0.707107, 0 0 -1) =  0 0 -1
  testing total-internal reflection:
    refract (0.707107 -0.707107 0, 0 1 0, 1.42) =  0 0 0
    frensel:  Kr= 1  Kt = 0  R = 0.707107 0.707107 0  T = 0 0 0

--- a/testsuite/geomath/test.osl
+++ b/testsuite/geomath/test.osl
@@ -16,6 +16,14 @@ test ()
         printf ("   reflect (%g, %g) =  %g\n", vI, vN, pretty(reflect (vI, vN)));
         vN = vector(-1, 0, 0);
         printf ("   reflect (%g, %g) =  %g\n", vI, vN, pretty(reflect (vI, vN)));
+        vI = vector(0, -1, -1);
+        vI = normalize(vI);
+        vN = vector(0, 0, 1);
+        printf ("   faceforward (%g, %g) =  %g\n",
+                vN, vI, pretty(faceforward (vN, vI)));
+        vector vNg = vector(0, 0, -1);
+        printf ("   faceforward (%g, %g, %g) =  %g\n",
+                vN, vI, vNg, pretty(faceforward (vN, vI, vNg)));
 
         // test total internal reflection (going from greater to lesser IOR)
         printf (" testing total-internal reflection:\n");


### PR DESCRIPTION
These functions are declared as builtin in stdosl.h but not implemented anywhere, which leads to errors when executing the shader. This fix implements them in stdosl.h following the OSL specification.

Alternatively, these functions could be removed since no one seems to have missed them until now, I don't really care one way or the other.