### PR TITLE
Shader parameter metadata [[ int allowconnect = 0 ]]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ OSL Language and oslc compiler:
   #840 and windows path separators #849. #841 (1.10.0/1.9.7)
 * oslc: Fix bug/undefined behavior when trying to format/printf a struct.
   #849 #841 (1.10.0/1.9.7)
+* A shader input parameter marked with metadata `[[ int allowconnect = 0 ]]`
+  will disallow runtime connections via `ConnectShaders()`, resulting in an
+  error. (1.10.0)
 
 OSL Standard library:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,8 @@ endmacro ()
 if (OSL_BUILD_TESTS)
 # List all the individual testsuite tests here, except those that need
 # special installed tests.
-TESTSUITE ( and-or-not-synonyms aastep arithmetic array array-derivs array-range
+TESTSUITE ( aastep allowconnect-err and-or-not-synonyms
+            arithmetic array array-derivs array-range
             blackbody blendmath breakcont
             bug-array-heapoffsets
             bug-locallifetime bug-outputinit bug-param-duplicate bug-peep

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -476,7 +476,8 @@ public:
           m_symtype(symtype),
           m_has_derivs(false), m_const_initializer(false),
           m_connected_down(false),
-          m_initialized(false), m_lockgeom(false), m_renderer_output(false),
+          m_initialized(false), m_lockgeom(false), m_allowconnect(true),
+          m_renderer_output(false),
           m_valuesource(DefaultVal), m_free_data(false),
           m_fieldid(-1), m_layer(-1),
           m_scope(0), m_dataoffset(-1), m_initializers(0),
@@ -686,6 +687,9 @@ public:
     bool lockgeom () const { return m_lockgeom; }
     void lockgeom (bool lock) { m_lockgeom = lock; }
 
+    bool allowconnect () const { return m_allowconnect; }
+    void allowconnect (bool val) { m_allowconnect = val; }
+
     int  arraylen () const { return m_typespec.arraylength(); }
     void arraylen (int len) {
         m_typespec.make_array(len);
@@ -731,6 +735,7 @@ protected:
     unsigned m_connected_down:1;///< Connected to a later/downtream layer
     unsigned m_initialized:1;   ///< If a param, has it been initialized?
     unsigned m_lockgeom:1;      ///< Is the param not overridden by geom?
+    unsigned m_allowconnect:1;  ///< Is the param not overridden by geom?
     unsigned m_renderer_output:1; ///< Is this sym a renderer output?
     char m_valuesource;         ///< Where did the value come from?
     bool m_free_data;           ///< Free m_data upon destruction?

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -450,10 +450,11 @@ OSOReaderToMaster::hint (string_view hintstring)
     }
     if (extract_prefix (h, "%meta{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
-        int lockval = -1;
-        int ok = sscanf (h.c_str(), " int , lockgeom , %d", &lockval);
-        if (ok)
-            sym.lockgeom (lockval);
+        int ival = -1;
+        if (sscanf (h.c_str(), " int , lockgeom , %d", &ival))
+            sym.lockgeom (ival);
+        else if (sscanf (h.c_str(), " int , allowconnect , %d", &ival))
+            sym.allowconnect (ival);
     }
 }
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2067,6 +2067,16 @@ ShadingSystemImpl::ConnectShaders (string_view srclayer, string_view srcparam,
         return false;
     }
 
+    const Symbol *dstsym = dstinst->mastersymbol(dstcon.param);
+    ASSERT (dstsym);
+    if (dstsym && !dstsym->allowconnect()) {
+        std::string name = dstlayer.size() ? Strutil::format("%s.%s", dstlayer, dstparam)
+                                           : std::string(dstparam);
+        error ("ConnectShaders: cannot connect to %s because it has metadata allowconnect=0",
+               name);
+        return false;
+    }
+
     dstinst->add_connection (srcinstindex, srccon, dstcon);
     dstinst->instoverride(dstcon.param)->valuesource (Symbol::ConnectedVal);
     srcinst->instoverride(srccon.param)->connected_down (true);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1114,10 +1114,13 @@ test_shade (int argc, const char *argv[])
                       << " to " << connections[i+2] << "." << connections[i+3]
                       << "\n";
             synchio();
-            shadingsys->ConnectShaders (connections[i].c_str(),
-                                        connections[i+1].c_str(),
-                                        connections[i+2].c_str(),
-                                        connections[i+3].c_str());
+            bool ok = shadingsys->ConnectShaders (connections[i].c_str(),
+                                                  connections[i+1].c_str(),
+                                                  connections[i+2].c_str(),
+                                                  connections[i+3].c_str());
+            if (!ok) {
+                return EXIT_FAILURE;
+            }
         }
     }
 

--- a/testsuite/allowconnect-err/a.osl
+++ b/testsuite/allowconnect-err/a.osl
@@ -1,0 +1,9 @@
+shader a (float Kd = 0.5,
+          output float f_out = 0,
+          output color c_out = 0
+    )
+{
+    f_out = Kd;
+    c_out = color (Kd/2, 1, 1);
+    printf ("a: f_out = %g, c_out = %g\n", f_out, c_out);
+}

--- a/testsuite/allowconnect-err/b.osl
+++ b/testsuite/allowconnect-err/b.osl
@@ -1,0 +1,6 @@
+shader b (float f_in = 41 [[ int allowconnect = 0 ]],
+          color c_in = 42
+    )
+{
+    printf ("b: f_in = %g, c_in = %g\n", f_in, c_in);
+}

--- a/testsuite/allowconnect-err/ref/out.txt
+++ b/testsuite/allowconnect-err/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect alayer.f_out to blayer.f_in
+ERROR: ConnectShaders: cannot connect to blayer.f_in because it has metadata allowconnect=0

--- a/testsuite/allowconnect-err/run.py
+++ b/testsuite/allowconnect-err/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+failureok = True    # Expect an error
+command += testshade("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in")
+outputs = [ "out.txt" ]

--- a/testsuite/missing-shader/ref/out.txt
+++ b/testsuite/missing-shader/ref/out.txt
@@ -4,4 +4,3 @@ ERROR: No .oso file could be found for shader "bar"
 ERROR: Could not find shader "bar"
 Connect lay1.x to lay2.y
 ERROR: ConnectShaders: source layer "lay1" not found
-

--- a/testsuite/missing-shader/run.py
+++ b/testsuite/missing-shader/run.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
 
+failureok = True    # Expect an error
 command = testshade("-g 2 2 --layer lay1 foo --layer lay2 bar --connect lay1 x lay2 y")


### PR DESCRIPTION
If a shader input parameter has this metadata present and set to
nonzero, no incoming connections via ConnectShaders() will be accepted,
resulting in a runtime error if it is attempted.

