### PR TITLE
Adjust deprecations

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -456,9 +456,6 @@ public:
     /// setup, don't actually run the shader.
     bool execute (ShadingContext *ctx, ShaderGroup &group,
                   ShaderGlobals &globals, bool run=true);
-    OSL_DEPRECATED("Deprecated since 1.6, pass context pointer, not reference.")
-    bool execute (ShadingContext &ctx, ShaderGroup &group,
-                  ShaderGlobals &globals, bool run=true);
 
     /// Bind a shader group and globals to the context, in preparation to
     /// execute, including optimization and JIT of the group (if it has not

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -244,8 +244,9 @@ public:
                           float dsdy, float dtdy, int nchannels,
                           float *result, float *dresultds, float *dresultdt,
                           ustring *errormessage);
-    // Deprecated version, with no errormessage parameter. This will
+    // DEPRECATED(1.8) version, with no errormessage parameter. This will
     // eventually disappear.
+    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
     virtual bool texture (ustring filename, TextureHandle *texture_handle,
                           TexturePerthread *texture_thread_info,
                           TextureOpt &options, ShaderGlobals *sg,
@@ -286,8 +287,9 @@ public:
                             float *result, float *dresultds,
                             float *dresultdt, float *dresultdr,
                             ustring *errormessage);
-    // Deprecated version, with no errormessage parameter. This will
+    // DEPRECATED(1.8) version, with no errormessage parameter. This will
     // eventually disappear.
+    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
     virtual bool texture3d (ustring filename, TextureHandle *texture_handle,
                             TexturePerthread *texture_thread_info,
                             TextureOpt &options, ShaderGlobals *sg,
@@ -325,8 +327,9 @@ public:
                               int nchannels, float *result,
                               float *dresultds, float *dresultdt,
                               ustring *errormessage);
-    // Deprecated version, with no errormessage parameter. This will
+    // DEPRECATED(1.8) version, with no errormessage parameter. This will
     // eventually disappear.
+    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
     virtual bool environment (ustring filename, TextureHandle *texture_handle,
                               TexturePerthread *texture_thread_info,
                               TextureOpt &options, ShaderGlobals *sg,

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -184,7 +184,7 @@ RendererServices::texture (ustring filename, TextureHandle *texture_handle,
 
 
 
-// Deprecated version
+// Deprecated version (1.8)
 bool
 RendererServices::texture (ustring filename, TextureHandle *texture_handle,
                            TexturePerthread *texture_thread_info,
@@ -256,7 +256,7 @@ RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
 
 
 
-// Deprecated version
+// Deprecated version (1.8)
 bool
 RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
                              TexturePerthread *texture_thread_info,
@@ -327,7 +327,7 @@ RendererServices::environment (ustring filename, TextureHandle *texture_handle,
 
 
 
-// Deprecated version
+// Deprecated version (1.8)
 bool
 RendererServices::environment (ustring filename, TextureHandle *texture_handle,
                                TexturePerthread *texture_thread_info,

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -238,15 +238,6 @@ ShadingSystem::execute (ShadingContext *ctx, ShaderGroup &group,
 
 
 bool
-ShadingSystem::execute (ShadingContext &ctx, ShaderGroup &group,
-                        ShaderGlobals &globals, bool run)
-{
-    return m_impl->execute (&ctx, group, globals, run);
-}
-
-
-
-bool
 ShadingSystem::execute_init (ShadingContext &ctx, ShaderGroup &group,
                              ShaderGlobals &globals, bool run)
 {


### PR DESCRIPTION
Remove a method that has been deprecated since OSL 1.6, and mark some
methods that were deprecated since 1.8 with the OSL_DEPRECATED warning.

