### PR TITLE
Warning fixes and general cleanup to recently added typecheck code

### DIFF
--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -105,6 +105,8 @@ public:
     {
         ASSERT (format.size());
         std::string msg = OIIO::Strutil::format (format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
         if (filename.size())
             m_errhandler->error ("%s:%d: error: %s", filename, line, msg);
         else
@@ -119,6 +121,8 @@ public:
     {
         ASSERT (format.size());
         std::string msg = OIIO::Strutil::format (format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
         if (m_err_on_warning) {
             error (filename, line, "%s", msg);
             return;
@@ -136,6 +140,8 @@ public:
     {
         ASSERT (format.size());
         std::string msg = OIIO::Strutil::format (format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
         if (filename.size())
             m_errhandler->info ("%s:%d: info: %s", filename, line, msg);
         else
@@ -149,6 +155,8 @@ public:
     {
         ASSERT (format.size());
         std::string msg = OIIO::Strutil::format (format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
         if (filename.size())
             m_errhandler->message ("%s:%d: %s", filename, line, msg);
         else


### PR DESCRIPTION
The most important change here is to modify the practice making
multi-line warnings/errors by issuing a warning/error for the first line
followed by message() calls for the subsequent line.  Instead, we
generate those line-by-line messages as strings, and at the very end
issue a single warning or error call.

Also, directly call m_compiler->warning or error, don't bypass the
compiler by calling the app's error handler.

The reason both of those are important is that I have a separate change
I am ready to submit that is about giving a `#pragma nowarn` that can be
used to suppress warnings on the following line. This is totally borked
by warnings that span multiple calls and where most of their output is
in the form of message() and thus aren't easily recognized as part of
the warning.

This includes some general stylistic cleanup also in a few spots, some
preferences I have but but did not feel was worth nit picking line by
line in the original PRs.

