### PR TITLE
Fix confusing argument order issue for testshade

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -120,8 +120,6 @@ inject_params ()
 static void
 set_shadingsys_options ()
 {
-    if (shadingsys_options_set)
-        return;
     shadingsys->attribute ("debug", debug2 ? 2 : (debug ? 1 : 0));
     shadingsys->attribute ("compile_report", debug|debug2);
     int opt = 2;  // default
@@ -419,8 +417,8 @@ action_groupspec (int argc, const char *argv[])
         // If it names a file, use the contents of the file as the group
         // specification.
         OIIO::Filesystem::read_text_file (groupspec, groupspec);
-        set_shadingsys_options ();
     }
+    set_shadingsys_options ();
     if (verbose)
         std::cout << "Processing group specification:\n---\n"
                   << groupspec << "\n---\n";
@@ -1061,6 +1059,10 @@ test_shade (int argc, const char *argv[])
         std::cerr << "ERROR: Invalid shader group. Exiting testshade.\n";
         return EXIT_FAILURE;
     }
+
+    // Set shading sys options again, in case late-encountered command line
+    // options change their values.
+    set_shadingsys_options ();
 
     shadingsys->attribute (shadergroup.get(), "groupname", groupname);
 

--- a/testsuite/groupstring/ref/out-noopt.txt
+++ b/testsuite/groupstring/ref/out-noopt.txt
@@ -1,0 +1,27 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Processing group specification:
+---
+shader a alayer, shader b blayer, connect alayer.f_out blayer.f_in, connect alayer.c_out blayer.c_in
+---
+Shader group:
+---
+shader a alayer ;
+shader b blayer ;
+connect alayer.f_out blayer.f_in ;
+connect alayer.c_out blayer.c_in ;
+
+---
+
+Shader group "" layers are:
+    alayer
+	float Kd
+	output float f_out
+	output color c_out
+    blayer
+	float f_in
+	color c_in
+
+a: f_out = 0.5, c_out = 0.25 1 1
+b: f_in = 0.5, c_in = 0.25 1 1
+


### PR DESCRIPTION
testshade set certain command line options as a by-product of certain
other ones, and that introduced a weird order dependency to the arguments
that was confusing. In particular,

    testshade -O0 myshader

worked as expected, but

    testshade myshader -O0

set the options (including optimization level) when parsing myshader,
before it got to the -O0.

So this patch simply makes sure that the shader options are
re-established after all arguments are parsed.
