### PR TITLE
Wean ourselves off of 'operator int' of ustring, and bug fixes

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -949,7 +949,7 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename,
             lastline = -1;
         }
 
-        if (/*m_debug &&*/ op.sourcefile()) {
+        if (/*m_debug &&*/ !op.sourcefile().empty()) {
             ustring file = op.sourcefile();
             int line = op.sourceline();
             if (file != lastfile || line != lastline)
@@ -982,7 +982,7 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename,
         // %filename and %line document the source code file and line that
         // contained code that generated this op.  To avoid clutter, we
         // only output these hints when they DIFFER from the previous op.
-        if (op.sourcefile()) {
+        if (!op.sourcefile().empty()) {
             if (op.sourcefile() != lastfile) {
                 lastfile = op.sourcefile();
                 oso ("%c%%filename{\"%s\"}", firsthint ? '\t' : ' ', lastfile);

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -113,10 +113,10 @@ BackendLLVM::llvm_debug() const
 {
     if (shadingsys().llvm_debug() == 0)
         return 0;
-    if (shadingsys().debug_groupname() &&
+    if (!shadingsys().debug_groupname().empty() &&
         shadingsys().debug_groupname() != group().name())
         return 0;
-    if (inst() && shadingsys().debug_layername() &&
+    if (inst() && !shadingsys().debug_layername().empty() &&
         shadingsys().debug_layername() != inst()->layername())
         return 0;
     return shadingsys().llvm_debug();

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -325,7 +325,7 @@ ShadingContext::osl_get_attribute (ShaderGlobals *sg, void *objdata,
     bool ok;
 
     for (auto& f : m_failed_attribs) {
-        if ((obj_name || f.objdata == objdata) &&
+        if ((!obj_name.empty() || f.objdata == objdata) &&
             f.attr_name == attr_name && f.obj_name == obj_name &&
             f.attr_type == attr_type && f.array_lookup == array_lookup &&
             f.index == index && f.objdata) {

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2164,7 +2164,7 @@ llvm_gen_texture_options (BackendLLVM &rop, int opnum,
         ustring name = *(ustring *)Name.data();
         ++a;  // advance to next argument
 
-        if (! name)    // skip empty string param name
+        if (name.empty())    // skip empty string param name
             continue;
 
         Symbol &Val (*rop.opargsym(op,a));
@@ -2273,7 +2273,7 @@ llvm_gen_texture_options (BackendLLVM &rop, int opnum,
         if (name == Strings::subimage && valtype == TypeDesc::STRING) {
             if (Val.is_constant()) {
                 ustring v = *(ustring *)Val.data();
-                if (! v && ! subimage_set) {
+                if (v.empty() && ! subimage_set) {
                     continue;     // Ignore nulls unless they are overrides
                 }
             }
@@ -2680,7 +2680,7 @@ llvm_gen_noise_options (BackendLLVM &rop, int opnum,
         Symbol &Val (*rop.opargsym(op,a));
         TypeDesc valtype = Val.typespec().simpletype ();
         
-        if (! name)    // skip empty string param name
+        if (name.empty())    // skip empty string param name
             continue;
 
         if (name == Strings::anisotropic && Val.typespec().is_int()) {
@@ -2771,7 +2771,7 @@ LLVMGEN (llvm_gen_noise)
     derivs &= Result.has_derivs();  // ignore derivs if result doesn't need
 
     bool pass_name = false, pass_sg = false, pass_options = false;
-    if (! name) {
+    if (name.empty()) {
         // name is not a constant
         name = periodic ? Strings::genericpnoise : Strings::genericnoise;
         pass_name = true;

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -477,7 +477,7 @@ OSOReaderToMaster::codeend ()
         // If we were previously chalking up the code to init ops for a
         // symbol, mark the end.
         m_master->symbol(m_codesym)->initend (nextop);
-    } else if (m_codesection && m_codesection == "___main___") {
+    } else if (m_codesection == "___main___") {
         // If we were previously reading ops for the ___main___ entry
         // point, mark its end properly.
         m_master->m_maincodeend = nextop;

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -264,7 +264,7 @@ ShaderMaster::print ()
         for (size_t j = 0;  j < Opcode::max_jumps;  ++j)
             if (m_ops[i].jump(j) >= 0)
                 out << " " << m_ops[i].jump(j);
-        if (m_ops[i].sourcefile())
+        if (!m_ops[i].sourcefile().empty())
             out << "\t(" << m_ops[i].sourcefile() << ":" 
                       << m_ops[i].sourceline() << ")";
         out << "\n";

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -91,7 +91,7 @@ struct SortedPointCompare {
 PointCloud *
 PointCloud::get (ustring filename, bool write)
 {
-    if (! filename)
+    if (filename.empty())
         return NULL;
     spin_lock lock (pointcloudmap_mutex);
     PointCloudMap::const_iterator found = pointclouds.find(filename);
@@ -139,7 +139,7 @@ PointCloud::PointCloud (ustring filename,
 PointCloud::~PointCloud ()
 {
     // Save the file if we wrote to it
-    if (m_write && m_filename)
+    if (m_write && !m_filename.empty())
         Partio::write (m_filename.c_str(), *m_partio_cloud);
     if (m_partio_cloud)
         m_partio_cloud->release ();
@@ -238,7 +238,7 @@ RendererServices::pointcloud_search (ShaderGlobals *sg,
                                      float *out_distances, int derivs_offset)
 {
 #if USE_PARTIO
-    if (! filename)
+    if (filename.empty())
         return 0;
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
@@ -408,7 +408,7 @@ RendererServices::pointcloud_write (ShaderGlobals *sg,
                                     const void **data)
 {
 #if USE_PARTIO
-    if (! filename)
+    if (filename.empty())
         return false;
     PointCloud *pc = PointCloud::get(filename, true /* create file to write */);
     spin_lock lock (pc->m_mutex);

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -169,15 +169,15 @@ OSOProcessorBase::set_debug ()
 
     // If either group or layer was specified for debug, surely they want
     // debugging turned on.
-    if (shadingsys().debug_groupname() || shadingsys().debug_layername())
+    if (!shadingsys().debug_groupname().empty() || !shadingsys().debug_layername().empty())
         m_debug = std::max (m_debug, 1);
 
     // Force debugging off if a specific group was selected for debug
     // and we're not it, or a specific layer was selected for debug and
     // we're not it.
-    bool wronggroup = (shadingsys().debug_groupname() && 
+    bool wronggroup = (!shadingsys().debug_groupname().empty() &&
                        shadingsys().debug_groupname() != group().name());
-    bool wronglayer = (shadingsys().debug_layername() && inst() &&
+    bool wronglayer = (!shadingsys().debug_layername().empty() && inst() &&
                        shadingsys().debug_layername() != inst()->layername());
     if (wronggroup || wronglayer)
         m_debug = 0;
@@ -192,7 +192,7 @@ RuntimeOptimizer::set_debug ()
 
     // If a specific group is isolated for debugging and  the
     // 'optimize_dondebug' flag is on, fully optimize all other groups.
-    if (shadingsys().debug_groupname() &&
+    if (!shadingsys().debug_groupname().empty() &&
         shadingsys().debug_groupname() != group().name()) {
         if (shadingsys().m_optimize_nondebug) {
             // Debugging trick: if user said to only debug one group, turn
@@ -2270,7 +2270,7 @@ void
 RuntimeOptimizer::optimize_instance ()
 {
     // If "opt_layername" attribute is set, only optimize the named layer
-    if (shadingsys().m_opt_layername &&
+    if (!shadingsys().m_opt_layername.empty() &&
         shadingsys().m_opt_layername != inst()->layername())
         return;
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2815,7 +2815,7 @@ ShadingSystemImpl::optimize_group (ShaderGroup &group)
         return;
     }
 
-    if (m_only_groupname && m_only_groupname != group.name()) {
+    if (!m_only_groupname.empty() && m_only_groupname != group.name()) {
         // For debugging purposes, we are requested to compile only one
         // shader group, and this is not it.  Mark it as does_nothing,
         // and also as optimized so nobody locks on it again, and record

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -1151,9 +1151,11 @@ OSLToyMainWindow::set_param_instance_value (ParamRec *param)
     }
 
     if (m_diddlers[param->name.string()]) {
-        shadingsys()->ReParameter (*renderer()->shadergroup(), param->layername,
-                                   param->name, param->type,
-                                   m_shaderparam_instvalues[param->name].data());
+        auto val = m_shaderparam_instvalues.find (param->name);
+        if (val != m_shaderparam_instvalues.end())
+            shadingsys()->ReParameter (*renderer()->shadergroup(), param->layername,
+                                       param->name, param->type,
+                                       val->data());
         rerender_needed ();
     } else {
         build_shader_group ();


### PR DESCRIPTION
OIIO's ustring has an "operator int()" that is possibly ill-advised, as
claimed by Thiago Ize and John Haddon from an oiio-dev thread from back
in 2015 (I'm doing some old thread necromancy). They claimed that an
operator int (or for that matter bool) could result in subtle bugs from
type conversions you don't expect to happen.  The fact that there's no
equivalent operator int/bool for std::string or std::string_view
bolsters their argument.

I started off just trying to eliminate all OSL uses that assume this
operator would work (the proper idiom is simply `!str.empty()`). Along the
way, I found *TWO* bugs related to this -- one in osltoy and one
when constant folding "wrap" arguments to texture functions! So Thiago
and John were surely right, and I am appropriately chastened and
belatedly trying to find a way to get rid of the troublesome operator.

