### PR TITLE
Fix poorly defined behavior when choosing certain function overloads.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             error-dupes exit exponential
             fprintf
             function-earlyreturn function-simple function-outputelem
+            function-overloads
             geomath getattribute-camera getattribute-shader
             getsymbol-nonheap gettextureinfo
             group-outputs groupstring
@@ -266,8 +267,8 @@ TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
             operator-overloading
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul oslc-err-field
-            oslc-err-format oslc-err-funcredef oslc-err-intoverflow
-            oslc-err-noreturn oslc-err-notfunc
+            oslc-err-format oslc-err-funcoverload oslc-err-funcredef
+            oslc-err-intoverflow oslc-err-noreturn oslc-err-notfunc
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr
             oslc-err-struct-dup

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -881,17 +881,6 @@ public:
     }
 
 private:
-    /// Typecheck all polymorphic versions, return UNKNOWN if no match was
-    /// found, or a real type if there was a match.  Also, upon matching,
-    /// re-jigger m_sym to point to the specific polymorphic match.
-    /// Allow arguments to be coerced (e.g., substituting a vector where
-    /// a point was expected, or a float where a color was expected) only
-    /// if coerceargs is true.  For return values, allow spatial triples to
-    /// mutually match if 'equivreturn' is true, and allow any coercive
-    /// return type if 'expected' is TypeSpec() (i.e., unknown).
-    TypeSpec typecheck_all_poly (TypeSpec expected, bool coerceargs,
-                                 bool equivreturn);
-
     /// Handle all the special cases for built-ins.  This includes
     /// irregular patterns of which args are read vs written, special
     /// checks for printf- and texture-like, etc.

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1160,14 +1160,23 @@ ASTfunction_call::typecheck_struct_constructor ()
 ///
 /// Score a set of polymorphic functions based on arguments & return type.
 ///
-/// When choosing which varaint to use precedence is given to arguments and the
-/// return type is used as a possible tie breaker in case of any ambiguity.
-/// The highest score for an argument is given when it is an exact match.
-/// If the argument needs to be coerced into a type OSL will prefer going
-/// from any triple-types to any other triple-type before promotion of a
-/// float to a triple.  When converting one triple to another triple, OSL will
-/// prefer to coerce from one of the spatial triples (vector/point/normal) to
-/// another spatial triple before coercion from a spatial triple to color.
+/// The idea is that every function with the same name (visible from the scope)
+/// is evaluated and 'scored' against the actual arguments.
+///
+/// An exact match of all arguments will have the highest score and be chosen.
+/// If there is no exact match, then each possible overload is given a score
+/// based on the number and type of substitutions or coercions they require.
+///
+/// Different types of coercions having different costs so that: int to float is
+/// scored relatively high, beating out all other coercions; spatial-triple
+/// to spatial-triple is a closer match than spatial-triple to color;
+/// and triple to triple is a closer match than float to triple.
+///
+/// If a single choice has a best score, it wins.
+/// If there is a tie (and only then), the return type is considered in the score.
+/// If there is still not a single winner using the return type, it is considered
+/// an error whose message will show all the high scoring possibilities that
+/// cannot be dis-ambiguated.
 ///
 /// Float to int coercion is scored, but is currently a synmonym for kNoMatch
 /// as the spec does not allow implicit float to int conversion.

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1384,17 +1384,18 @@ public:
             default: break;
         }
 
-        int ambiguity = 0;
+        int ambiguity = -1;
         std::pair<const Candidate*, int> c = { nullptr, -1 };
         for (auto& candidate : m_candidates) {
             // re-score based on matching return value
-            if (candidate.rscore > c.second)
+            if (candidate.rscore > c.second) {
+                ambiguity = -1; // higher score, no longer ambiguous
                 c = std::make_pair(&candidate, candidate.rscore);
-            else if (candidate.rscore == c.second)
+            } else if (candidate.rscore == c.second)
                 ambiguity = candidate.rscore;
         }
 
-        if (ambiguity || strict) {
+        if ((ambiguity != -1) || strict) {
             ASSERT (caller);
             reportError(caller, m_candidates[0].name(), false,
                         !m_candidates.empty(), "Ambiguous call to");

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1164,6 +1164,9 @@ ASTfunction_call::typecheck_struct_constructor ()
 /// return type is used as a possible tie breaker in case of any ambiguity.
 /// The highest score for an argument is given when it is an exact match.
 ///
+/// Float to int coercion is scored, but is currently a synmonym for kNoMatch
+/// as the spec does not allow implicit float to int conversion.
+///
 class CandidateFunctions {
     enum {
         kExactMatch     = 100,
@@ -1174,7 +1177,7 @@ class CandidateFunctions {
         kNoMatch        = 0,
 
         // Additional named rules
-        kFPToIntegral   = 60,          // = kIntegralToFP to match c++
+        kFPToIntegral   = kNoMatch,    // = kIntegralToFP to match c++
     };
     struct Candidate {
         FunctionSymbol* sym;

--- a/testsuite/function-overloads/a_fcn.h
+++ b/testsuite/function-overloads/a_fcn.h
@@ -1,0 +1,11 @@
+
+void testA(float a, float b, float c) {
+    printf("testA float\n");
+}
+void testA(color a, float b, float c) {
+    printf("testA color\n");
+}
+void testA(normal a, float b, float c) {
+    printf("testA normal\n");
+}
+

--- a/testsuite/function-overloads/a_ivp.h
+++ b/testsuite/function-overloads/a_ivp.h
@@ -1,0 +1,11 @@
+
+void testA(int a, float b, float c) {
+    printf("testA int\n");
+}
+void testA(vector a, float b, float c) {
+    printf("testA vector\n");
+}
+void testA(point a, float b, float c) {
+    printf("testA point\n");
+}
+

--- a/testsuite/function-overloads/b_nci.h
+++ b/testsuite/function-overloads/b_nci.h
@@ -1,0 +1,12 @@
+
+
+void testB(normal a, float b, float c) {
+    printf("testB normal\n");
+}
+void testB(color a, float b, float c) {
+    printf("testB color\n");
+}
+void testB(int a, float b, float c) {
+    printf("testB int\n");
+}
+

--- a/testsuite/function-overloads/b_vpf.h
+++ b/testsuite/function-overloads/b_vpf.h
@@ -1,0 +1,11 @@
+
+void testB(vector a, float b, float c) {
+    printf("testB vector\n");
+}
+void testB(point a, float b, float c) {
+    printf("testB point\n");
+}
+void testB(float a, float b, float c) {
+    printf("testB float\n");
+}
+

--- a/testsuite/function-overloads/c_cnf.h
+++ b/testsuite/function-overloads/c_cnf.h
@@ -1,0 +1,11 @@
+
+
+void testC(color a, float b, float c) {
+    printf("testC color\n");
+}
+void testC(normal a, float b, float c) {
+    printf("testC normal\n");
+}
+void testC(float a, float b, float c) {
+    printf("testC float\n");
+}

--- a/testsuite/function-overloads/c_vpi.h
+++ b/testsuite/function-overloads/c_vpi.h
@@ -1,0 +1,11 @@
+
+void testC(vector a, float b, float c) {
+    printf("testC vector\n");
+}
+void testC(point a, float b, float c) {
+    printf("testC point\n");
+}
+void testC(int a, float b, float c) {
+    printf("testC int\n");
+}
+

--- a/testsuite/function-overloads/ref/out.txt
+++ b/testsuite/function-overloads/ref/out.txt
@@ -43,4 +43,7 @@ testD float
 testE color
 testE vector
 
+funcb.color
+funcb.float
+funcb.int
 

--- a/testsuite/function-overloads/ref/out.txt
+++ b/testsuite/function-overloads/ref/out.txt
@@ -42,6 +42,7 @@ testD float
 
 testE color
 testE vector
+testE vector
 
 funcb.color
 funcb.float

--- a/testsuite/function-overloads/ref/out.txt
+++ b/testsuite/function-overloads/ref/out.txt
@@ -1,3 +1,59 @@
+test.osl:177: warning: Ambiguous call to 'freturn ()'
+  Chosen function is:
+    test.osl:71	float freturn ()
+  Other candidates are:
+    test.osl:68	int freturn ()
+    test.osl:72	color freturn ()
+    test.osl:73	vector freturn ()
+    test.osl:69	point freturn ()
+    test.osl:74	normal freturn ()
+    test.osl:75	matrix freturn ()
+    test.osl:70	string freturn ()
+test.osl:178: warning: Ambiguous call to 'ireturn ()'
+  Chosen function is:
+    test.osl:80	int ireturn ()
+  Other candidates are:
+    test.osl:77	color ireturn ()
+    test.osl:81	vector ireturn ()
+    test.osl:78	point ireturn ()
+    test.osl:82	normal ireturn ()
+    test.osl:83	matrix ireturn ()
+    test.osl:79	string ireturn ()
+test.osl:179: warning: Ambiguous call to 'creturn ()'
+  Chosen function is:
+    test.osl:88	color creturn ()
+  Other candidates are:
+    test.osl:85	vector creturn ()
+    test.osl:87	point creturn ()
+    test.osl:86	normal creturn ()
+    test.osl:90	matrix creturn ()
+    test.osl:89	string creturn ()
+test.osl:180: warning: Ambiguous call to 'vreturn ()'
+  Chosen function is:
+    test.osl:93	vector vreturn ()
+  Other candidates are:
+    test.osl:92	point vreturn ()
+    test.osl:95	normal vreturn ()
+    test.osl:94	matrix vreturn ()
+    test.osl:96	string vreturn ()
+test.osl:181: warning: Ambiguous call to 'preturn ()'
+  Chosen function is:
+    test.osl:101	point preturn ()
+  Other candidates are:
+    test.osl:99	normal preturn ()
+    test.osl:100	matrix preturn ()
+    test.osl:98	string preturn ()
+test.osl:182: warning: Ambiguous call to 'nreturn ()'
+  Chosen function is:
+    test.osl:104	normal nreturn ()
+  Other candidates are:
+    test.osl:103	matrix nreturn ()
+    test.osl:105	string nreturn ()
+test.osl:183: warning: Ambiguous call to 'mreturn ()'
+  Chosen function is:
+    test.osl:107	matrix mreturn ()
+  Other candidates are:
+    test.osl:108	string mreturn ()
 Compiled test.osl -> test.oso
 testA int
 testB int
@@ -47,4 +103,13 @@ testE vector
 funcb.color
 funcb.float
 funcb.int
+
+freturn.float
+ireturn.int
+creturn.color
+vreturn.vector
+preturn.point
+nreturn.normal
+mreturn.matrix
+
 

--- a/testsuite/function-overloads/ref/out.txt
+++ b/testsuite/function-overloads/ref/out.txt
@@ -1,0 +1,46 @@
+Compiled test.osl -> test.oso
+testA int
+testB int
+testC int
+testD int
+testA int
+testB int
+testC int
+testD int2
+
+testA float
+testB float
+testC float
+testD float
+testA float
+testB float
+testC float
+testD float
+
+testD int
+testD int2
+testD float
+testD vector
+testD int
+testD int2
+testD float
+testD point
+testD int
+testD int2
+testD float
+testD color
+testD int
+testD int2
+testD float
+testD normal
+testD int
+testD int2
+testD float
+testD int
+testD int2
+testD float
+
+testE color
+testE vector
+
+

--- a/testsuite/function-overloads/run.py
+++ b/testsuite/function-overloads/run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+realruntest = runtest
+
+def runtest (command, *args, **kwargs) :
+    passed = True
+    for arg in  ("-DORDER_1 ", ""):
+        command =  oslc(arg + "test.osl")
+        command += testshade("-g 1 1 test")
+        if realruntest(command, *args, **kwargs):
+            passed = False
+    return not passed
+
+command = ""
+

--- a/testsuite/function-overloads/test.osl
+++ b/testsuite/function-overloads/test.osl
@@ -61,6 +61,10 @@ int testE(float a, int b, vector v) {
     return 4;
 }
 
+int   funcb() { printf("funcb.int\n");   return 1; }
+float funcb() { printf("funcb.float\n"); return 2; }
+color funcb() { printf("funcb.color\n"); return 3; }
+
 shader test ()
 {
   {
@@ -117,5 +121,11 @@ shader test ()
     testE(1, 1, color(0));
     testE(1, 1, vector(0));
     printf("\n");
+  }
+
+  {
+    (color) funcb();
+    (float) funcb();
+    (int) funcb();
   }
 }

--- a/testsuite/function-overloads/test.osl
+++ b/testsuite/function-overloads/test.osl
@@ -120,6 +120,7 @@ shader test ()
   {
     testE(1, 1, color(0));
     testE(1, 1, vector(0));
+    testE(1, 1, point(0));
     printf("\n");
   }
 

--- a/testsuite/function-overloads/test.osl
+++ b/testsuite/function-overloads/test.osl
@@ -65,6 +65,48 @@ int   funcb() { printf("funcb.int\n");   return 1; }
 float funcb() { printf("funcb.float\n"); return 2; }
 color funcb() { printf("funcb.color\n"); return 3; }
 
+int    freturn() { printf("freturn.int\n"); return 1; }
+point  freturn() { printf("freturn.point\n"); return 1; }
+string freturn() { printf("freturn.string\n"); return ""; }
+float  freturn() { printf("freturn.float\n"); return 1; }
+color  freturn() { printf("freturn.color\n"); return 1; }
+vector freturn() { printf("freturn.vector\n"); return 1; }
+normal freturn() { printf("freturn.normal\n"); return 1; }
+matrix freturn() { printf("freturn.matrix\n"); return 1; }
+
+color  ireturn() { printf("ireturn.color\n"); return 1; }
+point  ireturn() { printf("ireturn.point\n"); return 1; }
+string ireturn() { printf("ireturn.string\n"); return ""; }
+int    ireturn() { printf("ireturn.int\n"); return 1; }
+vector ireturn() { printf("ireturn.vector\n"); return 1; }
+normal ireturn() { printf("ireturn.normal\n"); return 1; }
+matrix ireturn() { printf("ireturn.matrix\n"); return 1; }
+
+vector creturn() { printf("creturn.vector\n"); return 1; }
+normal creturn() { printf("creturn.normal\n"); return 1; }
+point  creturn() { printf("creturn.point\n"); return 1; }
+color  creturn() { printf("creturn.color\n"); return 1; }
+string creturn() { printf("creturn.string\n"); return ""; }
+matrix creturn() { printf("creturn.matrix\n"); return 1; }
+
+point  vreturn() { printf("vreturn.point\n"); return 1; }
+vector vreturn() { printf("vreturn.vector\n"); return 1; }
+matrix vreturn() { printf("vreturn.matrix\n"); return 1; }
+normal vreturn() { printf("vreturn.normal\n"); return 1; }
+string vreturn() { printf("vreturn.string\n"); return ""; }
+
+string preturn() { printf("preturn.string\n"); return ""; }
+normal preturn() { printf("preturn.normal\n"); return 1; }
+matrix preturn() { printf("preturn.matrix\n"); return 1; }
+point  preturn() { printf("preturn.point\n"); return 1; }
+
+matrix nreturn() { printf("nreturn.matrix\n"); return 1; }
+normal nreturn() { printf("nreturn.normal\n"); return 1; }
+string nreturn() { printf("nreturn.string\n"); return ""; }
+
+matrix mreturn() { printf("mreturn.matrix\n"); return 1; }
+string mreturn() { printf("mreturn.string\n"); return ""; }
+
 shader test ()
 {
   {
@@ -128,5 +170,17 @@ shader test ()
     (color) funcb();
     (float) funcb();
     (int) funcb();
+    printf("\n");
+  }
+
+  {
+    freturn();
+    ireturn();
+    creturn();
+    vreturn();
+    preturn();
+    nreturn();
+    mreturn();
+    printf("\n");
   }
 }

--- a/testsuite/function-overloads/test.osl
+++ b/testsuite/function-overloads/test.osl
@@ -112,9 +112,10 @@ shader test ()
     float  f2 = testD(floatval(), 1, 1);
     printf("\n");
   }
+
   {
-    testE(1.0, 1, color(0));
-    testE(1, 1.0, vector(0));
+    testE(1, 1, color(0));
+    testE(1, 1, vector(0));
     printf("\n");
   }
 }

--- a/testsuite/function-overloads/test.osl
+++ b/testsuite/function-overloads/test.osl
@@ -1,0 +1,120 @@
+
+#ifdef ORDER_1
+  #include "a_fcn.h"
+  #include "b_nci.h"
+  #include "c_vpi.h"
+
+  #include "a_ivp.h"
+  #include "b_vpf.h"
+  #include "c_cnf.h"
+#else
+  #include "a_ivp.h"
+  #include "b_vpf.h"
+  #include "c_cnf.h"
+
+  #include "a_fcn.h"
+  #include "b_nci.h"
+  #include "c_vpi.h"
+#endif
+
+int intval() { return 0; }
+float floatval() { return 0.0; }
+
+
+normal testD(normal a, float b, float c) {
+    printf("testD normal\n");
+    return normal(0);
+}
+color testD(color a, float b, float c) {
+    printf("testD color\n");
+    return color(1);
+}
+vector testD(vector a, float b, float c) {
+    printf("testD vector\n");
+    return vector(2);
+}
+point testD(point a, float b, float c) {
+    printf("testD point\n");
+    return point(3);
+}
+int testD(int a, float b, float c) {
+    printf("testD int\n");
+    return 4;
+}
+float testD(float a, float b, float c) {
+    printf("testD float\n");
+    return 5;
+}
+
+// This would break C++
+int testD(int a, int b, float c) {
+    printf("testD int2\n");
+    return 4;
+}
+
+int testE(int a, float b, color s) {
+    printf("testE color\n");
+    return 4;
+}
+int testE(float a, int b, vector v) {
+    printf("testE vector\n");
+    return 4;
+}
+
+shader test ()
+{
+  {
+      testA(intval(), 1.0, 1.0);
+      testB(intval(), 1.0, 1.0);
+      testC(intval(), 1.0, 1.0);
+      testD(intval(), 1.0, 1.0);
+      testA(intval(), 1, 1);
+      testB(intval(), 1, 1);
+      testC(intval(), 1, 1);
+      testD(intval(), 1, 1);
+      printf("\n");
+  }
+
+  {
+      testA(floatval(), 1.0, 1.0);
+      testB(floatval(), 1.0, 1.0);
+      testC(floatval(), 1.0, 1.0);
+      testD(floatval(), 1.0, 1.0);
+      testA(floatval(), 1, 1);
+      testB(floatval(), 1, 1);
+      testC(floatval(), 1, 1);
+      testD(floatval(), 1, 1);
+      printf("\n");
+  }
+
+  {
+    vector v0 = testD(intval(), 1.0, 1.0);
+    vector v1 = testD(intval(), 1, 1);
+    vector v2 = testD(floatval(), 1, 1);
+    vector v3 = testD(vector(0), 1, 1);
+    point  p0 = testD(intval(), 1.0, 1.0);
+    point  p1 = testD(intval(), 1, 1);
+    point  p2 = testD(floatval(), 1, 1);
+    point  p3 = testD(point(0), 1, 1);
+    color  c0 = testD(intval(), 1.0, 1.0);
+    color  c1 = testD(intval(), 1, 1);
+    color  c2 = testD(floatval(), 1, 1);
+    color  c3 = testD(color(0), 1, 1);
+    normal n0 = testD(intval(), 1.0, 1.0);
+    normal n1 = testD(intval(), 1, 1);
+    normal n2 = testD(floatval(), 1, 1);
+    normal n3 = testD(normal(0), 1, 1);
+    int    i0 = testD(intval(), 1.0, 1.0);
+    int    i1 = testD(intval(), 1, 1);
+    int    i2 = (int) testD(floatval(), 1, 1);
+    float  f0 = testD(intval(), 1.0, 1.0);
+    float  f1 = testD(intval(), 1, 1);
+    float  f2 = testD(floatval(), 1, 1);
+    printf("\n");
+  }
+  {
+    testE(1.0, 1, color(0));
+    testE(1, 1.0, vector(0));
+    printf("\n");
+  }
+}

--- a/testsuite/isconstant/test.osl
+++ b/testsuite/isconstant/test.osl
@@ -4,5 +4,5 @@ shader test (float A = 1)
 {
     printf ("Is param A const? %d\n", isconstant(A));
     printf ("Is 2*A const? %d\n", isconstant(2*A));
-    printf ("Is noise(P) const? %d\n", isconstant(noise(P)));
+    printf ("Is noise(P) const? %d\n", isconstant((color)noise(P)));
 }

--- a/testsuite/oslc-err-funcoverload/ref/out.txt
+++ b/testsuite/oslc-err-funcoverload/ref/out.txt
@@ -14,9 +14,10 @@ test.osl:14: error: No matching function call to 'funca (int, float)'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
-test.osl:15: error: Ambiguous call to 'funcb'
-  Candidates are:
-    test.osl:7	color funcb ()
+test.osl:15: warning: Ambiguous call to 'funcb ()'
+  Chosen function is:
     test.osl:6	float funcb ()
+  Other candidates are:
     test.osl:5	int funcb ()
+    test.osl:7	color funcb ()
 FAILED test.osl

--- a/testsuite/oslc-err-funcoverload/ref/out.txt
+++ b/testsuite/oslc-err-funcoverload/ref/out.txt
@@ -1,0 +1,9 @@
+test.osl:8: error: No matching function call to 'funca ()'
+  Candidates are:
+    test.osl:3	void funca (int, int)
+    test.osl:2	void funca (int)
+test.osl:9: error: No matching function call to 'funca (int, int, int)'
+  Candidates are:
+    test.osl:3	void funca (int, int)
+    test.osl:2	void funca (int)
+FAILED test.osl

--- a/testsuite/oslc-err-funcoverload/ref/out.txt
+++ b/testsuite/oslc-err-funcoverload/ref/out.txt
@@ -1,17 +1,22 @@
-test.osl:8: error: No matching function call to 'funca ()'
+test.osl:11: error: No matching function call to 'funca ()'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
-test.osl:9: error: No matching function call to 'funca (int, int, int)'
+test.osl:12: error: No matching function call to 'funca (int, int, int)'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
-test.osl:10: error: No matching function call to 'funca (float, int)'
+test.osl:13: error: No matching function call to 'funca (float, int)'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
-test.osl:11: error: No matching function call to 'funca (int, float)'
+test.osl:14: error: No matching function call to 'funca (int, float)'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
+test.osl:15: error: Ambiguous call to 'funcb'
+  Candidates are:
+    test.osl:7	color funcb ()
+    test.osl:6	float funcb ()
+    test.osl:5	int funcb ()
 FAILED test.osl

--- a/testsuite/oslc-err-funcoverload/ref/out.txt
+++ b/testsuite/oslc-err-funcoverload/ref/out.txt
@@ -6,4 +6,12 @@ test.osl:9: error: No matching function call to 'funca (int, int, int)'
   Candidates are:
     test.osl:3	void funca (int, int)
     test.osl:2	void funca (int)
+test.osl:10: error: No matching function call to 'funca (float, int)'
+  Candidates are:
+    test.osl:3	void funca (int, int)
+    test.osl:2	void funca (int)
+test.osl:11: error: No matching function call to 'funca (int, float)'
+  Candidates are:
+    test.osl:3	void funca (int, int)
+    test.osl:2	void funca (int)
 FAILED test.osl

--- a/testsuite/oslc-err-funcoverload/run.py
+++ b/testsuite/oslc-err-funcoverload/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-funcoverload/test.osl
+++ b/testsuite/oslc-err-funcoverload/test.osl
@@ -5,7 +5,9 @@ void funca(int a, int b) {}
 
 shader test()
 {
-    funca();
-    funca(1,2,3);
+    funca();        // fail too few arguments
+    funca(1, 2, 3); // fail too many arguments
+    funca(1.0, 2);  // fail float -> int
+    funca(1, 2.0);  // fail float -> int
 }
 

--- a/testsuite/oslc-err-funcoverload/test.osl
+++ b/testsuite/oslc-err-funcoverload/test.osl
@@ -1,0 +1,11 @@
+
+void funca(int a) {}
+void funca(int a, int b) {}
+
+
+shader test()
+{
+    funca();
+    funca(1,2,3);
+}
+

--- a/testsuite/oslc-err-funcoverload/test.osl
+++ b/testsuite/oslc-err-funcoverload/test.osl
@@ -2,6 +2,9 @@
 void funca(int a) {}
 void funca(int a, int b) {}
 
+int funcb() { return 1; }
+float funcb() { return 2; }
+color funcb() { return 3; }
 
 shader test()
 {
@@ -9,5 +12,8 @@ shader test()
     funca(1, 2, 3); // fail too many arguments
     funca(1.0, 2);  // fail float -> int
     funca(1, 2.0);  // fail float -> int
+    funcb();        // fail unresolvable ambiguity
+
+    (int) funcb();  // ok
 }
 


### PR DESCRIPTION
## Description

OSL currently does not define how function overloads are chosen very well.
As such oslc can choose different overloads depending on the order of declaration.
This attempts to define how overloads are chosen in a more concrete way by scoring:

all arguments match without conversion
prefer spatial -> spatial conversion over spatial <-> color
prefer triple -> triple conversion over float -> triple promotion
use return type to resolve any possible ambiguities
more erring for unresolvable ambiguities

Adds more verbose warning/error messages showing location of ambiguous functions.
Adds **OSL_LEGACY_FUNCTION_RESOLUTION** environment variable so that changes in behavior can be ignored, reported, or reverted.

## Tests
**testsuite/function-overloads
testsuite/oslc-err-funcoverloads**

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.
