### PR TITLE
Force -Wall on Travis builds

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -64,8 +64,11 @@ endif ()
 # turn on more detailed warnings and consider warnings as errors
 if (NOT MSVC)
     add_definitions ("-Wall")
-    if (STOP_ON_WARNING)
+    if (STOP_ON_WARNING OR DEFINED ENV{CI})
         add_definitions ("-Werror")
+        # N.B. Force CI builds (Travis defines $CI) to use -Werror, even if
+        # STOP_ON_WARNING has been switched off by default, which we may do
+        # in release branches.
     endif ()
 endif ()
 


### PR DESCRIPTION
This makes it safe so that if we want to disable -Wall by default for *release* branches as part of the branching prep process (but never master!), we'll still catch any new warnings on the CI builds.
