### PR TITLE
Fix oslc read/write error for regex_search/regex_match

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1261,6 +1261,7 @@ ASTfunction_call::typecheck_builtin_specialcase ()
     }
 
     if (func()->readwrite_special_case()) {
+        int nargs = (int)listlength(args());
         if (m_name == "sincos") {
             argwriteonly (1);
             argwriteonly (2);
@@ -1268,11 +1269,16 @@ ASTfunction_call::typecheck_builtin_specialcase ()
                    m_name == "gettextureinfo" || m_name == "getmatrix" ||
                    m_name == "dict_value") {
             // these all write to their last argument
-            argwriteonly ((int)listlength(args()));
+            argwriteonly (nargs);
         } else if (m_name == "pointcloud_get") {
             argwriteonly (5);
         } else if (m_name == "pointcloud_search") {
             mark_optional_output(5, pointcloud_out_args);
+        } else if ((m_name == "regex_search" || m_name == "regex_match")
+                   && nargs == 3) {
+            // the kind of regex_search and regex_match that contains a
+            // results argument should mark it writeable.
+            argwriteonly (2);
         } else if (m_name == "split") {
             argwriteonly (2);
         } else if (func()->texture_args()) {
@@ -2068,8 +2074,8 @@ static const char * builtin_func_args [] = {
     "printf", "xs*", "!printf", NULL,
     "psnoise", PNOISE_ARGS, NULL,
     "random", "f", "c", "p", "v", "n", NULL,
-    "regex_match", "iss", "isi[]s", NULL,
-    "regex_search", "iss", "isi[]s", NULL,
+    "regex_match", "iss", "isi[]s", "!rw", NULL,
+    "regex_search", "iss", "isi[]s", "!rw", NULL,
     "setmessage", "xs?", "xs?[]", NULL,
     "sincos", "xfff", "xccc", "xppp", "xvvv", "xnnn", "!rw", NULL,
     "snoise", NOISE_ARGS, NULL,

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -434,9 +434,16 @@ OSOReaderToMaster::hint (string_view hintstring)
         }
         ASSERT(m_nargs == i);
         // Fix old bug where oslc forgot to mark getmatrix last arg as write
+        ustring opname = m_master->m_ops.back().opname();
         static ustring getmatrix("getmatrix");
-        if (m_master->m_ops.back().opname() == getmatrix)
-            m_master->m_ops.back().argwrite(m_nargs-1, true);
+        if (opname == getmatrix)
+            m_master->m_ops.back().argwriteonly (m_nargs-1);
+        // Fix old bug where oslc forgot to mark regex results as write.
+        // This was a bug prior to 1.10.
+        static ustring regex_search("regex_search");
+        static ustring regex_match("regex_match");
+        if (opname == regex_search || opname == regex_search)
+            m_master->m_ops.back().argwriteonly (2);
     }
     if (extract_prefix(h, "%argderivs{")) {
         while (1) {


### PR DESCRIPTION
For these functions, oslc failed to mark the results output param as write only.

Fix the bug in oslc, and also put in a provision in loadshader that will correct the old already-compiled incorrect files.

Thanks to Steena Monteiro from Intel for pointing this out!

