### PR TITLE
OSL built-in displace() and bump() were documented but never implemented

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3823,26 +3823,28 @@ computed (using {\cf filterwidth()}).
 \index{functions!displacement}
 
 \apiitem{void {\ce displace} (float amp) \\
+void {\ce displace} (vector offset) \\
 void {\ce displace} (string space, float amp) \\
-void {\ce displace} (vector offset)}
+void {\ce displace} (string space, vector offset)}
 \indexapi{displace()}
 
 Displace the surface in the direction of the shading normal \N by
-\emph{amp} units as measured in the named \emph{space} (or \commonspace
-if none is specified).  Alternately, the surface may be moved by a fully
-general \emph{offset}, which does not need to be in the direction of the
-surface normal.
+\emph{amp} units, or by an arbitrary offset vector.
+If an optional \emph{space} name is supplied, the amplitude or offset
+are expressed in the named coordinte system (rather than the default
+of \commonspace).
 
-In either case, this function both displaces the surface and adjusts the
-shading normal \N to be the new surface normal of the displaced surface
+For all cases, the surface itself is displaced and the shadingnormal \N is
+adjusted to be the new surface normal of the displaced surface
 (properly handling both continuously smooth surfaces as well as
 interpolated normals on faceted geometry, without introducing faceting
 artifacts).
 \apiend
 
 \apiitem{void {\ce bump} (float amp) \\
+void {\ce bump} (vector offset) \\
 void {\ce bump} (string space, float amp) \\
-void {\ce bump} (vector offset)}
+void {\ce bump} (string space, vector offset)}
 \indexapi{bump()}
 
 Adjust the shading normal \N to be the surface normal as if the

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -2036,7 +2036,6 @@ static const char * builtin_func_args [] = {
 
     "area", "fp", "!deriv", NULL,
     "arraylength", "i?[]", NULL,
-    "bump", "xf", "xsf", "xv", "!deriv", NULL,
     "calculatenormal", "vp", "!deriv", NULL,
     "cellnoise", NOISE_ARGS, NULL,
     "concat", "sss", /*"ss.",*/ NULL,   // FIXME -- further checking
@@ -2046,7 +2045,6 @@ static const char * builtin_func_args [] = {
     "Dx", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "Dy", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
     "Dz", "ff", "vp", "vv", "vn", "cc", "!deriv", NULL,
-    "displace", "xf", "xsf", "xv", "!deriv", NULL,
     "environment", "fsv.", "fsvvv.","csv.", "csvvv.",
                "vsv.", "vsvvv.", "!tex", "!rw", "!deriv", NULL,
     "error", "xs*", "!printf", NULL,

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -407,6 +407,35 @@ int hash (point p, float t) BUILTIN;
 
 
 // Displacement functions
+void displace (vector offset) {
+    P += offset;
+    N = normalize (calculatenormal (P));
+}
+void displace (float amp) {
+    displace (amp * N);
+}
+void displace (string space, float amp) {
+    float len = length (transform (space, N));
+    displace (amp * len * N);
+}
+void displace (string space, vector offset) {
+    displace (transform (space, "common", offset));
+}
+
+void bump (vector offset) {
+    N = normalize (calculatenormal (P+offset));
+}
+void bump (float amp) {
+    bump (amp * N);
+}
+void bump (string space, float amp) {
+    float len = length (transform (space, N));
+    bump (amp * len * N);
+}
+void bump (string space, vector offset) {
+    bump (transform (space, "common", offset));
+}
+
 
 
 // String functions


### PR DESCRIPTION
Add them now. Also, an additional variety that takes a vector offset in
a non-common space.

There's no good reason why these were never implemented. I think that
people just used the `P += ...; N = calculatenormal(...)` idiom
directly. But they were always documented in the OSL Language Spec, so I
see no reason not to add them now.
