### PR TITLE
Fixes to make recent osltoy changes not break against OIIO 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: cpp
 sudo: false
-osx_image: xcode7.3
+osx_image: xcode8.3
 dist: trusty
 
 

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -26,6 +26,7 @@ brew install ilmbase openexr
 brew install opencolorio partio
 brew install freetype libpng
 brew install llvm${LLVMBREWVER}
+brew install qt
 #brew install homebrew/science/hdf5 --with-threadsafe
 #brew install field3d webp ffmpeg openjpeg opencv
 echo ""

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -141,8 +141,9 @@ public:
         ROI roi(info.x-sample, info.x+sample, info.y-sample, info.y+sample);
 
         ImageBuf display(ImageSpec(pixels, pixels, 3, TypeDesc::UINT8));
-        ImageBufAlgo::colorconvert (display, ImageBufAlgo::cut(info.full, roi),
-                                    "linear", "sRGB");
+        ImageBuf cut;
+        ImageBufAlgo::cut (cut, info.full, roi);
+        ImageBufAlgo::colorconvert (display, cut, "linear", "sRGB");
 
         // Use Qt to do the image scaling, so minimal interpolation
         QImage qimage = QtUtils::ImageBuf_to_QImage (display).scaled(res, res, Qt::IgnoreAspectRatio);
@@ -313,7 +314,7 @@ public:
         using namespace OIIO;
 
         // Copy from the renderer's framebuffer to ours
-        m_framebuffer = ImageBufAlgo::resize(image);
+        ImageBufAlgo::resize(m_framebuffer, image);
 
         // Copy from the renderer's framebuffer (linear float) to display (sRGB uint8)
         OIIO::ImageBuf display(ImageSpec(width(), height(), 3, TypeDesc::UINT8));


### PR DESCRIPTION
Recent changes used a new ImageBufAlgo convention only present in current
OIIO master, not older 1.8 that we still promise compatibility with.

Didn't catch this before because the Travis tests don't install qt and
therefore don't build osltoy at all. Add qt to the Mac travis setup so
that it at least builds to prevent this from happening.

