### PR TITLE
Errors for writing to read-only function parameters or globals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,21 @@
-Release 1.10? -- ?? 2018? (compared to 1.9)
+Release 1.10? -- ?? 2018 (compared to 1.9)
 --------------------------------------------------
 Dependency and standards changes:
-* **LLVM 4.0 / 5.0 / 6.0**: Support has been removed for LLVM 3.x.
+* **LLVM 4.0 / 5.0 / 6.0**: Support has been removed for LLVM 3.x,
+  added for 6.0.
 * **OpenImageIO 1.8+**: This release of OSL should build properly against
   OIIO 1.8 or newer. Support has been dropped for OIIO 1.7.
+
+New back-end targets:
+* **OptiX** Work in progress: Experimental back end for NVIDIA OptiX GPU ray
+  tracing toolkit. #861
+    - Build with USE_OPTIX=1
+    - Requires OptiX 5.0+, Cuda 8.0+, OpenImageIO 1.8.10+, LLVM >= 5.0 with
+      PTX target enabled.
+    - New utility **testoptix** is an example of a simple OptiX renderer
+      that uses OSL for shaders.
+    * Work is in progress to support the majority of OSL, but right now it
+      is restricted to a small subset.
 
 New tools:
 * **osltoy** : GUI tool for interactive shader editing and pattern
@@ -15,6 +27,22 @@ New tools:
   Doxygen, but markdeep!) Experimental, caveat emptor. #842 (1.10.0)
 
 OSL Language and oslc compiler:
+* C++11 style Initializer lists. (#838) This lets you have constructs like
+
+        // pass a {} list as a triple, matrix, or struct
+        void func (point p);
+        func ({x, y, z});
+
+        // Assign {} to a struct if the types match up
+        struct vec2 { float x, y; };
+        vec2 v = {a,b};
+
+        // Compact 'return' notation, it knows to construct the return type
+        vec2 func (float a, float b)
+        {
+            return {a, b};
+        }
+
 * osl now warns when it detects duplicate declarations of functions with
   the exact same argument list, in the same scope. #746
 * Fix oslc crash with invalid field selection syntax. #835 (1.10.0/1.9.6)
@@ -38,9 +66,12 @@ OSL Language and oslc compiler:
   will disallow runtime connections via `ConnectShaders()`, resulting in an
   error. #857 (1.10.0)
 * oslc command-line argument `-Werror` will treat all warnings as hard
-  errors (failed compilation). (1.10.0)
-* `#pragma nowarn` will suppress any warnings arising from code on the
-  immediately following line of that source file. (1.10.0)
+  errors (failed compilation). #862 (1.10.0)
+* `#pragma osl nowarn` will suppress any warnings arising from code on the
+  immediately following line of that source file. #864 (1.10.0)
+* oslc error reporting is improved, many multi-line syntactic constructs
+  will report errors in a more intuitive, easy-to-understand line number.
+  #867 (1.10.0)
 
 OSL Standard library:
 
@@ -85,12 +116,19 @@ Build & test system improvements:
   minimize build breaks for users when a new compiler warning is hit. We
   still enable it in development/master branches as well as any CI build
   in any branch. #850 (1.10.0/1.9.7)
+* Testsuite is now Python 2/3 agnostic. #873 (1.10.0)
+* Build the version into the shared library .so names. #876
+  (1.8.13/1.9.8/1.10.0)
 
 Developer goodies:
 
 Documentation:
 * `osltoy` documentations in `doc/osltoy.md.html` (1.10.0).
 
+
+Release 1.9.8 -- 1 Apr 2018 (compared to 1.9.7)
+-----------------------------------------------
+* Build the version into the shared library .so names. #876 (1.8.13/1.9.8)
 
 Release 1.9.7 -- 1 Feb 2018 (compared to 1.9.6)
 -----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,8 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-closuremul oslc-err-field
             oslc-err-format oslc-err-funcoverload
-            oslc-err-intoverflow oslc-err-noreturn oslc-err-notfunc
+            oslc-err-intoverflow oslc-err-write-nonoutput
+            oslc-err-noreturn oslc-err-notfunc
             oslc-err-initlist-args oslc-err-initlist-return
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ adding OSL support):
 * [DNA Research: 3Delight](http://www.3delight.com/)
 * Ubisoft motion picture group's proprietary renderer
 * [Autodesk/SolidAngle: Arnold](https://www.solidangle.com/arnold/)
+* [Autodesk: 3DS Max 2019](https://help.autodesk.com/view/3DSMAX/2019/ENU/?guid=__developer_3ds_max_sdk_features_rendering_osl_html)
 
 Films using OSL (grouped by year of release date):
 * **(2012)**
@@ -276,8 +277,10 @@ Films using OSL (grouped by year of release date):
   Suicide Squad,
   Kingsglaive: Final Fantasy XV,
   Storks,
-  Miss Peregrine's Home for Peculiar Children, Assassin's Creed
-* **(2017) / upcoming**
+  Miss Peregrine's Home for Peculiar Children,
+  Fantastic Beasts and Where to Find Them,
+  Assassin's Creed
+* **(2017)**
   Lego Batman,
   The Great Wall,
   A Cure for Wellness,
@@ -302,6 +305,13 @@ Films using OSL (grouped by year of release date):
   Geostorm,
   Coco,
   Justice League,
+  Thor: Ragnarok
+* **(2018) / upcoming**
+  Peter Rabbit,
+  Black Panther,
+  Annnihilation,
+  Red Sparrow,
+  Pacific Rom Uprising
   ...
 
 
@@ -343,13 +353,12 @@ Van Lommel.
 Additionally, many others have contributed features, bug fixes, and other
 changes: Steve Agland, Shane Ambler, Martijn Berger, Farchad Bidgolirad,
 Nicholas Bishop, Stefan Büttner, Matthaus G. Chajdas, Thomas Dinges, Mark
-Final, Henri Fousse, Syoyo Fujita, Derek Haase, Sven-Hendrik Haase, John
-Haddon, Daniel Heckenberg, Ronan Keryell, Elvic Liang, Max Liani, Bastien
-
-Montagne, Alexis Oblet, Erich Ocean, Mikko Ohtamaa, Alex Schworer, Jonathan
-Scruggs, Sergey Sharybin, Stephan Steinbach, Esteban Tovagliari, Alexander
-von Knorring, Roman Zulak. (Listed alphabetically; if we've left anybody
-out, please let us know.)
+Final, Henri Fousse, Syoyo Fujita, Tim Grant, Derek Haase, Sven-Hendrik
+Haase, John Haddon, Daniel Heckenberg, Matt Johnson, Ronan Keryell, Elvic
+Liang, Max Liani, Bastien Montagne, Alexis Oblet, Erich Ocean, Mikko
+Ohtamaa, Alex Schworer, Jonathan Scruggs, Sergey Sharybin, Stephan
+Steinbach, Esteban Tovagliari, Alexander von Knorring, Roman Zulak. (Listed
+alphabetically; if we've left anybody out, please let us know.)
 
 We cannot possibly express sufficient gratitude to the managers at Sony
 Pictures Imageworks who allowed this project to proceed, supported it

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -60,8 +60,8 @@ Language Specification
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 30 Jun 2017 \\
- (with corrections, 17 Jan 2018)
+\date{{\large Date: 31 Mar 2018 \\
+% (with corrections, 31 Mar 2018)
 }
 \bigskip
 \bigskip
@@ -2059,6 +2059,22 @@ you can construct built-in types like \color or \point:
 
     // pass constructor expression as a parameter:
     RGBA d = add (c, RGBA(color(.3,.4,.5), 0));
+\end{code}
+
+\NEW % 1.10
+You may also use the \emph{compound initializer list} syntax to construct a
+type when it can be deduced from context which compound type is required.
+For example, this is equivalent to the preceding example:
+
+\begin{code}
+    RGBA c = {col,alpha};    // deduce by what is being assigned to
+
+    RGBA add (RGBA a, RGBA b)
+    {
+        return { a.rgb+b.rgb, a.a+b.a }; // deduce by func return type
+    }
+
+    RGBA d = add (c, {{.3,.4,.5}, 0}); // deduce by expected arg type
 \end{code}
 
 It is permitted to have a structure field that is an array, as well as to
@@ -4200,6 +4216,14 @@ The first channel to look up from the texture map (default: 0).
 \apiend
 \vspace{-16pt}
 
+\apiitem{"subimage", <int> \\
+"subimage", <string>}
+\vspace{12pt}
+Specify the subimage (by numerical index, or name) of the subimage
+within a multi-image texture file (default: subimage 0).
+\apiend
+\vspace{-16pt}
+
 \apiitem{"fill", <float>}
 \vspace{12pt}
 The value to return for any channels that are requested,
@@ -5431,6 +5455,7 @@ nothing (empty, no token).
 \alt <ternary-expression>
 \alt <typecast-expression>
 \alt <variable-ref>
+\alt <compound-initializer>
 
 <compound-expression> ::= <expression> \{ "," <expression> \}
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -477,7 +477,7 @@ public:
           m_has_derivs(false), m_const_initializer(false),
           m_connected_down(false),
           m_initialized(false), m_lockgeom(false), m_allowconnect(true),
-          m_renderer_output(false),
+          m_renderer_output(false), m_readonly(false),
           m_valuesource(DefaultVal), m_free_data(false),
           m_fieldid(-1), m_layer(-1),
           m_scope(0), m_dataoffset(-1), m_initializers(0),
@@ -699,6 +699,9 @@ public:
     bool renderer_output () const { return m_renderer_output; }
     void renderer_output (bool v) { m_renderer_output = v; }
 
+    bool readonly () const { return m_readonly; }
+    void readonly (bool v) { m_readonly = v; }
+
     bool is_constant () const { return symtype() == SymTypeConst; }
     bool is_temp () const { return symtype() == SymTypeTemp; }
 
@@ -737,6 +740,7 @@ protected:
     unsigned m_lockgeom:1;      ///< Is the param not overridden by geom?
     unsigned m_allowconnect:1;  ///< Is the param not overridden by geom?
     unsigned m_renderer_output:1; ///< Is this sym a renderer output?
+    unsigned m_readonly:1;      ///< read-only symbol
     char m_valuesource;         ///< Where did the value come from?
     bool m_free_data;           ///< Free m_data upon destruction?
     short m_fieldid;            ///< Struct field of this var (or -1)

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -365,6 +365,11 @@ protected:
 	codegen_aassign (TypeSpec elemtype, Symbol *src, Symbol *lval,
                      Symbol* index, int i = 0);
 
+    // Check whether the node's symbol destination is ok to write. Return
+    // true if ok, return false and issue error or warning if not. (Used to
+    // check for writing to read-only variables like non-output parameters.)
+    bool check_symbol_writeability (ASTNode *var);
+
     // Helper for param_default_literals: generate the string that gives
     // the initialization of the literal value (and/or the default, if
     // init==NULL) and append it to 'out'.  Return whether the full
@@ -523,9 +528,7 @@ private:
 class ASTpreincdec : public ASTNode
 {
 public:
-    ASTpreincdec (OSLCompilerImpl *comp, int op, ASTNode *expr)
-        : ASTNode (preincdec_node, comp, op, expr)
-    { }
+    ASTpreincdec (OSLCompilerImpl *comp, int op, ASTNode *expr);
     const char *nodetypename () const { return m_op==Incr ? "preincrement" : "predecrement"; }
     const char *childname (size_t i) const;
     TypeSpec typecheck (TypeSpec expected);
@@ -539,9 +542,7 @@ public:
 class ASTpostincdec : public ASTNode
 {
 public:
-    ASTpostincdec (OSLCompilerImpl *comp, int op, ASTNode *expr)
-        : ASTNode (postincdec_node, comp, op, expr)
-    { }
+    ASTpostincdec (OSLCompilerImpl *comp, int op, ASTNode *expr);
     const char *nodetypename () const { return m_op==Incr ? "postincrement" : "postdecrement"; }
     const char *childname (size_t i) const;
     TypeSpec typecheck (TypeSpec expected);

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -670,6 +670,10 @@ OSLCompilerImpl::compile_buffer (string_view sourcecode,
 struct GlobalTable {
     const char *name;
     TypeSpec type;
+    bool readonly;
+
+    GlobalTable (const char *name, TypeSpec type, bool readonly=true)
+        : name(name), type(type), readonly(readonly) {}
 };
 
 
@@ -677,34 +681,24 @@ void
 OSLCompilerImpl::initialize_globals ()
 {
     static GlobalTable globals[] = {
-        { "P", TypeDesc::TypePoint },
+        { "P", TypeDesc::TypePoint, false },
         { "I", TypeDesc::TypeVector },
-        { "N", TypeDesc::TypeNormal },
+        { "N", TypeDesc::TypeNormal, false },
         { "Ng", TypeDesc::TypeNormal },
         { "u", TypeDesc::TypeFloat },
         { "v", TypeDesc::TypeFloat },
         { "dPdu", TypeDesc::TypeVector },
         { "dPdv", TypeDesc::TypeVector },
-    #if 0
-        // Light variables -- we don't seem to be on a route to support this
-        // kind of light shader, so comment these out for now.
-        { "L", TypeDesc::TypeVector },
-        { "Cl", TypeDesc::TypeColor },
-        { "Ns", TypeDesc::TypeNormal },
-        { "Pl", TypeDesc::TypePoint },
-        { "Nl", TypeDesc::TypeNormal },
-    #endif
         { "Ps", TypeDesc::TypePoint },
-        { "Ci", TypeSpec (TypeDesc::TypeColor, true) },
+        { "Ci", TypeSpec (TypeDesc::TypeColor, true), false },
         { "time", TypeDesc::TypeFloat },
         { "dtime", TypeDesc::TypeFloat },
-        { "dPdtime", TypeDesc::TypeVector },
-        { NULL }
+        { "dPdtime", TypeDesc::TypeVector }
     };
 
-    for (int i = 0;  globals[i].name;  ++i) {
-        Symbol *s = new Symbol (ustring(globals[i].name), globals[i].type,
-                                SymTypeGlobal);
+    for (auto& g : globals) {
+        Symbol *s = new Symbol (ustring(g.name), g.type, SymTypeGlobal);
+        s->readonly (g.readonly);
         symtab().insert (s);
     }
 }

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -234,11 +234,16 @@ formal_param
         : outputspec typespec IDENTIFIER initializer_opt metadata_block_opt
                 {
                     TypeSpec t = oslcompiler->current_typespec();
+                    bool is_output = $1;
                     auto var = new ASTvariable_declaration (oslcompiler,
                                             t, ustring($3), $4 /*init*/,
                                             oslcompiler->declaring_shader_formals() /*isparam*/,
-                                            false /*ismeta*/, $1 /*isoutput*/,
+                                            false /*ismeta*/, is_output,
                                             false /*instlist*/, @3.first_line);
+                    if (! oslcompiler->declaring_shader_formals() && !is_output) {
+                        // these are function formals, not shader formals,
+                        var->sym()->readonly (true);
+                    }
                     var->add_meta ($5);
                     $$ = var;
                 }

--- a/src/shaders/oslutil.h
+++ b/src/shaders/oslutil.h
@@ -90,8 +90,9 @@ float wireframe() { return wireframe("polygons", 1.0, 1); }
 
 float draw_string(string str, float s, float t, int wrap_s, int wrap_t, int jitter) {
    // Glyphs from http://font.gohu.org/ (8x14 version, most common ascii characters only)
-   int glyph_pixel(int c, int x, int y) {
-      c -= 33; x--; // nudge to origin
+   int glyph_pixel(int c_, int x_, int y) {
+      int c = c_ - 33;   // nudge to origin
+      int x = x_ - 1;
       if (c < 0  || x < 0 || y < 0 ) return 0;
       if (c > 93 || x > 6 || y > 13) return 0;
       int i = 98 * c + 7 * y + x;

--- a/testsuite/oslc-err-write-nonoutput/ref/out.txt
+++ b/testsuite/oslc-err-write-nonoutput/ref/out.txt
@@ -1,0 +1,6 @@
+test.osl:4: error: cannot write to "x" (read-only symbol)
+test.osl:5: error: cannot write to "x" (read-only symbol)
+test.osl:6: error: cannot write to "i" (read-only symbol)
+test.osl:7: error: cannot write to "i" (read-only symbol)
+test.osl:20: error: cannot write to "u" (read-only symbol)
+FAILED test.osl

--- a/testsuite/oslc-err-write-nonoutput/run.py
+++ b/testsuite/oslc-err-write-nonoutput/run.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+oslcargs = "-Werror"
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-write-nonoutput/test.osl
+++ b/testsuite/oslc-err-write-nonoutput/test.osl
@@ -1,0 +1,21 @@
+// A function that tries verious ways to write to its non-output params
+float func (float x, int i)
+{
+    x = 0;
+    x += 3;
+    ++i;
+    i++;
+    return x*x;
+}
+
+
+shader test ()
+{
+    float y = 1;
+    int j = 1;
+    float z = func(y, j);
+    printf ("z=%g\n", z);
+
+    // Try writing to non-writeable global
+    u = 0;
+}

--- a/testsuite/struct-array-mixture/test.osl
+++ b/testsuite/struct-array-mixture/test.osl
@@ -3,8 +3,8 @@ struct B { A a; };
 struct C { B bs[5]; };
 struct D { C c; };
 
-        
-void Awrite (A a, int multiplier)
+
+void Awrite (output A a, int multiplier)
 {
     printf ("passing a ref to a A:\n");
     a.i = multiplier;
@@ -20,7 +20,7 @@ void Aprint (A a)
 
 
 
-void Bwrite (B b, int multiplier)
+void Bwrite (output B b, int multiplier)
 {
     printf ("passing a ref to a B:\n");
     b.a.i = multiplier;
@@ -36,7 +36,7 @@ void Bprint (B b)
 
 
 
-void Barraywrite (B bs[], int multiplier)
+void Barraywrite (output B bs[], int multiplier)
 {
     printf ("passing a ref to a B[]:\n");
     for (int i = 0;  i < 5;  ++i)
@@ -54,7 +54,7 @@ void Barrayprint (B bs[])
 
 
 
-void Cwrite (C c, int multiplier)
+void Cwrite (output C c, int multiplier)
 {
     printf ("passing a ref to a C:\n");
     for (int i = 0;  i < 5;  ++i)
@@ -72,7 +72,7 @@ void Cprint (C c)
 
 
 
-void Dwrite (D d, int multiplier)
+void Dwrite (output D d, int multiplier)
 {
     printf ("passing a ref to a D:\n");
     for (int i = 0;  i < 5;  ++i)


### PR DESCRIPTION
It has been a longstanding problem that oslc did not properly flag
attempts to write to function paramseters that were not marked as
'output'.

I've rigged this so that in the current master (and any past releases,
assuming we backport this to release branches), it will just be a
warning. In future versions, it will be a full error. That should give
people some advanced warning (no pun intended) to fix any problems that
this catches that previously went unnoticed.

