### PR TITLE
Bump minimum OIIO dependency to 1.8 (master only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,7 +218,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: USE_SIMD=0 LLVM_VERSION=3.9.1 OIIOBRANCH=RB-1.7
+        env: USE_SIMD=0 LLVM_VERSION=3.9.1 OIIOBRANCH=RB-1.8
 
 notifications:
     email:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,7 @@ Release 1.10? -- ?? 2018? (compared to 1.9)
 Dependency and standards changes:
 * **LLVM 3.9 / 4.0 / 5.0**: Support has been removed for LLVM 3.5.
 * **OpenImageIO 1.8+**: This release of OSL should build properly against
-  OIIO 1.8 or newer. You may find that 1.7 is still ok, but we are not doing
-  any work to ensure that.
+  OIIO 1.8 or newer. Support has been dropped for OIIO 1.7.
 
 Language features:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
   OSL should compile also properly with C++14 or C++17, but they are not
   required.
 
-* [OpenImageIO](http://openimageio.org) 1.7 or newer
+* **[OpenImageIO](http://openimageio.org) 1.8 or newer**
 
     OSL uses OIIO both for its texture mapping functionality as well as
     numerous utility classes.  If you are integrating OSL into an existing

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -52,7 +52,7 @@ endif ()
 ###########################################################################
 # OpenImageIO
 
-find_package (OpenImageIO 1.7 REQUIRED)
+find_package (OpenImageIO 1.8 REQUIRED)
 include_directories ("${OPENIMAGEIO_INCLUDE_DIR}")
 link_directories ("${OPENIMAGEIO_LIBRARY_DIRS}")
 message (STATUS "Using OpenImageIO ${OPENIMAGEIO_VERSION}")


### PR DESCRIPTION
OSL 1.9 will of course remain compatible with OIIO 1.7.
