### PR TITLE
Device Strings

### DIFF
--- a/src/cmake/modules/FindOptiX.cmake
+++ b/src/cmake/modules/FindOptiX.cmake
@@ -14,6 +14,8 @@
 # If 'OPTIXHOME' not set, use the env variable of that name if available
 if (NOT OPTIXHOME AND NOT $ENV{OPTIXHOME} STREQUAL "")
     set (OPTIXHOME $ENV{OPTIXHOME})
+elseif (NOT $ENV{OPTIX_INSTALL_DIR} STREQUAL "")
+    set (OPTIXHOME $ENV{OPTIX_INSTALL_DIR})
 endif ()
 
 if (NOT OptiX_FIND_QUIETLY)
@@ -54,11 +56,6 @@ find_package_handle_standard_args (OptiX
     REQUIRED_VARS OPTIX_INCLUDE_DIR OPTIX_LIBRARIES
     )
 
-if (NOT OptiX_FIND_QUIETLY)
-    message (STATUS "OptiX includes  = ${OPTIX_INCLUDE_DIR}")
-    message (STATUS "OptiX libraries = ${OPTIX_LIBRARIES}")
-endif ()
-
 # Pull out the API version from optix.h
 file(STRINGS ${OPTIX_INCLUDE_DIR}/optix.h OPTIX_VERSION_LINE LIMIT_COUNT 1 REGEX OPTIX_VERSION)
 string(REGEX MATCH "([0-9]+)" OPTIX_VERSION "${OPTIX_VERSION_LINE}")
@@ -69,6 +66,13 @@ set(OPTIX_VERSION_STRING ${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR}.${OPTIX_V
 
 if (OPTIX_FOUND)
     message (STATUS "OptiX version = ${OPTIX_VERSION_STRING}")
+    if (NOT OptiX_FIND_QUIETLY)
+        message (STATUS "OptiX includes  = ${OPTIX_INCLUDE_DIR}")
+        message (STATUS "OptiX libraries = ${OPTIX_LIBRARIES}")
+    endif ()
+    if (${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR} STRLESS "5.1")
+        message (FATAL_ERROR "Minimum OptiX version is 5.1, found ${OPTIX_VERSION_STRING}")
+    endif()
 else ()
     message (FATAL_ERROR "OptiX not found")
 endif ()

--- a/src/include/OSL/device_string.h
+++ b/src/include/OSL/device_string.h
@@ -30,28 +30,58 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OSL/oslconfig.h>
 
+
+// A device_string is a special string representation intended for use on GPUs,
+// which do not readily support ustrings.
+//
+// Two device_strings can be tested for equality simply by comparing their m_tag
+// fields; m_chars is available for cases where the actual string contents are
+// required (e.g., for printf).
+//
+// For comparisons between device_strings to be valid, OSL library code
+// (shadeops, noise gen, etc.), compiled shaders, and renderer application code
+// must all agree on the tag for each string.
+//
+// The other design goal is that compiled shaders containing strings can be
+// cached, because tags are consistent from run to run.
+//
+// For "standard" strings (in particular, members of the 'Strings' namespace in
+// liboslexec/oslexec_pvt.h), we declare fixed tags to make it easier to write
+// CUDA code that uses them.
+//
+// Strings that do not need to be shared between liboslexec and the renderer,
+// but which have special significance in the renderer (such as custom closure
+// parameters), can be registered with the shading system at runtime via
+// register_string_tag().
+//
+// For other strings, the tag is the ustring hash.
+//
+// A pre-declared device_string is listed:
+//
+// 1) In the StringTags enum in this file. This file can be included in your
+//    OptiX/CUDA renderer to make the tags available.
+//
+// 2) In the definitions in liboslexec/device_string.cpp. These are linked with
+//    the other 'shadeops' sources (opnoise.cpp, etc) and made available as
+//    global symbols to executing shaders.
+//
+// 3) In ShadingSystemImpl::setup_string_tags(), which registers the enum value
+//    as the tag for that ustring. This lets libsolexec create a device_string
+//    with the appropriate tag during shader compilation.
+
+
 OSL_NAMESPACE_ENTER
 
 
-// For the universe of "standard" strings, we want to fix the tags so that OSL
-// library code (shadeops, noise gen, etc.), compiled shaders, and the renderer
-// can agree on the tag associated with each "canonical" string.
-enum StringTags: uint64_t {
-    EMPTY_STRING = 0,
-    TEST_STRING,
-    UNKNOWN_STRING = ~0u
-};
-
-
 struct device_string {
-    OSL_HOSTDEVICE uint64_t tag ()
+    OSL_HOSTDEVICE uint64_t tag () const
     {
         return m_tag;
     }
 
     OSL_HOSTDEVICE const char* c_str () const
     {
-        return m_ptr;
+        return m_chars;
     }
 
     OSL_HOSTDEVICE bool operator== (const device_string& other) const
@@ -65,7 +95,14 @@ struct device_string {
     }
 
     uint64_t    m_tag;
-    const char* m_ptr;
+    const char* m_chars;
+};
+
+
+enum StringTags: uint64_t {
+    EMPTY_STRING = 0,
+    TEST_STRING,
+    UNKNOWN_STRING = ~0u
 };
 
 

--- a/src/include/OSL/device_string.h
+++ b/src/include/OSL/device_string.h
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <OSL/oslconfig.h>
+
+OSL_NAMESPACE_ENTER
+
+
+// For the universe of "standard" strings, we want to fix the tags so that OSL
+// library code (shadeops, noise gen, etc.), compiled shaders, and the renderer
+// can agree on the tag associated with each "canonical" string.
+enum StringTags: uint64_t {
+    EMPTY_STRING = 0,
+    TEST_STRING,
+    UNKNOWN_STRING = ~0u
+};
+
+
+struct device_string {
+    OSL_HOSTDEVICE uint64_t tag ()
+    {
+        return m_tag;
+    }
+
+    OSL_HOSTDEVICE const char* c_str () const
+    {
+        return m_ptr;
+    }
+
+    OSL_HOSTDEVICE bool operator== (const device_string& other) const
+    {
+        return m_tag == other.m_tag;
+    }
+
+    OSL_HOSTDEVICE bool operator!= (const device_string& other) const
+    {
+        return m_tag != other.m_tag;
+    }
+
+    uint64_t    m_tag;
+    const char* m_ptr;
+};
+
+
+OSL_NAMESPACE_EXIT

--- a/src/include/OSL/genclosure.h
+++ b/src/include/OSL/genclosure.h
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/ustring.h>
 #include <OSL/oslconfig.h>
+#include <OSL/device_string.h>
 
 OSL_NAMESPACE_ENTER
 
@@ -57,6 +58,8 @@ struct ClosureParam {
     { TypeDesc::TypeString, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 #define CLOSURE_CLOSURE_PARAM(st, fld) \
     { TypeDesc::PTR, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
+#define CLOSURE_DEVICE_STRING_PARAM(st, fld) \
+    { TypeDesc(TypeDesc::UINT64, TypeDesc::SCALAR, 2), (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 
 #define CLOSURE_INT_ARRAY_PARAM(st, fld, n) \
     { TypeDesc(TypeDesc::INT,   TypeDesc::SCALAR, TypeDesc::NOXFORM, n),(int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }

--- a/src/include/OSL/genclosure.h
+++ b/src/include/OSL/genclosure.h
@@ -56,10 +56,10 @@ struct ClosureParam {
     { TypeDesc::TypeVector, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 #define CLOSURE_STRING_PARAM(st, fld) \
     { TypeDesc::TypeString, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
-#define CLOSURE_CLOSURE_PARAM(st, fld) \
-    { TypeDesc::PTR, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 #define CLOSURE_DEVICE_STRING_PARAM(st, fld) \
     { TypeDesc(TypeDesc::UINT64, TypeDesc::SCALAR, 2), (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
+#define CLOSURE_CLOSURE_PARAM(st, fld) \
+    { TypeDesc::PTR, (int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }
 
 #define CLOSURE_INT_ARRAY_PARAM(st, fld, n) \
     { TypeDesc(TypeDesc::INT,   TypeDesc::SCALAR, TypeDesc::NOXFORM, n),(int)reckless_offsetof(st, fld), NULL, fieldsize(st, fld) }

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -322,6 +322,10 @@ public:
     /// data type, return the llvm::Value of the new pointer.
     llvm::Value *ptr_cast (llvm::Value* val, const OIIO::TypeDesc &type);
 
+    /// Cast the variable specified by val to a pointer of type void*,
+    /// return the llvm::Value of the new pointer.
+    llvm::Value *int_to_ptr_cast (llvm::Value* val);
+
     /// Cast the pointer variable specified by val to a pointer of type
     /// void* return the llvm::Value of the new pointer.
     llvm::Value *void_ptr (llvm::Value* val);

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -570,6 +570,15 @@ public:
     bool query_closure (const char **name, int *id,
                         const ClosureParam **params);
 
+
+    /// Register a device_string tag for the specified string. Return
+    /// false if the string has been registered with a different tag.
+    bool register_string_tag (string_view str, uint64_t tag);
+
+    /// Lookup the tag registered for the given string.
+    /// Return StringTags::UNKNOWNSTRING if the string is not registered.
+    uint64_t lookup_string_tag (string_view str);
+
     /// For the proposed raytype name, return the bit pattern that
     /// describes it, or 0 for an unrecognized name.  (This retrieves
     /// data passed in via attribute("raytypes")).

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -158,6 +158,7 @@ MACRO ( CUDA_SHADEOPS_COMPILE srclist )
         llvm_ops.cpp
         opnoise.cpp
         ../liboslnoise/simplexnoise.cpp
+        device_string.cpp
         )
 
     SET ( shadeops_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.bc.cpp" )

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -355,12 +355,10 @@ BackendLLVM::addGlobalVariable(const std::string& name, int size, int alignment,
 
         ASSERT (g_var && "Unable to create GlobalVariable");
 
-        g_var->setAlignment  (alignment);
-        g_var->setLinkage    (llvm::GlobalValue::PrivateLinkage);
-        g_var->setVisibility (llvm::GlobalValue::DefaultVisibility);
         g_var->setInitializer(constant);
     }
 
+    g_var->setAlignment  (alignment);
     g_var->setLinkage    (llvm::GlobalValue::PrivateLinkage);
     g_var->setVisibility (llvm::GlobalValue::DefaultVisibility);
 

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -328,6 +328,8 @@ llvm::Value*
 BackendLLVM::addGlobalVariable(const std::string& name, int size, int alignment,
                                void* data, const std::string& type)
 {
+    ASSERT (use_optix() && "This function is only supposed to be used with OptiX!"); 
+
     llvm::GlobalVariable* g_var    = nullptr;
     llvm::Constant*       constant = nullptr;
 
@@ -372,6 +374,8 @@ BackendLLVM::addGlobalVariable(const std::string& name, int size, int alignment,
 llvm::Value*
 BackendLLVM::makeTaggedString (const std::string& var_name, ustring str)
 {
+    ASSERT (use_optix() && "This function is only supported when using OptiX!");
+
     llvm::GlobalVariable* g_var    = nullptr;
     llvm::Constant*       constant = nullptr;
 
@@ -455,6 +459,8 @@ llvm::Value*
 BackendLLVM::createOptixVariable(const std::string& name, const std::string& type,
                                  int size, void* data)
 {
+    ASSERT (use_optix() && "This function is only supported when using OptiX!");
+
     // Return the Value if it has already been allocated
     std::map<std::string, llvm::GlobalVariable*>::iterator it =
         get_const_map().find (name);
@@ -521,6 +527,8 @@ BackendLLVM::createOptixVariable(const std::string& name, const std::string& typ
 llvm::Value *
 BackendLLVM::getOrAllocateLLVMGlobal (const Symbol& sym)
 {
+    ASSERT (use_optix() && "This function is only supported when using OptiX!");
+
     std::stringstream ss;
     if (sym.typespec().is_string()) {
         // Use the ustring hash to create a name for the symbol that's based on

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -165,6 +165,14 @@ public:
         return llvm_load_arg (sym, sym.has_derivs());
     }
 
+    /// Return the llvm::Value* of the char* member of the device_string pointed
+    /// to by val.
+    llvm::Value *llvm_load_device_string_char_ptr (llvm::Value* val);
+
+    /// Return the llvm::Value* of the uint64_t member of the device_string pointed
+    /// to by val.
+    llvm::Value *llvm_load_device_string_tag (llvm::Value* val);
+
     /// Store new_val into the given symbol, given the derivative
     /// (0=value, 1=dx, 2=dy), array index (NULL if it's not an array),
     /// and component (x=0 or scalar, y=1, z=2).  If deriv>0 and the
@@ -218,6 +226,9 @@ public:
     /// Allocate a GlobalVariable for the given OSL symbol and return a pointer
     /// to it, or return the pointer if it has already been allocated
     llvm::Value *getOrAllocateLLVMGlobal (const Symbol& sym);
+
+    /// Create a GlobalVariable for a "tagged string" for use on GPUs
+    llvm::Value *makeTaggedString (const std::string& var_name, ustring str);
 
     /// Create a GlobalVariable and add it to the current Module
     llvm::Value *addGlobalVariable (const std::string& name, int size,

--- a/src/liboslexec/device_string.cpp
+++ b/src/liboslexec/device_string.cpp
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "oslexec_pvt.h"
+#include <OSL/device_string.h>
+
+OSL_NAMESPACE_ENTER
+
+
+#ifdef __CUDA_ARCH__
+namespace Strings {
+__device__ device_string test_string = { StringTags::TEST_STRING, "test_string" };
+}
+#endif
+
+
+OSL_NAMESPACE_EXIT

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2847,15 +2847,7 @@ LLVMGEN (llvm_gen_noise)
     std::string funcname = "osl_" + name.string() + "_" + arg_typecode(&Result,derivs);
     std::vector<llvm::Value *> args;
     if (pass_name) {
-        if (! rop.use_optix()) {
-            args.push_back (rop.llvm_load_value(*Name));
-        }
-        else {
-            llvm::Value* name_arg = (Name->is_constant())
-                ? rop.getOrAllocateLLVMGlobal (*Name)
-                : rop.llvm_load_value (*Name, 0, nullptr, 0);
-            args.push_back (name_arg);
-        }
+        args.push_back (rop.llvm_load_value(*Name));
     }
     llvm::Value *tmpresult = NULL;
     // triple return, or float return with derivs, passes result pointer

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -358,12 +358,17 @@ LLVMGEN (llvm_gen_printf)
                         s += " ";
                     s += ourformat;
 
-                    // In the OptiX case, we need to use the device-side string constant,
-                    // as added to the LLVM Module.
-                    llvm::Value* loaded = (simpletype.basetype == TypeDesc::STRING &&
-                                           sym.is_constant() && rop.use_optix())
-                        ? rop.getOrAllocateLLVMGlobal (sym)
-                        : rop.llvm_load_value (sym, 0, arrind, c);
+                    llvm::Value* loaded = nullptr;
+                    if (rop.use_optix() && simpletype.basetype == TypeDesc::STRING) {
+                        // In the OptiX case, we use the device_string.
+                        llvm::Value* device_string = (sym.is_constant())
+                            ? rop.getOrAllocateLLVMGlobal (sym)
+                            : rop.llvm_load_value (sym, 0, arrind, c);
+                        loaded = rop.llvm_load_device_string_char_ptr (device_string);
+                    }
+                    else {
+                        loaded = rop.llvm_load_value (sym, 0, arrind, c);
+                    }
 
                     if (simpletype.basetype == TypeDesc::FLOAT) {
                         // C varargs convention upconverts float->double.
@@ -386,6 +391,17 @@ LLVMGEN (llvm_gen_printf)
         }
     }
 
+    if (rop.use_optix() && arg > (format_arg + 2)) {
+        ASSERT (0 && "OptiX printf only supports 0 or 1 arguments at this time");
+    }
+
+    // In OptiX, printf currently supports 0 or 1 arguments, and the signature
+    // requires 1 argument, so push a null pointer onto the call args if there
+    // is no argument.
+    if (rop.use_optix() && arg == format_arg + 1) {
+        call_args.push_back(rop.ll.void_ptr_null());
+    }
+
     // Some ops prepend things
     if (op.opname() == op_error || op.opname() == op_warning) {
         std::string prefix = Strutil::format ("Shader %s [%s]: ",
@@ -395,11 +411,15 @@ LLVMGEN (llvm_gen_printf)
     }
 
     // Now go back and put the new format string in its place
-    call_args[new_format_slot] = (! rop.use_optix())
-        ? rop.ll.constant (s.c_str())
-        // In the OptiX case, we need to use the pointer to the constant format
-        // string added to the LLVM Module
-        : rop.llvm_get_pointer (format_sym);
+    if (! rop.use_optix()) {
+        call_args[new_format_slot] = rop.ll.constant (s.c_str());
+    }
+    else {
+        // In the OptiX case, we need to use the pointer to the device_string
+        // added to the LLVM Module.
+        llvm::Value* device_string = rop.getOrAllocateLLVMGlobal (format_sym);
+        call_args[new_format_slot] = rop.llvm_load_device_string_char_ptr (device_string);
+    }
 
     // Construct the function name and call it.
     std::string opname = std::string("osl_") + op.opname().string();
@@ -1752,16 +1772,20 @@ LLVMGEN (llvm_gen_compare_op)
     ustring opname = op.opname();
 
     if (rop.use_optix() && A.typespec().is_string()) {
-        // Compare two strings for equality by comparing the pointers to
-        // their global constants.
-
         ASSERT (B.typespec().is_string() && "Only string-to-string comparison is supported");
 
-        llvm::Value* a = (A.is_constant())
-            ? rop.llvm_get_pointer (A) : rop.llvm_load_value (A);
+        // Since we are using device_strings in the OptiX case, we compare the
+        // tags rather than comparing the string contents or the pointers
+        llvm::Value* string_a = (A.is_constant())
+            ? rop.getOrAllocateLLVMGlobal (A)
+            : rop.llvm_load_value (A, 0, nullptr, 0);
 
-        llvm::Value* b = (B.is_constant())
-            ? rop.llvm_get_pointer (B) : rop.llvm_load_value (B);
+        llvm::Value* string_b = (B.is_constant())
+            ? rop.getOrAllocateLLVMGlobal (B)
+            : rop.llvm_load_value (B, 0, nullptr, 0);
+
+        llvm::Value* a = rop.llvm_load_device_string_tag (string_a);
+        llvm::Value* b = rop.llvm_load_device_string_tag (string_b);
 
         if (opname == op_eq) {
             final_result = rop.ll.op_eq (a, b);
@@ -2649,6 +2673,12 @@ llvm_gen_noise_options (BackendLLVM &rop, int opnum,
 {
     llvm::Value* opt = rop.ll.call_function ("osl_get_noise_options",
                                              rop.sg_void_ptr());
+
+    // TODO: implement noise options in OptiX
+    if (rop.use_optix()) {
+        return opt;
+    }
+
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));
@@ -2816,8 +2846,17 @@ LLVMGEN (llvm_gen_noise)
 
     std::string funcname = "osl_" + name.string() + "_" + arg_typecode(&Result,derivs);
     std::vector<llvm::Value *> args;
-    if (pass_name)
-        args.push_back (rop.llvm_load_value(*Name));
+    if (pass_name) {
+        if (! rop.use_optix()) {
+            args.push_back (rop.llvm_load_value(*Name));
+        }
+        else {
+            llvm::Value* name_arg = (Name->is_constant())
+                ? rop.getOrAllocateLLVMGlobal (*Name)
+                : rop.llvm_load_value (*Name, 0, nullptr, 0);
+            args.push_back (name_arg);
+        }
+    }
     llvm::Value *tmpresult = NULL;
     // triple return, or float return with derivs, passes result pointer
     if (outdim == 3 || derivs) {
@@ -3318,10 +3357,24 @@ LLVMGEN (llvm_gen_closure)
         DASSERT(p.offset + p.field_size <= clentry->struct_size);
         Symbol &sym = *rop.opargsym (op, carg + 2 + weighted);
         TypeDesc t = sym.typespec().simpletype();
-        if (!sym.typespec().is_closure_array() && !sym.typespec().is_structure()
-            && equivalent(t,p.type)) {
+
+        if (rop.use_optix() && sym.typespec().is_string()) {
+            // For OptiX, need to copy the entire 16-byte device_string, which
+            // is a struct consisting of the 8-byte tag and the char*.
             llvm::Value* dst = rop.ll.offset_ptr (mem_void_ptr, p.offset);
-            llvm::Value* src = rop.llvm_void_ptr (sym);
+            llvm::Value* src = nullptr;
+            src = (sym.is_constant())
+                ? rop.getOrAllocateLLVMGlobal (sym)
+                : rop.llvm_load_value (sym, 0, nullptr, 0);
+            src = rop.ll.int_to_ptr_cast(src);
+            rop.ll.op_memcpy (dst, src, (int)p.type.size(),
+                              4 /* use 4 byte alignment for now */);
+        }
+        else if (!sym.typespec().is_closure_array() && !sym.typespec().is_structure()
+                 && equivalent(t,p.type)) {
+            llvm::Value* dst = rop.ll.offset_ptr (mem_void_ptr, p.offset);
+            llvm::Value* src = nullptr;
+            src = rop.llvm_void_ptr (sym);
             rop.ll.op_memcpy (dst, src, (int)p.type.size(),
                              4 /* use 4 byte alignment for now */);
         } else {

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2847,7 +2847,15 @@ LLVMGEN (llvm_gen_noise)
     std::string funcname = "osl_" + name.string() + "_" + arg_typecode(&Result,derivs);
     std::vector<llvm::Value *> args;
     if (pass_name) {
-        args.push_back (rop.llvm_load_value(*Name));
+        if (! rop.use_optix()) {
+            args.push_back (rop.llvm_load_value(*Name));
+        }
+        else {
+            llvm::Value* name_arg = (Name->is_constant())
+                ? rop.getOrAllocateLLVMGlobal (*Name)
+                : rop.llvm_load_value (*Name, 0, nullptr, 0);
+            args.push_back (name_arg);
+        }
     }
     llvm::Value *tmpresult = NULL;
     // triple return, or float return with derivs, passes result pointer

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -991,6 +991,14 @@ LLVM_Util::ptr_cast (llvm::Value* val, const TypeDesc &type)
 
 
 llvm::Value *
+LLVM_Util::int_to_ptr_cast (llvm::Value* val)
+{
+    return builder().CreateIntToPtr(val,type_void_ptr());
+}
+
+
+
+llvm::Value *
 LLVM_Util::void_ptr (llvm::Value* val)
 {
     return builder().CreatePointerCast(val,type_void_ptr());
@@ -1527,8 +1535,7 @@ LLVM_Util::ptx_compile_group (llvm::Module* lib_module, const std::string& name,
 
     // Second, link in the shadeops library, keeping only the functions that are needed
     std::unique_ptr<llvm::Module> lib_ptr (lib_module);
-    failed = llvm::Linker::linkModules (*linked_module, std::move (lib_ptr),
-                                        llvm::Linker::LinkOnlyNeeded);
+    failed = llvm::Linker::linkModules (*linked_module, std::move (lib_ptr));
 
     // Verify that the NVPTX target has been initialized
     std::string error;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/oslclosure.h>
 #include <OSL/dual.h>
 #include <OSL/dual_vec.h>
+#include <OSL/device_string.h>
 #include "osl_pvt.h"
 #include "constantpool.h"
 
@@ -706,6 +707,14 @@ public:
     ustring colorspace () const { return m_colorspace; }
     OIIO::ColorConfig& colorconfig () { return m_colorconfig; }
 
+    /// Return the tag associated with the given string
+    uint64_t lookup_string_tag (ustring str);
+
+    /// Register a string/tag pair. Return false if the string has already
+    /// been registered with a different tag.
+    bool register_string_tag (ustring str, uint64_t tag);
+
+
 private:
     void printstats () const;
 
@@ -738,6 +747,10 @@ private:
     void SetupLLVM ();
 
     void setup_op_descriptors ();
+
+    /// Set up the mapping from string contents to integer tags, to be used when
+    /// constructing tagged strings for use on GPUs
+    void setup_string_tags ();
 
     RendererServices *m_renderer;         ///< Renderer services
     TextureSystem *m_texturesys;          ///< Texture system
@@ -912,6 +925,9 @@ private:
     atomic_int m_threads_currently_compiling;
     mutable std::map<ustring,long long> m_group_profile_times;
     // N.B. group_profile_times is protected by m_stat_mutex.
+
+    // A mapping from strings to integers, used for constructing tagged strings
+    std::map<ustring, uint64_t> m_tag_map;
 
     friend class OSL::ShadingContext;
     friend class ShaderMaster;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -395,6 +395,22 @@ ShadingSystem::query_closure (const char **name, int *id,
 
 
 
+bool
+ShadingSystem::register_string_tag (string_view str, uint64_t tag)
+{
+    return m_impl->register_string_tag (ustring(str), tag);
+}
+
+
+
+uint64_t
+ShadingSystem::lookup_string_tag (string_view str)
+{
+    return m_impl->lookup_string_tag (ustring(str));
+}
+
+
+
 int
 ShadingSystem::raytype_bit (ustring name)
 {
@@ -780,6 +796,8 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
         attribute ("options", TypeDesc::STRING, &options);
 
     setup_op_descriptors ();
+
+    setup_string_tags ();
 }
 
 
@@ -974,6 +992,15 @@ ShadingSystemImpl::setup_op_descriptors ()
 
 
 void
+ShadingSystemImpl::setup_string_tags ()
+{
+    m_tag_map [ustring("")]            = StringTags::EMPTY_STRING;
+    m_tag_map [ustring("test_string")] = StringTags::TEST_STRING;
+}
+
+
+
+void
 ShadingSystemImpl::register_closure (string_view name, int id,
                                      const ClosureParam *params,
                                      PrepareClosureFunc prepare,
@@ -1008,6 +1035,18 @@ ShadingSystemImpl::query_closure(const char **name, int *id,
     if (params)
         *params = &entry->params[0];
 
+    return true;
+}
+
+
+
+bool
+ShadingSystemImpl::register_string_tag (ustring str, uint64_t tag)
+{
+    if (m_tag_map.count(str) && m_tag_map[str] != tag)
+        return false;
+
+    m_tag_map[str] = tag;
     return true;
 }
 
@@ -1884,6 +1923,14 @@ ShadingSystemImpl::getstats (int level) const
     }
 
     return out.str();
+}
+
+
+
+uint64_t
+ShadingSystemImpl::lookup_string_tag (ustring str)
+{
+    return m_tag_map.count(str) ? m_tag_map[str] : StringTags::UNKNOWN_STRING;
 }
 
 

--- a/src/testoptix/cuda/rend_lib.cu
+++ b/src/testoptix/cuda/rend_lib.cu
@@ -90,7 +90,7 @@ extern "C" {
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
-        if  (w->x == 0.0f && w->y == 0.0f && w->z == 0.0f) {
+        if (w->x == 0.0f && w->y == 0.0f && w->z == 0.0f) {
             return NULL;
         }
 
@@ -108,15 +108,15 @@ extern "C" {
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
-        if  (a == NULL) {
+        if (a == NULL) {
             return NULL;
         }
 
-        if  (w->x == 0.0f && w->y == 0.0f && w->z == 0.0f) {
+        if (w->x == 0.0f && w->y == 0.0f && w->z == 0.0f) {
             return NULL;
         }
 
-        if  (w->x == 1.0f && w->y == 1.0f && w->z == 1.0f) {
+        if (w->x == 1.0f && w->y == 1.0f && w->z == 1.0f) {
             return a;
         }
 
@@ -132,11 +132,11 @@ extern "C" {
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
-        if  (a == NULL || w == 0.0f) {
+        if (a == NULL || w == 0.0f) {
             return NULL;
         }
 
-        if  (w == 1.0f) {
+        if (w == 1.0f) {
             return a;
         }
 
@@ -152,11 +152,11 @@ extern "C" {
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
-        if  (a == NULL) {
+        if (a == NULL) {
             return b;
         }
 
-        if  (b == NULL) {
+        if (b == NULL) {
             return a;
         }
 
@@ -185,7 +185,8 @@ extern "C" {
         return rend_get_userdata ((char*)name, symbol_data, symbol_data_size);
     }
 
-     __device__
+
+    __device__
     void osl_printf (void* sg_, char* fmt_str, void* args)
     {
         printf (fmt_str, args);

--- a/src/testoptix/cuda/rend_lib.cu
+++ b/src/testoptix/cuda/rend_lib.cu
@@ -184,4 +184,10 @@ extern "C" {
         int layer = 0;
         return rend_get_userdata ((char*)name, symbol_data, symbol_data_size);
     }
+
+        __device__
+    void osl_printf (void* sg_, char* fmt_str, void* args)
+    {
+        printf (fmt_str, args);
+    }
 }

--- a/src/testoptix/cuda/rend_lib.cu
+++ b/src/testoptix/cuda/rend_lib.cu
@@ -185,7 +185,7 @@ extern "C" {
         return rend_get_userdata ((char*)name, symbol_data, symbol_data_size);
     }
 
-        __device__
+     __device__
     void osl_printf (void* sg_, char* fmt_str, void* args)
     {
         printf (fmt_str, args);

--- a/src/testoptix/cuda/wrapper.cu
+++ b/src/testoptix/cuda/wrapper.cu
@@ -30,11 +30,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optix.h>
 #include <optixu/optixu_math_namespace.h>
 
+#include <OSL/device_string.h>
+
 #include "rend_lib.h"
 #include "util.h"
 
-
 #define OSL_EXCEPTION_0 (RT_EXCEPTION_USER + 0)
+
+using OSL::device_string;
 
 // Ray payload
 rtDeclareVariable (PRD_radiance, prd_radiance, rtPayload, );
@@ -144,8 +147,21 @@ float3 process_closure(const ClosureColor* closure_tree)
         case WARD_ID:
         case REFLECTION_ID:
         case REFRACTION_ID:
-        case FRESNEL_REFLECTION_ID:
+        case FRESNEL_REFLECTION_ID: {
+            result += ((ClosureComponent*) cur)->w * weight;
+            cur = NULL;
+            break;
+        }
+
         case MICROFACET_ID: {
+#if 0
+            const char*          mem = ((ClosureComponent*) cur)->mem;
+            const device_string* ds  = (const device_string*) &mem[0];
+            if (launch_index.x == launch_dim.x / 2 && launch_index.y == launch_dim.y / 2) {
+                printf ("microfacet, tag %lu, str %s\n", ds->m_tag, ds->m_ptr);
+            }
+#endif
+
             result += ((ClosureComponent*) cur)->w * weight;
             cur = NULL;
             break;

--- a/src/testoptix/cuda/wrapper.cu
+++ b/src/testoptix/cuda/wrapper.cu
@@ -155,8 +155,10 @@ float3 process_closure(const ClosureColor* closure_tree)
 #if 0
             const char*          mem = ((ClosureComponent*) cur)->mem;
             const device_string* ds  = (const device_string*) &mem[0];
+            uint64_t    tag = ds->tag();
+            const char* str = ds->c_str();
             if (launch_index.x == launch_dim.x / 2 && launch_index.y == launch_dim.y / 2) {
-                printf ("microfacet, tag %lu, str %s\n", ds->m_tag, ds->m_ptr);
+                printf ("microfacet, tag %lu, str %s\n", tag, str);
             }
 #endif
 

--- a/src/testoptix/cuda/wrapper.cu
+++ b/src/testoptix/cuda/wrapper.cu
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rend_lib.h"
 #include "util.h"
 
-#define OSL_EXCEPTION_0 (RT_EXCEPTION_USER + 0)
-
 using OSL::device_string;
 
 // Ray payload
@@ -170,11 +168,6 @@ float3 process_closure(const ClosureColor* closure_tree)
         default:
             cur = NULL;
             break;
-        }
-
-        // Throw an exception if the traversal stack overflows
-        if (stack_idx >= STACK_SIZE) {
-            rtThrow(OSL_EXCEPTION_0);
         }
 
         if (cur == NULL && stack_idx > 0) {

--- a/src/testoptix/shading.cpp
+++ b/src/testoptix/shading.cpp
@@ -1,4 +1,5 @@
 #include "shading.h"
+#include <OSL/device_string.h>
 #include <OSL/genclosure.h>
 
 using namespace OSL;
@@ -30,7 +31,7 @@ struct PhongParams      { Vec3 N; float exponent; };
 struct WardParams       { Vec3 N, T; float ax, ay; };
 struct ReflectionParams { Vec3 N; float eta; };
 struct RefractionParams { Vec3 N; float eta; };
-struct MicrofacetParams { ustring dist; Vec3 N, U; float xalpha, yalpha, eta; int refract; };
+struct MicrofacetParams { device_string dist; Vec3 N, U; float xalpha, yalpha, eta; int refract; };
 
 } // anonymous namespace
 
@@ -62,7 +63,7 @@ void register_closures(OSL::ShadingSystem* shadingsys) {
                                                   CLOSURE_FLOAT_PARAM (WardParams, ax),
                                                   CLOSURE_FLOAT_PARAM (WardParams, ay),
                                                   CLOSURE_FINISH_PARAM(WardParams) } },
-        { "microfacet", MICROFACET_ID,          { CLOSURE_STRING_PARAM(MicrofacetParams, dist),
+        { "microfacet", MICROFACET_ID,          { CLOSURE_DEVICE_STRING_PARAM(MicrofacetParams, dist),
                                                   CLOSURE_VECTOR_PARAM(MicrofacetParams, N),
                                                   CLOSURE_VECTOR_PARAM(MicrofacetParams, U),
                                                   CLOSURE_FLOAT_PARAM (MicrofacetParams, xalpha),
@@ -90,6 +91,22 @@ void register_closures(OSL::ShadingSystem* shadingsys) {
             builtins[i].params,
             NULL, NULL);
     }
+}
+
+void register_string_tags(OSL::ShadingSystem* shadingsys) {
+#if 0
+    // The renderer can optionally register strings with specific tags.
+    // The registration will fail if the given string has already been
+    // registered with a different tag.
+    shadingsys->register_string_tag("my_cool_string", 1234u);
+    uint64_t tag = shadingsys->lookup_string_tag("my_cool_string");
+    ASSERT (tag != StringTags::UNKNOWN_STRING && "Unable to register string");
+
+    // Similarly, the renderer can check whether or not a string has been
+    // registered.
+    uint64_t fake_tag = shadingsys->lookup_string_tag("my_fake_string");
+    ASSERT (fake_tag == StringTags::UNKNOWN_STRING && "Unregistered string check failed");
+#endif
 }
 
 OSL_NAMESPACE_EXIT

--- a/src/testoptix/shading.h
+++ b/src/testoptix/shading.h
@@ -9,5 +9,6 @@
 OSL_NAMESPACE_ENTER
 
 void register_closures(ShadingSystem* shadingsys);
+void register_string_tags(ShadingSystem* shadingsys);
 
 OSL_NAMESPACE_EXIT

--- a/src/testoptix/testoptix.cpp
+++ b/src/testoptix/testoptix.cpp
@@ -92,7 +92,6 @@ static std::string shaderpath;
 //     testrender can be used as-is (and they will eventually be used, when
 //     path tracing is added to testoptix)
 
-bool optix_exceptions = false;
 optix::Context optix_ctx = NULL;
 
 static std::string renderer_ptx;  // ray generation, etc.
@@ -132,7 +131,6 @@ void getargs(int argc, const char *argv[])
                 "--debugnan", &debugnan, "Turn on 'debugnan' mode",
                 "--path %s", &shaderpath, "Specify oso search path",
                 "--options %s", &extraoptions, "Set extra OSL options",
-                "--exceptions", &optix_exceptions, "Enable OptiX device exceptions",
                 NULL);
     if (ap.parse(argc, argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
@@ -418,14 +416,7 @@ void init_optix_context ()
     optix_ctx->setRayTypeCount (2);
     optix_ctx->setEntryPointCount (1);
     optix_ctx->setStackSize (2048);
-
     optix_ctx->setPrintEnabled (true);
-
-    // OptiX device exceptions and printing are disabled by default, but they
-    // can be enabled for debugging using the command-line option --exceptions
-    if (optix_exceptions) {
-        optix_ctx->setExceptionEnabled (RT_EXCEPTION_ALL, true);
-    }
 
     optix_ctx["radiance_ray_type"]->setUint  (0u);
     optix_ctx["shadow_ray_type"  ]->setUint  (1u);

--- a/src/testoptix/testoptix.cpp
+++ b/src/testoptix/testoptix.cpp
@@ -72,6 +72,7 @@ bool debug2 = false;
 bool verbose = false;
 bool runstats = false;
 bool saveptx = false;
+bool warmup = false;
 int profile = 0;
 bool O0 = false, O1 = false, O2 = false;
 bool debugnan = false;
@@ -122,6 +123,7 @@ void getargs(int argc, const char *argv[])
                 "--debug2", &debug2, "Even more debugging info",
                 "--runstats", &runstats, "Print run statistics",
                 "--saveptx", &saveptx, "Save the generated PTX",
+                "--warmup", &warmup, "Perform a warmup launch",
                 "-r %d %d", &xres, &yres, "Render a WxH image",
                 "-aa %d", &aa, "Trace NxN rays per pixel",
                 "-t %d", &num_threads, "Render using N threads (default: auto-detect)",
@@ -620,7 +622,9 @@ int main (int argc, const char *argv[])
     double setuptime = timer.lap ();
 
     // Perform a tiny launch to warm up the OptiX context
-    optix_ctx->launch (0, 1, 1);
+    if (warmup)
+        optix_ctx->launch (0, 1, 1);
+
     double warmuptime = timer.lap ();
 
     // Launch the GPU kernel to render the scene
@@ -655,7 +659,9 @@ int main (int argc, const char *argv[])
         double writetime = timer.lap();
         std::cout << "\n";
         std::cout << "Setup : " << OIIO::Strutil::timeintervalformat (setuptime,2) << "\n";
-        std::cout << "Warmup: " << OIIO::Strutil::timeintervalformat (warmuptime,2) << "\n";
+        if (warmup) {
+            std::cout << "Warmup: " << OIIO::Strutil::timeintervalformat (warmuptime,2) << "\n";
+        }
         std::cout << "Run   : " << OIIO::Strutil::timeintervalformat (runtime,2) << "\n";
         std::cout << "Write : " << OIIO::Strutil::timeintervalformat (writetime,2) << "\n";
         std::cout << "\n";

--- a/testsuite/testoptix/ref/out.txt
+++ b/testsuite/testoptix/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled checkerboard.osl -> checkerboard.oso
+Compiled matte.osl -> matte.oso
+Compiled test_print.osl -> test_print.oso
+str: default

--- a/testsuite/testoptix/run.py
+++ b/testsuite/testoptix/run.py
@@ -2,5 +2,6 @@
 
 failthresh = 0.03   # allow a little more LSB noise between platforms
 failpercent = .5
-outputs = [ "out.exr" ]
-command = testoptix("-r 320 240 scene.xml out.exr")
+outputs  = [ "out.exr", "out.txt" ]
+command  = testoptix("-r 320 240 scene.xml out.exr")
+command += testoptix("-r 1 1 test_print.xml dummy.exr")

--- a/testsuite/testoptix/test_print.osl
+++ b/testsuite/testoptix/test_print.osl
@@ -1,0 +1,21 @@
+surface
+test_print
+    [[ string description = "Lambertian diffuse material" ]]
+(
+    float Kd = 1
+        [[  string description = "Diffuse scaling",
+            float UImin = 0, float UIsoftmax = 1 ]],
+    string str = "default",
+    color Cs = 1
+        [[  string description = "Base color",
+            float UImin = 0, float UImax = 1 ]]
+  )
+{
+    string tmp_str;
+    if (Cs[0] == 0)
+        tmp_str = "non-default";
+    else
+        tmp_str = str;
+
+    printf("str: %s\n", str);
+}

--- a/testsuite/testoptix/test_print.osl
+++ b/testsuite/testoptix/test_print.osl
@@ -1,21 +1,5 @@
-surface
-test_print
-    [[ string description = "Lambertian diffuse material" ]]
-(
-    float Kd = 1
-        [[  string description = "Diffuse scaling",
-            float UImin = 0, float UIsoftmax = 1 ]],
-    string str = "default",
-    color Cs = 1
-        [[  string description = "Base color",
-            float UImin = 0, float UImax = 1 ]]
-  )
+surface test_print ( string str = "default", color Cs = 1)
 {
-    string tmp_str;
-    if (Cs[0] == 0)
-        tmp_str = "non-default";
-    else
-        tmp_str = str;
-
     printf("str: %s\n", str);
+    Ci = Cs * diffuse (N);
 }

--- a/testsuite/testoptix/test_print.xml
+++ b/testsuite/testoptix/test_print.xml
@@ -1,0 +1,9 @@
+<World>
+   <Camera eye="0, 0, 100" look_at="0,0,0" fov="70" />
+
+   <ShaderGroup name="printer">
+     shader test_print layer1;
+   </ShaderGroup>
+   <Quad corner="-100,-100,0" edge_x="200,0,0" edge_y="0,200,0" />
+   
+</World>


### PR DESCRIPTION
## Description

This pull request adds a new string representation, ``device_string``, which is intended to be a GPU-friendly alternative to ``OIIO::ustring``. A ``device_string`` is essentially a struct consisting of an integer ID and a pointer to a C-style string:

```C++
    struct device_string {
        uint64_t m_tag;
        const char* m_chars;
    };
```

The ID can be used to perform fast comparison between two ``device_string`` values, similar to how pointer comparisons are used with ``ustring``. The ``char*`` is available for cases where the string contents are needed (mainly ``printf``).

``device_string`` only supports a limited sub-set of string functionality. No dynamic operations are supported.

___IMPORTANT NOTE___
The minimum version of OptiX has been increased to 5.1, to accommodate ``device_string`` initializers in compiled C++/CUDA code.

#### Assigning IDs
For comparisons between compiled and user-supplied strings to be valid, all parties (especially ``liboslexec`` and the renderer) must agree on their IDs. This approach involves assigning fixed IDs to some subset of "important" strings (closure parameters, texture options, etc.), while allowing the user to assign additional tags via the OSL ShadingSystem. Shader compile-time strings that do not have a pre-defined tag fall back to the ``ustring`` hash.

The tags for important, common strings are defined in a shared header file (``OSL/device_string.h``):  
```c++
    enum StringTags: uint64_t {
        EMPTY_STRING = 0,
        PERLIN,
        UPERLIN,
        ...
        UNKNOWN_STRING = ~0u
    };
```

Additional string tags can be registered int the renderer setup code (a more detailed example is in ``testoptix/shading.cpp``):
```C++
    // this call will fail if "test string" has been registered with a different tag
    shadingsystem->register_string_tag ("test", 1234u);
    // the renderer can query the ShadingSystem for registered strings
    uint64_t tag = shadingsystem->lookup_string_tag ("perlin");
```

It should be noted that no attempt is made to guarantee the uniqueness of ``device_string`` IDs, as that implies a central run-time registry, which is a mechanism we are trying to avoid. This places some burden on the renderer to ensure that tag values are used consistently.

## Tests

We have added a ``printf`` test to the testsuite. More tests will be forthcoming in subsequent pull requests that exercise string functionality more thoroughly.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

