### PR TITLE
Enable symbols in the JIT for the Intel Vtune profiler

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -18,7 +18,7 @@ ifeq ($(SP_OS), rhel7)
 
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_5.0.0
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_5.0.1_rc2
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
@@ -28,8 +28,8 @@ ifeq ($(SP_OS), rhel7)
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_4.0_final/bin/clang++
     else ifeq (${COMPILER}, clang5)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.0/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.0/bin/clang++
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.1_rc2/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.1_rc2/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc490)


### PR DESCRIPTION
This also bumps the version of llvm we're using at SPI, that part won't affect anyone else.

