### PR TITLE
OSL runtime constant folding of % (modulus)

### DIFF
--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -303,6 +303,36 @@ DECLFOLDER(constfold_div)
 
 
 
+DECLFOLDER(constfold_mod)
+{
+    Opcode &op (rop.inst()->ops()[opnum]);
+    Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
+    Symbol &B (*rop.inst()->argsymbol(op.firstarg()+2));
+    ASSERT (A.typespec().is_int() && B.typespec().is_int());
+    if (rop.is_zero(A)) {
+        // R = 0 % B  =>   R = 0
+        rop.turn_into_assign (op, rop.inst()->arg(op.firstarg()+1),
+                              "0 % A => 0");
+        return 1;
+    }
+    if (rop.is_zero(B)) {
+        // R = A % 0   =>   R = 0
+        rop.turn_into_assign (op, rop.inst()->arg(op.firstarg()+2),
+                              "A % 0 => 0");
+        return 1;
+    }
+    if (A.is_constant() && B.is_constant()) {
+        int a = A.get_int();
+        int b = B.get_int();
+        int cind = rop.add_constant (b ? (a % b) : 0);
+        rop.turn_into_assign (op, cind, "const % const");
+        return 1;
+    }
+    return 0;
+}
+
+
+
 DECLFOLDER(constfold_dot)
 {
     Opcode &op (rop.inst()->ops()[opnum]);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -895,7 +895,7 @@ shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_desc
     OP (mxcompref,   mxcompref,           none,          true,      0);
     OP (min,         minmax,              min,           true,      0);
     OP (mix,         mix,                 mix,           true,      0);
-    OP (mod,         modulus,             none,          true,      0);
+    OP (mod,         modulus,             mod,           true,      0);
     OP (mul,         mul,                 mul,           true,      0);
     OP (neg,         neg,                 neg,           true,      0);
     OP (neq,         compare_op,          neq,           true,      0);


### PR DESCRIPTION
This was never done as a runtime optimization, just never got around to it because % is so rarely used in shaders. But once somebody pointed it out, it was just a few minutes of work.

No new tests need to be added, since % is already tested in the testsuite. If the constant folding doesn't work, testsuite/arithmetic will break.

