### PR TITLE
ShadingSystem option "allow_shader_replacement"

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -128,6 +128,8 @@ public:
     ///                              means a param CANNOT be overridden by
     ///                              interpolated geometric parameters.
     ///    int countlayerexecs    Add extra code to count total layers run.
+    ///    int allow_shader_replacement Allow shader to be specified more than
+    ///                              once, replacing former definition.
     ///    string archive_groupname  Name of a group to pickle and archive.
     ///    string archive_filename   Name of file to save the group archive.
     /// 3. Attributes that that are intended for developers debugging

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -636,9 +636,9 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
     ustring name (shadername);
     lock_guard guard (m_mutex);  // Thread safety
     ShaderNameMap::const_iterator found = m_shader_masters.find (name);
-    if (found != m_shader_masters.end()) {
+    if (found != m_shader_masters.end() && ! allow_shader_replacement()) {
         if (debug())
-            info ("Preload shader %s already exists in shader_masters", name.c_str());
+            info ("Preload shader %s already exists in shader_masters", name);
         return false;
     }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -620,6 +620,7 @@ public:
     bool no_noise() const { return m_no_noise; }
     bool no_pointcloud() const { return m_no_pointcloud; }
     bool force_derivs() const { return m_force_derivs; }
+    bool allow_shader_replacement() const { return m_allow_shader_replacement; }
     ustring commonspace_synonym () const { return m_commonspace_synonym; }
 
     ustring debug_groupname() const { return m_debug_groupname; }
@@ -819,6 +820,7 @@ private:
     bool m_no_noise;                      ///< Substitute trivial noise calls
     bool m_no_pointcloud;                 ///< Substitute trivial pointcloud calls
     bool m_force_derivs;                  ///< Force derivs on everything
+    bool m_allow_shader_replacement;      ///< Allow shader masters to replace
     int m_exec_repeat;                    ///< How many times to execute group
 
     // Derived/cached calculations from options:

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -677,6 +677,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_no_noise(false),
       m_no_pointcloud(false),
       m_force_derivs(false),
+      m_allow_shader_replacement(false),
       m_exec_repeat(1),
       m_in_group (false),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
@@ -1105,6 +1106,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("no_noise", int, m_no_noise);
     ATTR_SET ("no_pointcloud", int, m_no_pointcloud);
     ATTR_SET ("force_derivs", int, m_force_derivs);
+    ATTR_SET ("allow_shader_replacement", int, m_allow_shader_replacement);
     ATTR_SET ("exec_repeat", int, m_exec_repeat);
     ATTR_SET_STRING ("commonspace", m_commonspace_synonym);
     ATTR_SET_STRING ("debug_groupname", m_debug_groupname);
@@ -1223,6 +1225,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("no_noise", int, m_no_noise);
     ATTR_DECODE ("no_pointcloud", int, m_no_pointcloud);
     ATTR_DECODE ("force_derivs", int, m_force_derivs);
+    ATTR_DECODE ("allow_shader_replacement", int, m_allow_shader_replacement);
     ATTR_DECODE ("exec_repeat", int, m_exec_repeat);
 
     ATTR_DECODE ("stat:masters", int, m_stat_shaders_loaded);
@@ -1648,6 +1651,7 @@ ShadingSystemImpl::getstats (int level) const
     INTOPT (no_noise);
     INTOPT (no_pointcloud);
     INTOPT (force_derivs);
+    INTOPT (allow_shader_replacement);
     INTOPT (exec_repeat);
     STROPT (debug_groupname);
     STROPT (debug_layername);


### PR DESCRIPTION
Default is 0, for old behavior in which it's an error for
LoadMemoryCompiledShader to try to load the same named shader more than
once.

If set to nonzero, this is allowed, replacing the old shader master.
This does not change any already declared shader groups, which
will continue to use the original definition at the time of their
declaration. But subsequent groups that reference the master will get
the latest one.
