### PR TITLE
Rewrite OSOReaderToMaster::hint

### DIFF
--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -331,108 +331,70 @@ OSOReaderToMaster::parameter_done ()
 
 
 
-inline bool
-starts_with (const std::string &source, const std::string &pattern)
-{
-    return ! strncmp (source.c_str(), pattern.c_str(), pattern.length());
-}
-
-
-
-// If the string 'source' begins with 'pattern', erase the pattern from
-// the start of source and return true.  Otherwise, do not alter source
-// and return false.
-inline bool
-extract_prefix (std::string &source, const std::string &pattern)
-{
-    if (starts_with (source, pattern)) {
-        source.erase (0, pattern.length());
-        return true;
-    }
-    return false;
-}
-
-
-
-// Return the prefix of source that doesn't contain any characters in
-// 'stop', erase that prefix from source (up to and including the stop
-// character.  Also, the returned string is trimmed of leading and trailing
-// spaces if 'do_trim' is true.
-static std::string
-readuntil (std::string &source, const std::string &stop, bool do_trim=false)
-{
-    size_t e = source.find_first_of (stop);
-    if (e == source.npos)
-        return std::string ();
-    std::string r (source, 0, e);
-    source.erase (0, e == source.npos ? e : e+1);
-    if (do_trim)
-        r = Strutil::strip (r); // trim whitespace
-    return r;
-}
-
-
-
 void
 OSOReaderToMaster::hint (string_view hintstring)
 {
-    std::string h (hintstring);   // FIXME -- use string_view ops here
-    if (extract_prefix (h, "%filename{\"")) {
-        m_sourcefile = readuntil (h, "\"");
+    string_view h (hintstring);
+
+    if (Strutil::parse_prefix (h, "%filename{\"")) {
+        m_sourcefile = Strutil::parse_until (h, "\"");
         return;
     }
-    if (extract_prefix (h, "%line{")) {
-        m_sourceline = atoi (h.c_str());
+    if (Strutil::parse_prefix (h, "%line{")) {
+        Strutil::parse_int (h, m_sourceline);
         return;
     }
-    if (extract_prefix (h, "%structfields{")) {
-        ASSERT (m_master->m_symbols.size() && "structfields hint but no sym");
+    if (Strutil::parse_prefix (h, "%structfields{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         StructSpec *structspec = sym.typespec().structspec();
         if (structspec->numfields() == 0) {
             while (1) {
-                std::string afield = readuntil (h, ",}", true);
+                std::string afield = Strutil::parse_until (h, ",}");
+                Strutil::parse_char (h, ','); // skip the separator
                 if (! afield.length())
                     break;
-//                std::cerr << " struct field " << afield << "\n";
                 structspec->add_field (TypeSpec(), ustring(afield));
             }
         }
         return;
     }
-    if (extract_prefix (h, "%mystructfield{")) {
-        ASSERT (m_master->m_symbols.size() && "mystructfield hint but no sym");
-        Symbol &sym (m_master->m_symbols.back());
-        sym.fieldid (atoi(h.c_str()+15));
+    if (Strutil::parse_prefix (h, "%mystructfield{") && m_master->m_symbols.size()) {
+        int ival = -1;
+        if (Strutil::parse_int (h, ival) && ival >= 0)
+            m_master->m_symbols.back().fieldid (ival);
         return;
     }
-    if (extract_prefix (h, "%read{")) {
-        ASSERT (m_master->m_symbols.size() && "read hint but no sym");
-        Symbol &sym (m_master->m_symbols.back());
-        int first, last;
-        sscanf (h.c_str(), "%d,%d", &first, &last);
-        sym.set_read (first, last);
-        return;
-    }
-    if (extract_prefix (h, "%write{")) {
-        ASSERT (m_master->m_symbols.size() && "write hint but no sym");
+    if (Strutil::parse_prefix (h, "%read{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         int first, last;
-        sscanf (h.c_str(), "%d,%d", &first, &last);
-        sym.set_write (first, last);
+        if (Strutil::parse_int (h, first) && Strutil::parse_char(h, ',')
+                && Strutil::parse_int (h, last))
+            sym.set_read (first, last);
         return;
     }
-    if (extract_prefix(h, "%argrw{")) {
-        const char* str = h.c_str();
-        ASSERT(*str == '\"');
-        str++; // skip open quote
-        size_t i = 0;
-        for (; *str != '\"'; i++, str++) {
-            ASSERT(*str == 'r' || *str == 'w' || *str == 'W' || *str == '-');
-            m_master->m_ops.back().argwrite(i, *str == 'w' || *str =='W');
-            m_master->m_ops.back().argread(i, *str == 'r' || *str =='W');
+    if (Strutil::parse_prefix (h, "%write{") && m_master->m_symbols.size()) {
+        Symbol &sym (m_master->m_symbols.back());
+        int first, last;
+        if (Strutil::parse_int (h, first) && Strutil::parse_char(h, ',')
+                && Strutil::parse_int (h, last))
+            sym.set_write (first, last);
+        return;
+    }
+    if (Strutil::parse_prefix(h, "%argrw{") && m_master->m_ops.size()) {
+        Opcode &op (m_master->m_ops.back());
+        string_view str = Strutil::parse_until (h, "}");
+        Strutil::parse_string (str, str, false, Strutil::DeleteQuotes);
+        if (str.size() != m_nargs) {
+            m_shadingsys.error ("Parsing shader %s: malformed hint '%s' on op %s line %d",
+                                m_master->shadername(), hintstring,
+                                m_master->m_ops.back().opname(), m_sourceline);
+            m_errors = true;
         }
-        ASSERT(m_nargs == i);
+        for (size_t i = 0; str.size() && i < m_nargs; i++, str.remove_prefix(1)) {
+            char c = str.front();
+            op.argwrite (i, c == 'w' || c =='W');
+            op.argread (i, c == 'r' || c =='W');
+        }
         // Fix old bug where oslc forgot to mark getmatrix last arg as write
         ustring opname = m_master->m_ops.back().opname();
         static ustring getmatrix("getmatrix");
@@ -444,24 +406,34 @@ OSOReaderToMaster::hint (string_view hintstring)
         static ustring regex_match("regex_match");
         if (opname == regex_search || opname == regex_search)
             m_master->m_ops.back().argwriteonly (2);
+        return;
     }
-    if (extract_prefix(h, "%argderivs{")) {
+    if (Strutil::parse_prefix(h, "%argderivs{")) {
         while (1) {
-            std::string afield = readuntil (h, ",}", true);
+            string_view afield = Strutil::parse_until (h, ",}");
+            Strutil::parse_char (h, ','); // skip the separator
             if (! afield.length())
                 break;
-            int arg = atoi (afield.c_str());
-            if (arg >= 0)
+            int arg = -1;
+            if (Strutil::parse_int (afield, arg) && arg >= 0)
                 m_master->m_ops.back().argtakesderivs (arg, true);
         }
+        return;
     }
-    if (extract_prefix (h, "%meta{") && m_master->m_symbols.size()) {
+    if (Strutil::parse_prefix (h, "%meta{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         int ival = -1;
-        if (sscanf (h.c_str(), " int , lockgeom , %d", &ival))
+        TypeDesc type (Strutil::parse_identifier (h, "", true));
+        Strutil::parse_char (h, ',');
+        string_view ident = Strutil::parse_identifier (h, "", true);
+        Strutil::parse_char (h, ',');
+        if (type == TypeDesc::TypeInt && ident == "lockgeom"
+                && Strutil::parse_int (h, ival) && ival >= 0)
             sym.lockgeom (ival);
-        else if (sscanf (h.c_str(), " int , allowconnect , %d", &ival))
+        else if (type == TypeDesc::TypeInt && ident == "allowconnect"
+                && Strutil::parse_int (h, ival) && ival >= 0)
             sym.allowconnect (ival);
+        return;
     }
 }
 


### PR DESCRIPTION
Zap is seeing sporadic (but frustraingly impossible to reproduce) crash
reports from inside this function, specifically in the part that parses
%argrw hints.

There was a longstanding comment:   // FIXME -- use string_view ops here

So, sure, rewrite the whole thing using string_view and Strutil::parse
functions, and remove the assertions, and put extra guards to make sure
we aren't acessing a symbol or op (via blah.back()) if there aren't any
in the vector yet, and pretty much just let it ignore or be robust to any
malformed hints.

I've never seen a repro case, so I don't know that this will fix it, but
it's programmed a lot more defensively now, so hopefully there will be
no further crashes (after I backport this to whatever version Zap is
using).  I even put in an error message for a certain way to malform
%argrw, in the hopes that it might give us a clue, but even that is just
a guess.
