### PR TITLE
testshade --shader <shadername> <layername>

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -227,6 +227,17 @@ add_shader (int argc, const char *argv[])
 
 
 
+static void
+action_shaderdecl (int argc, const char *argv[])
+{
+    // `--shader shadername layername` is exactly equivalent to:
+    // `--layer layername` followed by naming the shader.
+    layername = argv[2];
+    add_shader (1, argv+1);
+}
+
+
+
 // The --expr ARG command line option will take ARG that is a snipped of
 // OSL source code, embed it in some boilerplate shader wrapper, compile
 // it from memory, and run that in the same way that would have been done
@@ -473,6 +484,8 @@ getargs (int argc, const char *argv[])
                 "--layer %s", &layername, "Set next layer name",
                 "--param %@ %s %s", &action_param, NULL, NULL,
                         "Add a parameter (args: name value) (options: type=%s, lockgeom=%d)",
+                "--shader %@ %s %s", &action_shaderdecl, NULL, NULL,
+                        "Declare a shader node (args: shader layername)",
                 "--connect %L %L %L %L",
                     &connections, &connections, &connections, &connections,
                     "Connect fromlayer fromoutput tolayer toinput",


### PR DESCRIPTION
--shader is like a combination of --layer, and then naming the shader to create an instance of it.

The reason I prefer --shader is that when you use it, the command line is almost identical to the shader group serialization. So much nicer!

For example:

```
$ testshade -param texturename "grid.tx" \
            -shader texturemap tex1 \
            -param frequency 4.0 \
            -shader noisy noise1 \
            -param scale 1.0 \
            -shader contrast cont1 \
            -shader umixer mix1 \
            -connect tex1 out cont1 in \
            -connect cont1 out mix1 left \
            -connect noise1 out mix1 right \
            -g 256 256 -o out noisetex.jpg
```

corresponds very symmetrically to the shader group

```
param texturename "grid.tx" ;
shader texturemap tex1 ;
param frequency 4.0 ;
shader noisy noise1 ;
param scale 1.0 ;
shader contrast cont1 ;
shader umixer mix1 ;
connect tex1.out cont1.in ;
connect cont1.out mix1.left ;
connect noise1.out mix1.right ;
```

whereas, in comparison, using the old --layer notation works, but is
a less direct mapping to the serialization format:

```
$ testshade -layer tex1 -param texturename "grid.tx" texturemap \
            -layer noise1 -param frequency 4.0 noisy \
            -layer cont1 -param scale 1.0 contrast \
            -layer mix1 umixer \
            -connect tex1 out cont1 in \
            -connect cont1 out mix1 left \
            -connect noise1 out mix1 right \
            -g 256 256 -o out noisetex.jpg
```

