### PR TITLE
Use memmove as dst & src may overlap

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -554,7 +554,7 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
     // Just copy equivalent types
     if (equivalent (dsttype, srctype)) {
         if (dst && src)
-            memcpy (dst, src, dsttype.size());
+            memmove (dst, src, dsttype.size());
         return true;
     }
 
@@ -600,7 +600,7 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
     if ((srctype == TypeFloatArray3 && equivalent(dsttype, TypeDesc::TypePoint)) ||
         (dsttype == TypeFloatArray3 && equivalent(srctype, TypeDesc::TypePoint))) {
         if (dst && src)
-            memcpy (dst, src, dsttype.size());
+            memmove (dst, src, dsttype.size());
         return true;
     }
 
@@ -608,7 +608,7 @@ ShadingSystem::convert_value (void *dst, TypeDesc dsttype,
     if ((srctype == TypeFloatArray4 && equivalent(dsttype, TypeDesc::TypeFloat4)) ||
         (dsttype == TypeFloatArray4 && equivalent(srctype, TypeDesc::TypeFloat4))) {
         if (dst && src)
-            memcpy (dst, src, dsttype.size());
+            memmove (dst, src, dsttype.size());
         return true;
     }
 


### PR DESCRIPTION
## Description
Admittedly a fairly unlikely occurrence, but `ShadingSystem::convert_value` could lead to undefined behaviour if src & dst overlap.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

