### PR TITLE
SS attrib "error_repeats" controls suppression of repeat errors & warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Release 1.8.14 -- ?? 2018 (compared to 1.8.13)
 --------------------------------------------------
-
+* New SS attribute "error_repeats", if set to non-zero, turns off the
+ suppression of multiple identical errors and warnings. Setting it (even to
+ its existing value) also clears the "already seen" lists. #880
 
 Release 1.8.13 -- 1 Apr 2018 (compared to 1.8.12)
 --------------------------------------------------

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -110,6 +110,9 @@ public:
     ///                              fails to find the layer or parameter? (1)
     ///    int strict_messages    Issue error if a message is set after
     ///                              being queried (1).
+    ///    int error_repeats      If zero, suppress repeats of errors and
+    ///                              warnings that are exact duplicates of
+    ///                              earlier ones. (0)
     ///    int lazylayers         Evaluate shader layers only when their
     ///                              outputs are first needed (1)
     ///    int lazyglobals        Run layers lazily even if they write to

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -751,6 +751,7 @@ private:
     bool m_debug_uninit;                  ///< Find use of uninitialized vars?
     bool m_lockgeom_default;              ///< Default value of lockgeom
     bool m_strict_messages;               ///< Strict checking of message passing usage?
+    bool m_error_repeats;                 ///< Allow repeats of identical err/warn?
     bool m_range_checking;                ///< Range check arrays & components?
     bool m_unknown_coordsys_error;        ///< Error to use unknown xform name?
     bool m_connection_error;              ///< Error for ConnectShaders to fail?

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -643,6 +643,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_lazy_userdata(false), m_userdata_isconnected(false),
       m_clearmemory (false), m_debugnan (false), m_debug_uninit(false),
       m_lockgeom_default (true), m_strict_messages(true),
+      m_error_repeats(false),
       m_range_checking(true),
       m_unknown_coordsys_error(true), m_connection_error(true),
       m_greedyjit(false), m_countlayerexecs(false),
@@ -1085,6 +1086,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_SET ("llvm_debug_ops", int, m_llvm_debug_ops);
     ATTR_SET ("strict_messages", int, m_strict_messages);
+    ATTR_SET ("error_repeats", int, m_error_repeats);
     ATTR_SET ("range_checking", int, m_range_checking);
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);
     ATTR_SET ("connection_error", int, m_connection_error);
@@ -1157,6 +1159,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     }
 
     lock_guard guard (m_mutex);  // Thread safety
+
     ATTR_DECODE_STRING ("searchpath:shader", m_searchpath);
     ATTR_DECODE ("statistics:level", int, m_statslevel);
     ATTR_DECODE ("lazylayers", int, m_lazylayers);
@@ -1277,6 +1280,14 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("stat:mem_inst_paramvals_peak", long long, m_stat_mem_inst_paramvals.peak());
     ATTR_DECODE ("stat:mem_inst_connections_current", long long, m_stat_mem_inst_connections.current());
     ATTR_DECODE ("stat:mem_inst_connections_peak", long long, m_stat_mem_inst_connections.peak());
+
+    if (name == "error_repeats") {
+        // Special case: setting error_repeats also clears the "previously
+        // seen" error and warning lists.
+        m_errseen.clear();
+        m_warnseen.clear();
+        ATTR_DECODE ("error_repeats", int, m_error_repeats);
+    }
 
     return false;
 #undef ATTR_DECODE
@@ -1505,7 +1516,7 @@ ShadingSystemImpl::error (const std::string &msg) const
     lock_guard guard (m_errmutex);
     int n = 0;
     BOOST_FOREACH (std::string &s, m_errseen) {
-        if (s == msg)
+        if (s == msg && !m_error_repeats)
             return;
         ++n;
     }
@@ -1523,7 +1534,7 @@ ShadingSystemImpl::warning (const std::string &msg) const
     lock_guard guard (m_errmutex);
     int n = 0;
     BOOST_FOREACH (std::string &s, m_warnseen) {
-        if (s == msg)
+        if (s == msg && !m_error_repeats)
             return;
         ++n;
     }
@@ -1616,6 +1627,7 @@ ShadingSystemImpl::getstats (int level) const
     BOOLOPT (debug_uninit);
     BOOLOPT (lockgeom_default);
     BOOLOPT (strict_messages);
+    BOOLOPT (error_repeats);
     BOOLOPT (range_checking);
     BOOLOPT (greedyjit);
     BOOLOPT (countlayerexecs);

--- a/testsuite/error-dupes/ref/out.txt
+++ b/testsuite/error-dupes/ref/out.txt
@@ -1,4 +1,5 @@
 Compiled test.osl -> test.oso
+Without repeated errors:
 WARNING: Shader warning [test]: hi
 
 WARNING: Shader warning [test]: there
@@ -6,5 +7,87 @@ WARNING: Shader warning [test]: there
 ERROR: Shader error [test]: hi
 
 ERROR: Shader error [test]: there
+
+
+With repeated errors:
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: there
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: there
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: there
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: there
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: there
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: there
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: there
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+WARNING: Shader warning [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: there
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
+
+ERROR: Shader error [test]: hi
 
 

--- a/testsuite/error-dupes/run.py
+++ b/testsuite/error-dupes/run.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env python
 
-command = testshade("-g 2 2 test")
+command = "echo 'Without repeated errors:' >> out.txt 2>&1 ;\n"
+command += testshade("-g 2 2 test")
+
+command += "echo 'With repeated errors:' >> out.txt 2>&1 ;\n"
+command += testshade("--options error_repeats=1 -g 2 2 test")


### PR DESCRIPTION
Previously, exactly identical error and warning messages (including from shaders themselves) printed the first time and suppressed the duplicates. The rationale is that an error in a shader could easily turn into thousands of error messages if duplicates weren't suppressed. There wasn't a way to turn this behavior off.

Now it's controlled by ShadingSystem attribute "error_repeats", an int, which has default value 0 (do not issue repeated errors -- the current behavior). If changed to 1, repeated errors and warnings will be allowed to pass to the error handler, without suppression in the ShadingSystem.

Furthermore, the act of setting the attribute (to either 0 or 1) has the side effect of clearing the list of remembered errors. This means that even if you want error suppression, poking it in this way will reset the counters, which might be a handy thing to do at the start of each frame (if you are using a single ShadingSystem to render multiple frames) so that you start the counts fresh for each render, rather than for each ShadingSystem.


This patch is intended to be applied to 1.8, 1.9, and master.
