### PR TITLE
Fix oslc assertion when passing stucts with operator overloading.

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1732,7 +1732,9 @@ ASTfunction_call::codegen (Symbol *dest)
                 // If the formal parameter is a struct, we also need to
                 // alias each of the fields
                 if (a->nodetype() == variable_ref_node ||
-                    a->nodetype() == function_call_node) {
+                    a->nodetype() == function_call_node ||
+                    a->nodetype() == binary_expression_node ||
+                    a->nodetype() == unary_expression_node) {
                     // Passed a variable that is a struct ; make the struct
                     // fields of the formal param alias to the struct fields
                     // of the actual param. Exact same logic if passed the

--- a/testsuite/operator-overloading/test.osl
+++ b/testsuite/operator-overloading/test.osl
@@ -24,6 +24,15 @@ vector4 __operator__neg__ (vector4 a) {
 }
 
 
+// Make a function to double check it's ok to pass the result of a
+// binary operator into a function argument
+vector4 add (vector4 a, vector4 b)
+{
+    return a+b;
+}
+
+
+
 shader test ()
 {
     vector4 a = vector4 (.2, .3, .4, .5);
@@ -46,4 +55,8 @@ shader test ()
 
     c = -a;
     printf ("-a = %g %g %g %g\n", c.x, c.y, c.z, c.w);
+
+    // regression test: #762 fixed a bug where passing a struct-returning
+    // binary expression into a function argument would hit an asseriton.
+    c = add (c,c);
 }


### PR DESCRIPTION
The recent patch that allows users to specify operator overloading
for structs means that, in this particular spot, the AST node type
that might be passed as the argument to a function might be a binary
or unary expression -- those could never have returned a struct before,
so were not enumerated in the list of nodes of this conditional, causing
an assertion to hit.