### PR TITLE
Minor fixes

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -1025,14 +1025,14 @@ ASTtype_constructor::childname (size_t i) const
 ASTfunction_call::ASTfunction_call (OSLCompilerImpl *comp, ustring name,
                                     ASTNode *args, FunctionSymbol *funcsym)
     : ASTNode (function_call_node, comp, 0, args), m_name(name),
+      m_sym(funcsym ? funcsym : comp->symtab().find (name)), // Look it up.
+      m_poly(funcsym),    // Default - resolved symbol or null
       m_argread(~1),      // Default - all args are read except the first
       m_argwrite(1),      // Default - first arg only is written by the op
       m_argtakesderivs(0) // Default - doesn't take derivs
 {
-    // If we weren't passed a function symbol directly, look it up.
-    m_sym = funcsym ? funcsym : comp->symtab().find (name);
     if (! m_sym) {
-        error ("function '%s' was not declared in this scope", name.c_str());
+        error ("function '%s' was not declared in this scope", name);
         // FIXME -- would be fun to troll through the symtab and try to
         // find the things that almost matched and offer suggestions.
         return;

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -204,8 +204,10 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
         context_type ctx (instring.begin(), instring.end(), filename.c_str());
 
         // Turn on support of variadic macros, e.g. #define FOO(...) __VA_ARGS__
+        // Turn off whitespace insertion.
         boost::wave::language_support lang = boost::wave::language_support (
-                ctx.get_language() | boost::wave::support_option_variadics);
+                (ctx.get_language() | boost::wave::support_option_variadics)
+                & ~boost::wave::language_support::support_option_insert_whitespace);
         ctx.set_language (lang);
 
         ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_MAJOR=%d",


### PR DESCRIPTION
## Description
Minor fixes that #836, #838, & #839 depend on that are less intrusive/controversial:

- `ASTfunction_call::m_poly` can possibly be left uninitialized.
- Duplicate/redefined functions are being silently ignored.
- Preprocessing with boost::wave is currently inserting whitespace into the _.osl_ source.

## Tests
Yes

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
