### PR TITLE
Change to search path rules for .oso files

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -83,6 +83,7 @@ public:
     /// 1. Attributes that should be exposed to users:
     ///    int statistics:level   Automatically print OSL statistics (0).
     ///    string searchpath:shader  Colon-separated path to search for .oso
+    ///                                files ("", meaning test "." only)
     ///    string colorspace      Name of RGB color space ("Rec709")
     ///    int range_checking     Generate extra code for component & array
     ///                              range checking (1)

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -593,10 +593,12 @@ ShadingSystemImpl::loadshader (string_view cname)
 
     // Not found in the map
     OSOReaderToMaster oso (*this);
+    bool testcwd = m_searchpath_dirs.empty();  // test "." if there's no searchpath
     std::string filename = OIIO::Filesystem::searchpath_find (name.string() + ".oso",
-                                                        m_searchpath_dirs);
+                                                        m_searchpath_dirs,
+                                                        testcwd);
     if (filename.empty ()) {
-        error ("No .oso file could be found for shader \"%s\"", name.c_str());
+        error ("No .oso file could be found for shader \"%s\"", name);
         return NULL;
     }
     OIIO::Timer timer;


### PR DESCRIPTION
New rules:

* If NO "searchpath:shader" attribute is specified to the ShadingSystem,
  the current working directory (".") will be searched.

* If a searchpath is specified, it will look ONLY in those directories,
  in order. The current working directory will only be searched if
  it is listed among the paths.

