### PR TITLE
VisualStudio 2015 x64 compilation fixes for 1.9.x

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -61,7 +61,7 @@ public:
 
     /// Default ctr leaves everything uninitialized
     ///
-    constexpr Dual () { }
+    OIIO_CONSTEXPR14 Dual () { }
 
     /// Construct a Dual from just a real value (derivs set to 0)
     ///

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1312,6 +1312,13 @@ public:
         m_current_block = 0;
     }
 
+    // avoid 'attempting to reference a deleted function' of std::unique_ptr<char>s
+    // in reference to those member variables of ShadingContext
+    SimplePool(const SimplePool &) = delete;
+    SimplePool(SimplePool &&) = delete;
+    SimplePool &operator=(const SimplePool &) = delete;
+    SimplePool &&operator=(SimplePool &&) = delete;
+
     ~SimplePool() {}
 
     char * alloc(size_t size, size_t alignment=1) {


### PR DESCRIPTION
## Description

There were a couple of compilation failures on VisualStudio 2015 (64-bit community edition tested) with the latest 1.9 code. This patch is to address those. Specifics are detailed in the commit messages.

## Tests

I ran the render-cornell test using testrender.exe after a successful build, comparing the generated .exr with previous versions of OSL on Windows (comparable results).


## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [N/A ] I have updated the documentation, if applicable.
- [N/A] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

