### PR TITLE
VisualStudio 2015 compilation fix for 1.9

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -79,6 +79,10 @@ public:
         Parameter () {}
         Parameter (const Parameter& src);
         Parameter (Parameter&& src);
+        // because a move constructor is defined, assignment operators will be implicitly deleted
+        // which is a problem for use in std::vectors
+        Parameter &operator=(const Parameter &) = default;
+        Parameter &operator=(Parameter &&) = default;
     };
 
     OSLQuery ();


### PR DESCRIPTION
## Description

Occurred with the latest OSLQuery::Parameter changes.

The compilation error is

```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\xutility(2316): error C2280: 'OSL_v1_9::OSLQuery::Parameter &OSL_v1_9::OSLQuery::Parameter::operator =(const OSL_v1_9::OSLQuery::Parameter &)': attempting to reference a deleted function
D:\dev\Thirdparty\OSL-1.9\src\include\OSL/oslquery.h(82): note: compiler has generated 'OSL_v1_9::OSLQuery::Parameter::operator =' here
```

The reason is because there is an explicit move constructor for
Parameter now, meaning an implicit assignment operator is deleted. See http://en.cppreference.com/w/cpp/language/copy_assignment

## Tests

Just tested compilation, but verified that the change is ok on my macOS and Linux builds.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

