### PR TITLE
Tweak OIIO related deprecations

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -216,17 +216,12 @@ private:
     std::vector<Parameter> m_meta;     //< Meta-data about the shader
     friend class pvt::OSOReaderQuery;
 
-#if OIIO_VERSION >= 10803
     // Internal error reporting routine, with printf-like arguments.
     template<typename... Args>
     inline void error (string_view fmt, const Args&... args) const {
         append_error(OIIO::Strutil::format (fmt, args...));
     }
-#else
-    // Fallback for older OIIO
-    TINYFORMAT_WRAP_FORMAT (void, error, const,
-                            std::ostringstream msg;, msg, append_error(msg.str());)
-#endif
+
     void append_error (const std::string& message) const {
         if (m_error.size())
             m_error += '\n';

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -68,13 +68,8 @@ private:
 ScopeExit print_node_counts ([](){
     for (int i = 0; i < ASTNode::_last_node; ++i)
         if (node_counts[i] > 0)
-#if OIIO_VERSION >= (10000 * 1 + 100 * 8)
             Strutil::printf ("ASTNode type %2d: %5d   (peak %5d)\n",
                              i, node_counts[i], node_counts_peak[i]);
-#else
-            printf("ASTNode type %2d: %5d   (peak %5d)\n",
-                             i, node_counts[i].load(), node_counts_peak[i].load());
-#endif
 });
 }
 #endif
@@ -185,12 +180,7 @@ ASTNode::~ASTNode ()
 void
 ASTNode::error_impl (string_view msg) const
 {
-#if OIIO_VERSION >= 10803
     m_compiler->error (sourcefile(), sourceline(), "%s", msg);
-#else
-    // DEPRECATED -- delete when minimum OIIO is at least 1.8
-    m_compiler->error (sourcefile(), sourceline(), "%s", msg.c_str());
-#endif
 }
 
 
@@ -198,12 +188,7 @@ ASTNode::error_impl (string_view msg) const
 void
 ASTNode::warning_impl (string_view msg) const
 {
-#if OIIO_VERSION >= 10803
     m_compiler->warning (sourcefile(), sourceline(), "%s", msg);
-#else
-    // DEPRECATED -- delete when minimum OIIO is at least 1.8
-    m_compiler->warning (sourcefile(), sourceline(), "%s", msg.c_str());
-#endif
 }
 
 
@@ -211,12 +196,7 @@ ASTNode::warning_impl (string_view msg) const
 void
 ASTNode::info_impl (string_view msg) const
 {
-#if OIIO_VERSION >= 10803
     m_compiler->info (sourcefile(), sourceline(), "%s", msg);
-#else
-    // DEPRECATED -- delete when minimum OIIO is at least 1.8
-    m_compiler->info (sourcefile(), sourceline(), "%s", msg.c_str());
-#endif
 }
 
 
@@ -224,12 +204,7 @@ ASTNode::info_impl (string_view msg) const
 void
 ASTNode::message_impl (string_view msg) const
 {
-#if OIIO_VERSION >= 10803
     m_compiler->message (sourcefile(), sourceline(), "%s", msg);
-#else
-    // DEPRECATED -- delete when minimum OIIO is at least 1.8
-    m_compiler->message (sourcefile(), sourceline(), "%s", msg.c_str());
-#endif
 }
 
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -186,11 +186,7 @@ public:
     void error (string_view format, const Args&... args) const
     {
         DASSERT (format.size());
-#if OIIO_VERSION >= 10803
         error_impl (OIIO::Strutil::format (format, args...));
-#else /* DEPRECATE when OIIO minimum is at least 1.8 */
-        error_impl (OIIO::Strutil::format (format.c_str(), args...));
-#endif
     }
 
     /// Warning reporting
@@ -198,11 +194,7 @@ public:
     void warning (string_view format, const Args&... args) const
     {
         DASSERT (format.size());
-#if OIIO_VERSION >= 10803
         warning_impl (OIIO::Strutil::format (format, args...));
-#else /* DEPRECATE when OIIO minimum is at least 1.8 */
-        warning_impl (OIIO::Strutil::format (format.c_str(), args...));
-#endif
     }
 
     /// info reporting
@@ -210,11 +202,7 @@ public:
     void info (string_view format, const Args&... args) const
     {
         DASSERT (format.size());
-#if OIIO_VERSION >= 10803
         info_impl (OIIO::Strutil::format (format, args...));
-#else /* DEPRECATE when OIIO minimum is at least 1.8 */
-        info_impl (OIIO::Strutil::format (format.c_str(), args...));
-#endif
     }
 
     /// message reporting
@@ -222,11 +210,7 @@ public:
     void message (string_view format, const Args&... args) const
     {
         DASSERT (format.size());
-#if OIIO_VERSION >= 10803
         message_impl (OIIO::Strutil::format (format, args...));
-#else /* DEPRECATE when OIIO minimum is at least 1.8 */
-        message_impl (OIIO::Strutil::format (format.c_str(), args...));
-#endif
     }
 
     bool is_lvalue () const { return m_is_lvalue; }

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -1001,11 +1001,7 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename,
         // %argderivs documents which arguments have derivs taken of
         // them by the op.
         if (op.argtakesderivs_all()) {
-#if OIIO_VERSION >= 10803
             oso (" %%argderivs{");
-#else
-            oso (" %cargderivs{", '%');  // trick to work with older OIIO
-#endif
             int any = 0;
             for (int i = 0;  i < op.nargs();  ++i)
                 if (op.argtakesderivs(i)) {

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -104,19 +104,11 @@ public:
                 string_view format, const Args&... args) const
     {
         ASSERT (format.size());
-#if OIIO_VERSION >= 10804
         std::string msg = OIIO::Strutil::format (format, args...);
         if (filename.size())
             m_errhandler->error ("%s:%d: error: %s", filename, line, msg);
         else
             m_errhandler->error ("error: %s", msg);
-#else /* Deprecate when the OIIO minimum is 1.8 */
-        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
-        if (filename.size())
-            m_errhandler->error ("%s:%d: error: %s", filename.c_str(), line, msg.c_str());
-        else
-            m_errhandler->error ("error: %s", msg.c_str());
-#endif
         m_err = true;
     }
 
@@ -126,19 +118,11 @@ public:
                   string_view format, const Args&... args) const
     {
         ASSERT (format.size());
-#if OIIO_VERSION >= 10804
         std::string msg = OIIO::Strutil::format (format, args...);
         if (filename.size())
             m_errhandler->warning ("%s:%d: warning: %s", filename, line, msg);
         else
             m_errhandler->warning ("warning: %s", msg);
-#else /* Deprecate when the OIIO minimum is 1.8 */
-        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
-        if (filename.size())
-            m_errhandler->warning ("%s:%d: warning: %s", filename.c_str(), line, msg.c_str());
-        else
-            m_errhandler->warning ("warning: %s", msg.c_str());
-#endif
     }
 
     /// Info reporting
@@ -147,19 +131,11 @@ public:
                   string_view format, const Args&... args) const
     {
         ASSERT (format.size());
-#if OIIO_VERSION >= 10804
         std::string msg = OIIO::Strutil::format (format, args...);
         if (filename.size())
             m_errhandler->info ("%s:%d: info: %s", filename, line, msg);
         else
             m_errhandler->info ("info: %s", msg);
-#else /* Deprecate when the OIIO minimum is 1.8 */
-        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
-        if (filename.size())
-            m_errhandler->info ("%s:%d: info: %s", filename.c_str(), line, msg.c_str());
-        else
-            m_errhandler->info ("info: %s", msg.c_str());
-#endif
     }
 
     /// message reporting
@@ -168,19 +144,11 @@ public:
                   string_view format, const Args&... args) const
     {
         ASSERT (format.size());
-#if OIIO_VERSION >= 10804
         std::string msg = OIIO::Strutil::format (format, args...);
         if (filename.size())
             m_errhandler->message ("%s:%d: %s", filename, line, msg);
         else
             m_errhandler->message ("%s", msg);
-#else /* Deprecate when the OIIO minimum is 1.8 */
-        std::string msg = OIIO::Strutil::format (format.c_str(), args...);
-        if (filename.size())
-            m_errhandler->message ("%s:%d: %s", filename.c_str(), line, msg.c_str());
-        else
-            m_errhandler->message ("%s", msg.c_str());
-#endif
     }
 
     /// Have we hit an error?
@@ -408,14 +376,10 @@ private:
     void write_oso_symbol (const Symbol *sym);
     void write_oso_metadata (const ASTNode *metanode) const;
 
-#if OIIO_VERSION >= 10803
     template<typename... Args>
     inline void oso (string_view fmt, const Args&... args) const {
         (*m_osofile) << OIIO::Strutil::format (fmt, args...);
     }
-#else
-    TINYFORMAT_WRAP_FORMAT (void, oso, const, , (*m_osofile), )
-#endif
 
     void track_variable_lifetimes () {
         track_variable_lifetimes (m_ircode, m_opargs, symtab().allsyms());

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -246,11 +246,7 @@ ShaderInstance::parameters (const ParamValueList &params)
 
             if (master()->shadingsys().relaxed_param_typecheck()) {
                 // first handle cases where we actually need to modify the data (like setting a float parameter with an int)
-#if OIIO_VERSION >= 10804
                  if ((paramtype == TypeDesc::FLOAT || paramtype.is_vec3()) && valuetype.basetype == TypeDesc::INT && valuetype.basevalues() == 1) {
-#else
-                 if ((paramtype == TypeDesc::FLOAT || paramtype.is_vec3()) && valuetype.basetype == TypeDesc::INT && valuetype.numelements()*valuetype.aggregate == 1) {
-#endif
                     int val = *static_cast<const int*>(p.data());
                     float conv = float(val);
                     if (val != int(conv))
@@ -268,19 +264,11 @@ ShaderInstance::parameters (const ParamValueList &params)
                 //   * if paramtype is sized (or not an array) just check for the total number of entries
                 //   * if paramtype is unsized (shader writer is flexible about how many values come in) -- make sure we are a multiple of the target type
                 //   * allow a single float setting a vec3 (or equivalent)
-#if OIIO_VERSION >= 10804
                 if (!( valuetype.basetype == paramtype.basetype &&
                       !valuetype.is_unsized_array() &&
                       ((!paramtype.is_unsized_array() && valuetype.basevalues() == paramtype.basevalues()) ||
                        ( paramtype.is_unsized_array() && valuetype.basevalues() % paramtype.aggregate == 0) ||
                        ( paramtype.is_vec3()          && valuetype == TypeDesc::FLOAT) ) )) {
-#else
-                if (!( valuetype.basetype == paramtype.basetype &&
-                      !valuetype.is_unsized_array() &&
-                      ((!paramtype.is_unsized_array() && valuetype.numelements()*valuetype.aggregate == paramtype.numelements()*paramtype.aggregate) ||
-                       ( paramtype.is_unsized_array() && valuetype.numelements()*valuetype.aggregate % paramtype.aggregate == 0) ||
-                       ( paramtype.is_vec3()          && valuetype == TypeDesc::FLOAT) ) )) {
-#endif
                     // We are being very relaxed in this mode, so if the user _still_ got it wrong
                     // something more serious is at play and we should treat it as an error.
                     shadingsys().error ("attempting to set parameter from incompatible type: %s (expected '%s', received '%s')",

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -522,7 +522,6 @@ public:
 
     // Internal error, warning, info, and message reporting routines that
     // take printf-like arguments.
-#if OIIO_VERSION >= 10803
     template<typename T1, typename... Args>
     inline void error (string_view fmt, const T1& v1, const Args&... args) const {
         error (Strutil::format (fmt, v1, args...));
@@ -546,20 +545,6 @@ public:
         message (Strutil::format (fmt, v1, args...));
     }
     void message (const std::string &message) const;
-#else
-    TINYFORMAT_WRAP_FORMAT (void, error, const,
-                            std::ostringstream msg;, msg, error(msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, warning, const,
-                            std::ostringstream msg;, msg, warning(msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, info, const,
-                            std::ostringstream msg;, msg, info(msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, message, const,
-                            std::ostringstream msg;, msg, message(msg.str());)
-    void error (const std::string &message) const;
-    void warning (const std::string &message) const;
-    void info (const std::string &message) const;
-    void message (const std::string &message) const;
-#endif
 
     std::string getstats (int level=1) const;
 
@@ -1780,7 +1765,6 @@ public:
     // Process all the recorded errors, warnings, printfs
     void process_errors () const;
 
-#if OIIO_VERSION >= 10803
     template<typename... Args>
     inline void error (string_view fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_ERROR, Strutil::format (fmt, args...));
@@ -1800,20 +1784,6 @@ public:
     inline void message (string_view fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_MESSAGE, Strutil::format (fmt, args...));
     }
-#else
-    TINYFORMAT_WRAP_FORMAT (void, error, const,
-                            std::ostringstream msg;, msg,
-                            record_error(ErrorHandler::EH_ERROR, msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, warning, const,
-                            std::ostringstream msg;, msg,
-                            record_error(ErrorHandler::EH_WARNING, msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, info, const,
-                            std::ostringstream msg;, msg,
-                            record_error(ErrorHandler::EH_INFO, msg.str());)
-    TINYFORMAT_WRAP_FORMAT (void, message, const,
-                            std::ostringstream msg;, msg,
-                            record_error(ErrorHandler::EH_MESSAGE, msg.str());)
-#endif
 
 private:
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -154,16 +154,11 @@ public:
     int turn_into_nop (int begin, int end, string_view why=NULL);
 
     void debug_opt_impl (string_view message) const;
-#if OIIO_VERSION >= 10803
+
     template<typename... Args>
     inline void debug_opt (string_view fmt, const Args&... args) const {
         debug_opt_impl (Strutil::format (fmt, args...));
     }
-#else
-    TINYFORMAT_WRAP_FORMAT (void, debug_opt, const,
-                            std::ostringstream msg;, msg,
-                            debug_opt_impl(msg.str());)
-#endif
 
     void debug_opt_ops (int opbegin, int opend, string_view message) const;
     void debug_turn_into (const Opcode &op, int numops,

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -87,15 +87,9 @@ public:
     OSLInput ();
     virtual ~OSLInput ();
     virtual const char * format_name (void) const { return "osl"; }
-#if OPENIMAGEIO_VERSION >= 10600
     virtual int supports (string_view feature) const {
         return (feature == "procedural");
     }
-#else  /* Remove the following when OIIO <= 1.5 is no longer needed */
-    virtual bool supports (const std::string& feature) const {
-        return (feature == "procedural");
-    }
-#endif
     virtual bool valid_file (const std::string &filename) const;
     virtual bool open (const std::string &name, ImageSpec &newspec);
     virtual bool open (const std::string &name, ImageSpec &newspec,

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -313,12 +313,7 @@ action_param (int argc, const char *argv[])
                    &f[0], &f[1], &f[2], &f[3],
                    &f[4], &f[5], &f[6], &f[7], &f[8], &f[9], &f[10], &f[11],
                    &f[12], &f[13], &f[14], &f[15]) == 16) {
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, TypeDesc::TypeMatrix, 1, f);
-#else
-        params.push_back (ParamValue());
-        params.back().init (paramname, TypeDesc::TypeMatrix, 1, f);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -328,12 +323,7 @@ action_param (int argc, const char *argv[])
         && sscanf (stringval.c_str(), "%g, %g, %g", &f[0], &f[1], &f[2]) == 3) {
         if (type == TypeDesc::UNKNOWN)
             type = TypeDesc::TypeVector;
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, f);
-#else
-        params.push_back (ParamValue());
-        params.back().init (paramname, type, 1, f);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -342,13 +332,7 @@ action_param (int argc, const char *argv[])
     // string.
     if ((type == TypeDesc::UNKNOWN || type == TypeDesc::TypeInt)
           && OIIO::Strutil::string_is<int>(stringval)) {
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, OIIO::Strutil::from_string<int>(stringval));
-#else
-        params.push_back (ParamValue());
-        int i = OIIO::Strutil::from_string<int>(stringval);
-        params.back().init (paramname, TypeDesc::TypeInt, 1, &i);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -357,13 +341,7 @@ action_param (int argc, const char *argv[])
     // whole string.
     if ((type == TypeDesc::UNKNOWN || type == TypeDesc::TypeFloat)
           && OIIO::Strutil::string_is<float>(stringval)) {
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, OIIO::Strutil::from_string<float>(stringval));
-#else
-        params.push_back (ParamValue());
-        float f = OIIO::Strutil::from_string<float>(stringval);
-        params.back().init (paramname, TypeDesc::TypeFloat, 1, &f);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -377,12 +355,7 @@ action_param (int argc, const char *argv[])
             OIIO::Strutil::parse_float (stringval, vals[i]);
             OIIO::Strutil::parse_char (stringval, ',');
         }
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &vals[0]);
-#else
-        params.push_back (ParamValue());
-        params.back().init (paramname, type, 1, &vals[0]);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -396,12 +369,7 @@ action_param (int argc, const char *argv[])
             OIIO::Strutil::parse_int (stringval, vals[i]);
             OIIO::Strutil::parse_char (stringval, ',');
         }
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &vals[0]);
-#else
-        params.push_back (ParamValue());
-        params.back().init (paramname, type, 1, &vals[0]);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -415,12 +383,7 @@ action_param (int argc, const char *argv[])
         std::vector<ustring> strelements;
         for (auto&& s : splitelements)
             strelements.push_back (ustring(s));
-#if OIIO_VERSION >= 10804
         params.emplace_back (paramname, type, 1, &strelements[0]);
-#else
-        params.push_back (ParamValue());
-        params.back().init (paramname, type, 1, &strelements[0]);
-#endif
         if (unlockgeom)
             params.back().interp (ParamValue::INTERP_VERTEX);
         return;
@@ -428,12 +391,7 @@ action_param (int argc, const char *argv[])
 
     // All remaining cases -- it's a string
     const char *s = stringval.c_str();
-#if OIIO_VERSION >= 10804
     params.emplace_back (paramname, TypeDesc::TypeString, 1, &s);
-#else
-    params.push_back (ParamValue());
-    params.back().init (paramname, TypeDesc::TypeString, 1, &s);
-#endif
     if (unlockgeom)
         params.back().interp (ParamValue::INTERP_VERTEX);
 }


### PR DESCRIPTION
For some time, the current master had advertised that it requires OIIO >= 1.8. This patch simplify code by removing #if clauses related to OIIO versions older than that.

