### PR TITLE
Fix to compile OSL debug against OIIO-1.7.x.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -30,6 +30,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <sstream>
 #include <functional>
+#ifndef NDEBUG
+#include <atomic>
+#endif
 
 #include "osl_pvt.h"
 #include "oslcomp_pvt.h"
@@ -65,8 +68,13 @@ private:
 ScopeExit print_node_counts ([](){
     for (int i = 0; i < ASTNode::_last_node; ++i)
         if (node_counts[i] > 0)
+#if OIIO_VERSION >= (10000 * 1 + 100 * 8)
             Strutil::printf ("ASTNode type %2d: %5d   (peak %5d)\n",
                              i, node_counts[i], node_counts_peak[i]);
+#else
+            printf("ASTNode type %2d: %5d   (peak %5d)\n",
+                             i, node_counts[i], node_counts_peak[i]);
+#endif
 });
 }
 #endif


### PR DESCRIPTION
## Description

Fixes edge case of building debug OSL 1.9 against OIIO 1.7. Affected Windows, Linux and macOS, as tested.
OIIO 1.8's atomic.h unconditionally includes <atomic>, and defines Strutil::printf.

I wasn't sure of the best alternative to Strutil::printf in OIIO 1.7, so went with just using printf as a fallback.
Also, I couldn't see a macro to generate an OIIO version number as an integer, so went for duplicating what's in oiioversion.h.in.

I haven't seen any replies to my post on OSL developers to see if anyone would use this combination, but I thought I'd submit this for completeness.

## Tests

Built debug on all three platforms. Tested render-cornell.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [N/A] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

