### PR TITLE
FindPugiXML.cmake touchup -- make robust to re-builds

### DIFF
--- a/src/cmake/modules/FindPugiXML.cmake
+++ b/src/cmake/modules/FindPugiXML.cmake
@@ -6,6 +6,8 @@
 # PUGIXML_LIBRARIES - library to link against
 # PUGIXML_FOUND - true if pugixml was found.
 
+unset (PUGIXML_LIBRARY CACHE)
+unset (PUGIXML_INCLUDE_DIR CACHE)
 find_path (PUGIXML_INCLUDE_DIR
            NAMES pugixml.hpp
            PATHS ${PUGIXML_HOME}/include


### PR DESCRIPTION
Without this, certain build / change cmake / rebuild cycles could give
cmake errors instead of correctly re-finding the pugi files.

