### PR TITLE
Remove long-deprecated methods

### DIFF
--- a/src/include/OSL/oslcomp.h
+++ b/src/include/OSL/oslcomp.h
@@ -41,9 +41,6 @@ namespace pvt {
 
 class OSLCOMPPUBLIC OSLCompiler {
 public:
-    OSL_DEPRECATED("Directly construct or new an OSLCompiler")
-    static OSLCompiler *create ();
-
     OSLCompiler (ErrorHandler *errhandler=NULL);
     ~OSLCompiler ();
 

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -244,15 +244,6 @@ public:
                           float dsdy, float dtdy, int nchannels,
                           float *result, float *dresultds, float *dresultdt,
                           ustring *errormessage);
-    // DEPRECATED(1.8) version, with no errormessage parameter. This will
-    // eventually disappear.
-    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
-    virtual bool texture (ustring filename, TextureHandle *texture_handle,
-                          TexturePerthread *texture_thread_info,
-                          TextureOpt &options, ShaderGlobals *sg,
-                          float s, float t, float dsdx, float dtdx,
-                          float dsdy, float dtdy, int nchannels,
-                          float *result, float *dresultds, float *dresultdt);
 
     /// Filtered 3D texture lookup for a single point.
     ///
@@ -287,16 +278,6 @@ public:
                             float *result, float *dresultds,
                             float *dresultdt, float *dresultdr,
                             ustring *errormessage);
-    // DEPRECATED(1.8) version, with no errormessage parameter. This will
-    // eventually disappear.
-    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
-    virtual bool texture3d (ustring filename, TextureHandle *texture_handle,
-                            TexturePerthread *texture_thread_info,
-                            TextureOpt &options, ShaderGlobals *sg,
-                            const Vec3 &P, const Vec3 &dPdx, const Vec3 &dPdy,
-                            const Vec3 &dPdz, int nchannels,
-                            float *result, float *dresultds,
-                            float *dresultdt, float *dresultdr);
 
     /// Filtered environment lookup for a single point.
     ///
@@ -327,15 +308,6 @@ public:
                               int nchannels, float *result,
                               float *dresultds, float *dresultdt,
                               ustring *errormessage);
-    // DEPRECATED(1.8) version, with no errormessage parameter. This will
-    // eventually disappear.
-    OSL_DEPRECATED ("Deprecated since 1.8, use the version with an errormessage parameter.")
-    virtual bool environment (ustring filename, TextureHandle *texture_handle,
-                              TexturePerthread *texture_thread_info,
-                              TextureOpt &options, ShaderGlobals *sg,
-                              const Vec3 &R, const Vec3 &dRdx, const Vec3 &dRdy,
-                              int nchannels, float *result,
-                              float *dresultds, float *dresultdt);
 
     /// Get information about the given texture.  Return true if found
     /// and the data has been put in *data.  Return false if the texture

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -184,38 +184,6 @@ RendererServices::texture (ustring filename, TextureHandle *texture_handle,
 
 
 
-// Deprecated version (1.8)
-bool
-RendererServices::texture (ustring filename, TextureHandle *texture_handle,
-                           TexturePerthread *texture_thread_info,
-                           TextureOpt &options, ShaderGlobals *sg,
-                           float s, float t, float dsdx, float dtdx,
-                           float dsdy, float dtdy, int nchannels,
-                           float *result, float *dresultds, float *dresultdt)
-{
-    ShadingContext *context = sg->context;
-    if (! texture_thread_info)
-        texture_thread_info = context->texture_thread_info();
-    bool status;
-    if (texture_handle)
-        status = texturesys()->texture (texture_handle, texture_thread_info,
-                                        options, s, t, dsdx, dtdx, dsdy, dtdy,
-                                        nchannels, result, dresultds, dresultdt);
-    else
-        status = texturesys()->texture (filename,
-                                        options, s, t, dsdx, dtdx, dsdy, dtdy,
-                                        nchannels, result, dresultds, dresultdt);
-    if (!status) {
-        std::string err = texturesys()->geterror();
-        if (err.size() && sg) {
-            context->error ("[RendererServices::texture] %s", err);
-        }
-    }
-    return status;
-}
-
-
-
 bool
 RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
                              TexturePerthread *texture_thread_info,
@@ -256,40 +224,6 @@ RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
 
 
 
-// Deprecated version (1.8)
-bool
-RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
-                             TexturePerthread *texture_thread_info,
-                             TextureOpt &options, ShaderGlobals *sg,
-                             const Vec3 &P, const Vec3 &dPdx, const Vec3 &dPdy,
-                             const Vec3 &dPdz, int nchannels, float *result,
-                             float *dresultds, float *dresultdt, float *dresultdr)
-{
-    ShadingContext *context = sg->context;
-    if (! texture_thread_info)
-        texture_thread_info = context->texture_thread_info();
-    bool status;
-    if (texture_handle)
-        status = texturesys()->texture3d (texture_handle, texture_thread_info,
-                                          options, P, dPdx, dPdy, dPdz,
-                                          nchannels, result,
-                                          dresultds, dresultdt, dresultdr);
-    else
-        status = texturesys()->texture3d (filename,
-                                          options, P, dPdx, dPdy, dPdz,
-                                          nchannels, result,
-                                          dresultds, dresultdt, dresultdr);
-    if (!status) {
-        std::string err = texturesys()->geterror();
-        if (err.size() && sg) {
-            sg->context->error ("[RendererServices::texture3d] %s", err);
-        }
-    }
-    return status;
-}
-
-
-
 bool
 RendererServices::environment (ustring filename, TextureHandle *texture_handle,
                                TexturePerthread *texture_thread_info,
@@ -320,37 +254,6 @@ RendererServices::environment (ustring filename, TextureHandle *texture_handle,
             }
         } else if (errormessage) {
             *errormessage = Strings::unknown;
-        }
-    }
-    return status;
-}
-
-
-
-// Deprecated version (1.8)
-bool
-RendererServices::environment (ustring filename, TextureHandle *texture_handle,
-                               TexturePerthread *texture_thread_info,
-                               TextureOpt &options, ShaderGlobals *sg,
-                               const Vec3 &R, const Vec3 &dRdx, const Vec3 &dRdy,
-                               int nchannels, float *result,
-                               float *dresultds, float *dresultdt)
-{
-    ShadingContext *context = sg->context;
-    if (! texture_thread_info)
-        texture_thread_info = context->texture_thread_info();
-    bool status;
-    if (texture_handle)
-        status = texturesys()->environment (texture_handle, texture_thread_info,
-                                            options, R, dRdx, dRdy,
-                                            nchannels, result, dresultds, dresultdt);
-    else
-        status = texturesys()->environment (filename, options, R, dRdx, dRdy,
-                                            nchannels, result, dresultds, dresultdt);
-    if (!status) {
-        std::string err = texturesys()->geterror();
-        if (err.size() && sg) {
-            sg->context->error ("[RendererServices::environment] %s", err);
         }
     }
     return status;


### PR DESCRIPTION
These were marked as deprecated in 1.8. The latest release is 1.10. Let's remove it from master.
