### PR TITLE
Improved compatibility of OSL 1.9 debug against OIIO 1.7.x

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -73,7 +73,7 @@ ScopeExit print_node_counts ([](){
                              i, node_counts[i], node_counts_peak[i]);
 #else
             printf("ASTNode type %2d: %5d   (peak %5d)\n",
-                             i, node_counts[i], node_counts_peak[i]);
+                             i, node_counts[i].load(), node_counts_peak[i].load());
 #endif
 });
 }


### PR DESCRIPTION
## Description

I missed this in the last PR I made.

Fixes compiler error (AppleClang,Gcc) in using std::atomic values as printf arguments.

Compiler error in AppleClang (Xcode8) is

```
/Users/mark/dev/Thirdparty/OSL-1.9/src/liboslcomp/ast.cpp:76:33: error: call to implicitly-deleted copy constructor of 'std::atomic<int>'
                             i, node_counts[i], node_counts_peak[i]);
                                ^~~~~~~~~~~~~~

```
Compiler error in Gcc (4.8) is

```
/home/mark/dev/Thirdparty/OSL-1.9/src/liboslcomp/ast.cpp:76:68: error: use of deleted function ‘std::atomic<int>::atomic(const std::atomic<int>&)’
                              i, node_counts[i], node_counts_peak[i]);
                                                                    ^

```

Believe this is a problem because printf accepts arguments by value, whereas OIIO 1.8's Strutil::printf takes by reference, and you can't copy a std::atomic.

## Tests

Compiled this change with MSVC, AppleClang (Xcode8), Gcc 4.8

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

