### PR TITLE
New shader types: camera, image

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -60,7 +60,7 @@ Language Specification
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 31 Mar 2018 \\
+\date{{\large Date: 22 Jun 2018 \\
 % (with corrections, 31 Mar 2018)
 }
 \bigskip
@@ -583,17 +583,11 @@ The attribute state also includes shader assignments --- the shaders or
 shader groups for each of several \emph{shader uses}, such as surface
 shaders that designate how light reflects or emits from each point on a shape,
 displacement shaders that can add fine detail to the shape on a
-point-by-point basis, and volume shaders that describe how light is
-scattered within a region of space.  A particular renderer may have
-additional shader types that it supports.
-
-%\subsection*{Shader types}
-%
-%There are several types of shaders: surface, displacement, light,
-%volume.  The type of shader determines what it's allowed to do (for
-%example, only displacement shaders can alter the surface position).
-%There is also a generic kind of shader that can be used for any of the
-%shader uses.
+point-by-point basis, volume shaders that describe how light is
+scattered within a region of space, camera shaders that can specify
+projection or lens effects, and image shaders that can perform image
+processing or compositing operations on output images.
+A particular renderer may support only a subset of shader types.
 
 \subsection*{Shader execution state: parameter binding and global variables}
 
@@ -916,9 +910,10 @@ ordinary execution instructions (such as assignments, etc.).
 \index{shader types} \index{types!shader}
 
 Shader types include the following: {\cf surface}, {\cf displacement},
-{\cf light}, {\cf volume}, and generic {\cf shader}.  Some operations
+{\cf light}, {\cf volume}, {\cf camera}, {\cf image},
+and generic {\cf shader}.  Some operations
 may only be performed from within certain types of shaders (e.g., one
-may only call {\cf displace()} or alter \P in a displacement shader),
+may only call {\cf displace()} or alter \P in a displacement or camera shader),
 and some global variables may only be accessed from within certain types
 of shaders (e.g., {\cf dPdu} is not defined inside a volume shader).
 
@@ -955,6 +950,20 @@ side of the medium.  They are similar to {\cf surface} shaders, except
 that they may be called from positions that do not lie upon (and are not
 necessarily associated with) any particular primitive.
 
+\subsection*{{\cf camera} shaders}
+
+Camera shaders take a $(u,v)$ coordinate on the image plane and optionally
+warp the view direction (as \P and \I). This can be used for certain
+projection and lens effects. (Note: there may be renderer implementations
+that are not able to support camera shaders.)
+
+\subsection*{{\cf image} shaders}
+
+Image shaders run on the results of a rendered images (including all outputs
+such as AOVs) and can generate new outputs. Alternatively, an image shader
+can be used to express most pixel-by-pixel image processing or compositing
+operations.
+
 
 
 \subsection*{{\cf shader} generic shaders}
@@ -962,10 +971,10 @@ necessarily associated with) any particular primitive.
 Generic shaders are used for utility code, generic routines that may be
 called as individual layers in a shader group.  Generic shaders need not
 specify a shader type, and therefore may be reused from inside surface,
-displacement, or volume shader groups.  But as a result, they may
+displacement, volume, camera, or image shader groups.  But as a result, they may
 not contain any functionality that cannot be performed from inside all
 shader types (for example, they may not alter \P, which can only be done
-from within a displacement shader).
+from within a displacement or camera shader).
 
 
 \section{Shader parameters}
@@ -2812,56 +2821,23 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 \end{table}
 
 
-\begin{comment}  % old table
-\begin{table}
-\begin{tabular}{|p{1in}p{0.75in}p{0.75in}p{0.75in}p{1.7in}|}
-\hline
-{\bf Variable} & surface & displacement & volume & light \\
-\hline
-\P            & R     & RW & R     & R \\
-\I            & R     &    & R &   \\
-\N            & RW    & RW &  &  \\
-{\cf Ng}      & R     & R  &  &  \\
-{\cf dPdu}    & R     & R  &  &  \\
-{\cf dPdv}    & R     & R  &  &  \\
-{\cf u, v}    & R     & R  & R$^1$ & R$^1$ \\
-{\cf time}    & R     & R  & R     & R \\
-{\cf dtime}   & R     & R  & R     & R \\
-{\cf dPdtime} & R     & R  & R     & R \\
-\Ci           & RW    &    & RW    & \\
-%\Oi           & RW    &    & RW    & \\
-%{\cf L}       & R$^2$ &    & R$^2$ & RW \\
-{\cf L}       &       &    &       & RW \\
-%{\cf Cl}      & R$^2$ &    & R$^2$ & RW \\
-{\cf Cl}      &       &    &       & RW \\
-{\cf Ps}      &       &    &       & R \\
-{\cf Ns}      &       &    &       & R \\
-%{\cf Pl}      &       &    & R$^2$ & R \\
-%{\cf Nl}      &       &    & R$^2$ & R \\
-{\cf Pl}      &       &    &  & R \\
-{\cf Nl}      &       &    &  & R \\
-\hline 
-\end{tabular}
-\end{table}
-\end{comment}
-
 \begin{table}
 \begin{tabular}{|p{1in}p{0.75in}p{0.75in}p{0.75in}|}
 \hline
-{\bf Variable} & surface & displacement & volume  \\
+{\bf Variable} & surface & displacement & volume & camera & image \\
 \hline
-\P            & R     & RW & R      \\
-\I            & R     &    & R    \\
-\N            & RW    & RW &    \\
-{\cf Ng}      & R     & R  &    \\
-{\cf dPdu}    & R     & R  &    \\
-{\cf dPdv}    & R     & R  &    \\
-{\cf Ps}      &       &    & R   \\
-{\cf u, v}    & R     & R  & R   \\
-{\cf time}    & R     & R  & R       \\
-{\cf dtime}   & R     & R  & R       \\
-{\cf dPdtime} & R     & R  & R       \\
-\Ci           & RW    &    & RW     \\
+\P            & R        & RW           & R      & RW     &       \\
+\I            & R        &              & R      & RW     &       \\
+\N            & RW       & RW           &        &        &       \\
+{\cf Ng}      & R        & R            &        &        &       \\
+{\cf dPdu}    & R        & R            &        & R      &       \\
+{\cf dPdv}    & R        & R            &        & R      &       \\
+%{\cf Ps}      &          &              & R      &        &       \\
+{\cf u, v}    & R        & R            & R      & R      & R     \\
+{\cf time}    & R        & R            & R      & R      & R     \\
+{\cf dtime}   & R        & R            & R      & R      & R     \\
+{\cf dPdtime} & R        & R            & R      & R      &       \\
+\Ci           & RW       &              & RW     &        &       \\
 \hline 
 \end{tabular}
 
@@ -5320,7 +5296,7 @@ nothing (empty, no token).
     <shadertype> <identifier> <metadata-block-opt> 
     "(" <shader-formal-params-opt> ")" "{" <statement-list> "}"
 
-<shadertype> ::= "displacement" |  "shader" | "surface" | "volume"
+<shadertype> ::= "camera" | displacement" | "image" | "shader" | "surface" | "volume"
 
 <shader-formal-params> ::= <shader-formal-param> \{ "," <shader-formal-param> \}
 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -43,10 +43,9 @@ class StructSpec;
 
 /// Kinds of shaders
 ///
-enum ShaderType {
-    ShadTypeUnknown=0, ShadTypeGeneric, ShadTypeSurface,
-    ShadTypeDisplacement, ShadTypeVolume, ShadTypeLight,
-    ShadTypeLast
+enum class ShaderType {
+    Unknown=0, Generic, Surface, Displacement, Volume, Light, Camera, Image,
+    Last
 };
 
 
@@ -62,9 +61,9 @@ ShaderType shadertype_from_name (string_view name);
 
 /// Uses of shaders
 ///
-enum ShaderUse {
-    ShadUseSurface, ShadUseDisplacement,
-    ShadUseLast, ShadUseUnknown = ShadUseLast
+enum class ShaderUse {
+    Surface, Displacement, Camera, Image,
+    Last, Unknown = Last
 };
 
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -413,6 +413,7 @@ public:
     ref formals () const { return child (1); }
     ref statements () const { return child (2); }
     ustring shadername () const { return m_shadername; }
+    ShaderType shadertype () const { return (ShaderType)m_op; }
     string_view shadertypename () const;
 
 private:

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -199,6 +199,17 @@ public:
     ///
     ASTNode::ref shader () const { return m_shader; }
 
+    /// Pointer to the ASTshader_declaration.
+    ASTshader_declaration* shaderdecl () const {
+        if (m_shader && m_shader->nodetype() == ASTNode::shader_declaration_node)
+            return (ASTshader_declaration *) m_shader.get();
+        else
+            return nullptr;
+    }
+
+    /// What kind of shader are we compiling?
+    ShaderType shadertype () const;
+
     /// Return a reference to the symbol table.
     ///
     SymbolTable &symtab () { return m_symtab; }

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -170,7 +170,7 @@ global_declaration
 shader_or_function_declaration
         : typespec_or_shadertype IDENTIFIER
                 {
-                    if ($1 == ShadTypeUnknown) {
+                    if ($1 == (int)ShaderType::Unknown) {
                         // It's a function declaration, not a shader
                         oslcompiler->symtab().push ();  // new scope
                         typespec_stack.push (oslcompiler->current_typespec());
@@ -178,7 +178,7 @@ shader_or_function_declaration
                 }
           metadata_block_opt '(' 
                 {
-                    if ($1 != ShadTypeUnknown)
+                    if ($1 != (int)ShaderType::Unknown)
                         oslcompiler->declaring_shader_formals (true);
                 }
           formal_params_opt ')'
@@ -187,7 +187,7 @@ shader_or_function_declaration
                 }
           metadata_block_opt function_body_or_just_decl
                 {
-                    if ($1 == ShadTypeUnknown) {
+                    if ($1 == (int)ShaderType::Unknown) {
                         // Function declaration
                         oslcompiler->symtab().pop ();  // restore scope
                         ASTfunction_declaration *f;
@@ -589,13 +589,17 @@ typespec_or_shadertype
                 {
                     ustring name ($1);
                     if (name == "shader")
-                        $$ = ShadTypeGeneric;
+                        $$ = (int)ShaderType::Generic;
                     else if (name == "surface")
-                        $$ = ShadTypeSurface;
+                        $$ = (int)ShaderType::Surface;
                     else if (name == "displacement")
-                        $$ = ShadTypeDisplacement;
+                        $$ = (int)ShaderType::Displacement;
                     else if (name == "volume")
-                        $$ = ShadTypeVolume;
+                        $$ = (int)ShaderType::Volume;
+                    else if (name == "camera")
+                        $$ = (int)ShaderType::Camera;
+                    else if (name == "image")
+                        $$ = (int)ShaderType::Image;
                     else {
                         Symbol *s = oslcompiler->symtab().find (name);
                         if (s && s->is_structure())
@@ -606,7 +610,7 @@ typespec_or_shadertype
                                                 oslcompiler->lineno(),
                                                 "Unknown struct name: %s", $1);
                         }
-                        $$ = ShadTypeUnknown;
+                        $$ = (int)ShaderType::Unknown;
                     }
                 }
         ;

--- a/src/liboslexec/oslexec.cpp
+++ b/src/liboslexec/oslexec.cpp
@@ -48,11 +48,13 @@ string_view
 shadertypename (ShaderType s)
 {
     switch (s) {
-    case ShadTypeGeneric:      return ("shader");
-    case ShadTypeSurface:      return ("surface");
-    case ShadTypeDisplacement: return ("displacement");
-    case ShadTypeVolume:       return ("volume");
-    case ShadTypeLight:        return ("light");
+    case ShaderType::Generic :      return ("shader");
+    case ShaderType::Surface :      return ("surface");
+    case ShaderType::Displacement : return ("displacement");
+    case ShaderType::Volume :       return ("volume");
+    case ShaderType::Light :        return ("light");
+    case ShaderType::Camera :       return ("camera");
+    case ShaderType::Image :        return ("image");
     default:
         ASSERT (0 && "Invalid shader type");
     }
@@ -64,16 +66,20 @@ ShaderType
 shadertype_from_name (string_view name)
 {
     if (name == "shader" || name == "generic")
-        return ShadTypeGeneric;
+        return ShaderType::Generic;
     if (name == "surface")
-        return ShadTypeSurface;
+        return ShaderType::Surface;
     if (name == "displacement")
-        return ShadTypeDisplacement;
+        return ShaderType::Displacement;
     if (name == "volume")
-        return ShadTypeVolume;
+        return ShaderType::Volume;
     if (name == "light")
-        return ShadTypeLight;
-    return ShadTypeUnknown;
+        return ShaderType::Light;
+    if (name == "camera")
+        return ShaderType::Camera;
+    if (name == "image")
+        return ShaderType::Image;
+    return ShaderType::Unknown;
 }
 
 
@@ -81,8 +87,10 @@ const char *
 shaderusename (ShaderUse s)
 {
     switch (s) {
-    case ShadUseSurface:      return ("surface");
-    case ShadUseDisplacement: return ("displacement");
+    case ShaderUse::Surface :      return ("surface");
+    case ShaderUse::Displacement : return ("displacement");
+    case ShaderUse::Camera :       return ("camera");
+    case ShaderUse::Image :        return ("image");
     default:
         ASSERT (0 && "Invalid shader use");
     }
@@ -94,10 +102,14 @@ ShaderUse
 shaderuse_from_name (string_view name)
 {
     if (name == "surface")
-        return ShadUseSurface;
+        return ShaderUse::Surface;
     if (name == "displacement")
-        return ShadUseDisplacement;
-    return ShadUseLast;
+        return ShaderUse::Displacement;
+    if (name == "camera")
+        return ShaderUse::Camera;
+    if (name == "image")
+        return ShaderUse::Image;
+    return ShaderUse::Last;
 }
 
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1942,7 +1942,7 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname)
         return ShaderGroupRef();
     }
     m_in_group = true;
-    m_group_use = ShadUseUnknown;
+    m_group_use = ShaderUse::Unknown;
     m_curgroup.reset (new ShaderGroup(groupname));
     m_curgroup->m_exec_repeat = m_exec_repeat;
     return m_curgroup;
@@ -1959,7 +1959,7 @@ ShadingSystemImpl::ShaderGroupEnd (void)
     }
 
     // Mark the layers that can be run lazily
-    if (m_group_use != ShadUseUnknown) {
+    if (m_group_use != ShaderUse::Unknown) {
         int nlayers = m_curgroup->nlayers ();
         for (int layer = 0;  layer < nlayers;  ++layer) {
             ShaderInstance *inst = (*m_curgroup)[layer];
@@ -1992,7 +1992,7 @@ ShadingSystemImpl::ShaderGroupEnd (void)
     }
 
     m_in_group = false;
-    m_group_use = ShadUseUnknown;
+    m_group_use = ShaderUse::Unknown;
 
     ustring groupname = m_curgroup->name();
     if (groupname.size() && groupname == m_archive_groupname) {
@@ -2023,7 +2023,7 @@ ShadingSystemImpl::Shader (string_view shaderusage,
     }
 
     ShaderUse use = shaderuse_from_name (shaderusage);
-    if (use == ShadUseUnknown) {
+    if (use == ShaderUse::Unknown) {
         error ("Unknown shader usage \"%s\"", shaderusage);
         return false;
     }
@@ -2040,13 +2040,13 @@ ShadingSystemImpl::Shader (string_view shaderusage,
     instance->parameters (m_pending_params);
     m_pending_params.clear ();
 
-    if (singleton || m_group_use == ShadUseUnknown) {
+    if (singleton || m_group_use == ShaderUse::Unknown) {
         // A singleton, or the first in a group
         m_curgroup->clear ();
         m_stat_groups += 1;
     }
     if (! singleton) {
-        if (m_group_use == ShadUseUnknown) {  // First shader in group
+        if (m_group_use == ShaderUse::Unknown) {  // First shader in group
             m_group_use = use;
         } else if (use != m_group_use) {
             error ("Shader usage \"%s\" does not match current group (%s)",
@@ -2554,7 +2554,7 @@ ShadingSystemImpl::find_named_layer_in_group (ustring layername,
                                               ShaderInstance * &inst)
 {
     inst = NULL;
-    if (m_group_use >= ShadUseUnknown)
+    if (m_group_use >= ShaderUse::Unknown)
         return -1;
     ShaderGroup &group (*m_curgroup);
     for (int i = 0;  i < group.nlayers();  ++i) {


### PR DESCRIPTION
'camera' shaders can do lens or projection effects, and are allowed to
modify P and I.

'image' shaders can do image processing or post-render passes on pixels.

For image shaders, we're presuming that u,v are image coordinates, and
that texture lookups are capable of referencing the AOV buffers, and
have special semantics that when it's clear you are directly looking up
at u,v, it directly grabs corresponding pixels and avoids "double
filtering". (The exact implementation of these details are coming
later.)

If the docs are a little vague, that's because we're still exploring how
they can and should be used. For this review, we're just allowing those
new names and types when compiling shaders, which primarily boils down
to what global variables you're allowed to mess with inside of them.

In the process, I fixed a longstanding bug, which is that we were not
properly checking that shaders weren't modifying global variables that
were documented to be read-only in that shader type. Hopefully this
won't break people much... you really shouldn't have been depending on
breaking the rules.

Note that I've changed the internal ShaderType and ShaderUse to be fully
modern 'enum class' with proper namespacing.
