### PR TITLE
Assignments to components of fields within a struct array are optimized away by the runtime optimizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             blackbody blendmath breakcont
             bug-array-heapoffsets
             bug-locallifetime bug-outputinit bug-param-duplicate bug-peep
+            bug-struct-assign
             cellnoise closure closure-array color comparison
             compile-buffer
             component-range const-array-params const-array-fill

--- a/testsuite/bug-struct-assign/ref/out.txt
+++ b/testsuite/bug-struct-assign/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+c[0].rgb: 1 2 3
+(-1 2 3)  == (-1 2 3)

--- a/testsuite/bug-struct-assign/run.py
+++ b/testsuite/bug-struct-assign/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+command = testshade("-g 1 1 test")
+failureok = failstage2 # diff should fail, bug still exists!

--- a/testsuite/bug-struct-assign/test.osl
+++ b/testsuite/bug-struct-assign/test.osl
@@ -1,0 +1,19 @@
+// Assignemnt to indexed struct element currently broken
+
+struct custom {
+    color rgb;
+};
+
+shader test ()
+{
+    custom c[2];
+    c[0].rgb = color(1,2,3);
+
+    // Broken:
+    c[0].rgb[0] = -c[0].rgb[0];
+
+    // Works:
+    c[1].rgb = color(-c[0].rgb[0], c[0].rgb[1], c[0].rgb[2]);
+
+    printf("(%g)  == (%g)\n", c[0].rgb, c[1].rgb);
+}

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -52,6 +52,11 @@ failthresh = 0.004
 hardfail = 0.01
 failpercent = 0.02
 
+# Fail on stage1 : oslc
+failstage1 = 1
+# Fail on stage2 : diff / ref comaprison
+failstage2 = 2
+
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd" ]
 
@@ -232,7 +237,7 @@ def runtest (command, outputs, failureok=0, failthresh=0, failpercent=0) :
 
     for sub_command in command.split(splitsymbol):
         cmdret = subprocess.call (sub_command, shell=True, env=test_environ)
-        if cmdret != 0 and failureok == 0 :
+        if cmdret != 0 and failureok != failstage1 :
             print "#### Error: this command failed: ", sub_command
             print "FAIL"
             return (1)
@@ -257,7 +262,8 @@ def runtest (command, outputs, failureok=0, failthresh=0, failpercent=0) :
             else :
                 # anything else
                 cmpresult = 0 if filecmp.cmp (out, testfile) else 1
-            if cmpresult == 0 :
+            # cmpresult should be 0 (no error), unless expected to fail the diff
+            if cmpresult == 0 if failureok != failstage2 else cmpresult != 0:
                 ok = 1
                 break      # we're done
 


### PR DESCRIPTION
## Description
The following code leaves c[0].rgb[0] in an undefined state when the runtime optimizer is used:

```
struct custom { color rgb; };


custom c[1];
c[0].rgb[0] = 123;
printf("rgb: %g\n", c[0].rgb);
printf("rgb: %g\n", c[0].rgb[0]);

```
Patch add ability to have a test pass who's diff operation fails.
Fixes nothing related to the bug, but adds a test showing the behavior.


<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.