### PR TITLE
Fix compiler error on MSVC -- suspicious static_assert

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -80,7 +80,6 @@ public:
             m_data[i] = T(x.m_data[i]);
     }
 
-#if 1
     /// Copy constructor from another Dual of same dimension and different,
     /// but castable, data type.
     template<class F>
@@ -88,7 +87,6 @@ public:
         for (int i = 0; i <= PARTIALS; ++i)
             m_data[i] = T(x.elem(i));
     }
-#endif
 
     /// Construct a Dual from a real and infinitesimals.
     ///
@@ -113,7 +111,9 @@ public:
     }
 
     OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (std::initializer_list<T> vals) {
+#if OIIO_CPLUSPLUS_VERSION >= 14
         static_assert (vals.size() == elements, "Wrong number of initializers");
+#endif
         for (int i = 0; i < elements; ++i)
             m_data[i] = vals.begin()[i];
     }


### PR DESCRIPTION
In dual.h, we static_assert involving std::initializer_list<T>::size(),
which is constexpr only for C++14 and on. This seemed to work for clang
and gcc, but MSVC 15 doesn't like it. Guard it so that it only applies
for C++ >= 14, in which the constexpr makes it more certainly legal for
static_assert to reference initializer_list::size().

Fixes #897

Couldn't help myself, also removed a pointless `#if 1` that was loitering nearby.
