### PR TITLE
Improve type checking errors with structs (#761)

### DIFF
--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -44,40 +44,6 @@ namespace pvt {   // OSL::pvt
 
 
 std::string
-TypeSpec::string () const
-{
-    std::string str;
-    if (is_closure() || is_closure_array()) {
-        str += "closure color";
-        if (is_unsized_array())
-            str += "[]";
-        else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-    }
-    else if (structure() > 0) {
-        str += Strutil::format ("struct %d", structure());
-        if (is_unsized_array())
-            str += "[]";
-        else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
-    } else {
-        str += simpletype().c_str();
-    }
-    return str;
-}
-
-
-
-const char *
-TypeSpec::c_str () const
-{
-    ustring s (this->string());
-    return s.c_str ();
-}
-
-
-
-std::string
 Symbol::mangled () const
 {
     // FIXME: De-alias

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -63,6 +63,44 @@ TypeSpec::TypeSpec (const char *name, int structid, int arraylen)
 
 
 
+std::string
+TypeSpec::string () const
+{
+    std::string str;
+    if (is_closure() || is_closure_array()) {
+        str += "closure color";
+        if (is_unsized_array())
+            str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
+    }
+    else if (structure() > 0) {
+        StructSpec *ss = structspec();
+        if (ss)
+            str += Strutil::format ("struct %s", structspec()->name());
+        else
+            str += Strutil::format ("struct %d", structure());
+        if (is_unsized_array())
+            str += "[]";
+        else if (arraylength() > 0)
+            str += Strutil::format ("[%d]", arraylength());
+    } else {
+        str += simpletype().c_str();
+    }
+    return str;
+}
+
+
+
+const char *
+TypeSpec::c_str () const
+{
+    ustring s (this->string());
+    return s.c_str ();
+}
+
+
+
 int
 TypeSpec::structure_id (const char *name, bool add)
 {


### PR DESCRIPTION
This is a back-port of a fix that went into master a long time ago, and seems to fix some reported bugs in RB-1.8.

Turns out that in addition to making nicer error printing (its original use, per the commit message), it also fixes a bug wherein use of arraylength() on an *array of struct* resulted in generated code that would make a confusing error message in `oslinfo/oslquery`.

Sorry for the confusing diffs; the function is changing a bit, in addition to moving from file to file.

----

Change the implementation of TypeSpec::string(), which returns the text
representation of a TypeSpec, so that it prints the name of the struct
rather than just its numerical designation.

An example of the old behavior, as applied to a type checking error
message:

    test.osl:10: error: No matching function call to 'max (struct 1, struct 1)'
        Candidates are:
            int max (int, int)
            float max (float, float)
            ...

And the new behavior:

    test.osl:10: error: No matching function call to 'max (struct vector4, struct vector4)'

