### PR TITLE
Fix ClosureComponent to work with SSE alignment requirements

### DIFF
--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -114,29 +114,26 @@ struct OSLEXECPUBLIC ClosureColor {
 
 /// ClosureComponent is a subclass of ClosureColor that holds the ID and
 /// parameter data for a single primitive closure component (such as
-/// diffuse, translucent, etc.).  The declaration leaves 4 bytes for
-/// parameter data (mem), but it's expected that the structure be
-/// allocated with enough space to house all the parameter data for
-/// whatever type of custom primitive component it actually is.
-struct OSLEXECPUBLIC ClosureComponent : public ClosureColor
+/// diffuse, translucent, etc.).
+///
+/// ClosureComponent itself takes up 16 bytes, and its allocation will be
+/// scaled to add parameters after the end of the struct. Alignment is
+/// set to 16 bytes so that 64 bit pointers and 128 bit SSE types in user
+/// structs have the required alignment.
+struct OSLEXECPUBLIC OSL_ALIGNAS(16) ClosureComponent : public ClosureColor
 {
     Vec3 w;                     ///< Weight of this component
-    alignas(void*) char mem[8]; ///< Memory for the primitive, 8 is the minimum, allocation will be
-                                ///  scaled to requirements of the registered closure struct.
-                                ///  Alignment is forced to a void* to match likely alignement requirements
-                                ///  of the user's structs.
 
     /// Handy method for getting the parameter memory as a void*.
-    ///
-    void *data () { return &mem; }
-    const void *data () const { return &mem; }
+    void *data () { return (char*)(this + 1); }
+    const void *data () const { return (const char*)(this + 1); }
 
     /// Handy methods for extracting the underlying parameters as a struct
     template <typename T>
-    const T* as() const { return reinterpret_cast<const T*>(mem); }
+    const T* as() const { return reinterpret_cast<const T*>(data()); }
 
     template <typename T>
-    T* as() { return reinterpret_cast<const T*>(mem); }
+    T* as() { return reinterpret_cast<const T*>(data()); }
 };
 
 

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -131,4 +131,12 @@ using OIIO::string_view;
 #  define OSL_DEPRECATED(msg)
 #endif
 
+/// Work around bug in GCC with mixed __attribute__ and alignas parsing
+/// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69585
+#ifdef __GNUC__
+#  define OSL_ALIGNAS(size) __attribute__((aligned(size)))
+#else
+#  define OSL_ALIGNAS(size) alignas(size)
+#endif
+
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1614,7 +1614,7 @@ public:
 
     ClosureComponent * closure_component_allot(int id, size_t prim_size, const Color3 &w) {
         // Allocate the component and the mul back to back
-        size_t needed = sizeof(ClosureComponent) - sizeof(void*) + prim_size;
+        size_t needed = sizeof(ClosureComponent) + prim_size;
         ClosureComponent *comp = (ClosureComponent *) m_closure_pool.alloc(needed, alignof(ClosureComponent));
         comp->id = id;
         comp->w = w;
@@ -1845,14 +1845,6 @@ private:
     // Buffering of error messages and printfs
     typedef std::pair<ErrorHandler::ErrCode, std::string> ErrorItem;
     mutable std::vector<ErrorItem> m_buffered_errors;
-
-    // Calculate offset needed to align ClosureComponent's mem to a given alignment.
-    inline size_t closure_alignment_offset_calc(size_t alignment) {
-        return alignment == 1
-            ? 0
-            : alignment - (reckless_offsetof(ClosureComponent, mem) & (alignment - 1));
-    }
-
 };
 
 


### PR DESCRIPTION
## Description

In #740 the `alignment` parameter was removed from `register_closure`. This was originally added in bcaf5778, and Cycles still needs 16 bytes alignment for SSE types, while it is fixed to 8 bytes in OSL master now.

This patch uses the simple solution of enforcing 16 byte alignment for `ClosureComponent.mem`, under the assumption that in practice this is the most alignment you need on x86.

Alternatively the `alignment` parameter could be added back. Maybe in theory someone might care about 32 byte alignment for AVX. In practice I guess it's not so likely since alignment is only required for older CPUs that don't support unaligned loads well.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

