### PR TITLE
Fixes for LLVM 6.0

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -30,6 +30,10 @@ ifeq ($(SP_OS), rhel7)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.1_rc2/bin/clang \
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.1_rc2/bin/clang++
+    else ifeq (${COMPILER}, clang6)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.0_rc2/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.0_rc2/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc490)

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -43,7 +43,7 @@ namespace llvm {
   class ExecutionEngine;
   class Function;
   class FunctionType;
-  class JITMemoryManager;
+  class SectionMemoryManager;
   class Linker;
   class LLVMContext;
   class Module;
@@ -503,7 +503,7 @@ private:
     llvm::LLVMContext *m_llvm_context;
     llvm::Module *m_llvm_module;
     IRBuilder *m_builder;
-    MemoryManager *m_llvm_jitmm;
+    llvm::SectionMemoryManager *m_llvm_jitmm;
     llvm::Function *m_current_function;
     llvm::legacy::PassManager *m_llvm_module_passes;
     llvm::legacy::FunctionPassManager *m_llvm_func_passes;


### PR DESCRIPTION
Fix some aspects of the MemoryManger interface that have changed in LLVM 6.0+. LLVM was technically source compatible, but because we release our memory managers via a global variable, we were being subjected to destruction order fiasco.

Work around this by implementing our own `MemoryMapper` (an exact clone of LLVM's).


There was also some confusing casting going on between our internal `MemoryManager` and the real llvm one which I refactored to be more clear.