### PR TITLE
Improve oso output efficiency with less redundant work on retrieve_source

### DIFF
--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -453,7 +453,12 @@ private:
             return NULL;
         return static_cast<ASTshader_declaration *>(m_shader.get());
     }
-    std::string retrieve_source (ustring filename, int line);
+
+    // Retrieve the particular line of a file.
+    string_view retrieve_source (ustring filename, int line);
+
+    // Clear internal caches that speed up retrieve_source().
+    void clear_filecontents_cache();
 
     ustring m_filename;       ///< Current file we're parsing
     int m_lineno;             ///< Current line we're parsing
@@ -479,8 +484,6 @@ private:
     int m_next_const;         ///< Next const symbol index
     std::vector<ConstantSymbol *> m_const_syms;  ///< All consts we've made
     std::ostream *m_osofile;  ///< Open .oso stream for output
-    std::string m_filecontents; ///< Contents of source file
-    ustring m_last_sourcefile;///< Last filename for retrieve_source
     ustring m_codegenmethod;  ///< Current method we're generating code for
     std::stack<FunctionSymbol *> m_function_stack; ///< Stack of called funcs
     int m_total_nesting;      ///< total conditional nesting level (0 == none)
@@ -490,6 +493,12 @@ private:
     int m_main_method_start;  ///< Instruction where 'main' starts
     bool m_declaring_shader_formals; ///< Are we declaring shader formals?
     std::set<std::pair<ustring,int>> m_nowarn_lines;  ///< Lines for 'nowarn'
+    typedef std::unordered_map<ustring,std::string,ustringHash> FCMap;
+    FCMap m_filecontents_map; ///< Contents of source files we've seen
+    ustring m_last_sourcefile;///< Last filename for retrieve_source
+    std::string* m_last_filecontents = nullptr; //< Last file contents
+    int m_last_sourceline;
+    size_t m_last_sourceline_offset;
 };
 
 


### PR DESCRIPTION
To make debugging easier and be more human-readable, oso files are littered
with comment lines reproducing the source code, so that you can see which
source corresponds to which "oso assembly".

The workhorse here is the retrieve_source(filename,line) function. But
it was unspeakably inefficient, reading the entire source file every
time an op needed a different source file than the previous op, and
scanning the file to find the n-th line *every* time. This seems like
the lookup is O(n^2) and also that we're rereading source files
potentially thousands of times.

Theory: If we cache all the files we read, so we never read each source
file more than once, and also remember which line we used last (we tend
to go in increasing order in a source file) and resume the search from
there, backtracking only when the line is less than the last one needed,
it ought to be blazingly fast!

Practice: It barely makes any difference.  Compiling all 600 MaterialX
source osl files takes 30 seconds on my laptop, and this fix saves maybe
a second or two at most.

Oh well. But I already made the change, so may as well keep the more
efficient algorithm. Perhaps there are other cases where it gives a bigger
advantage.

