### PR TITLE
Demote writing to non-output function parameters to be a warning.

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -943,10 +943,11 @@ ASTNode::check_symbol_writeability (ASTNode *var)
 
     if (dest) {
         if (dest->readonly()) {
-            if (OSL_VERSION >= 11001)
-                error ("cannot write to \"%s\" (read-only symbol)", dest->name());
-            else
-                warning ("cannot write to \"%s\" (read-only symbol)", dest->name());
+            warning ("cannot write to non-output parameter \"%s\"", dest->name());
+            // Note: Consider it only a warning to write to a non-output
+            // parameter. Users who want it to be a hard error can use
+            // -Werror. Writing to any other readonly symbols is a full
+            // error.
             return false;
         }
     } else {

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -1207,8 +1207,8 @@ OSLCompilerImpl::check_write_legality (const Opcode &op, int opnum,
     if (sym->symtype() == SymTypeParam && 
         (opnum < sym->initbegin() || opnum >= sym->initend())) {
         error (op.sourcefile(), op.sourceline(),
-               "Cannot write to input parameter '%s' (op %d)",
-               sym->name().c_str(), opnum);
+               "cannot write to non-output parameter \"%s\"",
+               sym->name());
     }
 }
 

--- a/testsuite/oslc-err-write-nonoutput/ref/out.txt
+++ b/testsuite/oslc-err-write-nonoutput/ref/out.txt
@@ -1,6 +1,6 @@
-test.osl:4: error: cannot write to "x" (read-only symbol)
-test.osl:5: error: cannot write to "x" (read-only symbol)
-test.osl:6: error: cannot write to "i" (read-only symbol)
-test.osl:7: error: cannot write to "i" (read-only symbol)
-test.osl:20: error: cannot write to "u" (read-only symbol)
+test.osl:4: error: cannot write to non-output parameter "x"
+test.osl:5: error: cannot write to non-output parameter "x"
+test.osl:6: error: cannot write to non-output parameter "i"
+test.osl:7: error: cannot write to non-output parameter "i"
+test.osl:20: error: cannot write to non-output parameter "u"
 FAILED test.osl


### PR DESCRIPTION
It was never supposed to be allowed. It used to be ignored in most
cases, error neither detected nor issued. PR #878 "fixed" it to detect
the error. But there were too many shaders that did it, users are
confused and it breaks things.

So this patch downgrades it from an error to a warning. If you ignore
the warning, you get what you deserve (which is probably not
bad... people lived with it for years). Anybody who wants it to be fully
illegal can always compile with -Werror to turn warnings in to full
errors.

I also "uniformized" two separate error messages on the same general
topic, so they look the same.
