### PR TITLE
Allow type conversion to float[4] in ShadingSystem::convert_value

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -637,13 +637,16 @@ public:
     /// assignment in OSL itself:
     ///   int -> float             convert to float
     ///   int -> triple            convert to float and replicate x3
+    ///   int -> float[4]          convert to float and replicate x4
     ///   float -> triple          replicate x3
+    ///   float -> float[4]        replicate x4
     ///   float -> int             truncate like a (int) type cast
     ///   triple -> triple         copy, regarless of differing vector types
     /// 3. Additional rules not allowed in OSL source code:
     ///   float -> float[2]        replicate x2
     ///   int -> float[2]          convert to float and replicate x2
     ///   float[2] -> triple       (f[0], f[1], 0)
+    ///   float[4] -> vec4         allow conversion to OIIO type (no vec4 in OSL)
     ///
     /// Observation: none of the supported conversions require more
     /// storage for src than for dst.

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -523,6 +523,7 @@ ShadingSystem::optimize_group (ShaderGroup *group,
 
 static TypeDesc TypeFloatArray2 (TypeDesc::FLOAT, 2);
 static TypeDesc TypeFloatArray3 (TypeDesc::FLOAT, 3);
+static TypeDesc TypeFloatArray4 (TypeDesc::FLOAT, 4);
 
 
 
@@ -581,12 +582,31 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
             }
             return true;
         }
+        // float->float[4]
+        if (dsttype == TypeFloatArray4) {
+            if (dst && src) {
+                float f = *(const float *)src;
+                ((float *)dst)[0] = f;
+                ((float *)dst)[1] = f;
+                ((float *)dst)[2] = f;
+                ((float *)dst)[3] = f;
+            }
+            return true;
+        }
         return false; // Unsupported conversion
     }
 
     // float[3] -> triple
     if ((srctype == TypeFloatArray3 && equivalent(dsttype, TypeDesc::TypePoint)) ||
         (dsttype == TypeFloatArray3 && equivalent(srctype, TypeDesc::TypePoint))) {
+        if (dst && src)
+            memcpy (dst, src, dsttype.size());
+        return true;
+    }
+
+    // float[4] -> vec4
+    if ((srctype == TypeFloatArray4 && equivalent(dsttype, TypeDesc::TypeFloat4)) ||
+        (dsttype == TypeFloatArray4 && equivalent(srctype, TypeDesc::TypeFloat4))) {
         if (dst && src)
             memcpy (dst, src, dsttype.size());
         return true;


### PR DESCRIPTION
## Description
Just mirror the conversions allowed for float[2] and float[3] types for float[4] 

## Tests
I'm not seeing a test-harness where I can..?

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

