### PR TITLE
ShaderType/ShaderUse refactoring

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -587,13 +587,6 @@ point-by-point basis, and volume shaders that describe how light is
 scattered within a region of space.  A particular renderer may have
 additional shader types that it supports.
 
-%\subsection*{Shader types}
-%
-%There are several types of shaders: surface, displacement, light,
-%volume.  The type of shader determines what it's allowed to do (for
-%example, only displacement shaders can alter the surface position).
-%There is also a generic kind of shader that can be used for any of the
-%shader uses.
 
 \subsection*{Shader execution state: parameter binding and global variables}
 

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -92,6 +92,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/platform.h>
 
+// Make sure we can use OIIO::cspan
+#if OIIO_VERSION >= 10904
+#  include <OpenImageIO/span.h>
+#else
+#  include <OpenImageIO/array_view.h>
+#endif
+
 // Extensions to Imath
 #include <OSL/matrix22.h>
 
@@ -137,6 +144,14 @@ using OIIO::TypeDesc;
 using OIIO::ustring;
 using OIIO::ustringHash;
 using OIIO::string_view;
+
+// Make sure we can use OIIO::cspan
+#if OIIO_VERSION >= 10904
+  using OIIO::cspan;
+#else
+  template<typename T> using cspan = OIIO::array_view<const T>;
+#endif
+
 
 #ifndef __has_attribute
 #  define __has_attribute(x) 0

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -277,6 +277,12 @@ public:
     ///   int unknown_closures_needed  Nonzero if additional closures may be
     ///                                needed, whose names can't be known
     ///                                without actually running the shader.
+    ///   int globals_read           Bitfield ("or'ed" SGBits values) of
+    ///                                which ShaderGlobals may be read by
+    ///                                by the shader group.
+    ///   int globals_write         Bitfield ("or'ed" SGBits values) of
+    ///                                which ShaderGlobals may be written by
+    ///                                by the shader group.
     ///   int num_globals_needed     The number of named globals needed.
     ///   ptr globals_needed         Retrieves a pointer to the ustring array
     ///                                containing all globals needed.
@@ -402,12 +408,12 @@ public:
     bool Parameter (string_view name, TypeDesc t, const void *val,
                     bool lockgeom);
 
-    /// Create a new shader instance, either replacing the one for the
-    /// specified usage (if not within a group) or appending to the
-    /// current group (if a group has been started).
+    /// Create a new shader instance, either replacing the current group (if
+    /// not within a group) or appending to the current group (if a group
+    /// has been started).
     bool Shader (string_view shaderusage,
-                 string_view shadername = string_view(),
-                 string_view layername = string_view());
+                 string_view shadername,
+                 string_view layername);
 
     /// Connect two shaders within the current group. The source layer must
     /// be *upstream* of down destination layer (i.e. source must be
@@ -569,6 +575,13 @@ public:
     /// optional but at least one of name or id must non NULL.
     bool query_closure (const char **name, int *id,
                         const ClosureParam **params);
+
+    /// For the proposed shader "global" name, return the corresponding
+    /// SGBits enum.
+    static SGBits globals_bit (ustring name);
+
+    /// For the SGBits value, return the shader "globals" name.
+    static ustring globals_name (SGBits bit);
 
     /// For the proposed raytype name, return the bit pattern that
     /// describes it, or 0 for an unrecognized name.  (This retrieves

--- a/src/include/OSL/shaderglobals.h
+++ b/src/include/OSL/shaderglobals.h
@@ -145,4 +145,25 @@ struct ShaderGlobals {
 };
 
 
+
+/// Enum giving values that can be 'or'-ed together to make a bitmask
+/// of which "global" variables are needed or written to by the shader.
+enum class SGBits {
+    None    = 0,
+    P       = 1 <<  0,
+    I       = 1 <<  1,
+    N       = 1 <<  2,
+    Ng      = 1 <<  3,
+    u       = 1 <<  4,
+    v       = 1 <<  5,
+    dPdu    = 1 <<  6,
+    dPdv    = 1 <<  7,
+    time    = 1 <<  8,
+    dtime   = 1 <<  9,
+    dPdtime = 1 << 10,
+    Ps      = 1 << 11,
+    Ci      = 1 << 12,
+    last
+};
+
 OSL_NAMESPACE_EXIT

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -43,10 +43,9 @@ class StructSpec;
 
 /// Kinds of shaders
 ///
-enum ShaderType {
-    ShadTypeUnknown=0, ShadTypeGeneric, ShadTypeSurface,
-    ShadTypeDisplacement, ShadTypeVolume, ShadTypeLight,
-    ShadTypeLast
+enum class ShaderType {
+    Unknown=0, Generic, Surface, Displacement, Volume, Light,
+    Last
 };
 
 
@@ -57,24 +56,6 @@ string_view shadertypename (ShaderType s);
 /// Convert a ShaderType to a human-readable name ("surface", etc.)
 ///
 ShaderType shadertype_from_name (string_view name);
-
-
-
-/// Uses of shaders
-///
-enum ShaderUse {
-    ShadUseSurface, ShadUseDisplacement,
-    ShadUseLast, ShadUseUnknown = ShadUseLast
-};
-
-
-/// Convert a ShaderUse to a human-readable name ("surface", etc.)
-///
-const char *shaderusename (ShaderUse s);
-
-/// Convert a ShaderUse to a human-readable name ("surface", etc.)
-///
-ShaderUse shaderuse_from_name (string_view name);
 
 
 

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -682,7 +682,7 @@ OSLCompilerImpl::initialize_globals ()
 {
     static GlobalTable globals[] = {
         { "P", TypeDesc::TypePoint, false },
-        { "I", TypeDesc::TypeVector },
+        { "I", TypeDesc::TypeVector, false },
         { "N", TypeDesc::TypeNormal, false },
         { "Ng", TypeDesc::TypeNormal },
         { "u", TypeDesc::TypeFloat },
@@ -1129,8 +1129,9 @@ OSLCompilerImpl::struct_field_pair (const StructSpec *structspec, int fieldnum,
 
 
 
-/// Verify that the given symbol (written by the given op) is legal to
-/// be written.
+/// Verify that the given symbol (written by the given op) is legal to be
+/// written. If writeable, it's writeable, We don't try to enforce
+/// differences in policy per shader types.
 void
 OSLCompilerImpl::check_write_legality (const Opcode &op, int opnum,
                                        const Symbol *sym)
@@ -1148,9 +1149,6 @@ OSLCompilerImpl::check_write_legality (const Opcode &op, int opnum,
                "Cannot write to input parameter '%s' (op %d)",
                sym->name().c_str(), opnum);
     }
-
-    // FIXME -- check for writing to globals.  But it's tricky, depends on
-    // what kind of shader we are.
 }
 
 

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -170,7 +170,7 @@ global_declaration
 shader_or_function_declaration
         : typespec_or_shadertype IDENTIFIER
                 {
-                    if ($1 == ShadTypeUnknown) {
+                    if ($1 == (int)ShaderType::Unknown) {
                         // It's a function declaration, not a shader
                         oslcompiler->symtab().push ();  // new scope
                         typespec_stack.push (oslcompiler->current_typespec());
@@ -178,7 +178,7 @@ shader_or_function_declaration
                 }
           metadata_block_opt '(' 
                 {
-                    if ($1 != ShadTypeUnknown)
+                    if ($1 != (int)ShaderType::Unknown)
                         oslcompiler->declaring_shader_formals (true);
                 }
           formal_params_opt ')'
@@ -187,7 +187,7 @@ shader_or_function_declaration
                 }
           metadata_block_opt function_body_or_just_decl
                 {
-                    if ($1 == ShadTypeUnknown) {
+                    if ($1 == (int)ShaderType::Unknown) {
                         // Function declaration
                         oslcompiler->symtab().pop ();  // restore scope
                         ASTfunction_declaration *f;
@@ -587,15 +587,19 @@ typespec_or_shadertype
                 }
         | IDENTIFIER /* struct name or shader type name */
                 {
+                    /* N.B. Shader types are considered obsolete. We are
+                     * promoting 'shader' for all, now (OSL 2.0). Some day
+                     * we may add a warning for using the old names.
+                     */
                     ustring name ($1);
                     if (name == "shader")
-                        $$ = ShadTypeGeneric;
+                        $$ = (int)ShaderType::Generic;
                     else if (name == "surface")
-                        $$ = ShadTypeSurface;
+                        $$ = (int)ShaderType::Surface;
                     else if (name == "displacement")
-                        $$ = ShadTypeDisplacement;
+                        $$ = (int)ShaderType::Displacement;
                     else if (name == "volume")
-                        $$ = ShadTypeVolume;
+                        $$ = (int)ShaderType::Volume;
                     else {
                         Symbol *s = oslcompiler->symtab().find (name);
                         if (s && s->is_structure())
@@ -606,7 +610,7 @@ typespec_or_shadertype
                                                 oslcompiler->lineno(),
                                                 "Unknown struct name: %s", $1);
                         }
-                        $$ = ShadTypeUnknown;
+                        $$ = (int)ShaderType::Unknown;
                     }
                 }
         ;

--- a/src/liboslexec/oslexec.cpp
+++ b/src/liboslexec/oslexec.cpp
@@ -48,11 +48,11 @@ string_view
 shadertypename (ShaderType s)
 {
     switch (s) {
-    case ShadTypeGeneric:      return ("shader");
-    case ShadTypeSurface:      return ("surface");
-    case ShadTypeDisplacement: return ("displacement");
-    case ShadTypeVolume:       return ("volume");
-    case ShadTypeLight:        return ("light");
+    case ShaderType::Generic :      return ("shader");
+    case ShaderType::Surface :      return ("surface");
+    case ShaderType::Displacement : return ("displacement");
+    case ShaderType::Volume :       return ("volume");
+    case ShaderType::Light :        return ("light");
     default:
         ASSERT (0 && "Invalid shader type");
     }
@@ -64,40 +64,16 @@ ShaderType
 shadertype_from_name (string_view name)
 {
     if (name == "shader" || name == "generic")
-        return ShadTypeGeneric;
+        return ShaderType::Generic;
     if (name == "surface")
-        return ShadTypeSurface;
+        return ShaderType::Surface;
     if (name == "displacement")
-        return ShadTypeDisplacement;
+        return ShaderType::Displacement;
     if (name == "volume")
-        return ShadTypeVolume;
+        return ShaderType::Volume;
     if (name == "light")
-        return ShadTypeLight;
-    return ShadTypeUnknown;
-}
-
-
-const char *
-shaderusename (ShaderUse s)
-{
-    switch (s) {
-    case ShadUseSurface:      return ("surface");
-    case ShadUseDisplacement: return ("displacement");
-    default:
-        ASSERT (0 && "Invalid shader use");
-    }
-}
-
-
-
-ShaderUse
-shaderuse_from_name (string_view name)
-{
-    if (name == "surface")
-        return ShadUseSurface;
-    if (name == "displacement")
-        return ShadUseDisplacement;
-    return ShadUseLast;
+        return ShaderType::Light;
+    return ShaderType::Unknown;
 }
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -517,9 +517,8 @@ public:
     bool Parameter (string_view name, TypeDesc t, const void *val);
     bool Parameter (string_view name, TypeDesc t, const void *val,
                     bool lockgeom);
-    bool Shader (string_view shaderusage,
-                 string_view shadername = string_view(),
-                 string_view layername = string_view());
+    bool Shader (string_view shaderusage, string_view shadername,
+                 string_view layername);
     ShaderGroupRef ShaderGroupBegin (string_view groupname = string_view());
     bool ShaderGroupEnd (void);
     bool ConnectShaders (string_view srclayer, string_view srcparam,
@@ -836,7 +835,7 @@ private:
 
     // State
     bool m_in_group;                      ///< Are we specifying a group?
-    ShaderUse m_group_use;                ///< Use of group
+    std::string m_group_use;              ///< "Use" of group
     ParamValueList m_pending_params;      ///< Pending Parameter() values
     ShaderGroupRef m_curgroup;            ///< Current shading attribute state
     mutable mutex m_mutex;                ///< Thread safety
@@ -1578,9 +1577,11 @@ private:
     int m_raytypes_on = 0;           ///< Bitmask of raytypes we assume to be on
     int m_raytypes_off = 0;          ///< Bitmask of raytypes we assume to be off
     mutable mutex m_mutex;           ///< Thread-safe optimization
+    int m_globals_read = 0;
+    int m_globals_write = 0;
     std::vector<ustring> m_textures_needed;
     std::vector<ustring> m_closures_needed;
-    std::vector<ustring> m_globals_needed;
+    std::vector<ustring> m_globals_needed;  // semi-deprecated
     std::vector<ustring> m_userdata_names;
     std::vector<TypeDesc> m_userdata_types;
     std::vector<int> m_userdata_offsets;
@@ -1711,10 +1712,6 @@ public:
     /// Look up an attribute of the given dictionary node.  If
     /// attribname is "", return the value of the node itself.
     int dict_value (int nodeID, ustring attribname, TypeDesc type, void *data);
-
-    /// Various setup of the context done by execute().  Return true if
-    /// the function should be executed, otherwise false.
-    bool prepare_execution (ShaderUse use, ShaderGroup &sas);
 
     bool osl_get_attribute (ShaderGlobals *sg, void *objdata, int dest_derivs,
                             ustring obj_name, ustring attr_name,

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3149,6 +3149,8 @@ RuntimeOptimizer::run ()
     m_unknown_attributes_needed = false;
     m_textures_needed.clear();
     m_closures_needed.clear();
+    m_globals_read = 0;
+    m_globals_write = 0;
     m_globals_needed.clear();
     m_userdata_needed.clear();
     m_attributes_needed.clear();
@@ -3177,6 +3179,11 @@ RuntimeOptimizer::run ()
             // Track which globals the group needs
             if (s.symtype() == SymTypeGlobal) {
                 m_globals_needed.insert (s.name());
+                int bit = int(ShadingSystem::globals_bit (s.name()));
+                if (s.everread())
+                    m_globals_read |= bit;
+                if (s.everwritten())
+                    m_globals_write |= bit;
             }
             if (s.has_derivs())
                 ++new_deriv_syms;

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -442,6 +442,8 @@ private:
     std::set<ustring> m_textures_needed;
     std::set<ustring> m_closures_needed;
     std::set<ustring> m_globals_needed;
+    int m_globals_read = 0;
+    int m_globals_write = 0;
     std::set<AttributeNeeded> m_attributes_needed;
     bool m_unknown_textures_needed;
     bool m_unknown_closures_needed;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -405,21 +405,35 @@ ShadingSystem::query_closure (const char **name, int *id,
 
 
 
+static OIIO::cspan< std::pair<ustring,SGBits> >
+sgbit_table ()
+{
+    static const std::pair<ustring,SGBits> table[] = {
+        { ustring("P"),       SGBits::P },
+        { ustring("I"),       SGBits::I },
+        { ustring("N"),       SGBits::N },
+        { ustring("Ng"),      SGBits::Ng },
+        { ustring("u"),       SGBits::u },
+        { ustring("v"),       SGBits::v },
+        { ustring("dPdu"),    SGBits::dPdu },
+        { ustring("dPdv"),    SGBits::dPdv },
+        { ustring("time"),    SGBits::time },
+        { ustring("dtime"),   SGBits::dtime },
+        { ustring("dPdtime"), SGBits::dPdtime },
+        { ustring("Ps"),      SGBits::Ps },
+        { ustring("Ci"),      SGBits::Ci }
+    };
+    return table;
+}
+
+
+
 SGBits
 ShadingSystem::globals_bit (ustring name)
 {
-    // **MUST** match the order of SGBits!!
-    static ustring globalnames[] = {
-        ustring("P"), ustring("I"), ustring("N"), ustring("Ng"),
-        ustring("u"), ustring("v"), ustring("dPdu"), ustring("dPdv"),
-        ustring("time"), ustring("dtim"), ustring("dPdtime"), ustring("Ps"),
-        ustring("Ci")
-    };
-    int i = 0;
-    for (auto n : globalnames) {
-        if (name == n)
-            return SGBits(1<<i);
-        ++i;
+    for (auto t : sgbit_table()) {
+        if (name == t.first)
+            return t.second;
     }
     return SGBits::None;
 }
@@ -429,18 +443,9 @@ ShadingSystem::globals_bit (ustring name)
 ustring
 ShadingSystem::globals_name (SGBits bit)
 {
-    // **MUST** match the order of SGBits!!
-    static ustring globalnames[] = {
-        ustring("P"), ustring("I"), ustring("N"), ustring("Ng"),
-        ustring("u"), ustring("v"), ustring("dPdu"), ustring("dPdv"),
-        ustring("time"), ustring("dtim"), ustring("dPdtime"), ustring("Ps"),
-        ustring("Ci")
-    };
-    int b = 1;
-    for (auto n : globalnames) {
-        if (b == int(bit))
-            return n;
-        b <<= 1;
+    for (auto t : sgbit_table()) {
+        if (bit == t.second)
+            return t.first;
     }
     return ustring();
 }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -405,7 +405,7 @@ ShadingSystem::query_closure (const char **name, int *id,
 
 
 
-static OIIO::cspan< std::pair<ustring,SGBits> >
+static cspan< std::pair<ustring,SGBits> >
 sgbit_table ()
 {
     static const std::pair<ustring,SGBits> table[] = {
@@ -423,7 +423,7 @@ sgbit_table ()
         { ustring("Ps"),      SGBits::Ps },
         { ustring("Ci"),      SGBits::Ci }
     };
-    return table;
+    return cspan<std::pair<ustring,SGBits>>(table);
 }
 
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -405,6 +405,48 @@ ShadingSystem::query_closure (const char **name, int *id,
 
 
 
+SGBits
+ShadingSystem::globals_bit (ustring name)
+{
+    // **MUST** match the order of SGBits!!
+    static ustring globalnames[] = {
+        ustring("P"), ustring("I"), ustring("N"), ustring("Ng"),
+        ustring("u"), ustring("v"), ustring("dPdu"), ustring("dPdv"),
+        ustring("time"), ustring("dtim"), ustring("dPdtime"), ustring("Ps"),
+        ustring("Ci")
+    };
+    int i = 0;
+    for (auto n : globalnames) {
+        if (name == n)
+            return SGBits(1<<i);
+        ++i;
+    }
+    return SGBits::None;
+}
+
+
+
+ustring
+ShadingSystem::globals_name (SGBits bit)
+{
+    // **MUST** match the order of SGBits!!
+    static ustring globalnames[] = {
+        ustring("P"), ustring("I"), ustring("N"), ustring("Ng"),
+        ustring("u"), ustring("v"), ustring("dPdu"), ustring("dPdv"),
+        ustring("time"), ustring("dtim"), ustring("dPdtime"), ustring("Ps"),
+        ustring("Ci")
+    };
+    int b = 1;
+    for (auto n : globalnames) {
+        if (b == int(bit))
+            return n;
+        b <<= 1;
+    }
+    return ustring();
+}
+
+
+
 int
 ShadingSystem::raytype_bit (ustring name)
 {
@@ -1455,6 +1497,18 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
         *(ustring **)val = n ? &group->m_globals_needed[0] : NULL;
         return true;
     }
+    if (name == "globals_read" && type.basetype == TypeDesc::INT) {
+        if (! group->optimized())
+            optimize_group (*group);
+        *(int *)val = group->m_globals_read;
+        return true;
+    }
+    if (name == "globals_write" && type.basetype == TypeDesc::INT) {
+        if (! group->optimized())
+            optimize_group (*group);
+        *(int *)val = group->m_globals_write;
+        return true;
+    }
 
     if (name == "num_userdata" && type == TypeDesc::TypeInt) {
         if (! group->optimized())
@@ -1942,7 +1996,7 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname)
         return ShaderGroupRef();
     }
     m_in_group = true;
-    m_group_use = ShadUseUnknown;
+    m_group_use.clear();   // unknown/unset group
     m_curgroup.reset (new ShaderGroup(groupname));
     m_curgroup->m_exec_repeat = m_exec_repeat;
     return m_curgroup;
@@ -1959,7 +2013,7 @@ ShadingSystemImpl::ShaderGroupEnd (void)
     }
 
     // Mark the layers that can be run lazily
-    if (m_group_use != ShadUseUnknown) {
+    if (! m_group_use.empty()) {
         int nlayers = m_curgroup->nlayers ();
         for (int layer = 0;  layer < nlayers;  ++layer) {
             ShaderInstance *inst = (*m_curgroup)[layer];
@@ -1992,7 +2046,7 @@ ShadingSystemImpl::ShaderGroupEnd (void)
     }
 
     m_in_group = false;
-    m_group_use = ShadUseUnknown;
+    m_group_use.clear();  // Mark use as unset/unknown
 
     ustring groupname = m_curgroup->name();
     if (groupname.size() && groupname == m_archive_groupname) {
@@ -2022,9 +2076,8 @@ ShadingSystemImpl::Shader (string_view shaderusage,
         return false;
     }
 
-    ShaderUse use = shaderuse_from_name (shaderusage);
-    if (use == ShadUseUnknown) {
-        error ("Unknown shader usage \"%s\"", shaderusage);
+    if (shaderusage.empty()) {
+        error ("Shader usage required");
         return false;
     }
 
@@ -2040,17 +2093,17 @@ ShadingSystemImpl::Shader (string_view shaderusage,
     instance->parameters (m_pending_params);
     m_pending_params.clear ();
 
-    if (singleton || m_group_use == ShadUseUnknown) {
+    if (singleton || m_group_use.empty()) {
         // A singleton, or the first in a group
         m_curgroup->clear ();
         m_stat_groups += 1;
     }
     if (! singleton) {
-        if (m_group_use == ShadUseUnknown) {  // First shader in group
-            m_group_use = use;
-        } else if (use != m_group_use) {
+        if (m_group_use.empty()) {  // First shader in group
+            m_group_use = shaderusage;
+        } else if (shaderusage != m_group_use) {
             error ("Shader usage \"%s\" does not match current group (%s)",
-                   shaderusage, shaderusename (m_group_use));
+                   shaderusage, m_group_use);
             return false;
         }
     }
@@ -2554,7 +2607,7 @@ ShadingSystemImpl::find_named_layer_in_group (ustring layername,
                                               ShaderInstance * &inst)
 {
     inst = NULL;
-    if (m_group_use >= ShadUseUnknown)
+    if (m_group_use.empty())
         return -1;
     ShaderGroup &group (*m_curgroup);
     for (int i = 0;  i < group.nlayers();  ++i) {
@@ -2786,6 +2839,8 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group)
         group.m_closures_needed.push_back (f);
     for (auto&& f : rop.m_globals_needed)
         group.m_globals_needed.push_back (f);
+    group.m_globals_read = rop.m_globals_read;
+    group.m_globals_write = rop.m_globals_write;
     size_t num_userdata = rop.m_userdata_needed.size();
     group.m_userdata_names.reserve (num_userdata);
     group.m_userdata_types.reserve (num_userdata);

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -615,7 +615,7 @@ OSLToyMainWindow::build_shader_group ()
             ss->Parameter (instparam.name(), instparam.type(),
                            instparam.data(), !m_diddlers[instparam.name().string()]);
         }
-        ss->Shader ("surface", m_firstshadername);
+        ss->Shader ("surface", m_firstshadername, "layer1");
         ss->ShaderGroupEnd ();
     }
     renderer()->set_shadergroup (group);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -836,13 +836,29 @@ test_group_attributes (ShaderGroup *group)
     }
     int nglobals = 0;
     if (shadingsys->getattribute (group, "num_globals_needed", nglobals)) {
-        std::cout << "Need " << nglobals << " globals:\n";
+        std::cout << "Need " << nglobals << " globals: ";
         ustring *globals = NULL;
         shadingsys->getattribute (group, "globals_needed",
                                   TypeDesc::PTR, &globals);
         for (int i = 0; i < nglobals; ++i)
-            std::cout << "    " << globals[i] << "\n";
+            std::cout << " " << globals[i];
+        std::cout << "\n";
     }
+
+    int globals_read = 0;
+    int globals_write = 0;
+    shadingsys->getattribute (group, "globals_read", globals_read);
+    shadingsys->getattribute (group, "globals_write", globals_write);
+    std::cout << "Globals read: (" << globals_read << ") ";
+    for (int i = 1; i < int(SGBits::last); i <<= 1)
+        if (globals_read & i)
+            std::cout << ' ' << shadingsys->globals_name (SGBits(i));
+    std::cout << "\nGlobals written: (" << globals_write << ") ";
+    for (int i = 1; i < int(SGBits::last); i <<= 1)
+        if (globals_write & i)
+            std::cout << ' ' << shadingsys->globals_name (SGBits(i));
+    std::cout << "\n";
+
     int nuser = 0;
     if (shadingsys->getattribute (group, "num_userdata", nuser) && nuser) {
         std::cout << "Need " << nuser << " user data items:\n";


### PR DESCRIPTION
Deprecate the use of shader "types" (surface, displacement, etc.)
designated in OSL source code. Those words will still be accepted for
backward-compatibility, but they are no longer required or encouraged.
Generic "shader" type is the only one we will talk about as we move
forward.

Excise the ShaderUse enum. Renderers (or non-renderers using OSL for
programmability) are allowed to determine and document whatever type of
shader "uses" they want to support. The only enforcement from the
liboslexec side is that all the shader nodes within one group must be
tagged with the same "use" string.

The "use" parameter to ShadingSystem::Shader() is intended to be removed
entirely, eventually. However, that's the first of three (optional)
parameters to Shader(), so it's a subtle change that can break renderers
in annoying and confusing ways if we do it all at once, so we'll do it
in stages: For this major release, we will make all three parameters to
Shader() be required (no optional params), which even if it generates a
compile-time error for a renderer, is a very obvious one to fix. Then in
a later major release (2.1?), after we know that all renderer code is
making 3-argument calls to Shader(), we will introduce a 2-argument
version that lacks a "use" parameter (can't break renderer code) and
deprecate the 3-argument call that has the useless "use" parameter, and
then in a later release, we can remove the 3-argument version once and
for all.

Add new queries for shader groups: "globals_read" and "globals_write",
which return a bit field of which shaderglobals fields will be read or
written, respectively, by the shader group after it's optimized.
The bitfield meanings are given by the new enum class SGBits, defined
in shaderglobals.h. This is easier to query (as an `int`) than to sort
through the list of strings you'd get with "globals_needed", and allows
renderers (if they so desire) to (a) verify that shaders don't use or
modify globals they aren't supposed to, for the type of shader use they
are being used for; (b) potentially to avoid any expensive computations
that would need to be performed to prepare certain shaderglobals fields,
for shader groups that won't end up using them.

Also make the `I` global variable be writeable and clarify that if a
global is writeable, it's writeable from any shader type, and we don't
intend to do differing checks based on shader type.

