### PR TITLE
Allow an (optional) slightly more relaxed policy when declaring parameters

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -240,7 +240,21 @@ ShaderInstance::parameters (const ParamValueList &params)
             // compatible accounts for indefinite-length arrays.
             TypeDesc paramtype = sm_typespec.simpletype();
             TypeDesc valuetype = p.type();
-            if (!compatible_param(paramtype, valuetype)) {
+            if (master()->shadingsys().relaxed_param_typecheck()) {
+                // Relaxed rules just look to see that the types are isomorphic to each other (ie: same number of base values)
+                // Note that:
+                //   * basetypes must match exactly (int vs float vs string)
+                //   * paramtype cannot be unsized (we must know the concrete number of values)
+                //   * if valuetype is sized (or not an array) just check for the total number of entries
+                //   * if valuetype is unsized (shader writer is flexible about how many values come in) -- make sure we are a multiple of the target type
+                if (!(paramtype.basetype == valuetype.basetype && !paramtype.is_unsized_array() &&
+                            ((!valuetype.is_unsized_array() && paramtype.basevalues() == valuetype.basevalues()) ||
+                            (( valuetype.is_unsized_array() && paramtype.basevalues() % valuetype.aggregate == 0))))) {
+                    shadingsys().warning ("attempting to set parameter from incompatible type: %s (expected '%s', received '%s')",
+                                          sm->name(), paramtype, valuetype);
+                    continue;
+                }
+            } else if (!compatible_param(paramtype, valuetype)) {
                 shadingsys().warning ("attempting to set parameter with wrong type: %s (expected '%s', received '%s')",
                                       sm->name(), paramtype, valuetype);
                 continue;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -600,6 +600,7 @@ public:
     bool range_checking() const { return m_range_checking; }
     bool unknown_coordsys_error() const { return m_unknown_coordsys_error; }
     bool connection_error() const { return m_connection_error; }
+    bool relaxed_param_typecheck() const { return m_relaxed_param_typecheck; }
     int optimize () const { return m_optimize; }
     int llvm_optimize () const { return m_llvm_optimize; }
     int llvm_debug () const { return m_llvm_debug; }
@@ -770,6 +771,7 @@ private:
     bool m_connection_error;              ///< Error for ConnectShaders to fail?
     bool m_greedyjit;                     ///< JIT as much as we can?
     bool m_countlayerexecs;               ///< Count number of layer execs?
+    bool m_relaxed_param_typecheck;       ///< Allow parameters to be set from isomorphic types (same data layout)
     int m_max_warnings_per_thread;        ///< How many warnings to display per thread before giving up?
     int m_profile;                        ///< Level of profiling of shader execution
     int m_optimize;                       ///< Runtime optimization level

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -651,6 +651,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_range_checking(true),
       m_unknown_coordsys_error(true), m_connection_error(true),
       m_greedyjit(false), m_countlayerexecs(false),
+      m_relaxed_param_typecheck(false),
       m_max_warnings_per_thread(100),
       m_profile(0),
       m_optimize(2),
@@ -1094,6 +1095,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_SET ("connection_error", int, m_connection_error);
     ATTR_SET ("greedyjit", int, m_greedyjit);
+    ATTR_SET ("relaxed_param_typecheck", int, m_relaxed_param_typecheck);
     ATTR_SET ("countlayerexecs", int, m_countlayerexecs);
     ATTR_SET ("max_warnings_per_thread", int, m_max_warnings_per_thread);
     ATTR_SET ("max_local_mem_KB", int, m_max_local_mem_KB);
@@ -1204,6 +1206,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("connection_error", int, m_connection_error);
     ATTR_DECODE ("greedyjit", int, m_greedyjit);
     ATTR_DECODE ("countlayerexecs", int, m_countlayerexecs);
+    ATTR_DECODE ("relaxed_param_typecheck", int, m_relaxed_param_typecheck);
     ATTR_DECODE ("max_warnings_per_thread", int, m_max_warnings_per_thread);
     ATTR_DECODE_STRING ("commonspace", m_commonspace_synonym);
     ATTR_DECODE_STRING ("colorspace", m_colorspace);


### PR DESCRIPTION
This allows a color to be declared as float[3] for example. This may be useful when declaring shaders from systems that do not explicitly keep track of the source data type.
