### PR TITLE
Bump LLVM minimum from 3.5 to 3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_HOME=$PWD/openexr-install ;
           export OPENEXR_HOME=$PWD/openexr-install ;
-          if [ "$LLVM_VERSION" == "" ]; then export LLVM_VERSION="error3.9.0" ; fi ;
+          if [ "$LLVM_VERSION" == "" ]; then export LLVM_VERSION="error" ; fi ;
           if [ "$LLVM_VERSION" == "5.0.0" ]; then export LLVMTAR=clang+llvm-${LLVM_VERSION}-linux-x86_64-ubuntu14.04.tar.xz ; else export LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz ; fi;
           echo LLVMTAR = $LLVMTAR ;
           wget http://releases-origin.llvm.org/${LLVM_VERSION}/${LLVMTAR} ;
@@ -112,7 +112,8 @@ branches:
 matrix:
     fast_finish: true
     include:
-      # Build with C++11, default compiler, optimized build, against OIIO master
+      # Build with C++11, default compiler, optimized build, against OIIO
+      # master, and LLVM 4.0.
       - os: linux
         compiler: gcc
         addons:
@@ -128,11 +129,11 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: LLVM_VERSION=3.9.0
+        env: WHICHGCC=4.8 LLVM_VERSION=4.0.0
       - os: osx
         compiler: clang
     # Test against the older release branch of OIIO (all the other tests
-    # are against OIIO master). Test against a higher SSE level.
+    # are against OIIO master). Simultaneously, test a higher SIMD level.
       - os: linux
         compiler: gcc
         addons:
@@ -148,7 +149,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: OIIOBRANCH=release USE_SIMD=sse4.2 LLVM_VERSION=3.9.0
+        env: OIIOBRANCH=release USE_SIMD=sse4.2 LLVM_VERSION=4.0.0
     # Test gcc6, and highest SIMD level supported by Travis, and newer LLVM
       - os: linux
         compiler: gcc
@@ -165,7 +166,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: WHICHGCC=6 USE_SIMD=avx,f16c LLVM_VERSION=4.0.0
+        env: WHICHGCC=6 USE_SIMD=avx,f16c LLVM_VERSION=5.0.0
     # Linux only: test gcc 7, also test C++14 and even newer LLVM
       - os: linux
         compiler: gcc
@@ -217,7 +218,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: USE_SIMD=0 LLVM_VERSION=3.5.2 OIIOBRANCH=RB-1.7
+        env: USE_SIMD=0 LLVM_VERSION=3.9.1 OIIOBRANCH=RB-1.7
 
 notifications:
     email:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,7 @@
 Release 1.10? -- ?? 2018? (compared to 1.9)
 --------------------------------------------------
 Dependency and standards changes:
-* LLVM 3.5 / 3.9 / 4.0 / 5.0: Support has been added for LLVM 3.9, 4.0, and
-  5.0.
+* **LLVM 3.9 / 4.0 / 5.0**: Support has been removed for LLVM 3.5.
 * **OpenImageIO 1.8+**: This release of OSL should build properly against
   OIIO 1.8 or newer. You may find that 1.7 is still ok, but we are not doing
   any work to ensure that.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X) and then OSL's build scripts will be able
     to find it.
 
-* **[LLVM](http://www.llvm.org) 3.5, 3.9, 4.0, or 5.0**
+* **[LLVM](http://www.llvm.org) 3.9, 4.0, or 5.0**
 
    Optionally, if Clang libraries are installed alongside LLVM, OSL will
    in most circumstances use Clang's internals for C-style preprocessing of

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -64,7 +64,7 @@ message (STATUS "Using OpenImageIO ${OPENIMAGEIO_VERSION}")
 ###########################################################################
 # LLVM library setup
 
-find_package (LLVM 3.5 REQUIRED)
+find_package (LLVM 3.9 REQUIRED)
 
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")
@@ -109,17 +109,6 @@ if (GCC_VERSION)
     if (${GCC_VERSION} VERSION_LESS 4.9)
         set (_CLANG_PREPROCESSOR_CAN_WORK ON)
     endif ()
-endif ()
-if (${LLVM_VERSION} VERSION_LESS 3.9)
-    # Bug in old LLVM creates some linkage problems we've seen involving
-    # some singleton globals that are duplicated when we include both
-    # the clang libs we need for the preprocessing as well as certain
-    # LLVM support libraries we also need, triggering assertions.
-    # See this for description of the issue:
-    # http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20140203/203968.html
-    # Sweep under the rug by falling back to boost wave when using older
-    # LLVM (it seems fixed and no longer triggers for 3.9+).
-    set (_CLANG_PREPROCESSOR_CAN_WORK OFF)
 endif ()
 if (USE_BOOST_WAVE OR (NOT CLANG_LIBRARIES)
     OR (NOT _CLANG_PREPROCESSOR_CAN_WORK))

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -319,13 +319,8 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     inst.createFileManager();
     inst.createSourceManager(inst.getFileManager());
-#if OSL_LLVM_VERSION <= 35
-    clang::FrontendInputFile inputFile(mbuf.release(), clang::IK_None);
-    inst.InitializeSourceManager(inputFile);
-#else
     clang::SourceManager &sm = inst.getSourceManager();
     sm.setMainFileID (sm.createFileID(std::move(mbuf), clang::SrcMgr::C_User));
-#endif
 
     inst.getPreprocessorOutputOpts().ShowCPP = 1;
     inst.getPreprocessorOutputOpts().ShowMacros = 0;


### PR DESCRIPTION
This cleans up a lot of #if cases where we were trying to support a very
wide range of LLVM releases in the face of changing APIs. With 3.5 gone,
so too is the "old" JIT (it's all MCJIT now).

By the time we get around to the next major release, we may further
reduce the complexity by dropping support for 3.9 (i.e., minimum LLVM >=
4.0), but I'll leave that for a later review.

Also tweak the Travis settings to assure we test against all the supported
LLVM releases.
