### PR TITLE
Minor changes to build with clang 7.

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -20,7 +20,7 @@ ifeq ($(SP_OS), rhel7)
 
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_5.0.1
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_7.0.0
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
@@ -34,8 +34,12 @@ ifeq ($(SP_OS), rhel7)
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_5.0.1/bin/clang++
     else ifeq (${COMPILER}, clang6)
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.0_rc2/bin/clang \
-           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.0_rc2/bin/clang++
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.1/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.1/bin/clang++
+    else ifeq (${COMPILER}, clang7)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_7.0.0/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_7.0.0/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc490)

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -326,6 +326,10 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     inst.getPreprocessorOutputOpts().ShowCPP = 1;
     inst.getPreprocessorOutputOpts().ShowMacros = 0;
+    inst.getPreprocessorOutputOpts().ShowComments = 0;
+    inst.getPreprocessorOutputOpts().ShowLineMarkers = 1;
+    inst.getPreprocessorOutputOpts().ShowMacroComments = 0;
+    inst.getPreprocessorOutputOpts().ShowIncludeDirectives = 0;
 
     clang::HeaderSearchOptions &headerOpts = inst.getHeaderSearchOpts();
     headerOpts.UseBuiltinIncludes = 0;


### PR DESCRIPTION
The changes in oslcomp.cpp seem only to be necessary with particular
combinations of clang7 and older llvm. Which we don't recommend!  Better
to use the same generation of clang and llvm. But in any case, may as
well make set those options explicitly.

Also switch SPI to build with clang7/llvm7 by default.

