### PR TITLE
Fixes to group names and debug bitcode output

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -721,28 +721,23 @@ ShaderInstance::mergeable (const ShaderInstance &b, const ShaderGroup &g) const
 
 
 ShaderGroup::ShaderGroup (string_view name)
-  : m_optimized(0), m_does_nothing(false),
-    m_llvm_groupdata_size(0), m_num_entry_layers(0),
-    m_llvm_compiled_version(NULL),
-    m_name(name), m_exec_repeat(1), m_raytype_queries(-1), m_raytypes_on(0), m_raytypes_off(0)
 {
-    m_executions = 0;
-    m_stat_total_shading_time_ticks = 0;
     m_id = ++(*(atomic_int *)&next_id);
+    if (name.size()) {
+        m_name = name;
+    } else {
+        // No name -- make one up using the unique
+        m_name = ustring::format ("unnamed_group_%d", m_id);
+    }
 }
 
 
 
 ShaderGroup::ShaderGroup (const ShaderGroup &g, string_view name)
-  : m_optimized(0), m_does_nothing(false),
-    m_llvm_groupdata_size(0), m_num_entry_layers(g.m_num_entry_layers),
-    m_llvm_compiled_version(NULL),
-    m_layers(g.m_layers),
-    m_name(name), m_exec_repeat(1), m_raytype_queries(-1), m_raytypes_on(0), m_raytypes_off(0)
+    : ShaderGroup(name)  // delegate most of the work
 {
-    m_executions = 0;
-    m_stat_total_shading_time_ticks = 0;
-    m_id = ++(*(atomic_int *)&next_id);
+    m_num_entry_layers = g.m_num_entry_layers;
+    m_layers = g.m_layers;
 }
 
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1105,15 +1105,17 @@ BackendLLVM::run ()
 
     // Debug code to dump the pre-optimized bitcode to a file
     if (llvm_debug() >= 2 || shadingsys().llvm_output_bitcode()) {
-        std::string name = Strutil::format ("%s_%s_%d.bc", group().name(),
-                                            inst()->layername(), inst()->id());
-        ll.write_bitcode_file (name.c_str());
-        name = Strutil::format ("%s_%s_%d.ll", group().name(),
-                                inst()->layername(), inst()->id());
+        // Make a safe group name that doesn't have "/" in it! Also beware
+        // filename length limits.
+        std::string safegroup = Strutil::replace (group().name(), "/", ".", true);
+        if (safegroup.size() > 235)
+            safegroup = Strutil::format ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
+        std::string name = Strutil::format ("%s.ll", safegroup);
         std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
         if (out.good()) {
             out << ll.bitcode_string (ll.module());
-            out.close ();
+        } else {
+            shadingcontext()->error ("Could not write to '%s'", name);
         }
     }
 
@@ -1132,15 +1134,17 @@ BackendLLVM::run ()
 
     // Debug code to dump the post-optimized bitcode to a file
     if (llvm_debug() >= 2 || shadingsys().llvm_output_bitcode()) {
-        std::string name = Strutil::format ("%s_%s_%d_opt.bc", group().name(),
-                                            inst()->layername(), inst()->id());
-        ll.write_bitcode_file (name.c_str());
-        name = Strutil::format ("%s_%s_%d_opt.ll", group().name(),
-                                inst()->layername(), inst()->id());
+        // Make a safe group name that doesn't have "/" in it! Also beware
+        // filename length limits.
+        std::string safegroup = Strutil::replace (group().name(), "/", ".", true);
+        if (safegroup.size() > 235)
+            safegroup = Strutil::format ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
+        std::string name = Strutil::format ("%s_opt.ll", safegroup);
         std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
         if (out.good()) {
             out << ll.bitcode_string (ll.module());
-            out.close ();
+        } else {
+            shadingcontext()->error ("Could not write to '%s'", name);
         }
     }
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1489,9 +1489,11 @@ LLVM_Util::write_bitcode_file (const char *filename, std::string *err)
 {
     std::error_code local_error;
     llvm::raw_fd_ostream out (filename, local_error, llvm::sys::fs::F_None);
-    llvm::WriteBitcodeToFile (module(), out);
-    if (err && local_error)
-        *err = local_error.message ();
+    if (! out.has_error()) {
+        llvm::WriteBitcodeToFile (module(), out);
+        if (err && local_error)
+            *err = local_error.message ();
+    }
 }
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1554,20 +1554,20 @@ private:
     // Put all the things that are read-only (after optimization) and
     // needed on every shade execution at the front of the struct, as much
     // together on one cache line as possible.
-    volatile int m_optimized;        ///< Is it already optimized?
-    bool m_does_nothing;             ///< Is the shading group just func() { return; }
-    size_t m_llvm_groupdata_size;    ///< Heap size needed for its groupdata
+    volatile int m_optimized = 0;    ///< Is it already optimized?
+    bool m_does_nothing = false;     ///< Is the shading group just func() { return; }
+    size_t m_llvm_groupdata_size = 0;///< Heap size needed for its groupdata
     int m_id;                        ///< Unique ID for the group
-    int m_num_entry_layers;          ///< Number of marked entry layers
-    RunLLVMGroupFunc m_llvm_compiled_version;
-    RunLLVMGroupFunc m_llvm_compiled_init;
+    int m_num_entry_layers = 0;      ///< Number of marked entry layers
+    RunLLVMGroupFunc m_llvm_compiled_version = nullptr;
+    RunLLVMGroupFunc m_llvm_compiled_init = nullptr;
     std::vector<RunLLVMGroupFunc> m_llvm_compiled_layers;
     std::vector<ShaderInstanceRef> m_layers;
     ustring m_name;
-    int m_exec_repeat;               ///< How many times to execute group
-    int m_raytype_queries;           ///< Bitmask of raytypes queried
-    int m_raytypes_on;               ///< Bitmask of raytypes we assume to be on
-    int m_raytypes_off;              ///< Bitmask of raytypes we assume to be off
+    int m_exec_repeat = 1;           ///< How many times to execute group
+    int m_raytype_queries = -1;      ///< Bitmask of raytypes queried
+    int m_raytypes_on = 0;           ///< Bitmask of raytypes we assume to be on
+    int m_raytypes_off = 0;          ///< Bitmask of raytypes we assume to be off
     mutable mutex m_mutex;           ///< Thread-safe optimization
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;
@@ -1582,8 +1582,8 @@ private:
     bool m_unknown_textures_needed;
     bool m_unknown_closures_needed;
     bool m_unknown_attributes_needed;
-    atomic_ll m_executions;          ///< Number of times the group executed
-    atomic_ll m_stat_total_shading_time_ticks; ///< Total shading time (ticks)
+    atomic_ll m_executions {0};       ///< Number of times the group executed
+    atomic_ll m_stat_total_shading_time_ticks {0}; ///< Total shading time (ticks)
 
     friend class OSL::pvt::ShadingSystemImpl;
     friend class OSL::pvt::BackendLLVM;


### PR DESCRIPTION
* Better guaranteed unique naming of missing names.

* When dumping ll/bc files for debugging to filenames derived from the
  group name, beware group names that have slashes in them! Also,
  sheesh, watch out for group names that are so long that they exceed
  the longest filename allowed (256 chars for most modern filesystems).

* Decided only the ll files are useful for debugging, I don't think we
  need the binary bc files, so I removed the bc output.

* Simplify ShaderGroup ctr by using C++11 data member defaults and
  delegating constructors.

