### PR TITLE
Fix regression where function overload candidates might not be reported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,8 +267,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             operator-overloading
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul oslc-err-field
-            oslc-err-format oslc-err-funcredef oslc-err-intoverflow
-            oslc-err-noreturn oslc-err-notfunc
+            oslc-err-format oslc-err-funcoverload oslc-err-funcredef
+            oslc-err-intoverflow oslc-err-noreturn oslc-err-notfunc
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr
             oslc-err-struct-dup

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1017,26 +1017,26 @@ class CandidateFunctions {
                 ++fargs;
             case '\0':
                 if (fargs < m_nargs)
-                    return 0;
+                    return kNoMatch;
                 break;
 
             default:
                 // TODO: Scoring default function arguments would go here
                 // Curently an unused formal argument, so no match at all.
-                return 0;
+                return kNoMatch;
         }
         ASSERT (*formals == 0);
 
         int highscore = m_candidates.empty() ? 0 : m_candidates.front().ascore;
         if (argscore < highscore)
-            return 0;
+            return kNoMatch;
 
         
         if (argscore == highscore) {
             // Check for duplicate declarations
             for (auto& candidate : m_candidates) {
                 if (candidate.sym->argcodes() == func->argcodes())
-                    return 0;
+                    return kNoMatch;
             }
         } else  // clear any prior ambiguous matches
             m_candidates.clear();

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1392,6 +1392,9 @@ ASTfunction_call::typecheck (TypeSpec expected)
         return typecheck_struct_constructor ();
     }
 
+    // Save the current symbol to maybe report an error later.
+    FunctionSymbol *poly = func();
+
     CandidateFunctions candidates(m_compiler, expected, args(), func());
     std::tie(m_sym, m_typespec) = candidates.best(this);
 
@@ -1418,8 +1421,10 @@ ASTfunction_call::typecheck (TypeSpec expected)
     // message.
 	candidates.reportError(this, m_name);
 
-    for (FunctionSymbol *poly = func();  poly;  poly = poly->nextpoly())
+    while (poly) {
         candidates.reportAmbiguity(poly);
+        poly = poly->nextpoly();
+    }
 
     return TypeSpec();
 }

--- a/testsuite/oslc-err-funcoverload/ref/out.txt
+++ b/testsuite/oslc-err-funcoverload/ref/out.txt
@@ -1,0 +1,11 @@
+test.osl:8: error: No matching function call to 'funca ()'
+test.osl:3 candidate function:
+	void funca (int, int)
+test.osl:2 candidate function:
+	void funca (int)
+test.osl:9: error: No matching function call to 'funca (int, int, int)'
+test.osl:3 candidate function:
+	void funca (int, int)
+test.osl:2 candidate function:
+	void funca (int)
+FAILED test.osl

--- a/testsuite/oslc-err-funcoverload/run.py
+++ b/testsuite/oslc-err-funcoverload/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-funcoverload/test.osl
+++ b/testsuite/oslc-err-funcoverload/test.osl
@@ -1,0 +1,11 @@
+
+void funca(int a) {}
+void funca(int a, int b) {}
+
+
+shader test()
+{
+    funca();
+    funca(1,2,3);
+}
+


### PR DESCRIPTION
## Description
597b6b1 introduced a bug which might make the error message less verbose than it used to be.
This rectifies that.

## Tests
**oslc-err-funcoverload**

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
