### PR TITLE
Make OSL work with clang5/llvm5

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -16,26 +16,18 @@ ifeq ($(SP_OS), rhel7)
 
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final/
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_4.0_final
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
-    ifeq (${COMPILER}, clang342)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.4.2/bin/clang++
-    else ifeq (${COMPILER}, clang35)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/spinux1/llvm_3.5/bin/clang++
-    else ifeq (${COMPILER}, clang39)
-        MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_3.9/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_3.9/bin/clang++
-    else ifeq (${COMPILER}, clang40)
+    ifeq (${COMPILER}, clang4)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_4.0_final/bin/clang \
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_4.0_final/bin/clang++
+    else ifeq (${COMPILER}, clang5)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc490)

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -286,7 +286,12 @@ public:
         mm->registerEHFrames (Addr, LoadAddr, Size);
     }
     virtual void deregisterEHFrames(uint8_t *Addr, uint64_t LoadAddr, size_t Size) {
+#if OSL_LLVM_VERSION < 50
         mm->deregisterEHFrames(Addr, LoadAddr, Size);
+#else
+        // TODO: verify this is correct
+        mm->deregisterEHFrames();
+#endif
     }
     virtual uint64_t getSymbolAddress(const std::string &Name) {
         return mm->getSymbolAddress (Name);
@@ -859,12 +864,16 @@ LLVM_Util::make_function (const std::string &name, bool fastcall,
                           llvm::Type *arg3,
                           llvm::Type *arg4)
 {
-    llvm::Function *func = llvm::cast<llvm::Function>(
-        module()->getOrInsertFunction (name, rettype,
-                                       arg1, arg2, arg3, arg4, NULL));
-    if (fastcall)
-        func->setCallingConv(llvm::CallingConv::Fast);
-    return func;
+    std::vector<llvm::Type*> argtypes;
+    if (arg1)
+        argtypes.emplace_back(arg1);
+    if (arg2)
+        argtypes.emplace_back(arg2);
+    if (arg3)
+        argtypes.emplace_back(arg3);
+    if (arg4)
+        argtypes.emplace_back(arg4);
+    return make_function (name, fastcall, rettype, argtypes, false);
 }
 
 


### PR DESCRIPTION
Very minor. This is the most minimal LLVM upgrade I can recall.

Note that the changes to Makefile-bits are site-specific to SPI.
