### PR TITLE
Improve oslc error reporting

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -420,7 +420,7 @@ class ASTfunction_declaration : public ASTNode
 {
 public:
     ASTfunction_declaration (OSLCompilerImpl *comp, TypeSpec type, ustring name,
-                             ASTNode *form, ASTNode *stmts, ASTNode *meta=NULL,
+                             ASTNode *form, ASTNode *stmts, ASTNode *meta,
                              int sourceline_start=-1);
     const char *nodetypename () const { return "function_declaration"; }
     const char *childname (size_t i) const;
@@ -450,9 +450,9 @@ class ASTvariable_declaration : public ASTNode
 {
 public:
     ASTvariable_declaration (OSLCompilerImpl *comp, const TypeSpec &type,
-                             ustring name, ASTNode *init, bool isparam=false,
-                             bool ismeta=false, bool isoutput=false,
-                             bool initlist=false);
+                             ustring name, ASTNode *init, bool isparam,
+                             bool ismeta, bool isoutput,
+                             bool initlist, int sourceline_start=-1);
     const char *nodetypename () const;
     const char *childname (size_t i) const;
     void print (std::ostream &out, int indentlevel=0) const;


### PR DESCRIPTION
For many grammatical constructs, the "source line" recorded in the AST
node is where the grammatical case ENDS. As an example,

    1:  shader foo (int holdout
    2:                    =
    3:                    1)
    4:  { }

There is a warning because 'holdout' masks another symbol at the same
scope. You would think the warning should be reported as occurring on
line 1, but it is reported for line 3, because that's where the clause
ends.

This will tend to happen for grammatical constructs that look like

     ANCHOR potentially-long-expression-that-may-span-lines

where any sensible person would want the warning associated this to be
on the line of the anchor, not wherever the long expression happens to
end.

In this patch, I carefully fix a whole lot of these grammatical
constructs to patch the 'sourceline' of the AST node they create with
the line that a particular anchor symbol is on.

There's a bit of extra work for ASTvariable_declaration, because there
are some errors (for duplicate symbols, etc.) that happen in the
constructor itself, so it's too late to return from the constructor and
then reset the source line; the misleading error has already been
issued.  So in that case, I added a line override parameter to the ctr
itself, mimicking the solution I implemented some time back for a
similar situation with function declarations.

