### PR TITLE
Various windows fixes.

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -68,6 +68,7 @@ find_package (LLVM 3.9 REQUIRED)
 
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")
+include_directories (BEFORE SYSTEM "${CLANG_INCLUDES}")
 link_directories ("${LLVM_LIB_DIR}")
 # Extract and concatenate major & minor, remove wayward patches,
 # dots, and "svn" or other suffixes.
@@ -109,6 +110,9 @@ if (GCC_VERSION)
     if (${GCC_VERSION} VERSION_LESS 4.9)
         set (_CLANG_PREPROCESSOR_CAN_WORK ON)
     endif ()
+endif ()
+if (MSVC)
+    set (_CLANG_PREPROCESSOR_CAN_WORK ON)
 endif ()
 if (USE_BOOST_WAVE OR (NOT CLANG_LIBRARIES)
     OR (NOT _CLANG_PREPROCESSOR_CAN_WORK))

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -52,6 +52,7 @@ if (NOT ${LLVM_VERSION} VERSION_LESS 3.8)
     execute_process (COMMAND ${LLVM_CONFIG} --system-libs
                      OUTPUT_VARIABLE LLVM_SYSTEM_LIBRARIES
                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REPLACE " " ";" LLVM_SYSTEM_LIBRARIES ${LLVM_SYSTEM_LIBRARIES})
 else ()
     # Older LLVM did not have llvm-config --system-libs, but we know that
     # on Linux, we'll need curses.
@@ -74,7 +75,7 @@ foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangEdit clangLex)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
-                  PATHS ${LLVM_LIB_DIR})
+                  PATHS ${LLVM_LIB_DIR} ${CLANG_LIB_DIR})
     if (_CLANG_${COMPONENT}_LIBRARY)
         list (APPEND CLANG_LIBRARIES ${_CLANG_${COMPONENT}_LIBRARY})
     endif ()

--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -61,7 +61,7 @@ public:
 
     /// Default ctr leaves everything uninitialized
     ///
-    constexpr Dual () { }
+    OIIO_CONSTEXPR14 Dual () { }
 
     /// Construct a Dual from just a real value (derivs set to 0)
     ///


### PR DESCRIPTION
-Fix compilation issue in dual.h with msvc2015 (constexpr not initializing all members is not allowed)
-Split llvm's platform libraries from a string into a list to prevent the linker seeing it as a single file to look for.
-Enable the use of clang instead of boost::wave for msvc
-Allow clang and llvm libraries and includes to live in a different directory.


## Description

Bumped into these while integrating into blender. 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

