### PR TITLE
Export struct OSLQuery::Parameter for Windows

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -107,7 +107,7 @@ public:
     /// `Parameter` holds all the information about a single shader
     /// parameter.
     /// <code>
-    struct Parameter {
+    struct OSLQUERYPUBLIC Parameter {
         ustring name;                    //< name
         TypeDesc type;                   //< data type
         bool isoutput = false;           //< is it an output param?


### PR DESCRIPTION
## Description

On Windows, osltoy fails to link because of a missing OSLQuery::Parameter constructor. Even when a class is properly exported, nested structs or classes within this class must be exported too.

## Tests

Just made myself sure it compiles and links :-^