### PR TITLE
Fix osl_range_check not found error with USE_LLVM_BITCODE=OFF.

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -219,6 +219,9 @@ DECL (osl_dict_find_iss, "iXXX")
 DECL (osl_dict_next, "iXi")
 DECL (osl_dict_value, "iXiXLX")
 DECL (osl_raytype_name, "iXX")
+#ifdef OSL_LLVM_NO_BITCODE
+DECL (osl_range_check, "iiiXXXiXiXX")
+#endif
 DECL (osl_range_check_err, "iiiXXXiXiXX")
 DECL (osl_naninf_check, "xiXiXXiXiiX")
 DECL (osl_uninit_check, "xLXXXiXiXXiXiXii")


### PR DESCRIPTION
This broke in master in a9c21bdf, there's a runtime error for many OSL shaders when building with USE_LLVM_BITCODE=OFF.