### PR TITLE
Make sure that changed headers properly rebuild llvm_ops.cpp bitcode

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,7 +1,5 @@
 file (GLOB public_headers OSL/*.h)
 
-message (STATUS "Create oslversion.h from oslversion.h.in")
-
 if (USE_CPP VERSION_GREATER 11)
     set (OSL_BUILD_CPP14 1)
 endif ()
@@ -9,7 +7,10 @@ if (USE_CPP VERSION_GREATER 17)
     set (OSL_BUILD_CPP17 1)
 endif ()
 
+message (STATUS "Create oslversion.h from oslversion.h.in")
 configure_file (OSL/oslversion.h.in "${CMAKE_BINARY_DIR}/include/OSL/oslversion.h" @ONLY)
 list (APPEND public_headers "${CMAKE_BINARY_DIR}/include/OSL/oslversion.h")
 
 INSTALL ( FILES ${public_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/OSL )
+
+set (PROJECT_PUBLIC_HEADERS ${public_headers} PARENT_SCOPE)

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -120,6 +120,7 @@ MACRO ( LLVM_COMPILE llvm_src srclist )
       COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash" ${llvm_bc} ${llvm_bc_cpp}
       MAIN_DEPENDENCY ${llvm_src}
       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/serialize-bc.bash"
+              ${exec_headers} ${PROJECT_PUBLIC_HEADERS}
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 ENDMACRO ( )
 


### PR DESCRIPTION
I noticed, doing some unrelated work, that changes to certain header files were not triggering a recompile of llvm_ops.cpp into bitcode.
