### PR TITLE
Fix improper parsing of string_view integer and try to validate it better.

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2532,7 +2532,11 @@ ShadingSystemImpl::decode_connected_param (string_view connectionname,
 
     c.type = sym->typespec();
 
-    if (!bracket.empty() && c.type.is_array()) {
+    // Early out redundant checks below
+    if (bracket.empty())
+        return c;
+
+    if (c.type.is_array()) {
         // There was at least one set of brackets that appears to be
         // selecting an array element.
         c.arrayindex = parse_bracketed_int (bracket, c.type.arraylength());


### PR DESCRIPTION
## Description
Current code is passing **string_view::data()** to both **strchr** and **atoi**, which expect/require null terminated strings.

## Tests

Part 1 of 2 which allows connecting individual components of aggregate types.
Second part includes proper test against **ShadingSystemImpl::decode_connected_param**.

## Checklist:
- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ x] I have previously submitted a [Contributor License Agreement (http://opensource.imageworks.com/cla/).
