### PR TITLE
Remove use of a fixed path to call bash

### DIFF
--- a/src/liboslexec/serialize-bc.bash
+++ b/src/liboslexec/serialize-bc.bash
@@ -1,4 +1,4 @@
-#!usr/bin/env bash
+#!/usr/bin/env bash
 
 # Turn an LLVM-compiled bitfile into a C++ source file where the compiled
 # bitcode is in a huge array.

--- a/src/liboslexec/serialize-bc.bash
+++ b/src/liboslexec/serialize-bc.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!usr/bin/env bash
 
 # Turn an LLVM-compiled bitfile into a C++ source file where the compiled
 # bitcode is in a huge array.


### PR DESCRIPTION
## Description

Not every system has bash installed in /usr using env to call bash is a better cross platform method.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

