### PR TITLE
Speed up parsing of long initializer lists.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -77,37 +77,17 @@ ScopeExit print_node_counts ([](){
 
 
 
-ASTNode *
-reverse (ASTNode *list)
+ASTNode::ref
+reverse (ASTNode::ref list)
 {
-    // trivial case: empty or just one item
-    if (!list || !list->nextptr())
-        return list;
-
-#ifndef OIIO_REFCNT_HAS_RELEASE
-    ASSERT (0 && "Do not call reverse() if you didn't build with an OIIO "
-                 "new enough to have intrustive_ptr::release().");
-    return nullptr;
-#else
-    // Turn the list (whose `next` fields are ref-counted pointers) into
-    // a vector of raw pointers, releasing the ref-counted pointers in the
-    // process (but don't free the nodes!).
-    std::vector<ASTNode *> nodes;
+    ASTNode::ref new_list;
     while (list) {
-        nodes.push_back (list);
-        list = list->m_next.release();
+        ASTNode::ref next = list->next();
+        list->m_next = new_list;
+        new_list = list;
+        list = next;
     }
-
-    // reverse the list
-    std::reverse (nodes.begin(), nodes.end());
-
-    // reassemble!
-    for (size_t i = 0, e = nodes.size(); i < e; ++i)
-        nodes[i]->m_next.reset ((i+1 < e) ? nodes[i+1] : nullptr);
-
-    // return the new head of list
-    return nodes[0];
-#endif
+    return new_list;
 }
 
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -172,6 +172,9 @@ public:
             return B;
     }
 
+    /// Reverse the order of the list.
+    friend ASTNode *reverse (ASTNode *list);
+
     /// What source file was this parse node created from?
     ///
     ustring sourcefile () const { return m_sourcefile; }

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -173,7 +173,7 @@ public:
     }
 
     /// Reverse the order of the list.
-    friend ASTNode *reverse (ASTNode *list);
+    friend ASTNode::ref reverse (ASTNode::ref list);
 
     /// What source file was this parse node created from?
     ///

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -505,21 +505,21 @@ init_expression_list
         | init_expression_list_rev ',' init_expression
                 {
                 #ifdef OIIO_REFCNT_HAS_RELEASE
-                    /* Left recursion is much more efficient for Bison, but
-                     * concatenating the sole last expression ($3) on the
-                     * far end of the running list ($1) leads to an
-                     * inadvertently quadratic algorithm, which is very
-                     * painful for long initializer lists of thousands of
-                     * items (like for a big table). So we use a trick:
-                     * accumulate the list in referse order (lets us prepend
-                     * as O(1) instead of append with O(n)) and then reverse
-                     * it right before we return the list. BUT... note that
-                     * we only do this for sufficiently new OIIO that lets
-                     * use implement reverse in a safe way with respect
-                     * to the ref-counted pointers involved.
-                     */
-                    auto revlist = concat ($3, $1);
-                    $$ = reverse (revlist);
+                    // Left recursion is much more efficient for Bison, but
+                    // concatenating the sole last expression ($3) on the
+                    // far end of the running list ($1) leads to an
+                    // inadvertently quadratic algorithm, which is very
+                    // painful for long initializer lists of thousands of
+                    // items (like for a big table). So we use a trick:
+                    // accumulate the list in referse order (lets us prepend
+                    // as O(1) instead of append with O(n)) and then reverse
+                    // it right before we return the list. BUT... note that
+                    // we only do this for sufficiently new OIIO that lets
+                    // us safely convert the ref-counted pointer to a raw
+                    // pointer.
+                    ASTNode::ref revlist = concat ($3, $1);
+                    revlist = reverse (revlist);
+                    $$ = revlist.release ();
                 #else
                     // OIIO too old to support reverse(), so just do it
                     // the old way, normal order.

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -107,6 +107,7 @@ static std::stack<TypeSpec> typespec_stack; // just for function_declaration
 %type <n> variable_declaration def_expressions def_expression
 %type <n> initializer_opt initializer initializer_list_opt initializer_list 
 %type <n> compound_initializer init_expression_list init_expression
+%type <n> init_expression_list_rev
 %type <i> outputspec arrayspec simple_typename
 %type <i> typespec typespec_or_shadertype
 %type <n> statement_list statement scoped_statements local_declaration
@@ -501,9 +502,45 @@ compound_initializer
 
 init_expression_list
         : init_expression
-        | init_expression_list ',' init_expression
+        | init_expression_list_rev ',' init_expression
                 {
+                #ifdef OIIO_REFCNT_HAS_RELEASE
+                    /* Left recursion is much more efficient for Bison, but
+                     * concatenating the sole last expression ($3) on the
+                     * far end of the running list ($1) leads to an
+                     * inadvertently quadratic algorithm, which is very
+                     * painful for long initializer lists of thousands of
+                     * items (like for a big table). So we use a trick:
+                     * accumulate the list in referse order (lets us prepend
+                     * as O(1) instead of append with O(n)) and then reverse
+                     * it right before we return the list. BUT... note that
+                     * we only do this for sufficiently new OIIO that lets
+                     * use implement reverse in a safe way with respect
+                     * to the ref-counted pointers involved.
+                     */
+                    auto revlist = concat ($3, $1);
+                    $$ = reverse (revlist);
+                #else
+                    // OIIO too old to support reverse(), so just do it
+                    // the old way, normal order.
                     $$ = concat ($1, $3);
+                #endif
+                }
+        ;
+
+init_expression_list_rev
+        : init_expression
+        | init_expression_list_rev ',' init_expression
+                {
+                #ifdef OIIO_REFCNT_HAS_RELEASE
+                    $$ = concat ($3, $1);
+                    // NOTE: intentionally concat in reverse order!
+                    // Because this is init_expression_list_rev!
+                #else
+                    // OIIO too old to support reverse(), so just do it
+                    // the old way, normal order.
+                    $$ = concat ($1, $3);
+                #endif
                 }
         ;
 


### PR DESCRIPTION
If you have something like

    float table[65536] = { 0.1, 0.35, -0.72, ... }

This might take TENS of seconds for oslc to parse, because the mechanics
of how that long list of values is parsed -- it involves a singly-linked
list of ASTNodes, and with each new one, we are appending to the far end
of the linked list. This leads to an O(n^2) parsing time, where n is the
length of the list.

The straightforward (but wrong!) way to fix it is to change the Bison
grammar for init_expression_list from "left-recursive" to "right-recursive".
That makes it natural to prepend items (O(1)) to the accumulating list,
but it's very inefficient for Bison and can overrun Bison's fixed-size
parsing stack. Bison docs discurage use of right-recursion in grammars,
since left-recursion grammar can parse arbitrarily deep recursive
structures in a fixed memory size.

OK, so how do we fix this? Trickery! Keep left recursion, but accumulate
in the reverse order (i.e., prepend, not append), and then do a single
reverse of the backwards list at the very end. That makes the whole
parsing affair O(n) instead of O(n^2).

Sounds good, but one final wrinkle is that the list we need to reverse
is is a raw pointer to the head, followed by ref-counted pointers to
each subsequent element. In order to keep from accidentally freeing
things if the ref counts reach zero, we have our fancy reverse()
function rely on a brand spanking new feature of OIIO's intrusive_ptr<>
to add a release() method (https://github.com/OpenImageIO/oiio/pull/1986).
But since that doesn't exist in older OIIO, to avoid a compatibility
break, we only do our special left recursion + backwards list + reversal
trick if the OIIO version we build against has that new feature.
Otherwise, it's #ifdef'ed out and we just do it the old slow way.

This fixes OSL issue #723, and for the pathological test case presented
in that issue, it improves compile time (on my laptop) from ~26 seconds
to 0.4 seconds.

I also checked that this funny business with the reversal doesn't slow
down the simple cases for ordinary shader. Compiling the whole
collection of 500+ MaterialX shaders took about 20.5 seconds, and with
the new parsing code is exactly the same, or at least, too close to
accurately discern in the time trials.

