### PR TITLE
Fix oslc crash with invalid field selection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             pnoise pnoise-cell pnoise-gabor pnoise-perlin pnoise-uperlin
             operator-overloading
             oslc-comma oslc-D
-            oslc-err-arrayindex oslc-err-closuremul
+            oslc-err-arrayindex oslc-err-closuremul oslc-err-field
             oslc-err-format oslc-err-intoverflow
             oslc-err-noreturn oslc-err-notfunc
             oslc-err-outputparamvararray oslc-err-paramdefault

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -628,6 +628,8 @@ ASTstructselect::find_fieldsym (int &structid, int &fieldid)
 {
     if (! lvalue()->typespec().is_structure() &&
         ! lvalue()->typespec().is_structure_array()) {
+        error ("type '%s' does not have a member '%s'",
+               type_c_str(lvalue()->typespec()), m_field);
         return NULL;
     }
 

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1873,10 +1873,13 @@ ASTfunction_call::codegen_arg (SymbolPtrVec &argdest, SymbolPtrVec &index1,
                    form->typespec().c_str());
         }
     }
-    argdest.push_back (thisarg);
-    index1.push_back (ind1);
-    index2.push_back (ind2);
-    index3.push_back (ind3);
+    if (thisarg) {
+        argdest.push_back (thisarg);
+        index1.push_back (ind1);
+        index2.push_back (ind2);
+        index3.push_back (ind3);
+    } else
+        arg->error("Invalid argument to function");
 }
 
 

--- a/testsuite/oslc-err-field/ref/out.txt
+++ b/testsuite/oslc-err-field/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:8: error: type 'color' does not have a member 'nope'
+test.osl:11: error: struct type 'custom' does not have a member 'bad'
+FAILED test.osl

--- a/testsuite/oslc-err-field/run.py
+++ b/testsuite/oslc-err-field/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-field/test.osl
+++ b/testsuite/oslc-err-field/test.osl
@@ -1,0 +1,12 @@
+// Test invalid field selections in function calls
+
+struct custom { float field; };
+
+shader test ()
+{
+    color c = color(4,3,2);
+    printf("c.nope: %g\n", c.nope);
+
+    custom cc = { 1 };
+    printf("cc.bad: %g\n", cc.bad);
+}


### PR DESCRIPTION
## Description
Attempting to access a non existent field on struct or type will crash oslc:
```
shader test ()
{
    color c = color(4,3,2);
    printf("c.nope: %g\n", c.nope);
}

```

## Tests
**testsuite/oslc-err-field/test.osl**

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.