### PR TITLE
Fixes to ShadingSystemImpl::decode_connected_param

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -223,7 +223,7 @@ void preprocess (const char *yytext);
 
 
 {FLT}                   {
-                            yylval.f = atof (yytext);
+                            yylval.f = OIIO::Strutil::from_string<float>(yytext);
                             SETLINE;
                             return FLOAT_LITERAL;
                         }

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1239,7 +1239,7 @@ DECLFOLDER(constfold_stoi)
     if (S.is_constant()) {
         ASSERT (S.typespec().is_string());
         ustring s = *(ustring *)S.data();
-        int cind = rop.add_constant ((int) strtol(s.c_str(), NULL, 10));
+        int cind = rop.add_constant (Strutil::from_string<int>(s));
         rop.turn_into_assign (op, cind, "const fold stoi");
         return 1;
     }
@@ -1256,7 +1256,7 @@ DECLFOLDER(constfold_stof)
     if (S.is_constant()) {
         ASSERT (S.typespec().is_string());
         ustring s = *(ustring *)S.data();
-        int cind = rop.add_constant ((float) strtod(s.c_str(), NULL));
+        int cind = rop.add_constant (Strutil::from_string<float>(s));
         rop.turn_into_assign (op, cind, "const fold stof");
         return 1;
     }

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -372,10 +372,11 @@ Dictionary::dict_value (int nodeID, ustring attribname,
     }
     if (type.basetype == TypeDesc::INT) {
         r.valueoffset = (int) m_intdata.size();
+        string_view valstr (val);
         for (int i = 0;  i < n;  ++i) {
-            int v = (int) strtol (val, (char **)&val, 10);
-            while (isspace(*val) || *val == ',')
-                ++val;
+            int v;
+            OIIO::Strutil::parse_int (valstr, v);
+            OIIO::Strutil::parse_char (valstr, ',');
             m_intdata.push_back (v);
             ((int *)data)[i] = v;
         }
@@ -384,10 +385,11 @@ Dictionary::dict_value (int nodeID, ustring attribname,
     }
     if (type.basetype == TypeDesc::FLOAT) {
         r.valueoffset = (int) m_floatdata.size();
+        string_view valstr (val);
         for (int i = 0;  i < n;  ++i) {
-            float v = (float) strtod (val, (char **)&val);
-            while (isspace(*val) || *val == ',')
-                ++val;
+            float v;
+            OIIO::Strutil::parse_float (valstr, v);
+            OIIO::Strutil::parse_char (valstr, ',');
             m_floatdata.push_back (v);
             ((float *)data)[i] = v;
         }

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -105,13 +105,13 @@ osl_endswith_iss (const char *s_, const char *substr_)
 OSL_SHADEOP int
 osl_stoi_is (const char *str)
 {
-    return str ? strtol(str, NULL, 10) : 0;
+    return str ? Strutil::from_string<int>(str) : 0;
 }
 
 OSL_SHADEOP float
 osl_stof_fs (const char *str)
 {
-    return str ? (float)strtod(str, NULL) : 0.0f;
+    return str ? Strutil::from_string<float>(str) : 0.0f;
 }
 
 OSL_SHADEOP const char *

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -194,13 +194,13 @@ using namespace OSL::pvt;
 
  /* Literal values */
 {INTEGER}               {
-                            yylval.i = atoi (yytext);
+                            yylval.i = OIIO::Strutil::from_string<int>(yytext);
                             // std::cerr << "lex int " << yylval.i << "\n";
                             return INT_LITERAL;
                         }
 
 {FLT}                   {
-                            yylval.f = atof (yytext);
+                            yylval.f = OIIO::Strutil::from_string<float>(yytext);
                             // std::cerr << "lex float " << yylval.f << "\n";
                             return FLOAT_LITERAL;
                         }

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -152,22 +152,14 @@ void getargs(int argc, const char *argv[])
         errhandler.verbosity (ErrorHandler::VERBOSE);
 }
 
-Vec3 strtovec(const char* str) {
+Vec3 strtovec(string_view str) {
     Vec3 v(0, 0, 0);
-    sscanf(str, " %f , %f , %f", &v.x, &v.y, &v.z);
+    OIIO::Strutil::parse_float (str, v[0]);
+    OIIO::Strutil::parse_char (str, ',');
+    OIIO::Strutil::parse_float (str, v[1]);
+    OIIO::Strutil::parse_char (str, ',');
+    OIIO::Strutil::parse_float (str, v[2]);
     return v;
-}
-
-int strtoint(const char* str) {
-    int i = 0;
-    sscanf(str, " %d", &i);
-    return i;
-}
-
-float strtoflt(const char* str) {
-    float f = 0;
-    sscanf(str, " %f", &f);
-    return f;
 }
 
 bool strtobool(const char* str) {
@@ -281,7 +273,7 @@ void parse_scene() {
             if (dir_attr) dir = strtovec(dir_attr.value()); else
             if ( at_attr) dir = strtovec( at_attr.value()) - eye;
             if ( up_attr)  up = strtovec( up_attr.value());
-            if (fov_attr) fov = strtoflt(fov_attr.value());
+            if (fov_attr) fov = OIIO::Strutil::from_string<float>(fov_attr.value());
 
             // create actual camera
             camera = Camera(eye, dir, up, fov, xres, yres);
@@ -291,7 +283,7 @@ void parse_scene() {
             pugi::xml_attribute radius_attr = node.attribute("radius");
             if (center_attr && radius_attr) {
                 Vec3  center = strtovec(center_attr.value());
-                float radius = strtoflt(radius_attr.value());
+                float radius = OIIO::Strutil::from_string<float>(radius_attr.value());
                 if (radius > 0) {
                     pugi::xml_attribute light_attr = node.attribute("is_light");
                     bool is_light = light_attr ? strtobool(light_attr.value()) : false;
@@ -314,7 +306,7 @@ void parse_scene() {
         } else if (strcmp(node.name(), "Background") == 0) {
             pugi::xml_attribute res_attr = node.attribute("resolution");
             if (res_attr)
-                backgroundResolution = strtoint(res_attr.value());
+                backgroundResolution = OIIO::Strutil::from_string<int>(res_attr.value());
             backgroundShaderID = int(shaders.size()) - 1;
         } else if (strcmp(node.name(), "ShaderGroup") == 0) {
             ShaderGroupRef group;


### PR DESCRIPTION
@marsupial correctly points out that we are unsafely passing
a string_view.data() into both atoi and strchr, which is unsafe because
there's no guarantee that a string_view is null-terminated. Ugh!

He proposed a fix here: https://github.com/imageworks/OpenShadingLanguage/pull/800
and there's nothing wrong with it per se, but I suspected it could be done
more simply, so this PR is my stab at it, using the `OIIO::Strutil::parse_*`
functions.

