### PR TITLE
Defensive parsing of hints in oso files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
         env: USE_CPP11=1 USE_CPP=11 OIIOBRANCH=RB-1.8
       - os: osx
         compiler: clang
-        env: USE_CPP11=1 USE_CPP=11 OIIOBRANCH=RB-1.8
+        env: USE_CPP11=1 USE_CPP=11 OIIOBRANCH=RB-1.8 LLVMBREWVER="@5"
       # Build with C++11, DEBUG build, against OIIO 1.8
       - os: linux
         compiler: gcc

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -387,8 +387,7 @@ OSOReaderToMaster::hint (string_view hintstring)
         m_sourceline = atoi (h.c_str());
         return;
     }
-    if (extract_prefix (h, "%structfields{")) {
-        ASSERT (m_master->m_symbols.size() && "structfields hint but no sym");
+    if (extract_prefix (h, "%structfields{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         StructSpec *structspec = sym.typespec().structspec();
         if (structspec->numfields() == 0) {
@@ -402,39 +401,34 @@ OSOReaderToMaster::hint (string_view hintstring)
         }
         return;
     }
-    if (extract_prefix (h, "%mystructfield{")) {
-        ASSERT (m_master->m_symbols.size() && "mystructfield hint but no sym");
+    if (extract_prefix (h, "%mystructfield{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         sym.fieldid (atoi(h.c_str()+15));
         return;
     }
-    if (extract_prefix (h, "%read{")) {
-        ASSERT (m_master->m_symbols.size() && "read hint but no sym");
+    if (extract_prefix (h, "%read{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         int first, last;
         sscanf (h.c_str(), "%d,%d", &first, &last);
         sym.set_read (first, last);
         return;
     }
-    if (extract_prefix (h, "%write{")) {
-        ASSERT (m_master->m_symbols.size() && "write hint but no sym");
+    if (extract_prefix (h, "%write{") && m_master->m_symbols.size()) {
         Symbol &sym (m_master->m_symbols.back());
         int first, last;
         sscanf (h.c_str(), "%d,%d", &first, &last);
         sym.set_write (first, last);
         return;
     }
-    if (extract_prefix(h, "%argrw{")) {
+    if (extract_prefix(h, "%argrw{") && m_master->m_ops.size()) {
         const char* str = h.c_str();
-        ASSERT(*str == '\"');
-        str++; // skip open quote
-        size_t i = 0;
-        for (; *str != '\"'; i++, str++) {
-            ASSERT(*str == 'r' || *str == 'w' || *str == 'W' || *str == '-');
+        if (*str == '\"')
+            ++str;   // skip open quote
+        for (size_t i = 0; *str && *str != '\"' && i < m_nargs; i++, str++) {
+            DASSERT(*str == 'r' || *str == 'w' || *str == 'W' || *str == '-');
             m_master->m_ops.back().argwrite(i, *str == 'w' || *str =='W');
             m_master->m_ops.back().argread(i, *str == 'r' || *str =='W');
         }
-        ASSERT(m_nargs == i);
         // Fix old bug where oslc forgot to mark getmatrix last arg as write
         static ustring getmatrix("getmatrix");
         if (m_master->m_ops.back().opname() == getmatrix)


### PR DESCRIPTION
This is hoped to relieve 3DSMax users of some unexplained crashes in
this section of code. (We can't reproduce, we're making our best guess.)

Related to a more extensive change under review in master (923), which
backports straightforwardly to OSL 1.9, but for this backport to OSL
1.8, we need to accommodate much older OIIO so we are more focused
here. (The other, more permanent, overhaul of this section of code
relies on string parsing that was part of OIIO 1.7, but OSL 1.8 must be
compatible with OIIO 1.6.)

