### PR TITLE
Flex --wincompat patch

### DIFF
--- a/src/cmake/flexbison.cmake
+++ b/src/cmake/flexbison.cmake
@@ -76,8 +76,13 @@ IF ( FLEX_EXECUTABLE AND BISON_EXECUTABLE )
           MAIN_DEPENDENCY ${bisonsrc}
           DEPENDS ${${compiler_headers}}
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
+        if ( WINDOWS )
+            SET ( WINCOMPAT --wincompat )
+        else ()
+            SET ( WINCOMPAT )
+        endif ()
         ADD_CUSTOM_COMMAND ( OUTPUT ${flexoutputcxx} 
-          COMMAND ${FLEX_EXECUTABLE} -o ${flexoutputcxx} "${CMAKE_CURRENT_SOURCE_DIR}/${flexsrc}"
+          COMMAND ${FLEX_EXECUTABLE} ${WINCOMPAT} -o ${flexoutputcxx} "${CMAKE_CURRENT_SOURCE_DIR}/${flexsrc}"
           MAIN_DEPENDENCY ${flexsrc}
           DEPENDS ${${compiler_headers}}
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )


### PR DESCRIPTION
## Description

The windows version of flex needs the --wincompat flag set.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

