### PR TITLE
Dual refactor and generalization

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -875,8 +875,8 @@ inline Dual<T,P> fast_exp(const Dual<T,P> &a)
 template<class T, int P>
 inline Dual<T,P> exp2 (const Dual<T,P> &a)
 {
-    // FIXME: std::exp2 is only available in C++11
-    T f = exp2f(float(a.val()));
+    using std::exp2;
+    T f = exp2(a.val());
     return dualfunc (a, f, f*T(M_LN2));
 }
 
@@ -892,8 +892,8 @@ inline Dual<T,P> fast_exp2(const Dual<T,P> &a)
 template<class T, int P>
 inline Dual<T,P> expm1 (const Dual<T,P> &a)
 {
-    // FIXME: std::expm1 is only available in C++11
-    T f  = expm1f(float(a.val())); // float version!
+    using std::expm1;
+    T f  = expm1(a.val());
     T df = std::exp  (a.val());
     return dualfunc (a, f, df);
 }
@@ -910,8 +910,8 @@ inline Dual<T,P> fast_expm1(const Dual<T,P> &a)
 template<class T, int P>
 inline Dual<T,P> erf (const Dual<T,P> &a)
 {
-    // FIXME: std::erf is only defined in C++11
-    T f = erff (float(a.val())); // float version!
+    using std::erf;
+    T f = erf (a.val());
     const T two_over_sqrt_pi = T(1.128379167095512573896158903);
     T df = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
     return dualfunc (a, f, df);
@@ -930,8 +930,8 @@ inline Dual<T,P> fast_erf(const Dual<T,P> &a)
 template<class T, int P>
 inline Dual<T,P> erfc (const Dual<T,P> &a)
 {
-    // FIXME: std::erfc is only defined in C++11
-    T f = erfcf (float(a.val())); // float version!
+    using std::erfc;
+    T f = erfc (a.val()); // float version!
     const T two_over_sqrt_pi = -T(1.128379167095512573896158903);
     T df = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
     return dualfunc (a, f, df);

--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -28,133 +28,233 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <initializer_list>
 #include <OSL/oslversion.h>
 #include <OpenImageIO/fmath.h>
 OSL_NAMESPACE_ENTER
+
+
+// Shortcut notation for enable_if trickery
+# define DUAL_REQUIRES(...) \
+  typename std::enable_if<(__VA_ARGS__), bool>::type = true
+
 
 
 /// Dual numbers are used to represent values and their derivatives.
 ///
 /// The method is summarized in:
 ///      Piponi, Dan, "Automatic Differentiation, C++ Templates,
-///      and Photogrammetry," Journal of Graphics, GPU, and Game 
+///      and Photogrammetry," Journal of Graphics, GPU, and Game
 ///      Tools (JGT), Vol 9, No 4, pp. 41-55 (2004).
 ///
-/// See http://jgt.akpeters.com/papers/Piponi04/ for downloadable
-/// software that attempts to be general to N dimensions of partial
-/// derivatives.  But for OSL, we only are interested in partials with
-/// respect to "x" and "y", and don't need to be more general, so for
-/// speed and simplicity we are hard-coding our implementation to
-/// dimensionality 2.  We also change some of his nomenclature.
 ///
 
-template<class T>
-class Dual2 {
+template<
+         class T,           // Base data type
+         int PARTIALS=1     // Number of dimentions of partial derivs
+        >
+class Dual {
+    static const int elements = PARTIALS+1;   // main value + partials
+    static_assert (PARTIALS>=1, "Can't have a Dual with 0 partials");
 public:
+    using value_type = T;
+
     /// Default ctr leaves everything uninitialized
     ///
-    Dual2 () { }
+    constexpr Dual () { }
 
     /// Construct a Dual from just a real value (derivs set to 0)
     ///
-    Dual2 (const T &x) : m_val(x), m_dx(T(0.0)), m_dy(T(0.0)) { }
-
-    template <class F>
-    Dual2 (const Dual2<F> &x) : m_val(T(x.val())), m_dx(T(x.dx())), m_dy(T(x.dy())) { }
-
-    /// Construct a Dual from a real and both infinitesimal.
-    ///
-    Dual2 (const T &x, const T &dx, const T &dy) 
-        : m_val(x), m_dx(dx), m_dy(dy) { }
-
-    void set (const T &x, const T &dx, const T &dy) {
-        m_val = x;  m_dx = dx;  m_dy = dy;
+    OIIO_CONSTEXPR14 Dual (const T &x) {
+        m_data[0] = x;
+        for (int i = 1; i <= PARTIALS; ++i)
+            m_data[i] = T(0.0);
     }
 
-    /// Return the real value of *this.
-    ///
-    const T& val () const { return m_val; }
-    T& val () { return m_val; }
+    /// Copy constructor from another Dual of same type and dimension.
+    OIIO_CONSTEXPR14 Dual (const Dual &x) {
+        for (int i = 0; i <= PARTIALS; ++i)
+            m_data[i] = T(x.m_data[i]);
+    }
 
-    /// Return the partial derivative with respect to x
-    ///
-    const T& dx () const { return m_dx; }
-    T& dx () { return m_dx; }
+#if 1
+    /// Copy constructor from another Dual of same dimension and different,
+    /// but castable, data type.
+    template<class F>
+    OIIO_CONSTEXPR14 Dual (const Dual<F,PARTIALS> &x) {
+        for (int i = 0; i <= PARTIALS; ++i)
+            m_data[i] = T(x.elem(i));
+    }
+#endif
 
-    /// Return the partial derivative with respect to y
+    /// Construct a Dual from a real and infinitesimals.
     ///
-    const T& dy () const { return m_dy; }
-    T& dy () { return m_dy; }
+    constexpr Dual (const T &x, const T &dx) : m_data{ x, dx } {
+        static_assert(PARTIALS==1, "Wrong number of initializers");
+    }
+    constexpr Dual (const T &x, const T &dx, const T &dy)
+        : m_data{ x, dx, dy }
+    {
+        static_assert(PARTIALS==2, "Wrong number of initializers");
+    }
+    void set (const T &x, const T &dx) {
+        static_assert(PARTIALS==1, "Wrong number of initializers");
+        m_data[0] = x;
+        m_data[1] = dx;
+    }
+    void set (const T &x, const T &dx, const T &dy) {
+        static_assert(PARTIALS==2, "Wrong number of initializers");
+        m_data[0] = x;
+        m_data[1] = dx;
+        m_data[2] = dy;
+    }
 
-    void set_val (const T &val) { m_val = val; }
-    void set_dx  (const T &dx)  { m_dx  = dx;  }
-    void set_dy  (const T &dy)  { m_dy  = dy;  }
+    OIIO_CONSTEXPR14 Dual (std::initializer_list<T> vals) {
+        static_assert (vals.size() == elements, "Wrong number of initializers");
+        for (int i = 0; i < elements; ++i)
+            m_data[i] = vals.begin()[i];
+    }
+
+    /// Return the real value.
+    constexpr const T& val () const { return m_data[0]; }
+    T& val () { return m_data[0]; }
+
+    /// Return the partial derivative with respect to x.
+    constexpr const T& dx () const { return m_data[1]; }
+    T& dx () { return m_data[1]; }
+
+    /// Return the partial derivative with respect to y.
+    /// Only valid if there are at least 2 partial dimensions.
+    constexpr const T& dy () const {
+        static_assert(PARTIALS>=2, "Cannot call dy without at least 2 partials");
+        return m_data[2];
+    }
+    T& dy () {
+        static_assert(PARTIALS>=2, "Cannot call dy without at least 2 partials");
+        return m_data[2];
+    }
+
+    /// Return the partial derivative with respect to z.
+    /// Only valid if there are at least 3 partial dimensions.
+    constexpr const T& dz () const {
+        static_assert(PARTIALS>=3, "Cannot call dz without at least 3 partials");
+        return m_data[3];
+    }
+    T& dz () {
+        static_assert(PARTIALS>=3, "Cannot call dz without at least 3 partials");
+        return m_data[3];
+    }
 
     /// Clear the derivatives; leave the value alone.
-    ///
-    void clear_d () { m_dx = T(0);  m_dy = T(0); }
-
-    /// Return the special dual number (i == 0 is the dx imaginary
-    /// number, i == 1 is the dy imaginary number).
-    static Dual2<T> d (int i) {
-        return i==0 ? Dual2<T> (T(0),T(1),T(0)) : Dual2<T> (T(0),T(0),T(1));
+    void clear_d () {
+        for (int i = 1; i <= PARTIALS; ++i)
+            m_data[i] = T(0.0);
     }
 
-    const Dual2<T> & operator= (const T &x) {
-        set (x, T(0), T(0));
+    /// Return the i-th partial derivative.
+    constexpr const T& partial (int i) const {
+        return m_data[i+1];
+    }
+
+    /// Return a mutable reference to the i-th partial derivative.
+    /// Use with caution!
+    T& partial (int i) {
+        return m_data[i+1];
+    }
+
+    /// Assignment of a real (the derivs are implicitly 0).
+    const Dual & operator= (const T &x) {
+        m_data[0] = x;
+        for (int i = 1; i <= PARTIALS; ++i)
+            m_data[i] = T(0);
         return *this;
     }
 
-    /// Stream output.  Format as: "val[dx,dy]"
+    /// Access like an array -- be careful! Element 0 is the main value,
+    /// elements [1..PARTIALS] are the infinitessimals.
+    constexpr const T& elem (int i) const { return m_data[i]; }
+    T& elem (int i) { return m_data[i]; }
+
+    /// Stream output.  Format as: "val[dx,dy,...]"
     ///
-    friend std::ostream& operator<< (std::ostream &out, const Dual2<T> &x) {
-        return out << x.val() << "[" << x.dx() << "," << x.dy() << "]";
+    friend std::ostream& operator<< (std::ostream &out, const Dual &x) {
+        out << x.m_data[0] << "[";
+        for (int i = 1; i < PARTIALS; ++i)
+            out << x.m_data[i] << ',';
+        return out << x.m_data[PARTIALS] << "]";
     }
 
 private:
-    T m_val;   ///< The value
-    T m_dx;    ///< Infinitesimal partial differential with respect to x
-    T m_dy;    ///< Infinitesimal partial differential with respect to y
+    T m_data[elements];  ///< [0] is the value, [1..PARTIALS] are derivs
 };
 
+
+
+/// is_Dual<TYPE>::value is true for Dual, false for everything else.
+/// You can also evaluate an is_Dual<T> as a bool.
+template<class T> struct is_Dual : std::false_type {};
+template<class T, int P> struct is_Dual<Dual<T,P>> : std::true_type {};
+
+/// Dualify<T>::type returns Dual<T> if T is not a dual, or just T if it's
+/// already a dual.
+template<class T> struct UnDual { typedef T type; };
+template<class T, int P> struct UnDual<Dual<T,P>> { typedef T type; };
+
+/// Dualify<T,P>::type returns Dual<T,P> if T is not a dual, or just T if
+/// it's already a dual.
+template<class T, int P=1> struct Dualify {
+    typedef Dual<typename UnDual<T>::type, P> type;
+};
+
+
+
+/// Define Dual2<T> as a Dual<T,2> -- a T-based quantity with x and y
+/// partial derivatives.
+template<class T> using Dual2 = Dual<T,2>;
 
 
 
 /// Addition of duals.
 ///
-template<class T>
-inline Dual2<T> operator+ (const Dual2<T> &a, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const Dual<T,P> &b)
 {
-    return Dual2<T> (a.val()+b.val(), a.dx()+b.dx(), a.dy()+b.dy());
+    Dual<T,P> result = a;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) += b.elem(i);
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T> operator+ (const Dual2<T> &a, const T &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const T &b)
 {
-    return Dual2<T> (a.val()+b, a.dx(), a.dy());
+    Dual<T,P> result = a;
+    result.val() += b;
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T> operator+ (const T &a, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const T &a, const Dual<T,P> &b)
 {
-    return Dual2<T> (a+b.val(), b.dx(), b.dy());
+    Dual<T,P> result = b;
+    result.val() += a;
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T>& operator+= (Dual2<T> &a, const Dual2<T> &b)
+template<class T, int P>
+inline Dual<T,P>& operator+= (Dual<T,P> &a, const Dual<T,P> &b)
 {
-    a.val() += b.val();
-    a.dx()  += b.dx();
-    a.dy()  += b.dy();
+    for (int i = 0; i <= P; ++i)
+        a.elem(i) += b.elem(i);
     return a;
 }
 
 
-template<class T>
-inline Dual2<T>& operator+= (Dual2<T> &a, const T &b)
+template<class T, int P>
+inline Dual<T,P>& operator+= (Dual<T,P> &a, const T &b)
 {
     a.val() += b;
     return a;
@@ -163,39 +263,47 @@ inline Dual2<T>& operator+= (Dual2<T> &a, const T &b)
 
 /// Subtraction of duals.
 ///
-template<class T>
-inline Dual2<T> operator- (const Dual2<T> &a, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const Dual<T,P> &b)
 {
-    return Dual2<T> (a.val()-b.val(), a.dx()-b.dx(), a.dy()-b.dy());
+    Dual<T,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = a.elem(i) - b.elem(i);
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T> operator- (const Dual2<T> &a, const T &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const T &b)
 {
-    return Dual2<T> (a.val()-b, a.dx(), a.dy());
+    Dual<T,P> result = a;
+    result.val() -= b;
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T> operator- (const T &a, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const T &a, const Dual<T,P> &b)
 {
-    return Dual2<T> (a-b.val(), -b.dx(), -b.dy());
+    Dual<T,P> result;
+    result.val() = a - b.val();
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = -b.elem(i);
+    return result;
 }
 
 
-template<class T>
-inline Dual2<T>& operator-= (Dual2<T> &a, const Dual2<T> &b)
+template<class T, int P>
+inline Dual<T,P>& operator-= (Dual<T,P> &a, const Dual<T,P> &b)
 {
-    a.val() -= b.val();
-    a.dx()  -= b.dx();
-    a.dy()  -= b.dy();
+    for (int i = 0; i <= P; ++i)
+        a.elem(i) -= b.elem(i);
     return a;
 }
 
 
-template<class T>
-inline Dual2<T>& operator-= (Dual2<T> &a, const T &b)
+template<class T, int P>
+inline Dual<T,P>& operator-= (Dual<T,P> &a, const T &b)
 {
     a.val() -= b.val();
     return a;
@@ -205,80 +313,89 @@ inline Dual2<T>& operator-= (Dual2<T> &a, const T &b)
 
 /// Negation of duals.
 ///
-template<class T>
-inline Dual2<T> operator- (const Dual2<T> &a)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a)
 {
-    return Dual2<T> (-a.val(), -a.dx(), -a.dy());
+    Dual<T,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = -a.elem(i);
+    return result;
 }
 
 
-/// Multiplication of duals.
-///
-template<class T>
-inline Dual2<T> operator* (const Dual2<T> &a, const Dual2<T> &b)
+/// Multiplication of duals. This will work for any Dual<T>*Dual<S>
+/// where T*S is meaningful.
+template<class T, int P, class S>
+inline OIIO_CONSTEXPR14 auto
+operator* (const Dual<T,P> &a, const Dual<S,P> &b) -> Dual<decltype(a.elem(0)*b.elem(0)),P>
 {
     // Use the chain rule
-    return Dual2<T> (a.val()*b.val(),
-                     a.val()*b.dx() + a.dx()*b.val(),
-                     a.val()*b.dy() + a.dy()*b.val());
+    Dual<decltype(a.elem(0)*b.elem(0)),P> result;
+    result.val() = a.val() * b.val();
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = a.val()*b.elem(i) + a.elem(i)*b.val();
+    return result;
 }
 
 
-/// Multiplication of dual by scalar.
-///
-template<class T>
-inline Dual2<T> operator* (const Dual2<T> &a, const T &b)
+/// Multiplication of dual by a non-dual scalar. This will work for any
+/// Dual<T> * S where T*S is meaningful.
+template<class T, int P, class S,
+         DUAL_REQUIRES(is_Dual<S>::value == false)>
+inline OIIO_CONSTEXPR14 auto
+operator* (const Dual<T,P> &a, const S &b) -> Dual<decltype(a.elem(0)*b),P>
 {
-    return Dual2<T> (a.val()*b, a.dx()*b, a.dy()*b);
+    Dual<decltype(a.elem(0)*b),P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = a.elem(i) * b;
+    return result;
 }
 
 
 /// Multiplication of dual by scalar in place.
 ///
-template<class T>
-inline const Dual2<T>& operator*= (Dual2<T> &a, const T &b)
+template<class T, int P, class S,
+         DUAL_REQUIRES(is_Dual<S>::value == false)>
+inline const Dual<T,P>& operator*= (Dual<T,P> &a, const S &b)
 {
-    a.val() *= b;
-    a.dx()  *= b;
-    a.dy()  *= b;
+    for (int i = 0; i <= P; ++i)
+        a.elem(i) *= b;
     return a;
 }
 
 
 
-/// Multiplication of dual by scalar.
-///
-template<class T>
-inline Dual2<T> operator* (const T &b, const Dual2<T> &a)
+/// Multiplication of dual by a non-dual scalar. This will work for any
+/// Dual<T> * S where T*S is meaningful.
+template<class T, int P, class S,
+         DUAL_REQUIRES(is_Dual<S>::value == false)>
+inline OIIO_CONSTEXPR14 auto
+operator* (const S &b, const Dual<T,P> &a) -> Dual<decltype(a.elem(0)*b),P>
 {
-    return Dual2<T> (a.val()*b, a.dx()*b, a.dy()*b);
-}
-
-template<class T, class S>
-inline Dual2<T> operator* (const S &b, const Dual2<T> &a)
-{
-    return Dual2<T> (a.val()*T(b), a.dx()*T(b), a.dy()*T(b));
+    return a*b;
 }
 
 
 
 /// Division of duals.
 ///
-template<class T>
-inline Dual2<T> operator/ (const Dual2<T> &a, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const Dual<T,P> &b)
 {
     T bvalinv = 1.0f / b.val();
     T aval_bval = a.val() * bvalinv;
-    return Dual2<T> (aval_bval,
-                     bvalinv * (a.dx() - aval_bval * b.dx()),
-                     bvalinv * (a.dy() - aval_bval * b.dy()));
+    Dual<T,P> result;
+    result.val() = aval_bval;
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = bvalinv * (a.elem(i) - aval_bval * b.elem(i));
+    return result;
 }
 
 
 /// Division of dual by scalar.
 ///
-template<class T>
-inline Dual2<T> operator/ (const Dual2<T> &a, const T &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const T &b)
 {
     T binv = 1.0f / b;
     return a * binv;
@@ -287,79 +404,95 @@ inline Dual2<T> operator/ (const Dual2<T> &a, const T &b)
 
 /// Division of scalar by dual.
 ///
-template<class T>
-inline Dual2<T> operator/ (const T &aval, const Dual2<T> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const T &aval, const Dual<T,P> &b)
 {
     T bvalinv = 1.0f / b.val();
     T aval_bval = aval * bvalinv;
-    return Dual2<T> (aval_bval,
-                     bvalinv * ( - aval_bval * b.dx()),
-                     bvalinv * ( - aval_bval * b.dy()));
+    Dual<T,P> result;
+    result.val() = aval_bval;
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = bvalinv * ( - aval_bval * b.elem(i));
+    return result;
 }
 
 
 
 
-template<class T>
-inline bool operator< (const Dual2<T> &a, const Dual2<T> &b) {
+template<class T, int P>
+inline constexpr bool operator< (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() < b.val();
 }
 
-template<class T>
-inline bool operator< (const Dual2<T> &a, const T &b) {
+template<class T, int P>
+inline constexpr bool operator< (const Dual<T,P> &a, const T &b) {
     return a.val() < b;
 }
 
-template<class T>
-inline bool operator> (const Dual2<T> &a, const Dual2<T> &b) {
+template<class T, int P>
+inline constexpr bool operator> (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() > b.val();
 }
 
-template<class T>
-inline bool operator> (const Dual2<T> &a, const T &b) {
+template<class T, int P>
+inline constexpr bool operator> (const Dual<T,P> &a, const T &b) {
     return a.val() > b;
 }
 
-template<class T>
-inline bool operator<= (const Dual2<T> &a, const Dual2<T> &b) {
+template<class T, int P>
+inline constexpr bool operator<= (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() <= b.val();
 }
 
-template<class T>
-inline bool operator<= (const Dual2<T> &a, const T &b) {
+template<class T, int P>
+inline constexpr bool operator<= (const Dual<T,P> &a, const T &b) {
     return a.val() <= b;
 }
 
-template<class T>
-inline bool operator>= (const Dual2<T> &a, const Dual2<T> &b) {
+template<class T, int P>
+inline constexpr bool operator>= (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() >= b.val();
 }
 
-template<class T>
-inline bool operator>= (const Dual2<T> &a, const T &b) {
+template<class T, int P>
+inline constexpr bool operator>= (const Dual<T,P> &a, const T &b) {
     return a.val() >= b;
 }
 
 
 
-// Eliminate the derivatives of a number
-template<class T> inline T removeDerivatives (const T &x)        { return x;       }
-template<class T> inline T removeDerivatives (const Dual2<T> &x) { return x.val(); }
+// Eliminate the derivatives of a number, works for scalar as well as Dual.
+template<class T> inline constexpr const T&
+removeDerivatives (const T &x) { return x; }
+
+template<class T, int P> inline constexpr const T&
+removeDerivatives (const Dual<T,P> &x) { return x.val(); }
+
 
 // Get the x derivative (or 0 for a non-Dual)
-template<class T> inline T getXDerivative (const T &x)        { return T(0);   }
-template<class T> inline T getXDerivative (const Dual2<T> &x) { return x.dx(); }
+template<class T> inline constexpr const T&
+getXDerivative (const T &x) { return T(0); }
+
+template<class T, int P> inline constexpr const T&
+getXDerivative (const Dual<T,P> &x) { return x.partial(0); }
+
 
 // Get the y derivative (or 0 for a non-Dual)
-template<class T> inline T getYDerivative (const T &x)        { return T(0);   }
-template<class T> inline T getYDerivative (const Dual2<T> &x) { return x.dy(); }
+template<class T> inline constexpr const T&
+getYDerivative (const T &x) { return T(0); }
+
+template<class T, int P> inline constexpr const T&
+getYDerivative (const Dual<T,P> &x) { return x.partial(1); }
+
 
 // Simple templated "copy" function
-template <class T> inline void assignment(T &a, T &b)        { a = b;       }
-template <class T> inline void assignment(T &a, Dual2<T> &b) { a = b.val(); }
+template<class T> inline void
+assignment (T &a, T &b) { a = b; }
+template<class T, int P> inline void
+assignment (T &a, Dual<T,P> &b) { a = b.val(); }
 
 // Templated value equality. For scalars, it's the same as regular ==.
-// For Dual2's, this only tests the value, not the derivatives. This solves
+// For Dual's, this only tests the value, not the derivatives. This solves
 // a pesky source of confusion about whether operator== of Duals ought to
 // return if just their value is equal or if the whole struct (including
 // derivs) are equal.
@@ -367,220 +500,286 @@ template<class T>
 inline constexpr bool equalVal (const T &x, const T &y) {
     return x == y;
 }
-template<class T>
-inline constexpr bool equalVal (const Dual2<T> &x, const Dual2<T> &y) {
+
+template<class T, int P>
+inline constexpr bool equalVal (const Dual<T,P> &x, const Dual<T,P> &y) {
     return x.val() == y.val();
+}
+
+template<class T, int P>
+inline constexpr bool equalVal (const Dual<T,P> &x, const T &y) {
+    return x.val() == y;
+}
+
+template<class T, int P>
+inline constexpr bool equalVal (const T &x, const Dual<T,P> &y) {
+    return x == y.val();
+}
+
+
+
+// Helper for constructing the result of a Dual function of one variable,
+// given the scalar version and its derivative. Suppose you have scalar
+// function f(scalar), then the dual function F(<u,u'>) is defined as:
+//    F(<u,u'>) = < f(u), f'(u)*u' >
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dualfunc (const Dual<T,P>& u, const T& f_val, const T& df_val)
+{
+    Dual<T,P> result;
+    result.val() = f_val;
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = df_val * u.elem(i);
+    return result;
+}
+
+// Helper for constructing the result of a Dual function of two variables,
+// given the scalar version and its derivative. In general, the dual-form of
+// the primitive function 'f(u,v)' is:
+//   F(<u,u'>, <v,v'>) = < f(u,v), dfdu(u,v)u' + dfdv(u,v)v' >
+// (from http://en.wikipedia.org/wiki/Automatic_differentiation)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dualfunc (const Dual<T,P>& u, const Dual<T,P>& v,
+          const T& f_val, const T& dfdu_val, const T& dfdv_val)
+{
+    Dual<T,P> result;
+    result.val() = f_val;
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = dfdu_val * u.elem(i) + dfdv_val * v.elem(i);
+    return result;
+}
+
+
+// Helper for construction the result of a Dual function of three variables.
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dualfunc (const Dual<T,P>& u, const Dual<T,P>& v, const Dual<T,P>& w,
+          const T& f_val, const T& dfdu_val, const T& dfdv_val, const T& dfdw_val)
+{
+    Dual<T,P> result;
+    result.val() = f_val;
+    for (int i = 1; i <= P; ++i)
+        result.elem(i) = dfdu_val * u.elem(i) + dfdv_val * v.elem(i) + dfdw_val * w.elem(i);
+    return result;
 }
 
 
 
 // f(x) = cos(x), f'(x) = -sin(x)
-template<class T>
-inline Dual2<T> cos (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> cos (const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::sincos(a.val(), &sina, &cosa);
-    return Dual2<T> (cosa, -sina * a.dx(), -sina * a.dy());
+    return dualfunc (a, cosa, -sina);
 }
 
-inline Dual2<float> fast_cos(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_cos(const Dual<T,P> &a)
 {
-    float sina, cosa;
+    T sina, cosa;
     OIIO::fast_sincos (a.val(), &sina, &cosa);
-    return Dual2<float> (cosa, -sina * a.dx(), -sina * a.dy());
+    return dualfunc (a, cosa, -sina);
 }
 
 // f(x) = sin(x),  f'(x) = cos(x)
-template<class T>
-inline Dual2<T> sin (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> sin (const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::sincos(a.val(), &sina, &cosa);
-    return Dual2<T> (sina, cosa * a.dx(), cosa * a.dy());
+    return dualfunc (a, sina, cosa);
 }
 
-inline Dual2<float> fast_sin(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_sin(const Dual<T,P> &a)
 {
-    float sina, cosa;
+    T sina, cosa;
     OIIO::fast_sincos (a.val(), &sina, &cosa);
-    return Dual2<float> (sina, cosa * a.dx(), cosa * a.dy());
+    return dualfunc (a, sina, cosa);
 }
 
-template <class T>
-inline void sincos(const Dual2<T> &a, Dual2<T> *sine, Dual2<T> *cosine)
+template<class T, int P>
+inline void sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
 {
 	T sina, cosa;
 	OIIO::sincos(a.val(), &sina, &cosa);
-	*cosine = Dual2<T> (cosa, -sina * a.dx(), -sina * a.dy());
-	  *sine = Dual2<T> (sina,  cosa * a.dx(),  cosa * a.dy());
+    *cosine = dualfunc (a, cosa, -sina);
+    *sine   = dualfunc (a, sina, cosa);
 }
 
-inline void fast_sincos(const Dual2<float> &a, Dual2<float> *sine, Dual2<float> *cosine)
+template<class T, int P>
+inline void fast_sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
 {
-	float sina, cosa;
+	T sina, cosa;
 	OIIO::fast_sincos(a.val(), &sina, &cosa);
-	*cosine = Dual2<float> (cosa, -sina * a.dx(), -sina * a.dy());
-	  *sine = Dual2<float> (sina,  cosa * a.dx(),  cosa * a.dy());
+    *cosine = dualfunc (a, cosa, -sina);
+    *sine   = dualfunc (a, sina, cosa);
 }
 
 // f(x) = tan(x), f'(x) = sec^2(x)
-template<class T>
-inline Dual2<T> tan (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> tan (const Dual<T,P> &a)
 {
     T tana  = std::tan (a.val());
     T cosa  = std::cos (a.val());
     T sec2a = T(1)/(cosa*cosa);
-    return Dual2<T> (tana, sec2a * a.dx(), sec2a * a.dy());
+    return dualfunc (a, tana, sec2a);
 }
 
-inline Dual2<float> fast_tan(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_tan(const Dual<T,P> &a)
 {
-    float tana  = OIIO::fast_tan (a.val());
-    float cosa  = OIIO::fast_cos (a.val());
-    float sec2a = 1 / (cosa * cosa);
-    return Dual2<float> (tana, sec2a * a.dx(), sec2a * a.dy());
+    T tana  = OIIO::fast_tan (a.val());
+    T cosa  = OIIO::fast_cos (a.val());
+    T sec2a = 1 / (cosa * cosa);
+    return dualfunc (a, tana, sec2a);
 }
 
 // f(x) = cosh(x), f'(x) = sinh(x)
-template<class T>
-inline Dual2<T> cosh (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> cosh (const Dual<T,P> &a)
 {
-    T cosha = std::cosh(a.val());
-    T sinha = std::sinh(a.val());
-    return Dual2<T> (cosha, sinha * a.dx(), sinha * a.dy());
+    T f = std::cosh(a.val());
+    T df = std::sinh(a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_cosh(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_cosh(const Dual<T,P> &a)
 {
-    float cosha = OIIO::fast_cosh(a.val());
-    float sinha = OIIO::fast_sinh(a.val());
-    return Dual2<float> (cosha, sinha * a.dx(), sinha * a.dy());
+    T f = OIIO::fast_cosh(a.val());
+    T df = OIIO::fast_sinh(a.val());
+    return dualfunc (a, f, df);
 }
 
 
 // f(x) = sinh(x), f'(x) = cosh(x)
-template<class T>
-inline Dual2<T> sinh (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> sinh (const Dual<T,P> &a)
 {
-    T cosha = std::cosh(a.val());
-    T sinha = std::sinh(a.val());
-    return Dual2<T> (sinha, cosha * a.dx(), cosha * a.dy());
+    T f = std::sinh(a.val());
+    T df = std::cosh(a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_sinh(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_sinh(const Dual<T,P> &a)
 {
-    float cosha = OIIO::fast_cosh(a.val());
-    float sinha = OIIO::fast_sinh(a.val());
-    return Dual2<float> (sinha, cosha * a.dx(), cosha * a.dy());
+    T f = OIIO::fast_sinh(a.val());
+    T df = OIIO::fast_cosh(a.val());
+    return dualfunc (a, f, df);
 }
 
 // f(x) = tanh(x), f'(x) = sech^2(x)
-template<class T>
-inline Dual2<T> tanh (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> tanh (const Dual<T,P> &a)
 {
     T tanha = std::tanh(a.val());
     T cosha = std::cosh(a.val());
     T sech2a = T(1)/(cosha*cosha);
-    return Dual2<T> (tanha, sech2a * a.dx(), sech2a * a.dy());
+    return dualfunc (a, tanha, sech2a);
 }
 
-inline Dual2<float> fast_tanh(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_tanh(const Dual<T,P> &a)
 {
-    float tanha = OIIO::fast_tanh(a.val());
-    float cosha = OIIO::fast_cosh(a.val());
-    float sech2a = 1 / (cosha * cosha);
-    return Dual2<float> (tanha, sech2a * a.dx(), sech2a * a.dy());
+    T tanha = OIIO::fast_tanh(a.val());
+    T cosha = OIIO::fast_cosh(a.val());
+    T sech2a = T(1) / (cosha * cosha);
+    return dualfunc (a, tanha, sech2a);
 }
 
 // f(x) = acos(x), f'(x) = -1/(sqrt(1 - x^2))
-template<class T>
-inline Dual2<T> safe_acos (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> safe_acos (const Dual<T,P> &a)
 {
     if (a.val() >= T(1))
-        return Dual2<T> (T(0), T(0), T(0));
+        return Dual<T,P> (T(0));
     if (a.val() <= T(-1))
-        return Dual2<T> (T(M_PI), T(0), T(0));
-    T arccosa = std::acos (a.val());
-    T denom   = -T(1) / std::sqrt (T(1) - a.val()*a.val());
-    return Dual2<T> (arccosa, denom * a.dx(), denom * a.dy());
+        return Dual<T,P> (T(M_PI));
+    T f = std::acos (a.val());
+    T df = -T(1) / std::sqrt (T(1) - a.val()*a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_acos(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_acos(const Dual<T,P> &a)
 {
-    float arccosa = OIIO::fast_acos(a.val());
-    float denom   = fabsf(a.val()) < 1.0f ? -1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
-    return Dual2<float> (arccosa, denom * a.dx(), denom * a.dy());
+    T f = OIIO::fast_acos(a.val());
+    T df = fabsf(a.val()) < 1.0f ? -1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
+    return dualfunc (a, f, df);
 }
 
 // f(x) = asin(x), f'(x) = 1/(sqrt(1 - x^2))
-template<class T>
-inline Dual2<T> safe_asin (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> safe_asin (const Dual<T,P> &a)
 {
     if (a.val() >= T(1))
-        return Dual2<T> (T(M_PI/2), T(0), T(0));
+        return Dual<T,P> (T(M_PI/2));
     if (a.val() <= T(-1))
-        return Dual2<T> (T(-M_PI/2), T(0), T(0));
-
-    T arcsina = std::asin (a.val());
-    T denom   = T(1) / std::sqrt (T(1) - a.val()*a.val());
-    return Dual2<T> (arcsina, denom * a.dx(), denom * a.dy());
+        return Dual<T,P> (T(-M_PI/2));
+    T f = std::asin (a.val());
+    T df = T(1) / std::sqrt (T(1) - a.val()*a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_asin(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_asin(const Dual<T,P> &a)
 {
-    float arcsina = OIIO::fast_asin(a.val());
-    float denom   = fabsf(a.val()) < 1.0f ? 1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
-    return Dual2<float> (arcsina, denom * a.dx(), denom * a.dy());
+    T f = OIIO::fast_asin(a.val());
+    T df = fabsf(a.val()) < 1.0f ? 1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
+    return dualfunc (a, f, df);
 }
 
 
 // f(x) = atan(x), f'(x) = 1/(1 + x^2)
-template<class T>
-inline Dual2<T> atan (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> atan (const Dual<T,P> &a)
 {
-    T arctana = std::atan (a.val());
-    T denom   = T(1) / (T(1) + a.val()*a.val());
-    return Dual2<T> (arctana, denom * a.dx(), denom * a.dy());
+    T f = std::atan (a.val());
+    T df = T(1) / (T(1) + a.val()*a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_atan(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_atan(const Dual<T,P> &a)
 {
-    float arctana = OIIO::fast_atan(a.val());
-    float denom   = 1.0f / (1.0f + a.val() * a.val());
-    return Dual2<float> (arctana, denom * a.dx(), denom * a.dy());
-
+    T f = OIIO::fast_atan(a.val());
+    T df = 1.0f / (1.0f + a.val() * a.val());
+    return dualfunc (a, f, df);
 }
 
-// f(x,x) = atan2(y,x); f'(x) =  y x' / (x^2 + y^2),
+// f(x,y) = atan2(y,x); f'(x) =  y x' / (x^2 + y^2),
 //                      f'(y) = -x y' / (x^2 + y^2)
-// reference:  http://en.wikipedia.org/wiki/Atan2 
+// reference:  http://en.wikipedia.org/wiki/Atan2
 // (above link has other formulations)
-template<class T>
-inline Dual2<T> atan2 (const Dual2<T> &y, const Dual2<T> &x)
+template<class T, int P>
+inline Dual<T,P> atan2 (const Dual<T,P> &y, const Dual<T,P> &x)
 {
     T atan2xy = std::atan2 (y.val(), x.val());
     T denom = (x.val() == T(0) && y.val() == T(0)) ? T(0) : T(1) / (x.val()*x.val() + y.val()*y.val());
-    return Dual2<T> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
-                               (y.val()*x.dy() - x.val()*y.dy())*denom );
+    return dualfunc (y, x, atan2xy, -x.val()*denom, y.val()*denom);
 }
 
-inline Dual2<float> fast_atan2(const Dual2<float> &y, const Dual2<float> &x)
+template<class T, int P>
+inline Dual<T,P> fast_atan2(const Dual<T,P> &y, const Dual<T,P> &x)
 {
-    float atan2xy = OIIO::fast_atan2(y.val(), x.val());
-    float denom = (x.val() == 0 && y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
-    return Dual2<float> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
-                                   (y.val()*x.dy() - x.val()*y.dy())*denom );
+    T atan2xy = OIIO::fast_atan2(y.val(), x.val());
+    T denom = (x.val() == 0 && y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
+    return dualfunc (y, x, atan2xy, -x.val()*denom, y.val()*denom);
 }
 
 
 // to compute pow(u,v), we need the dual-form representation of
-// the pow() operator.  In general, the dual-form of the primitive 
+// the pow() operator.  In general, the dual-form of the primitive
 // function 'g' is:
 //   g(<u,u'>, <v,v'>) = < g(u,v), dgdu(u,v)u' + dgdv(u,v)v' >
 //   (from http://en.wikipedia.org/wiki/Automatic_differentiation)
 // so, pow(u,v) = < u^v, vu^(v-1) u' + log(u)u^v v' >
-template<class T>
-inline Dual2<T> safe_pow (const Dual2<T> &u, const Dual2<T> &v)
+template<class T, int P>
+inline Dual<T,P> safe_pow (const Dual<T,P> &u, const Dual<T,P> &v)
 {
     // NOTE: this function won't return exactly the same as pow(x,y) because we
     // use the identity u^v=u * u^(v-1) which does not hold in all cases for our
@@ -588,231 +787,204 @@ inline Dual2<T> safe_pow (const Dual2<T> &u, const Dual2<T> &v)
     T powuvm1 = safe_pow(u.val(), v.val() - T(1));
     T powuv   = powuvm1 * u.val();
     T logu    = u.val() > 0 ? safe_log(u.val()) : T(0);
-    return Dual2<T> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
-                             v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
+    return dualfunc (u, v, powuv, v.val()*powuvm1, logu*powuv);
 }
 
-inline Dual2<float> fast_safe_pow(const Dual2<float> &u, const Dual2<float> &v)
+template<class T, int P>
+inline Dual<T,P> fast_safe_pow(const Dual<T,P> &u, const Dual<T,P> &v)
 {
     // NOTE: same issue as above (fast_safe_pow does even more clamping)
-    float powuvm1 = OIIO::fast_safe_pow (u.val(), v.val() - 1.0f);
-    float powuv   = powuvm1 * u.val();
-    float logu    = u.val() > 0 ? OIIO::fast_log(u.val()) : 0.0f;
-    return Dual2<float> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
-                                 v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
-
+    T powuvm1 = OIIO::fast_safe_pow (u.val(), v.val() - 1.0f);
+    T powuv   = powuvm1 * u.val();
+    T logu    = u.val() > 0 ? OIIO::fast_log(u.val()) : 0.0f;
+    return dualfunc (u, v, powuv, v.val()*powuvm1, logu*powuv);
 }
 
 // f(x) = log(a), f'(x) = 1/x
 // (log base e)
-template<class T>
-inline Dual2<T> safe_log (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> safe_log (const Dual<T,P> &a)
 {
-    T loga = safe_log(a.val());
-    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / a.val();
-    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
+    T f = safe_log(a.val());
+    T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / a.val();
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_log(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_log(const Dual<T,P> &a)
 {
-    float loga = OIIO::fast_log(a.val());
-    float inva = a.val() < std::numeric_limits<float>::min() ? 0.0f : 1.0f / a.val();
-    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
+    T f = OIIO::fast_log(a.val());
+    T df = a.val() < std::numeric_limits<float>::min() ? 0.0f : 1.0f / a.val();
+    return dualfunc (a, f, df);
 }
 
 // f(x) = log2(x), f'(x) = 1/(x*log2)
 // (log base 2)
-template<class T>
-inline Dual2<T> safe_log2 (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> safe_log2 (const Dual<T,P> &a)
 {
-    T loga = safe_log2(a.val());
-    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN2));
-    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
+    T f = safe_log2(a.val());
+    T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN2));
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_log2(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_log2(const Dual<T,P> &a)
 {
-    float loga = OIIO::fast_log2(a.val());
-    float aln2 = a.val() * float(M_LN2);
-    float inva = aln2 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln2;
-    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
+    T f = OIIO::fast_log2(a.val());
+    T aln2 = a.val() * float(M_LN2);
+    T df = aln2 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln2;
+    return dualfunc (a, f, df);
 }
 
 // f(x) = log10(x), f'(x) = 1/(x*log10)
 // (log base 10)
-template<class T>
-inline Dual2<T> safe_log10 (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> safe_log10 (const Dual<T,P> &a)
 {
-    T loga = safe_log10(a.val());
-    T inva = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN10));
-    return Dual2<T> (loga, inva * a.dx(), inva * a.dy());
+    T f = safe_log10(a.val());
+    T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN10));
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_log10(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_log10(const Dual<T,P> &a)
 {
-    float loga  = OIIO::fast_log10(a.val());
-    float aln10 = a.val() * float(M_LN10);
-    float inva  = aln10 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln10;
-    return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
+    T f  = OIIO::fast_log10(a.val());
+    T aln10 = a.val() * float(M_LN10);
+    T df  = aln10 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln10;
+    return dualfunc (a, f, df);
 }
 
 // f(x) = e^x, f'(x) = e^x
-template<class T>
-inline Dual2<T> exp (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> exp (const Dual<T,P> &a)
 {
-    T expa = std::exp(a.val());
-    return Dual2<T> (expa, expa * a.dx(), expa * a.dy());
+    T f = std::exp(a.val());
+    return dualfunc (a, f, f);
 }
 
-inline Dual2<float> fast_exp(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_exp(const Dual<T,P> &a)
 {
-    float expa = OIIO::fast_exp(a.val());
-    return Dual2<float> (expa, expa * a.dx(), expa * a.dy());
+    T f = OIIO::fast_exp(a.val());
+    return dualfunc (a, f, f);
 }
 
 // f(x) = 2^x, f'(x) = (2^x)*log(2)
-template<class T>
-inline Dual2<T> exp2 (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> exp2 (const Dual<T,P> &a)
 {
     // FIXME: std::exp2 is only available in C++11
-    T exp2a = exp2f(float(a.val()));
-    return Dual2<T> (exp2a, exp2a*T(M_LN2)*a.dx(), exp2a*T(M_LN2)*a.dy());
+    T f = exp2f(float(a.val()));
+    return dualfunc (a, f, f*T(M_LN2));
 }
 
-inline Dual2<float> fast_exp2(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_exp2(const Dual<T,P> &a)
 {
-    float exp2a = OIIO::fast_exp2(float(a.val()));
-    return Dual2<float> (exp2a, exp2a*float(M_LN2)*a.dx(), exp2a*float(M_LN2)*a.dy());
+    T f = OIIO::fast_exp2(float(a.val()));
+    return dualfunc (a, f, f*T(M_LN2));
 }
 
 
 // f(x) = e^x - 1, f'(x) = e^x
-template<class T>
-inline Dual2<T> expm1 (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> expm1 (const Dual<T,P> &a)
 {
     // FIXME: std::expm1 is only available in C++11
-    T expm1a = expm1f(float(a.val())); // float version!
-    T expa   = std::exp  (a.val());
-    return Dual2<T> (expm1a, expa * a.dx(), expa * a.dy());
+    T f  = expm1f(float(a.val())); // float version!
+    T df = std::exp  (a.val());
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_expm1(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_expm1(const Dual<T,P> &a)
 {
-    float expm1a = OIIO::fast_expm1(a.val());
-    float expa   = OIIO::fast_exp  (a.val());
-    return Dual2<float> (expm1a, expa * a.dx(), expa * a.dy());
+    T f  = OIIO::fast_expm1(a.val());
+    T df = OIIO::fast_exp  (a.val());
+    return dualfunc (a, f, df);
 }
 
 // f(x) = erf(x), f'(x) = (2e^(-x^2))/sqrt(pi)
-template<class T>
-inline Dual2<T> erf (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> erf (const Dual<T,P> &a)
 {
     // FIXME: std::erf is only defined in C++11
-    T erfa = erff (float(a.val())); // float version!
-    T two_over_sqrt_pi = T(1.128379167095512573896158903);
-    T derfadx = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
-    return Dual2<T> (erfa, derfadx * a.dx(), derfadx * a.dy());
+    T f = erff (float(a.val())); // float version!
+    const T two_over_sqrt_pi = T(1.128379167095512573896158903);
+    T df = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_erf(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_erf(const Dual<T,P> &a)
 {
-    float erfa = OIIO::fast_erf (float(a.val())); // float version!
-    float two_over_sqrt_pi = 1.128379167095512573896158903f;
-    float derfadx = OIIO::fast_exp(-a.val() * a.val()) * two_over_sqrt_pi;
-    return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
+    T f = OIIO::fast_erf (float(a.val())); // float version!
+    const T two_over_sqrt_pi = 1.128379167095512573896158903f;
+    T df = OIIO::fast_exp(-a.val() * a.val()) * two_over_sqrt_pi;
+    return dualfunc (a, f, df);
 }
 
 // f(x) = erfc(x), f'(x) = -(2e^(-x^2))/sqrt(pi)
-template<class T>
-inline Dual2<T> erfc (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> erfc (const Dual<T,P> &a)
 {
     // FIXME: std::erfc is only defined in C++11
-    T erfca = erfcf (float(a.val())); // float version!
-    T two_over_sqrt_pi = -T(1.128379167095512573896158903);
-    T derfcadx = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
-    return Dual2<T> (erfca, derfcadx * a.dx(), derfcadx * a.dy());
+    T f = erfcf (float(a.val())); // float version!
+    const T two_over_sqrt_pi = -T(1.128379167095512573896158903);
+    T df = std::exp (-a.val() * a.val()) * two_over_sqrt_pi;
+    return dualfunc (a, f, df);
 }
 
-inline Dual2<float> fast_erfc(const Dual2<float> &a)
+template<class T, int P>
+inline Dual<T,P> fast_erfc(const Dual<T,P> &a)
 {
-    float erfa = OIIO::fast_erfc (float(a.val())); // float version!
-    float two_over_sqrt_pi = -1.128379167095512573896158903f;
-    float derfadx = OIIO::fast_exp(-a.val() * a.val()) * two_over_sqrt_pi;
-    return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
+    T f = OIIO::fast_erfc (float(a.val())); // float version!
+    const T two_over_sqrt_pi = -1.128379167095512573896158903f;
+    T df = OIIO::fast_exp(-a.val() * a.val()) * two_over_sqrt_pi;
+    return dualfunc (a, f, df);
 }
 
 
 // f(x) = sqrt(x), f'(x) = 1/(2*sqrt(x))
-template<class T>
-inline Dual2<T> sqrt (const Dual2<T> &a)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P> sqrt (const Dual<T,P> &a)
 {
     if (a.val() <= T(0))
-        return Dual2<T> (T(0), T(0), T(0));
-
-    T sqrta      = std::sqrt(a.val());
-    T inv_2sqrta = T(1) / (T(2) * sqrta);
-
-    return Dual2<T> (sqrta, inv_2sqrta * a.dx(), inv_2sqrta * a.dy());
+        return Dual<T,P> (T(0));
+    T f  = std::sqrt(a.val());
+    T df = T(0.5) / f;
+    return dualfunc (a, f, df);
 }
 
 // f(x) = 1/sqrt(x), f'(x) = -1/(2*x^(3/2))
-template<class T>
-inline Dual2<T> inversesqrt (const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> inversesqrt (const Dual<T,P> &a)
 {
     // do we want to print an error message?
     if (a.val() <= T(0))
-        return Dual2<T> (T(0), T(0), T(0));
-
-    T sqrta          = std::sqrt(a.val());
-    T inv_neg2asqrta = -T(1)/(T(2)*a.val()*sqrta);
-
-    return Dual2<T> (T(1)/sqrta, inv_neg2asqrta * a.dx(), inv_neg2asqrta * a.dy());
+        return Dual<T,P> (T(0));
+    T f  = T(1)/std::sqrt(a.val());
+    T df = T(-0.5)*f/a.val();
+    return dualfunc (a, f, df);
 }
 
 // (fx) = x*(1-a) + y*a, f'(x) = (1-a)x' + (y - x)*a' + a*y'
-template<class T>
-inline Dual2<T> mix (const Dual2<T> &x, const Dual2<T> &y, const Dual2<T> &a)
+template<class T, int P>
+inline Dual<T,P> mix (const Dual<T,P> &x, const Dual<T,P> &y, const Dual<T,P> &a)
 {
-   T mixval = x.val()*(T(1)-a.val()) + y.val()*a.val();
-
-   return Dual2<T> (mixval, (T(1) - a.val())*x.dx() + (y.val() - x.val())*a.dx() + a.val()*y.dx(),
-                            (T(1) - a.val())*x.dy() + (y.val() - x.val())*a.dy() + a.val()*y.dy());
+    T mixval = x.val()*(T(1)-a.val()) + y.val()*a.val();
+    return dualfunc (x, y, a, mixval, T(1)-a.val(), a.val(), y.val() - x.val());
 }
 
-template<class T>
-inline Dual2<T> dual_min (const Dual2<T> &x, const Dual2<T> &y)
-{
-   if (x.val() > y.val())
-      return y;
-   else 
-      return x;
-}
-
-template<class T>
-inline Dual2<T> dual_max (const Dual2<T> &x, const Dual2<T> &y)
-{
-   if (x.val() > y.val())
-      return x;
-   else 
-      return y;
-}
-
-
-template<class T>
-inline Dual2<T> fabs (const Dual2<T> &x)
+template<class T, int P>
+inline Dual<T,P> fabs (const Dual<T,P> &x)
 {
     return x.val() >= T(0) ? x : -x;
 }
 
 
-
-template<class T>
-inline Dual2<T> dual_clamp (const Dual2<T> &x, const Dual2<T> &minv, const Dual2<T> &maxv)
-{
-   if (x.val() < minv.val()) return minv;
-   else if (x.val() > maxv.val()) return maxv;
-   else return x;
-}
 
 inline float smoothstep(float e0, float e1, float x) { 
     if (x < e0) return 0.0f;
@@ -824,33 +996,41 @@ inline float smoothstep(float e0, float e1, float x) {
 }
 
 // f(t) = (3-2t)t^2,   t = (x-e0)/(e1-e0)
-template<class T>
-inline Dual2<T> smoothstep (const Dual2<T> &e0, const Dual2<T> &e1, const Dual2<T> &x)
+template<class T, int P>
+inline Dual<T,P> smoothstep (const Dual<T,P> &e0, const Dual<T,P> &e1, const Dual<T,P> &x)
 {
    if (x.val() < e0.val()) {
-      return Dual2<T> (T(0), T(0), T(0));
+      return Dual<T,P> (T(0));
    }
    else if (x.val() >= e1.val()) {
-      return Dual2<T> (T(1), T(0), T(0));
+      return Dual<T,P> (T(1));
    }
-   Dual2<T> t = (x - e0)/(e1-e0);
+   Dual<T,P> t = (x - e0)/(e1-e0);
    return  (T(3) - T(2)*t)*t*t;
 }
 
 
 
+// ceil(Dual) loses derivatives
+template<class T, int P>
+inline constexpr float ceil (const Dual<T,P> &x)
+{
+    return std::ceil(x.val());
+}
+
+
 // floor(Dual) loses derivatives
-template<class T>
-inline float floor (const Dual2<T> &x)
+template<class T, int P>
+inline constexpr float floor (const Dual<T,P> &x)
 {
     return std::floor(x.val());
 }
 
 
 // floor, cast to an int.
-template<class T>
-inline int
-ifloor (const Dual2<T> &x)
+template<class T, int P>
+inline constexpr int
+ifloor (const Dual<T,P> &x)
 {
     return (int)floor(x);
 }

--- a/src/include/OSL/dual_vec.h
+++ b/src/include/OSL/dual_vec.h
@@ -26,6 +26,23 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+
+
+/// \file
+///
+/// Dual<> extensions specifically for dealing with Imath Vec, Color, and
+/// Matrix types.
+///
+/// In general, it's reasonable to handle a vector-with-derivs as a vector-
+/// of-floats-with-derivs, i.e. Vec<Dual<float>>. But OSL's design chose
+/// specifically require that any data with derivs has the same data layout
+/// as without derivs, just repeated for the partials.
+///
+/// Thus, OSL represents vectors-with-derivs as Dual<Vec<float>>, NOT as
+/// Vec<Dual<float>. So there are some special cases we need to deal with.
+///
+
+
 #pragma once
 
 #include <OSL/oslconfig.h>
@@ -35,106 +52,121 @@ OSL_NAMESPACE_ENTER
 
 
 /// Templated trick to be able to derive what type we use to represent
-/// a vector, given a scalar, automatically using the right kind of Dual2.
-template<typename T> struct Vec3FromScalar {};
-template<> struct Vec3FromScalar<float> { typedef Vec3 type; };
-template<> struct Vec3FromScalar<Dual2<float> > { typedef Dual2<Vec3> type; };
+/// a vector, given a scalar, automatically using the right kind of Dual.
+template<class T> struct Vec3FromScalar { typedef Imath::Vec3<T> type; };
+template<class T, int P> struct Vec3FromScalar<Dual<T,P>> { typedef Dual<Imath::Vec3<T>,P> type; };
 
 /// Templated trick to be able to derive what type we use to represent
 /// a color, given a scalar, automatically using the right kind of Dual2.
-template<typename T> struct Color3FromScalar {};
-template<> struct Color3FromScalar<float> { typedef Color3 type; };
-template<> struct Color3FromScalar<Dual2<float> > { typedef Dual2<Color3> type; };
+template<class T> struct Color3FromScalar { typedef Imath::Color3<T> type; };
+template<class T, int P> struct Color3FromScalar<Dual<T,P>> { typedef Dual<Imath::Color3<T>,P> type; };
 
 /// Templated trick to be able to derive the scalar component type of
 /// a vector, whether a VecN or a Dual2<VecN>.
-template<typename T> struct ScalarFromVec {};
+template<class T> struct ScalarFromVec {};
 template<> struct ScalarFromVec<Vec2> { typedef Float type; };
 template<> struct ScalarFromVec<Vec3> { typedef Float type; };
 template<> struct ScalarFromVec<Color3> { typedef Float type; };
+template<> struct ScalarFromVec<Dual<Vec2>> { typedef Dual<Float> type; };
+template<> struct ScalarFromVec<Dual<Vec3>> { typedef Dual<Float> type; };
+template<> struct ScalarFromVec<Dual<Color3>> { typedef Dual<Float> type; };
 template<> struct ScalarFromVec<Dual2<Vec2>> { typedef Dual2<Float> type; };
 template<> struct ScalarFromVec<Dual2<Vec3>> { typedef Dual2<Float> type; };
 template<> struct ScalarFromVec<Dual2<Color3>> { typedef Dual2<Float> type; };
 
 
 
-/// A uniform way to assemble a Vec3 from float and a Dual2<Vec3>
-/// from Dual2<float>.
+/// A uniform way to assemble a Vec3 from float and a Dual<Vec3>
+/// from Dual<float>.
 inline Vec3
 make_Vec3 (float x, float y, float z)
 {
     return Vec3 (x, y, z);
 }
 
-inline Dual2<Vec3>
-make_Vec3 (const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
+template<class T, int P>
+inline Dual<Imath::Vec3<T>,P>
+make_Vec3 (const Dual<T,P> &x, const Dual<T,P> &y, const Dual<T,P> &z)
 {
-    return Dual2<Vec3> (Vec3 (x.val(), y.val(), z.val()),
-                        Vec3 (x.dx(),  y.dx(),  z.dx()),
-                        Vec3 (x.dy(),  y.dy(),  z.dy()));
+    Dual<Imath::Vec3<T>,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i).setValue (x.elem(i), y.elem(i), z.elem(i));
+    return result;
 }
 
 
-/// Make a Dual2<Vec3> from a single Dual2<Float> x coordinate, and 0
+/// Make a Dual<Vec3> from a single Dual<Float> x coordinate, and 0
 /// for the other components.
-inline Dual2<Vec3>
-make_Vec3 (const Dual2<Float> &x)
+template<class T, int P>
+inline Dual<Imath::Vec3<T>,P>
+make_Vec3 (const Dual<T,P> &x)
 {
-    return Dual2<Vec3> (Vec3 (x.val(), 0.0f, 0.0f),
-                        Vec3 (x.dx(),  0.0f, 0.0f),
-                        Vec3 (x.dy(),  0.0f, 0.0f));
+    Dual<Imath::Vec3<T>,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i).setValue (x.elem(i), 0.0f, 0.0f);
+    return result;
 }
 
 
-inline Dual2<Vec3>
-make_Vec3 (const Dual2<Float> &x, const Dual2<Float> &y)
+template<class T, int P>
+inline Dual<Imath::Vec3<T>,P>
+make_Vec3 (const Dual<T,P> &x, const Dual<T,P> &y)
 {
-    return Dual2<Vec3> (Vec3 (x.val(), y.val(), 0.0f),
-                        Vec3 (x.dx(),  y.dx(),  0.0f),
-                        Vec3 (x.dy(),  y.dy(),  0.0f));
+    Dual<Imath::Vec3<T>,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i).setValue (x.elem(i), y.elem(i), 0.0f);
+    return result;
 }
 
 
 
-/// A uniform way to assemble a Color3 from float and a Dual2<Color3>
-/// from Dual2<float>.
+/// A uniform way to assemble a Color3 from float and a Dual<Color3>
+/// from Dual<float>.
 inline Color3
 make_Color3 (float x, float y, float z)
 {
     return Color3 (x, y, z);
 }
 
-inline Dual2<Color3>
-make_Color3 (const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
+template<class T, int P>
+inline Dual<Imath::Color3<T>,P>
+make_Color3 (const Dual<T,P> &x, const Dual<T,P> &y, const Dual<T,P> &z)
 {
-    return Dual2<Color3> (Color3 (x.val(), y.val(), z.val()),
-                          Color3 (x.dx(), y.dx(), z.dx()),
-                          Color3 (x.dy(), y.dy(), z.dy()));
+    Dual<Imath::Color3<T>,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i).setValue (x.elem(i), y.elem(i), z.elem(i));
+    return result;
 }
 
 
 
-
-
-/// A uniform way to assemble a Vec2 from float and a Dual2<Vec2>
-/// from Dual2<float>.
+/// A uniform way to assemble a Vec2 from float and a Dual<Vec2>
+/// from Dual<float>.
 inline Vec2
 make_Vec2 (float x, float y)
 {
     return Vec2 (x, y);
 }
 
-inline Dual2<Vec2>
-make_Vec2 (const Dual2<float> &x, const Dual2<float> &y)
+template<class T, int P>
+inline Dual<Imath::Vec2<T>,P>
+make_Vec2 (const Dual<T,P> &x, const Dual<T,P> &y)
 {
-    return Dual2<Vec2> (Vec2 (x.val(), y.val()),
-                        Vec2 (x.dx(),  y.dx()),
-                        Vec2 (x.dy(),  y.dy()));
+    Dual<Imath::Vec2<T>,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i).setValue (x.elem(i), y.elem(i));
+    return result;
 }
 
 
 
-/// A uniform way to extract a single component from a Vec3 or Dual2<Vec3>
+/// comp(X,c) is a uniform way to extract a single component from a Vec3 or
+/// Dual<Vec3>.
+///
+/// comp(Vec3,c) returns a float as the c-th component of the vector.
+/// comp(Dual<Vec3>,c) returns a Dual<float> of the c-th component (with
+/// derivs).
+
 inline float
 comp (const Vec3 &v, int c)
 {
@@ -142,289 +174,313 @@ comp (const Vec3 &v, int c)
 }
 
 
-inline Dual2<float>
-comp (const Dual2<Vec3> &v, int c)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+comp (const Dual<Imath::Vec3<T>,P> &v, int c)
 {
-    return Dual2<float> (v.val()[c], v.dx()[c], v.dy()[c]);
+    Dual<T,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = v.elem(i)[c];
+    return result;
 }
+
+
+
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+comp (const Dual<Imath::Color3<T>,P> &v, int c)
+{
+    Dual<T,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = v.elem(i)[c];
+    return result;
+}
+
+
+inline float
+comp (const Vec2 &v, int c)
+{
+    return v[c];
+}
+
+
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+comp (const Dual<Imath::Vec2<T>,P> &v, int c)
+{
+    Dual<T,P> result;
+    for (int i = 0; i <= P; ++i)
+        result.elem(i) = v.elem(i)[c];
+    return result;
+}
+
 
 
 
 /// Multiply a 3x3 matrix by a 3-vector, with derivs.
 ///
-template <class S, class T>
+template <class S, class T, int P>
 inline void
-multMatrix (const Imath::Matrix33<T> &M, const Dual2<Imath::Vec3<S> > &src,
-            Dual2<Imath::Vec3<S> > &dst)
+multMatrix (const Imath::Matrix33<T> &M, const Dual<Imath::Vec3<S>,P> &src,
+            Dual<Imath::Vec3<S>,P> &dst)
 {
-    Dual2<float> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
-    Dual2<S> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
-    Dual2<S> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
-    Dual2<S> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
+    // The simplest way to express this is to break up the Dual<Vec> into
+    // Vec<Dual>, do the usual matrix math, then reshuffle again.
+    Dual<S,P> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
+    Dual<S,P> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
+    Dual<S,P> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
+    Dual<S,P> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
     dst = make_Vec3 (a, b, c);
 }
 
 
 /// Multiply a row 3-vector (with derivatives) by a 3x3 matrix (no derivs).
 ///
-template <class S, class T>
-inline Dual2<Imath::Vec3<S>>
-operator* (const Dual2<Imath::Vec3<S>> &src, const Imath::Matrix33<T> &M)
+template <class S, class T, int P>
+inline OIIO_CONSTEXPR14 Dual<Imath::Vec3<S>,P>
+operator* (const Dual<Imath::Vec3<S>,P> &src, const Imath::Matrix33<T> &M)
 {
-    Dual2<S> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
-    Dual2<S> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
-    Dual2<S> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
-    Dual2<S> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
+    // The simplest way to express this is to break up the Dual<Vec> into
+    // Vec<Dual>, do the usual matrix math, then reshuffle again.
+    Dual<S,P> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
+    Dual<S,P> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
+    Dual<S,P> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
+    Dual<S,P> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
     return make_Vec3 (a, b, c);
 }
 
 
 /// Multiply a row 3-vector (with derivatives) by a 3x3 matrix (no derivs).
 ///
-template <class S, class T>
-inline Dual2<Imath::Color3<S>>
-operator* (const Dual2<Imath::Color3<S>> &src, const Imath::Matrix33<T> &M)
+template <class S, class T, int P>
+inline OIIO_CONSTEXPR14 Dual<Imath::Color3<S>,P>
+operator* (const Dual<Imath::Color3<S>,P> &src, const Imath::Matrix33<T> &M)
 {
-    Dual2<S> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
-    Dual2<S> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
-    Dual2<S> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
-    Dual2<S> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
+    // The simplest way to express this is to break up the Dual<Vec> into
+    // Vec<Dual>, do the usual matrix math, then reshuffle again.
+    Dual<S,P> src0 = comp(src,0), src1 = comp(src,1), src2 = comp(src,2);
+    Dual<S,P> a = src0 * M[0][0] + src1 * M[1][0] + src2 * M[2][0];
+    Dual<S,P> b = src0 * M[0][1] + src1 * M[1][1] + src2 * M[2][1];
+    Dual<S,P> c = src0 * M[0][2] + src1 * M[1][2] + src2 * M[2][2];
     return make_Color3 (a, b, c);
 }
 
 
-inline void robust_multVecMatrix(const Matrix44& x, const Imath::Vec3<float>& src, Imath::Vec3<float>& dst)
+template <class S, class T>
+inline void robust_multVecMatrix(const Imath::Matrix44<S>& x, const Imath::Vec3<T>& src, Imath::Vec3<T>& dst)
 {
-   float a = src[0] * x[0][0] + src[1] * x[1][0] + src[2] * x[2][0] + x[3][0];
-   float b = src[0] * x[0][1] + src[1] * x[1][1] + src[2] * x[2][1] + x[3][1];
-   float c = src[0] * x[0][2] + src[1] * x[1][2] + src[2] * x[2][2] + x[3][2];
-   float w = src[0] * x[0][3] + src[1] * x[1][3] + src[2] * x[2][3] + x[3][3];
+    auto a = src[0] * x[0][0] + src[1] * x[1][0] + src[2] * x[2][0] + x[3][0];
+    auto b = src[0] * x[0][1] + src[1] * x[1][1] + src[2] * x[2][1] + x[3][1];
+    auto c = src[0] * x[0][2] + src[1] * x[1][2] + src[2] * x[2][2] + x[3][2];
+    auto w = src[0] * x[0][3] + src[1] * x[1][3] + src[2] * x[2][3] + x[3][3];
 
-   if (w != 0) {
-      dst.x = a / w;
-      dst.y = b / w;
-      dst.z = c / w;
-   } else {
-      dst.x = 0;
-      dst.y = 0;
-      dst.z = 0;
-   }
+    if (! equalVal (w, T(0))) {
+        dst.x = a / w;
+        dst.y = b / w;
+        dst.z = c / w;
+    } else {
+        dst.x = 0;
+        dst.y = 0;
+        dst.z = 0;
+    }
 }
+
 
 /// Multiply a matrix times a vector with derivatives to obtain
 /// a transformed vector with derivatives.
+template <class S, class T, int P>
 inline void
-robust_multVecMatrix (const Matrix44 &M, const Dual2<Vec3> &in, Dual2<Vec3> &out)
+robust_multVecMatrix (const Imath::Matrix44<S> &M,
+                      const Dual<Imath::Vec3<T>,P> &in, Dual<Imath::Vec3<T>,P> &out)
 {
-    // Rearrange into a Vec3<Dual2<float> >
-    Imath::Vec3<Dual2<float> > din, dout;
-    for (int i = 0;  i < 3;  ++i)
-        din[i].set (in.val()[i], in.dx()[i], in.dy()[i]);
+    // Rearrange into a Vec3<Dual<float>>
+    Imath::Vec3<Dual<T,P>> din, dout;
+    for (int i = 0;  i < 3;  ++i) {
+        din[i] = comp (in, i);
+    }
 
-    Dual2<float> a = din[0] * M[0][0] + din[1] * M[1][0] + din[2] * M[2][0] + M[3][0];
-    Dual2<float> b = din[0] * M[0][1] + din[1] * M[1][1] + din[2] * M[2][1] + M[3][1];
-    Dual2<float> c = din[0] * M[0][2] + din[1] * M[1][2] + din[2] * M[2][2] + M[3][2];
-    Dual2<float> w = din[0] * M[0][3] + din[1] * M[1][3] + din[2] * M[2][3] + M[3][3];
+    auto a = din[0] * M[0][0] + din[1] * M[1][0] + din[2] * M[2][0] + M[3][0];
+    auto b = din[0] * M[0][1] + din[1] * M[1][1] + din[2] * M[2][1] + M[3][1];
+    auto c = din[0] * M[0][2] + din[1] * M[1][2] + din[2] * M[2][2] + M[3][2];
+    auto w = din[0] * M[0][3] + din[1] * M[1][3] + din[2] * M[2][3] + M[3][3];
 
-    if (w.val() != 0) {
+    if (! equalVal (w, T(0))) {
        dout.x = a / w;
        dout.y = b / w;
        dout.z = c / w;
     } else {
-       dout.x = 0;
-       dout.y = 0;
-       dout.z = 0;
+       dout.x = T(0);
+       dout.y = T(0);
+       dout.z = T(0);
     }
 
-    // Rearrange back into Dual2<Vec3>
-    out.set (Vec3 (dout[0].val(), dout[1].val(), dout[2].val()),
-             Vec3 (dout[0].dx(),  dout[1].dx(),  dout[2].dx()),
-             Vec3 (dout[0].dy(),  dout[1].dy(),  dout[2].dy()));
+    // Rearrange back into Dual<Vec3>
+    out = make_Vec3 (dout[0], dout[1], dout[2]);
 }
 
 /// Multiply a matrix times a direction with derivatives to obtain
 /// a transformed direction with derivatives.
+template <class S, class T, int P>
 inline void
-multDirMatrix (const Matrix44 &M, const Dual2<Vec3> &in, Dual2<Vec3> &out)
+multDirMatrix (const Imath::Matrix44<S> &M,
+               const Dual<Imath::Vec3<T>,P> &in, Dual<Imath::Vec3<T>,P> &out)
 {
-    M.multDirMatrix (in.val(), out.val());
-    M.multDirMatrix (in.dx(), out.dx());
-    M.multDirMatrix (in.dy(), out.dy());
+    for (int i = 0; i <= P; ++i)
+        M.multDirMatrix (in.elem(i), out.elem(i));
 }
 
 
 
 
 
-/// Various operator* permuations between Dual2<float> and Dual2<Vec3> 
-// datatypes.
-inline Dual2<Vec3> 
-operator* (float a, const Dual2<Vec3> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Dual<Imath::Vec3<T>,P> &a, const Dual<Imath::Vec3<T>,P> &b)
 {
-    return Dual2<Vec3>(a*b.val(), a*b.dx(), a*b.dy());
-}
-
-inline Dual2<Vec3> 
-operator* (const Dual2<Vec3> &a, float b)
-{
-    return Dual2<Vec3>(a.val()*b, a.dx()*b, a.dy()*b);
-}
-
-inline Dual2<Vec3> 
-operator* (const Vec3 &a, const Dual2<float> &b)
-{
-    return Dual2<Vec3>(a*b.val(), a*b.dx(), a*b.dy());
-}
-
-inline Dual2<Vec3>
-operator* (const Dual2<float> &b, const Vec3 &a)
-{
-    return Dual2<Vec3>(a*b.val(), a*b.dx(), a*b.dy());
-}
-
-inline Dual2<Vec3>
-operator* (const Dual2<Vec3> &a, const Dual2<float> &b)
-{
-    return Dual2<Vec3>(a.val()*b.val(), 
-                       a.val()*b.dx() + a.dx()*b.val(),
-                       a.val()*b.dy() + a.dy()*b.val());
-}
-
-inline Dual2<Vec3> 
-operator* (const Dual2<float> &b, const Dual2<Vec3> &a)
-{
-    return Dual2<Vec3>(a.val()*b.val(), 
-                       a.val()*b.dx() + a.dx()*b.val(),
-                       a.val()*b.dy() + a.dy()*b.val());
-}
-
-
-inline Dual2<float>
-dot (const Dual2<Vec3> &a, const Dual2<Vec3> &b)
-{
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
-    Dual2<float> bx (b.val().x, b.dx().x, b.dy().x);
-    Dual2<float> by (b.val().y, b.dx().y, b.dy().y);
-    Dual2<float> bz (b.val().z, b.dx().z, b.dy().z);
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto az = comp (a, 2);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
+    auto bz = comp (b, 2);
     return ax*bx + ay*by + az*bz;
 }
 
 
 
-inline Dual2<float>
-dot (const Dual2<Vec3> &a, const Vec3 &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Dual<Imath::Vec3<T>,P> &a, const Imath::Vec3<T> &b)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
-    return ax*b.x + ay*b.y + az*b.z;
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto az = comp (a, 2);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
+    auto bz = comp (b, 2);
+    return ax*bx + ay*by + az*bz;
 }
 
 
 
-inline Dual2<float>
-dot (const Vec3 &a, const Dual2<Vec3> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Imath::Vec3<T> &a, const Dual<Imath::Vec3<T>,P> &b)
 {
-    Dual2<float> bx (b.val().x, b.dx().x, b.dy().x);
-    Dual2<float> by (b.val().y, b.dx().y, b.dy().y);
-    Dual2<float> bz (b.val().z, b.dx().z, b.dy().z);
-    return a.x*bx + a.y*by + a.z*bz;
+    return dot (b, a);
 }
 
 
 
-inline Dual2<float>
-dot (const Dual2<Vec2> &a, const Dual2<Vec2> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Dual<Imath::Vec2<T>,P> &a, const Dual<Imath::Vec2<T>,P> &b)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> bx (b.val().x, b.dx().x, b.dy().x);
-    Dual2<float> by (b.val().y, b.dx().y, b.dy().y);
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
     return ax*bx + ay*by;
 }
 
 
 
-inline Dual2<float>
-dot (const Dual2<Vec2> &a, const Vec2 &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Dual<Imath::Vec2<T>,P> &a, const Vec2 &b)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    return ax*b.x + ay*b.y;
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
+    return ax*bx + ay*by;
 }
 
 
 
-inline Dual2<float>
-dot (const Vec2 &a, const Dual2<Vec2> &b)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+dot (const Vec2 &a, const Dual<Imath::Vec2<T>,P> &b)
 {
-    Dual2<float> bx (b.val().x, b.dx().x, b.dy().x);
-    Dual2<float> by (b.val().y, b.dx().y, b.dy().y);
-    return a.x*bx + a.y*by;
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
+    return ax*bx + ay*by;
 }
 
 
 
-inline Dual2<Vec3>
-cross (const Dual2<Vec3> &a, const Dual2<Vec3> &b)
+template<class T, int P>
+inline Dual<Imath::Vec3<T>,P>
+cross (const Dual<Imath::Vec3<T>,P> &a, const Dual<Imath::Vec3<T>,P> &b)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
-    Dual2<float> bx (b.val().x, b.dx().x, b.dy().x);
-    Dual2<float> by (b.val().y, b.dx().y, b.dy().y);
-    Dual2<float> bz (b.val().z, b.dx().z, b.dy().z);
-
-    Dual2<float> nx = ay*bz - az*by;
-    Dual2<float> ny = az*bx - ax*bz;
-    Dual2<float> nz = ax*by - ay*bx;
-
-    return Dual2<Vec3> (Vec3(nx.val(), ny.val(), nz.val()),
-                        Vec3(nx.dx(),  ny.dx(),  nz.dx()  ),
-                        Vec3(nx.dy(),  ny.dy(),  nz.dy()  ));
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto az = comp (a, 2);
+    auto bx = comp (b, 0);
+    auto by = comp (b, 1);
+    auto bz = comp (b, 2);
+    auto nx = ay*bz - az*by;
+    auto ny = az*bx - ax*bz;
+    auto nz = ax*by - ay*bx;
+    return make_Vec3 (nx, ny, nz);
 }
 
 
 
-inline Dual2<float>
-length (const Dual2<Vec3> &a)
+template<class T, int P>
+inline OIIO_CONSTEXPR14 Dual<T,P>
+length (const Dual<Imath::Vec3<T>,P> &a)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto az = comp (a, 2);
     return sqrt(ax*ax + ay*ay + az*az);
 }
 
 
 
-inline Dual2<Vec3>
-normalize (const Dual2<Vec3> &a)
+template<class T, int P>
+inline Dual<Imath::Vec3<T>,P>
+normalize (const Dual<Imath::Vec3<T>,P> &a)
 {
-    Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
-    Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
-    Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
-    Dual2<float> length = sqrt(ax * ax + ay * ay + az * az);
-    if (length.val() > 0.0f) {
+    auto ax = comp (a, 0);
+    auto ay = comp (a, 1);
+    auto az = comp (a, 2);
+    auto length = sqrt(ax * ax + ay * ay + az * az);
+    if (length > 0.0f) {
         // NOTE: do a full division here to match what OpenEXR Imath does in the non-dual case
         ax = ax / length;
         ay = ay / length;
         az = az / length;
-        return Dual2<Vec3>(Vec3(ax.val(), ay.val(), az.val()),
-                           Vec3(ax.dx(), ay.dx(), az.dx()),
-                           Vec3(ax.dy(), ay.dy(), az.dy()));
+        return make_Vec3 (ax, ay, az);
     } else {
-        return Dual2<Vec3> (Vec3(0, 0, 0),
-                            Vec3(0, 0, 0),
-                            Vec3(0, 0, 0));
+        return Vec3(0,0,0);
     }
 }
 
 
 
-inline Dual2<float>
-distance (const Dual2<Vec3> &a, const Dual2<Vec3> &b)
+template<class T, int P>
+inline Dual<T,P>
+distance (const Dual<Imath::Vec3<T>,P> &a, const Dual<Imath::Vec3<T>,P> &b)
+{
+    return length (a - b);
+}
+
+
+template<class T, int P>
+inline Dual<T,P>
+distance (const Dual<Imath::Vec3<T>,P> &a, const Imath::Vec3<T> &b)
+{
+    return length (a - b);
+}
+
+
+template<class T, int P>
+inline Dual<T,P>
+distance (const Imath::Vec3<T> &a, const Dual<Imath::Vec3<T>,P> &b)
 {
     return length (a - b);
 }

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -160,6 +160,10 @@ if (OSL_BUILD_TESTS)
     target_link_libraries ( accum_test oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_accum "${CMAKE_BINARY_DIR}/src/liboslexec/accum_test")
 
+    add_executable (dual_test dual_test.cpp)
+    target_link_libraries ( dual_test ${OPENIMAGEIO_LIBRARIES} ${ILMBASE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    add_test (unit_dual "${CMAKE_BINARY_DIR}/src/liboslexec/dual_test")
+
     add_executable (llvmutil_test llvmutil_test.cpp)
     target_link_libraries ( llvmutil_test oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     add_test (unit_llvmutil "${CMAKE_BINARY_DIR}/src/liboslexec/llvmutil_test")

--- a/src/liboslexec/dual_test.cpp
+++ b/src/liboslexec/dual_test.cpp
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2017 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <type_traits>
+
+#include <OpenImageIO/dassert.h>
+#include <OpenImageIO/unittest.h>
+
+#include <OSL/oslconfig.h>
+#include <OSL/dual.h>
+#include <OSL/dual_vec.h>
+
+using namespace OSL;
+
+// Fix namespace problem with OIIO unit tests in older versions.
+#if OIIO_VERSION < 10901
+using namespace OIIO;
+#endif
+
+typedef Dual<float,1> Dualf;
+typedef Dual2<float> Dual2f;
+
+
+
+void
+test_metaprogramming ()
+{
+    // Does is_Dual<> correctly discern duals from non-duals?
+    OIIO_CHECK_ASSERT (is_Dual<Dualf>());
+    OIIO_CHECK_ASSERT (is_Dual<Dual2f>());
+    OIIO_CHECK_ASSERT (! is_Dual<float>());
+    OIIO_CHECK_ASSERT (! is_Dual<Vec3>());
+
+    // Does Dualify<> correctly turn a scalar into a dual?
+    OIIO_CHECK_ASSERT ((std::is_same<Dualify<float>::type, Dualf>::value));
+    OIIO_CHECK_ASSERT ((std::is_same<Dualify<float,2>::type, Dual2f>::value));
+    OIIO_CHECK_ASSERT ((std::is_same<Dualify<Dualf,1>::type, Dualf>::value));
+    OIIO_CHECK_ASSERT ((std::is_same<Dualify<Dual2f,2>::type, Dual2f>::value));
+
+    OIIO_CHECK_ASSERT ((std::is_same<UnDual<float >::type, float>::value));
+    OIIO_CHECK_ASSERT ((std::is_same<UnDual<Vec3  >::type, Vec3> ::value));
+    OIIO_CHECK_ASSERT ((std::is_same<UnDual<Dualf >::type, float>::value));
+    OIIO_CHECK_ASSERT ((std::is_same<UnDual<Dual2f>::type, float>::value));
+}
+
+
+
+int main(int argc, char *argv[])
+{
+    test_metaprogramming ();
+
+    // FIXME: Some day, expand to more exhaustive tests of Dual
+
+    return 0;
+}

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -81,18 +81,6 @@ struct extractValueFromArray<OUTTYPE, INTYPE, false>
     }
 };
 
-inline Dual2<float> Clamp(Dual2<float> x, Dual2<float> minv, Dual2<float> maxv)
-{
-    return dual_clamp(x, minv, maxv);
-}
-
-inline float Clamp(float x, float minv, float maxv) {
-    if (x < minv) return minv;
-    else if (x > maxv) return maxv;
-    else return x;
-};
-
-
 
 
 struct SplineBasis {
@@ -110,7 +98,8 @@ void spline_evaluate(const SplineBasis *spline,
                      const KTYPE *knots,
                      int knot_count, int knot_arraylen)
 {
-    XTYPE x = Clamp(xval, XTYPE(0.0), XTYPE(1.0));
+    using OIIO::clamp;
+    XTYPE x = clamp(xval, XTYPE(0.0), XTYPE(1.0));
     int nsegs = ((knot_count - 4) / spline->basis_step) + 1;
     x = x*(float)nsegs;
     float seg_x = removeDerivatives(x);


### PR DESCRIPTION
In this patch, I completely overhaul the main class that implements our
dual arithmetic-based automatic differentiation. No more Dual2, with
hard-coded x and y partials. Now we have Dual<T,P>, templated on the
number of partial dimensions P. Now Dual2<T> is just a templated typedef
that specilizes to 2 dimensions.

In addition to general cleanup, this leads to several benefits:

1. It is now trivial to extend to 3 dimensions (dx, dy, dz) if we wanted
to use Dual for automatic differentiation of volumetric functions.

2. Dual<T,1> can be used for automatic differentiation of 1-D functions,
which doesn't have any applications within OSL that I'm aware of, but
makes it a whole lot more convenient to re-use outside of OSL, any time
you want to use A.D. with these techniques.

3. It sets us up for a potential future distribution of the Dual stuff
as a separate library, if it seems useful.  It's not 100% free of other
dependencies from OSL (& OIIO), but it's fairly close and would not be
hard to make it entirely self-contained (and header only). I don't need
to do that this week, but it's something I'd like to work toward.

I did double check this by benchmarking full renders, and have confirmed
that it doesn't affect performance at all.
