### PR TITLE
Fix texture3d lookups with derivatives

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -386,7 +386,7 @@ DECL (osl_texture_set_subimagename, "xXs")
 DECL (osl_texture_set_missingcolor_arena, "xXX")
 DECL (osl_texture_set_missingcolor_alpha, "xXif")
 DECL (osl_texture, "iXXXXffffffiXXXXXXX")
-DECL (osl_texture3d, "iXXXXXXXXiXXXXXXXXX")
+DECL (osl_texture3d, "iXXXXXXXiXXXXXXX")
 DECL (osl_environment, "iXXXXXXXiXXXXXXX")
 DECL (osl_get_textureinfo, "iXXXXiiiX")
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2461,32 +2461,18 @@ LLVMGEN (llvm_gen_texture3d)
     if (user_derivs) {
         args.push_back (rop.llvm_void_ptr (*rop.opargsym (op, 3)));
         args.push_back (rop.llvm_void_ptr (*rop.opargsym (op, 4)));
-        args.push_back (rop.llvm_void_ptr (*rop.opargsym (op, 5)));
     } else {
         // Auto derivs of P
         args.push_back (rop.llvm_void_ptr (P, 1));
         args.push_back (rop.llvm_void_ptr (P, 2));
-        // dPdz is correct for input P, zero for all else
-        if (&P == rop.inst()->symbol(rop.inst()->Psym())) {
-            args.push_back (rop.llvm_void_ptr (P, 3));
-        } else {
-            // zero for dPdz, for now
-            llvm::Value *fzero = rop.ll.constant (0.0f);
-            llvm::Value *vzero = rop.ll.op_alloca (rop.ll.type_triple());
-            for (int i = 0;  i < 3;  ++i)
-                rop.ll.op_store (fzero, rop.ll.GEP (vzero, 0, i));
-            args.push_back (rop.ll.void_ptr(vzero));
-        }
     }
     args.push_back (rop.ll.constant (nchans));
     args.push_back (rop.ll.void_ptr (rop.llvm_void_ptr (Result, 0)));
     args.push_back (rop.ll.void_ptr (rop.llvm_void_ptr (Result, 1)));
     args.push_back (rop.ll.void_ptr (rop.llvm_void_ptr (Result, 2)));
-    args.push_back (rop.ll.void_ptr_null());  // no dresultdz for now
     args.push_back (rop.ll.void_ptr (alpha    ? alpha    : rop.ll.void_ptr_null()));
     args.push_back (rop.ll.void_ptr (dalphadx ? dalphadx : rop.ll.void_ptr_null()));
     args.push_back (rop.ll.void_ptr (dalphady ? dalphady : rop.ll.void_ptr_null()));
-    args.push_back (rop.ll.void_ptr_null());  // No dalphadz for now
     args.push_back (rop.ll.void_ptr (errormessage ? errormessage : rop.ll.void_ptr_null()));
     rop.ll.call_function ("osl_texture3d", &args[0], (int)args.size());
     rop.generated_texture_call (texture_handle != NULL);


### PR DESCRIPTION
One side was trying to make use of dresultdz while the llvm codegen was always providing nullptr. Since the shading system only supports Dual2 at the moment for derivative lookups, it seems more consistent to forget about trying to come up with a meaningful Z derivative for the time being.