### PR TITLE
Suppress gcc7 warning about signed vs unsigned compare.

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -119,6 +119,12 @@ using namespace OSL::pvt;
 #endif
 #endif
 
+// flex itself will generate fatal warnings about signed vs unsigned.
+// Bypass that nonsense.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 void preprocess (const char *yytext);
 
 // Macro that sets the yylloc line variables to the current parse line.

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -117,6 +117,12 @@ using namespace OSL::pvt;
 #define isatty _isatty
 #endif
 
+// flex itself will generate fatal warnings about signed vs unsigned.
+// Bypass that nonsense.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
 %}
 
 /* Declare modes */


### PR DESCRIPTION
We can't fix the code -- it's not "our" code, it it's the stuff
generated as part of the build process by flex itself. The expedient
thing is to just suppress the warning in the flex-generated module.
