### PR TITLE
Improve type checking errors with structs

### DIFF
--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -76,7 +76,11 @@ TypeSpec::string () const
             str += Strutil::format ("[%d]", arraylength());
     }
     else if (structure() > 0) {
-        str += Strutil::format ("struct %d", structure());
+        StructSpec *ss = structspec();
+        if (ss)
+            str += Strutil::format ("struct %s", structspec()->name());
+        else
+            str += Strutil::format ("struct %d", structure());
         if (is_unsized_array())
             str += "[]";
         else if (arraylength() > 0)


### PR DESCRIPTION
Change the implementation of TypeSpec::string(), which returns the text
representation of a TypeSpec, so that it prints the name of the struct
rather than just its numerical designation.

An example of the old behavior, as applied to a type checking error
message:

    test.osl:10: error: No matching function call to 'max (struct 1, struct 1)'
    ...

And the new behavior:

    test.osl:10: error: No matching function call to 'max (struct vector4, struct vector4)'
    ...
