### PR TITLE
oslc: Fix param write analysis bug for token/value optional arguments

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -946,9 +946,17 @@ ASTfunction_call::mark_optional_output (int firstopt, const char **tags)
        ASTNode *s = argvec[a].get();
        bool isoutput = false;
        // compare against output tags
-       if (s->typespec().is_string() && s->nodetype() == ASTNode::literal_node) {
-           for (const char **tag = tags; *tag && !isoutput; ++tag)
-               isoutput = isoutput || mark_all || (! strcmp (((ASTliteral *)s)->strval(), *tag));
+       if (s->typespec().is_string()) {
+           if (s->nodetype() == ASTNode::literal_node) {
+               // If the token is a string literal, see if it's one of the
+               // ones designated as an output slot.
+               for (const char **tag = tags; *tag && !isoutput; ++tag)
+                   isoutput = isoutput || mark_all || (! strcmp (((ASTliteral *)s)->strval(), *tag));
+           } else {
+               // If the token is not a literal, we don't know what it'll
+               // be at runtime, so mark it conservatively as possible output.
+               isoutput = true;
+           }
        }
        if (isoutput) {
            // writes to the next arg!


### PR DESCRIPTION
Functions that take optional argument lists in token/value form, like `texture` or `pointcloud_search` needed to mark just those value references as "writeable" that are (for example, the one following "alpha" for texture calls, but all of the optional value slots for pointcloud_search).

The logic on the oslc side here was broken -- it worked when the token was a string literal, but when it was a variable whose value wouldn't be known until runtime, it was failing to mark it as writeable, whereas the correct thing to do is to conservatively conclude that it *might* be written to (we don't know yet) and mark it as such.

The cascade of errors could lead to incorrect runtime optimization, if the only used output of the function call was one of these parameters that failed to be marked as an output, so so the whole function call might be subject to the "useless op elision" optimization wherein ops whose writes are never subsequently read can be eliminated entirely.

