### PR TITLE
Restore support for OIIO 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,10 +136,10 @@ matrix:
         compiler: gcc
         env: DEBUG=1 LLVM_VERSION=3.9.0
     # One more, just for the heck of it, turn all SIMD off, and also test
-    # against the oldest LLVM we still support.
+    # against the oldest LLVM we still support and the oldest OIIO.
       - os: linux
         compiler: gcc
-        env: USE_SIMD=0 LLVM_VERSION=3.5.2
+        env: USE_SIMD=0 LLVM_VERSION=3.5.2 OIIOBRANCH=RB-1.7
 
 notifications:
     email:

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -246,7 +246,11 @@ ShaderInstance::parameters (const ParamValueList &params)
 
             if (master()->shadingsys().relaxed_param_typecheck()) {
                 // first handle cases where we actually need to modify the data (like setting a float parameter with an int)
-                if ((paramtype == TypeDesc::FLOAT || paramtype.is_vec3()) && valuetype.basetype == TypeDesc::INT && valuetype.basevalues() == 1) {
+#if OIIO_VERSION >= 10804
+                 if ((paramtype == TypeDesc::FLOAT || paramtype.is_vec3()) && valuetype.basetype == TypeDesc::INT && valuetype.basevalues() == 1) {
+#else
+                 if ((paramtype == TypeDesc::FLOAT || paramtype.is_vec3()) && valuetype.basetype == TypeDesc::INT && valuetype.numelements()*valuetype.aggregate == 1) {
+#endif
                     int val = *static_cast<const int*>(p.data());
                     float conv = float(val);
                     if (val != int(conv))
@@ -264,11 +268,19 @@ ShaderInstance::parameters (const ParamValueList &params)
                 //   * if paramtype is sized (or not an array) just check for the total number of entries
                 //   * if paramtype is unsized (shader writer is flexible about how many values come in) -- make sure we are a multiple of the target type
                 //   * allow a single float setting a vec3 (or equivalent)
+#if OIIO_VERSION >= 10804
                 if (!( valuetype.basetype == paramtype.basetype &&
                       !valuetype.is_unsized_array() &&
                       ((!paramtype.is_unsized_array() && valuetype.basevalues() == paramtype.basevalues()) ||
                        ( paramtype.is_unsized_array() && valuetype.basevalues() % paramtype.aggregate == 0) ||
                        ( paramtype.is_vec3()          && valuetype == TypeDesc::FLOAT) ) )) {
+#else
+                if (!( valuetype.basetype == paramtype.basetype &&
+                      !valuetype.is_unsized_array() &&
+                      ((!paramtype.is_unsized_array() && valuetype.numelements()*valuetype.aggregate == paramtype.numelements()*paramtype.aggregate) ||
+                       ( paramtype.is_unsized_array() && valuetype.numelements()*valuetype.aggregate % paramtype.aggregate == 0) ||
+                       ( paramtype.is_vec3()          && valuetype == TypeDesc::FLOAT) ) )) {
+#endif
                     // We are being very relaxed in this mode, so if the user _still_ got it wrong
                     // something more serious is at play and we should treat it as an error.
                     shadingsys().error ("attempting to set parameter from incompatible type: %s (expected '%s', received '%s')",

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -313,7 +313,12 @@ action_param (int argc, const char *argv[])
                    &f[0], &f[1], &f[2], &f[3],
                    &f[4], &f[5], &f[6], &f[7], &f[8], &f[9], &f[10], &f[11],
                    &f[12], &f[13], &f[14], &f[15]) == 16) {
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, TypeDesc::TypeMatrix, 1, f);
+#else
+        params.push_back (ParamValue());
+        params.back().init (paramname, TypeDesc::TypeMatrix, 1, f);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -323,7 +328,12 @@ action_param (int argc, const char *argv[])
         && sscanf (stringval.c_str(), "%g, %g, %g", &f[0], &f[1], &f[2]) == 3) {
         if (type == TypeDesc::UNKNOWN)
             type = TypeDesc::TypeVector;
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, f);
+#else
+        params.push_back (ParamValue());
+        params.back().init (paramname, type, 1, f);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -332,7 +342,13 @@ action_param (int argc, const char *argv[])
     // string.
     if ((type == TypeDesc::UNKNOWN || type == TypeDesc::TypeInt)
           && OIIO::Strutil::string_is<int>(stringval)) {
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, OIIO::Strutil::from_string<int>(stringval));
+#else
+        params.push_back (ParamValue());
+        int i = OIIO::Strutil::from_string<int>(stringval);
+        params.back().init (paramname, TypeDesc::TypeInt, 1, &i);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -341,7 +357,13 @@ action_param (int argc, const char *argv[])
     // whole string.
     if ((type == TypeDesc::UNKNOWN || type == TypeDesc::TypeFloat)
           && OIIO::Strutil::string_is<float>(stringval)) {
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, OIIO::Strutil::from_string<float>(stringval));
+#else
+        params.push_back (ParamValue());
+        float f = OIIO::Strutil::from_string<float>(stringval);
+        params.back().init (paramname, TypeDesc::TypeFloat, 1, &f);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -355,7 +377,12 @@ action_param (int argc, const char *argv[])
             OIIO::Strutil::parse_float (stringval, vals[i]);
             OIIO::Strutil::parse_char (stringval, ',');
         }
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &vals[0]);
+#else
+        params.push_back (ParamValue());
+        params.back().init (paramname, type, 1, &vals[0]);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -369,7 +396,12 @@ action_param (int argc, const char *argv[])
             OIIO::Strutil::parse_int (stringval, vals[i]);
             OIIO::Strutil::parse_char (stringval, ',');
         }
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &vals[0]);
+#else
+        params.push_back (ParamValue());
+        params.back().init (paramname, type, 1, &vals[0]);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -383,7 +415,12 @@ action_param (int argc, const char *argv[])
         std::vector<ustring> strelements;
         for (auto&& s : splitelements)
             strelements.push_back (ustring(s));
+#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &strelements[0]);
+#else
+        params.push_back (ParamValue());
+        params.back().init (paramname, type, 1, &strelements[0]);
+#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -391,7 +428,12 @@ action_param (int argc, const char *argv[])
 
     // All remaining cases -- it's a string
     const char *s = stringval.c_str();
+#if OIIO_VERSION >= 10804
     params.emplace_back (paramname, TypeDesc::TypeString, 1, &s);
+#else
+    params.push_back (ParamValue());
+    params.back().init (paramname, TypeDesc::TypeString, 1, &s);
+#endif
     if (unlockgeom)
         params.back().interp (ParamValue::INTERP_VERTEX);
 }


### PR DESCRIPTION
OSL's Travis tests build against OIIO master and release. A couple months ago when OIIO changed release from 1.7 to 1.8, that resulted in our no longer testing directly against OIIO 1.7, and a few incompatibilities creeped in despite our advertising that OIIO 1.9 ought to be compatible with OIIO >= 1.7.

This patch fixes those things, as well as adding an explicit test vs OIIO 1.7 to our Travis test matrix.

