### PR TITLE
oslc: handle args if the shader file is not the last argument

### DIFF
--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -118,13 +118,17 @@ main (int argc, const char *argv[])
 
     OIIO::Filesystem::convert_native_arguments (argc, (const char **)argv);
 
-    std::vector<std::string> args;
-    bool quiet = false;
+
     if (argc <= 1) {
         usage ();
         return EXIT_SUCCESS;
     }
 
+    std::vector<std::string> args;
+    bool quiet = false;
+    std::string shader_path;
+
+    // Parse arguments from command line
     for (int a = 1;  a < argc;  ++a) {
         if (! strcmp (argv[a], "--help") | ! strcmp (argv[a], "-h")) {
             usage ();
@@ -141,6 +145,7 @@ main (int argc, const char *argv[])
             quiet |= (strcmp (argv[a], "-q") == 0);
         }
         else if (! strcmp (argv[a], "-o") && a < argc-1) {
+            // Output filepath
             args.emplace_back(argv[a]);
             ++a;
             args.emplace_back(argv[a]);
@@ -150,17 +155,26 @@ main (int argc, const char *argv[])
             args.emplace_back(argv[a]);
         }
         else {
-            OSLCompiler compiler (&default_oslc_error_handler);
-            bool ok = compiler.compile (argv[a], args);
-            if (ok) {
-                if (!quiet)
-                    std::cout << "Compiled " << argv[a] << " -> " 
-                              << compiler.output_filename() << "\n";
-            } else {
-                std::cout << "FAILED " << argv[a] << "\n";
-                return EXIT_FAILURE;
-            }
+            // Shader to compile
+            shader_path = argv[a];
         }
+    }
+
+    if (shader_path.empty ()) {
+        std::cout << "ERROR: Missing shader path" << "\n\n";
+        usage ();
+        return EXIT_FAILURE;
+    }
+
+    OSLCompiler compiler (&default_oslc_error_handler);
+    bool ok = compiler.compile (shader_path, args);
+    if (ok) {
+        if (!quiet)
+            std::cout << "Compiled " << shader_path << " -> " << compiler.output_filename() << "\n";
+    }
+    else {
+        std::cout << "FAILED " << shader_path << "\n";
+        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Description

oslc command line arguments placed after the shader path are ignored.

Indeed, the compilation is triggered just after encountering the supposed shader path.

This PR handles that case.

That's true that the documentation says put `options` before `file`, but it could be nice to get the similar behavior of some unix commands.  

## Tests
testsuite/oslc-D
testsuite/oslc-comma
testsuite/oslc-empty
testsuite/oslc-err-arrayindex
testsuite/oslc-err-closuremul
testsuite/oslc-err-field
testsuite/oslc-err-format
testsuite/oslc-err-intoverflow
testsuite/oslc-err-noreturn
testsuite/oslc-err-notfunc
testsuite/oslc-err-outputparamvararray
testsuite/oslc-err-paramdefault
testsuite/oslc-err-struct-array-init
testsuite/oslc-err-struct-ctr
testsuite/oslc-err-struct-dup
testsuite/oslc-variadic-macro
testsuite/oslc-version
testsuite/oslc-warn-commainittestsuite/


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

