### PR TITLE
oslc: Fix type constructor dealing with ambiguity in function return types

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -697,14 +697,21 @@ ASTtype_constructor::typecheck (TypeSpec expected, bool report, bool bind)
     TypeSpec argexpected;  // default to unknown
     if (expected.is_float()) {
         patterns = float_patterns;
+        argexpected = TypeDesc::FLOAT;
+        // ^^^ Since simetimes tht constructor `float(expr)` is used as a
+        // synonym for a cast `(float)expr`, we know that ambiguously typed
+        // expressions should favor disambiguating to a float.
     } else if (expected.is_triple()) {
         patterns = triple_patterns;
         // For triples, the constructor that takes just one argument is often
         // is used as a typecast, i.e. (vector)foo <==> vector(foo)
         // So pass on the expected type so it can resolve polymorphism in
-        // the expected way.
+        // the expected way. Similarly, the three-argument triple constructor
+        // can infer that all three arguments should disambiguate to float.
         if (listlength(args()) == 1)
             argexpected = expected;
+        else
+            argexpected = TypeDesc::FLOAT;
     } else if (expected.is_matrix()) {
         patterns = matrix_patterns;
     } else if (expected.is_int()) {

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -52,7 +52,7 @@ failureok = 0
 failthresh = 0.004
 hardfail = 0.01
 failpercent = 0.02
-oslcargs = ""
+oslcargs = "-Wall"
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd" ]

--- a/testsuite/typecast/test.osl
+++ b/testsuite/typecast/test.osl
@@ -51,4 +51,13 @@ test ()
         // point q[2] = { ... };
         // color c = (color) q[1];
     }
+
+    // Test some tricky cases -- these should not warn! The constructors
+    // ought to be able to figure out the desired type of the ambiguous
+    // function arguments.
+    closure color result = diffuse(N) * float(cellnoise(u, v));
+    color c1 = float(cellnoise(u,v));
+    color c2 = color(cellnoise(u,v));
+    color c3 = color(cellnoise(u,v),0.0,0.0);
+    color c4 = c1 * cellnoise(u,v);
 }


### PR DESCRIPTION
If you have a function that is polymorphic based on return type --
like cellnoise, which could return a float or a color -- you will get
a warning about the ambiguity in certain situations which you can resolve
with an explicit type cast:

    (float) cellnoise (u, v)    // the cast disambiguates which you want

But Thiago found that the similar idiom using a type constructor (rather
than a cast) like this:

    float (cellnoise (u, v))    // fails to disambiguate cellnoise?

fails to disambiguate and gives a warning about ambiguous types (it will
choose the float-returning kind, but will warn about the ambiguity, which
will be an error if you compile with `-Wall`).

This patch fixes the problem by making ASTtype_constructor::typecheck()
aware that float(expr) ought to expect expr to be a float if possible,
and also triple(expr,expr,expr) should expect all three of the channel
expressions to disambiguate to float. It previously made no such inference
in those cases. Note, however, that triple(expr) did previously know that
the expression ought to prefer to disambiguate to the same triple type.

While investigating, I also saw that the oso generated by that same
constructor sometimes did an extra unnecessary temporary assignment, so
while I was ast it I also fixed that with the changes you see to
ASTtype_constructor::codegen (in fact, these changes altered more code
than the type checking part).

Fixes #930
