### PR TITLE
Add named component access and swizzling operations to vector types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             struct-isomorphic-overload struct-layers
             struct-operator-overload struct-return struct-with-array
             struct-nested struct-nested-assign struct-nested-deep
+            swizzle
             ternary
             testshade-expr
             texture-alpha texture-blur texture-connected-options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr
             oslc-err-struct-dup oslc-err-struct-print
+            oslc-err-swizzle
             oslc-warn-commainit
             oslc-variadic-macro
             oslc-version

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -694,12 +694,12 @@ ASTindex::childname (size_t i) const
 
 ASTstructselect::ASTstructselect (OSLCompilerImpl *comp, ASTNode *expr,
                                   ustring field)
-    : ASTNode (structselect_node, comp, 0, expr), m_field(field),
+    : ASTfieldselect (structselect_node, comp, expr, field),
       m_structid(-1), m_fieldid(-1), m_fieldsym(NULL)
 {
     m_fieldsym = find_fieldsym (m_structid, m_fieldid);
     if (m_fieldsym) {
-        m_fieldname = m_fieldsym->name();
+        m_fullname = m_fieldsym->name();
         m_typespec = m_fieldsym->typespec();
     }
 }
@@ -712,12 +712,7 @@ ASTstructselect::ASTstructselect (OSLCompilerImpl *comp, ASTNode *expr,
 Symbol *
 ASTstructselect::find_fieldsym (int &structid, int &fieldid)
 {
-    if (! lvalue()->typespec().is_structure() &&
-        ! lvalue()->typespec().is_structure_array()) {
-        error ("type '%s' does not have a member '%s'",
-               type_c_str(lvalue()->typespec()), m_field);
-        return NULL;
-    }
+    ASSERT (lvalue()->typespec().is_structure_based());
 
     ustring structsymname;
     TypeSpec structtype;
@@ -763,8 +758,7 @@ ASTstructselect::find_structsym (ASTNode *structnode, ustring &structname,
     // or array of structs) down to a symbol that represents the
     // particular field.  In the process, we set structname and its
     // type structtype.
-    ASSERT (structnode->typespec().is_structure() ||
-            structnode->typespec().is_structure_array());
+    ASSERT (structnode->typespec().is_structure_based());
     if (structnode->nodetype() == variable_ref_node) {
         // The structnode is a top-level struct variable
         ASTvariable_ref *var = (ASTvariable_ref *) structnode;
@@ -809,6 +803,21 @@ ASTstructselect::print (std::ostream &out, int indentlevel) const
     out << "select " << field() << "\n";
 }
 
+
+
+ASTfieldselect* ASTfieldselect::create (OSLCompilerImpl *comp, ASTNode *expr,
+                                        ustring field) {
+    if (expr->typespec().is_structure_based())
+        return new ASTstructselect (comp, expr, field);
+
+    comp->error (comp->filename(), comp->lineno(),
+                 "type '%s' does not have a member '%s'",
+                 comp->type_c_str(expr->typespec()), field);
+
+    // Don't leak expr node
+    delete expr;
+    return nullptr;
+}
 
 
 const char *

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -606,7 +606,8 @@ protected:
     ustring m_fullname;       ///< Full name of variable and field
 
 public:
-    static ASTNode* create (OSLCompilerImpl *comp, ASTNode *expr, ustring field);
+    static ASTNode* create (OSLCompilerImpl *comp, ASTNode *expr, ustring field,
+                            bool swizzle = false);
 
     ustring field () const { return m_field; }
     ustring fullname () const { return m_fullname; }

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -588,7 +588,28 @@ public:
 
 
 
-class ASTstructselect : public ASTNode
+class ASTfieldselect : public ASTNode
+{
+protected:
+    ASTfieldselect (NodeType type, OSLCompilerImpl *comp, ASTNode *expr,
+                    ustring field) :
+        ASTNode(type, comp, Nothing, expr), m_field(field) {}
+
+    ustring m_field;          ///< Name of the field
+    ustring m_fullname;       ///< Full name of variable and field
+
+public:
+    static ASTfieldselect* create (OSLCompilerImpl *comp, ASTNode *expr,
+                                   ustring field);
+
+    ustring field () const { return m_field; }
+    ustring fullname () const { return m_fullname; }
+    ref lvalue () const { return child (0); }
+};
+
+
+
+class ASTstructselect : public ASTfieldselect
 {
 public:
     ASTstructselect (OSLCompilerImpl *comp, ASTNode *expr, ustring field);
@@ -602,9 +623,7 @@ public:
     /// field.
     void codegen_assign (Symbol *dest, Symbol *src);
 
-    ref lvalue () const { return child (0); }
-    ustring field () const { return m_field; }
-    ustring fieldname () const { return m_fieldname; }
+    ustring fieldname () const { return fullname(); }
     Symbol *fieldsym () const { return m_fieldsym; }
 
 private:
@@ -613,10 +632,8 @@ private:
                                  TypeSpec &structtype);
     Symbol *codegen_index ();
 
-    ustring m_field;         ///< Name of the field
     int m_structid;          ///< index of the structure
     int m_fieldid;           ///< index of the field within the structure
-    ustring m_fieldname;     ///< Name of the field variable
     Symbol *m_fieldsym;      ///< Symbol of the field variable
 };
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -580,6 +580,13 @@ public:
                                             ustring destname, ustring srcname,
                                             Symbol *index);
 
+    /// Add another index: obj[current][extended]
+    ///
+    void extend (ASTNode *ext) {
+        ASSERT (nchildren() < 4);
+        m_children.emplace_back(ext);
+    }
+
     ref lvalue () const { return child (0); }
     ref index () const { return child (1); }
     ref index2 () const { return child (2); }
@@ -599,8 +606,7 @@ protected:
     ustring m_fullname;       ///< Full name of variable and field
 
 public:
-    static ASTfieldselect* create (OSLCompilerImpl *comp, ASTNode *expr,
-                                   ustring field);
+    static ASTNode* create (OSLCompilerImpl *comp, ASTNode *expr, ustring field);
 
     ustring field () const { return m_field; }
     ustring fullname () const { return m_fullname; }

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -62,7 +62,7 @@ public:
         unknown_node, shader_declaration_node, function_declaration_node,
         variable_declaration_node, compound_initializer_node,
         variable_ref_node, preincdec_node, postincdec_node,
-        index_node, structselect_node,
+        index_node, structselect_node, swizzle_node,
         conditional_statement_node,
         loop_statement_node, loopmod_statement_node, return_statement_node,
         binary_expression_node, unary_expression_node,
@@ -641,6 +641,34 @@ private:
     int m_structid;          ///< index of the structure
     int m_fieldid;           ///< index of the field within the structure
     Symbol *m_fieldsym;      ///< Symbol of the field variable
+};
+
+
+
+class ASTswizzle : public ASTfieldselect
+{
+public:
+    ASTswizzle (OSLCompilerImpl *comp, ASTNode *expr, ustring field);
+
+    const char *nodetypename () const { return "swizzle"; }
+    const char *childname (size_t i) const;
+    void print (std::ostream &out, int indentlevel=0) const;
+    TypeSpec typecheck (TypeSpec expected);
+    Symbol *codegen (Symbol *dest = NULL);
+
+    /// Get component indeces for a swizzle string.
+    /// consts allows '0' & '1' to be included in the string.
+    static size_t indices (ustring components, int *indexes, size_t N, bool consts);
+
+    /// Offset if the component index is really a constant ('0' or '1').
+    enum { const_offset = -2 };
+
+    /// Special code generation of assignment of src to proper components.
+    Symbol* codegen_assign (Symbol *src);
+
+    size_t indices (int *indexes, size_t N, bool consts) const {
+        return indices (m_field, indexes, N, consts);
+    }
 };
 
 

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -83,7 +83,7 @@ static std::stack<TypeSpec> typespec_stack; // just for function_declaration
 
 
 // Define the terminal symbols.
-%token <s> IDENTIFIER STRING_LITERAL
+%token <s> IDENTIFIER STRING_LITERAL SWIZZLE_IDENTIFIER
 %token <i> INT_LITERAL
 %token <f> FLOAT_LITERAL
 %token <i> COLORTYPE FLOATTYPE INTTYPE MATRIXTYPE 
@@ -777,6 +777,10 @@ id_or_field
         : IDENTIFIER 
                 {
                     $$ = new ASTvariable_ref (oslcompiler, ustring($1));
+                }
+        | variable_lvalue SWIZZLE_IDENTIFIER
+                {
+                    $$ = ASTfieldselect::create (oslcompiler, $1, ustring($2));
                 }
         | variable_lvalue '.' IDENTIFIER
                 {

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -780,7 +780,7 @@ id_or_field
                 }
         | variable_lvalue '.' IDENTIFIER
                 {
-                    $$ = new ASTstructselect (oslcompiler, $1, ustring($3));
+                    $$ = ASTfieldselect::create (oslcompiler, $1, ustring($3));
                 }
         ;
 

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -80,6 +80,11 @@ STR     \"(\\.|[^\\"\n])*\"
         /* " This extra quote fixes emacs syntax highlighting on this file */
  /* Identifier: alphanumeric, may contain digits after the first character */
 IDENT           ({ALPHA}|[_])({ALPHA}|{DIGIT}|[_])*
+ /* Swizzle that starts with a constant value
+    Needs to include the . selector to take precedence over FLT */
+SWIZZLE         (\.[01][01rgbxyz]{2})
+
+
  /* C preprocessor (cpp) directives */
 CPP             ^[ \t]*#.*\n
 CPLUSCOMMENT    \/\/.*\n
@@ -195,6 +200,11 @@ void preprocess (const char *yytext);
                             yylval.s = ustring(yytext).c_str();
                             SETLINE;
                             return IDENTIFIER;
+                        }
+{SWIZZLE}               {
+                            yylval.s = ustring(yytext+1).c_str();
+                            SETLINE;
+                            return SWIZZLE_IDENTIFIER;
                         }
 
  /* Literal values */

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -226,6 +226,22 @@ ASTindex::typecheck (TypeSpec expected)
 
 
 TypeSpec
+ASTswizzle::typecheck (TypeSpec expected)
+{
+    typecheck_children ();
+
+    // Can't be an lvalue if any of the args are constant floats.
+    for (ref arg = child(0); arg; arg = arg->next()) {
+        if (!(m_is_lvalue = arg->is_lvalue()))
+            break;
+    }
+
+    return m_typespec;
+}
+
+
+
+TypeSpec
 ASTstructselect::typecheck (TypeSpec expected)
 {
     // The ctr already figured out if this was a valid structure selection

--- a/testsuite/oslc-err-field/ref/out.txt
+++ b/testsuite/oslc-err-field/ref/out.txt
@@ -1,3 +1,6 @@
-test.osl:8: error: type 'color' does not have a member 'nope'
-test.osl:11: error: struct type 'custom' does not have a member 'bad'
+test.osl:11: error: type 'color' does not have a member 'invalid'
+test.osl:12: error: type 'color' does not have a member 'nope'
+test.osl:15: error: struct type 'custom' does not have a member 'bad'
+test.osl:18: error: type 'color' does not have a member 'sinvalid'
+test.osl:19: error: type 'color' does not have a member 'error'
 FAILED test.osl

--- a/testsuite/oslc-err-field/test.osl
+++ b/testsuite/oslc-err-field/test.osl
@@ -1,12 +1,20 @@
 // Test invalid field selections in function calls
 
 struct custom { float field; };
+struct A { color valid; };
+struct B { A a; };
+struct C { B b; };
 
 shader test ()
 {
     color c = color(4,3,2);
+    c.invalid = 45;
     printf("c.nope: %g\n", c.nope);
 
     custom cc = { 1 };
     printf("cc.bad: %g\n", cc.bad);
+
+    C nested;
+    nested.b.a.valid.sinvalid = color(1);
+    printf("nested.b.a.valid.error: %g\n", nested.b.a.valid.error);
 }

--- a/testsuite/oslc-err-swizzle/ref/out.txt
+++ b/testsuite/oslc-err-swizzle/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:7: error: Can't assign via = to something that isn't an lvalue
+test.osl:8: error: Can't assign via = to something that isn't an lvalue
+FAILED test.osl

--- a/testsuite/oslc-err-swizzle/run.py
+++ b/testsuite/oslc-err-swizzle/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-swizzle/test.osl
+++ b/testsuite/oslc-err-swizzle/test.osl
@@ -1,0 +1,10 @@
+// Error on invalid swizzle operations
+
+shader test ()
+{
+    color c;
+
+    c.rg0 = color(1);
+    c.01r = color(1);
+    // c.0;
+}

--- a/testsuite/swizzle/ref/out.txt
+++ b/testsuite/swizzle/ref/out.txt
@@ -1,4 +1,18 @@
 Compiled swizzle.osl -> swizzle.oso
+c: 1 2 3
+c.brg = c.grb = c.bgr: 3 1 2
+c.rgb = c.gbr: 1 2 3
+c.r00: 1 0 0
+c.g01: 2 0 1
+c.b11: 3 1 1
+c.bg1: 3 2 1
+c.rgb = c.brg: 3 1 2
+c.rgb = c.brg: 2 3 1
+c.rgb = c.brg: 1 2 3
+c.rgb = c.bgr: 3 2 1
+c.bgr = c.bgr: 3 2 1
+c.grb = c.bgr: 2 1 3
+c.ggr + c.rgr: 3 2 4
 c.r: 4
 c.g: 3
 c.b: 2
@@ -12,4 +26,15 @@ c4[0].b: 3
 c4[1].r: -1
 c4[1].b: -3
 c4[1].g: -2
+c.rrr: 4 4 4
+c.rgb: 4 3 2
+c.rbg: 4 2 3
+c.ggg: 3 3 3
+c.grb: 3 4 2
+c.gbr: 3 2 4
+c.bbb: 2 2 2
+c.brg: 2 4 3
+c.ggr: 3 3 4
+ca[0].brg: 3 1 2
+c.rgb = 1: 1 1 1
 

--- a/testsuite/swizzle/ref/out.txt
+++ b/testsuite/swizzle/ref/out.txt
@@ -6,6 +6,8 @@ c.r00: 1 0 0
 c.g01: 2 0 1
 c.b11: 3 1 1
 c.bg1: 3 2 1
+c.01g: 0 1 2
+c.101: 1 0 1
 c.rgb = c.brg: 3 1 2
 c.rgb = c.brg: 2 3 1
 c.rgb = c.brg: 1 2 3

--- a/testsuite/swizzle/ref/out.txt
+++ b/testsuite/swizzle/ref/out.txt
@@ -1,0 +1,15 @@
+Compiled swizzle.osl -> swizzle.oso
+c.r: 4
+c.g: 3
+c.b: 2
+v0.x: 6
+v0.y: 7
+v0.z: 8
+v0.z->x: 6
+c4[0].r: 1
+c4[0].g: 2
+c4[0].b: 3
+c4[1].r: -1
+c4[1].b: -3
+c4[1].g: -2
+

--- a/testsuite/swizzle/run.py
+++ b/testsuite/swizzle/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+command = testshade("swizzle")
+

--- a/testsuite/swizzle/swizzle.osl
+++ b/testsuite/swizzle/swizzle.osl
@@ -4,7 +4,44 @@
 
 shader swizzle ()
 {
-    color c = color(4,3,2);
+    color c = color(1,2,3);
+    printf("c: %g\n", c);
+
+    // transitive
+    // 1,2,3 -> 2,3,1 -> 3,1,2
+    c.brg = c.grb = c.bgr;
+    printf("c.brg = c.grb = c.bgr: %g\n", c);
+
+    c.rgb = c.gbr;
+    printf("c.rgb = c.gbr: %g\n", c);
+
+    printf("c.r00: %g\n", c.r00);
+    printf("c.g01: %g\n", c.g01);
+    printf("c.b11: %g\n", c.b11);
+    printf("c.bg1: %g\n", c.bg1);
+
+    c = c.brg;
+    printf("c.rgb = c.brg: %g\n", c);
+
+    c = c.brg;
+    printf("c.rgb = c.brg: %g\n", c);
+
+    c = c.brg;
+    printf("c.rgb = c.brg: %g\n", c);
+
+	c.rgb = c.bgr;
+    printf("c.rgb = c.bgr: %g\n", c);
+
+    c.bgr = c.bgr;
+    printf("c.bgr = c.bgr: %g\n", c);
+
+    c.grb = c.bgr;
+    printf("c.grb = c.bgr: %g\n", c);
+
+    printf("c.ggr + c.rgr: %g\n", c.ggr + c.rgr);
+
+    c.gbr = c.ggr + c.rgr;
+
     printf("c.r: %g\n", c.r);
     printf("c.g: %g\n", c.g);
     printf("c.b: %g\n", c.b);
@@ -26,4 +63,19 @@ shader swizzle ()
         printf("c4[%d].%s: %g\n", i, i ? "b" : "g", i ? c4[i].rgb.b : c4[i].rgb.g);
         printf("c4[%d].%s: %g\n", i, i ? "g" : "b", i ? c4[i].rgb.g : c4[i].rgb.b);
     }
+
+    printf("c.rrr: %g\n", c.rrr);
+    printf("c.rgb: %g\n", c.rgb);
+    printf("c.rbg: %g\n", c.rbg);
+    printf("c.ggg: %g\n", c.ggg);
+    printf("c.grb: %g\n", c.grb);
+    printf("c.gbr: %g\n", c.gbr);
+    printf("c.bbb: %g\n", c.bbb);
+    printf("c.brg: %g\n", c.brg);
+    printf("c.ggr: %g\n", c.ggr);
+
+    printf("ca[0].brg: %g\n", ca[0].brg);
+
+    c.rgb = 1;
+    printf("c.rgb = 1: %g\n", c);
 }

--- a/testsuite/swizzle/swizzle.osl
+++ b/testsuite/swizzle/swizzle.osl
@@ -1,0 +1,29 @@
+// Test swizzle statements
+
+#include "color4.h"
+
+shader swizzle ()
+{
+    color c = color(4,3,2);
+    printf("c.r: %g\n", c.r);
+    printf("c.g: %g\n", c.g);
+    printf("c.b: %g\n", c.b);
+
+    vector v0 = vector(6,7,8);
+    printf("v0.x: %g\n", v0.x);
+    printf("v0.y: %g\n", v0.y);
+    printf("v0.z: %g\n", v0.z);
+    v0.z = v0.x;
+    printf("v0.z->x: %g\n", v0.r);
+
+    color  ca[2] = { color(-1,2,3), color(1,-2,-3) };
+    color4 c4[2]; // FIXME: = { color4(color(1,2,3),4), color4(color(-1,-2,-3),-4) };
+
+    for (int i = 0; i < 2; ++i) {
+        ca[i].r = -ca[i].r;
+        c4[i].rgb = color(ca[i].x, ca[i].y, ca[i].z);
+        printf("c4[%d].r: %g\n", i, c4[i].rgb.r);
+        printf("c4[%d].%s: %g\n", i, i ? "b" : "g", i ? c4[i].rgb.b : c4[i].rgb.g);
+        printf("c4[%d].%s: %g\n", i, i ? "g" : "b", i ? c4[i].rgb.g : c4[i].rgb.b);
+    }
+}

--- a/testsuite/swizzle/swizzle.osl
+++ b/testsuite/swizzle/swizzle.osl
@@ -4,6 +4,10 @@
 
 shader swizzle ()
 {
+    // Make sure floats don't generate a swizzle operation.
+    float noswizzle = 1.101;
+    noswizzle = 1.001;
+
     color c = color(1,2,3);
     printf("c: %g\n", c);
 
@@ -19,6 +23,8 @@ shader swizzle ()
     printf("c.g01: %g\n", c.g01);
     printf("c.b11: %g\n", c.b11);
     printf("c.bg1: %g\n", c.bg1);
+    printf("c.01g: %g\n", c.01g);
+    printf("c.101: %g\n", c.101);
 
     c = c.brg;
     printf("c.rgb = c.brg: %g\n", c);


### PR DESCRIPTION
## Description
Accessing/reordering channels via rgb/xyz selectors makes for much more readable code.
Also porting GLSL code to OSL can be quite tedious if it make extensive use of swizzling.

## Tests
**testsuite/oslc-err-swizzle**
**testsuite/swizzle**

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
