### PR TITLE
Change all calls to Strutil::format to Strutil::sprintf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ matrix:
               - libboost-thread1.55
               - libboost-wave1.55
         env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OIIOBRANCH=release
-      - name: "Older things: release OIIO, llvm 5, OIIO 1.8/oldest, boost 1.55"
+      - name: "Older things: OIIO 1.9, llvm 5, boost 1.55"
         os: linux
         compiler: gcc
         addons:

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -110,6 +110,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  include <OpenImageIO/array_view.h>
 #endif
 
+// If we're using an old version of OIIO prior to the introduction of
+// Strutil::sprintf, define it ourselves to be a synonym for format.
+#ifndef OIIO_HAS_SPRINTF
+OIIO_NAMESPACE_BEGIN
+namespace Strutil {
+template<typename... Args>
+inline std::string sprintf (const char* fmt, const Args&... args) {
+    return Strutil::format (fmt, args...);
+}
+} // namespace strutil
+OIIO_NAMESPACE_END
+#endif
+
 // Extensions to Imath
 #include <OSL/matrix22.h>
 

--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -218,8 +218,8 @@ private:
 
     // Internal error reporting routine, with printf-like arguments.
     template<typename... Args>
-    inline void error (string_view fmt, const Args&... args) const {
-        append_error(OIIO::Strutil::format (fmt, args...));
+    inline void error (const char* fmt, const Args&... args) const {
+        append_error(OIIO::Strutil::sprintf (fmt, args...));
     }
 
     void append_error (const std::string& message) const {

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -414,14 +414,14 @@ ASTfunction_declaration::ASTfunction_declaration (OSLCompilerImpl *comp,
                 auto other = static_cast<ASTfunction_declaration*>(f->node());
                 if (!other || (other->statements() || other->is_builtin())) {
                     if (err.empty()) {
-                        err = Strutil::format("Function '%s %s (%s)' redefined "
+                        err = Strutil::sprintf("Function '%s %s (%s)' redefined "
                                               "in the same scope\n"
                                               "  Previous definitions:", type,
                                               name, list_to_types_string(form));
                     }
                     err += "\n    ";
                     if (other) {
-                        err += Strutil::format("%s:%d",
+                        err += Strutil::sprintf("%s:%d",
                                     OIIO::Filesystem::filename(other->sourcefile().string()),
                                     other->sourceline());
                     } else
@@ -530,11 +530,11 @@ ASTvariable_declaration::ASTvariable_declaration (OSLCompilerImpl *comp,
     m_typespec = type;
     Symbol *f = comp->symtab().clash (name);
     if (f  &&  ! m_ismetadata) {
-        std::string e = Strutil::format ("\"%s\" already declared in this scope", name.c_str());
+        std::string e = Strutil::sprintf ("\"%s\" already declared in this scope", name.c_str());
         if (f->node()) {
             std::string filename = OIIO::Filesystem::filename(f->node()->sourcefile().string());
-            e += Strutil::format ("\n\t\tprevious declaration was at %s:%d",
-                                  filename, f->node()->sourceline());
+            e += Strutil::sprintf ("\n\t\tprevious declaration was at %s:%d",
+                                   filename, f->node()->sourceline());
         }
         if (f->scope() == 0 && f->symtype() == SymTypeFunction && isparam) {
             // special case: only a warning for param to mask global function
@@ -773,13 +773,13 @@ ASTstructselect::find_fieldsym (int &structid, int &fieldid)
 
     if (fieldid < 0) {
         error ("struct type '%s' does not have a member '%s'",
-               structspec->name().c_str(), m_field.c_str());
+               structspec->name(), m_field);
         return NULL;
     }
 
     const StructSpec::FieldSpec &fieldrec (structspec->field(fieldid));
-    ustring fieldsymname = ustring::format ("%s.%s", structsymname.c_str(),
-                                            fieldrec.name.c_str());
+    ustring fieldsymname = ustring::format ("%s.%s", structsymname,
+                                            fieldrec.name);
     Symbol *sym = m_compiler->symtab().find (fieldsymname);
     return sym;
 }

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -186,34 +186,34 @@ public:
     void sourceline (int line) { m_sourceline = line; }
 
     template<typename... Args>
-    void error (string_view format, const Args&... args) const
+    void error (const char* format, const Args&... args) const
     {
-        DASSERT (format.size());
-        error_impl (OIIO::Strutil::format (format, args...));
+        DASSERT (format && format[0]);
+        error_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
     /// Warning reporting
     template<typename... Args>
-    void warning (string_view format, const Args&... args) const
+    void warning (const char* format, const Args&... args) const
     {
-        DASSERT (format.size());
-        warning_impl (OIIO::Strutil::format (format, args...));
+        DASSERT (format && format[0]);
+        warning_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
     /// info reporting
     template<typename... Args>
-    void info (string_view format, const Args&... args) const
+    void info (const char* format, const Args&... args) const
     {
-        DASSERT (format.size());
-        info_impl (OIIO::Strutil::format (format, args...));
+        DASSERT (format && format[0]);
+        info_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
     /// message reporting
     template<typename... Args>
-    void message (string_view format, const Args&... args) const
+    void message (const char* format, const Args&... args) const
     {
-        DASSERT (format.size());
-        message_impl (OIIO::Strutil::format (format, args...));
+        DASSERT (format && format[0]);
+        message_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
     bool is_lvalue () const { return m_is_lvalue; }

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -648,16 +648,16 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
         completed = false;
     } else if (type.is_int()) {
         if (islit && lit->typespec().is_int())
-            out += Strutil::format ("%d", lit->intval());
+            out += Strutil::sprintf ("%d", lit->intval());
         else {
             out += "0";  // FIXME?
             completed = false;
         }
     } else if (type.is_float()) {
         if (islit && lit->typespec().is_int())
-            out += Strutil::format ("%d", lit->intval());
+            out += Strutil::sprintf ("%d", lit->intval());
         else if (islit && lit->typespec().is_float())
-            out += Strutil::format ("%.9g", lit->floatval());
+            out += Strutil::sprintf ("%.9g", lit->floatval());
         else {
             out += "0";  // FIXME?
             completed = false;
@@ -665,10 +665,10 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
     } else if (type.is_triple()) {
         if (islit && lit->typespec().is_int()) {
             float f = lit->intval();
-            out += Strutil::format ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
+            out += Strutil::sprintf ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
         } else if (islit && lit->typespec().is_float()) {
             float f = lit->floatval();
-            out += Strutil::format ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
+            out += Strutil::sprintf ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
         } else if (init && init->typespec() == type &&
                    (init->nodetype() == ASTNode::type_constructor_node ||
                    (init->nodetype() == ASTNode::compound_initializer_node &&
@@ -697,23 +697,23 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
                 }
             }
             if (nargs == 1)
-                out += Strutil::format ("%.9g%s%.9g%s%.9g", f[0], sep, f[0], sep, f[0]);
+                out += Strutil::sprintf ("%.9g%s%.9g%s%.9g", f[0], sep, f[0], sep, f[0]);
             else
-                out += Strutil::format ("%.9g%s%.9g%s%.9g", f[0], sep, f[1], sep, f[2]);
+                out += Strutil::sprintf ("%.9g%s%.9g%s%.9g", f[0], sep, f[1], sep, f[2]);
         } else {
-            out += Strutil::format ("0%s0%s0", sep, sep);
+            out += Strutil::sprintf ("0%s0%s0", sep, sep);
             completed = false;
         }
     } else if (type.is_matrix()) {
         if (islit && lit->typespec().is_int()) {
             float f = lit->intval();
             for (int c = 0; c < 16; ++c)
-               out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
+               out += Strutil::sprintf ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
                                        c<15 ? sep.c_str() : "");
         } else if (islit && lit->typespec().is_float()) {
             float f = lit->floatval();
             for (int c = 0; c < 16; ++c)
-               out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
+               out += Strutil::sprintf ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
                                        c<15 ? sep.c_str() : "");
         } else if (init && init->typespec() == type &&
                    init->nodetype() == ASTNode::type_constructor_node) {
@@ -741,20 +741,20 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
             }
             if (nargs == 1) {
                 for (int c = 0; c < 16; ++c)
-                   out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f[0] : 0.0f,
+                   out += Strutil::sprintf ("%.9g%s", (c/4)==(c%4) ? f[0] : 0.0f,
                                            c<15 ? sep.c_str() : "");
             } else {
                 for (int c = 0; c < 16; ++c)
-                    out += Strutil::format ("%.9g%s", f[c], c<15 ? sep.c_str() : "");
+                    out += Strutil::sprintf ("%.9g%s", f[c], c<15 ? sep.c_str() : "");
             }
         } else {
             for (int c = 0; c < 16; ++c)
-                out += Strutil::format ("0%s", c<15 ? sep.c_str() : "");
+                out += Strutil::sprintf ("0%s", c<15 ? sep.c_str() : "");
             completed = false;
         }
     } else if (type.is_string()) {
         if (islit && lit->typespec().is_string())
-            out += Strutil::format ("\"%s\"", Strutil::escape_chars(lit->strval()));
+            out += Strutil::sprintf ("\"%s\"", Strutil::escape_chars(lit->strval()));
         else {
             out += "\"\"";  // FIXME?
             completed = false;

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -191,7 +191,7 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     std::string instring;
     if (!stdoslpath.empty())
-        instring = OIIO::Strutil::format("#include \"%s\"\n", stdoslpath.c_str());
+        instring = OIIO::Strutil::sprintf("#include \"%s\"\n", stdoslpath);
     else
         instring = "\n";
     instring += buffer;
@@ -211,13 +211,13 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
                 & ~boost::wave::language_support::support_option_insert_whitespace);
         ctx.set_language (lang);
 
-        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_MAJOR=%d",
+        ctx.add_macro_definition (OIIO::Strutil::sprintf("OSL_VERSION_MAJOR=%d",
                                                   OSL_LIBRARY_VERSION_MAJOR).c_str());
-        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_MINOR=%d",
+        ctx.add_macro_definition (OIIO::Strutil::sprintf("OSL_VERSION_MINOR=%d",
                                                   OSL_LIBRARY_VERSION_MINOR).c_str());
-        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION_PATCH=%d",
+        ctx.add_macro_definition (OIIO::Strutil::sprintf("OSL_VERSION_PATCH=%d",
                                                   OSL_LIBRARY_VERSION_PATCH).c_str());
-        ctx.add_macro_definition (OIIO::Strutil::format("OSL_VERSION=%d",
+        ctx.add_macro_definition (OIIO::Strutil::sprintf("OSL_VERSION=%d",
                                                   OSL_LIBRARY_VERSION_CODE).c_str());
         for (size_t i = 0; i < defines.size(); ++i) {
             if (defines[i][1] == 'D')
@@ -293,7 +293,7 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 {
     std::string instring;
     if (!stdoslpath.empty())
-        instring = OIIO::Strutil::format("#include \"%s\"\n", stdoslpath);
+        instring = OIIO::Strutil::sprintf("#include \"%s\"\n", stdoslpath);
     else
         instring = "\n";
     instring += buffer;
@@ -348,13 +348,13 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
 
     clang::PreprocessorOptions &preprocOpts = inst.getPreprocessorOpts();
     preprocOpts.UsePredefines = 0;
-    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_MAJOR=%d",
+    preprocOpts.addMacroDef (OIIO::Strutil::sprintf("OSL_VERSION_MAJOR=%d",
                                              OSL_LIBRARY_VERSION_MAJOR).c_str());
-    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_MINOR=%d",
+    preprocOpts.addMacroDef (OIIO::Strutil::sprintf("OSL_VERSION_MINOR=%d",
                                              OSL_LIBRARY_VERSION_MINOR).c_str());
-    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION_PATCH=%d",
+    preprocOpts.addMacroDef (OIIO::Strutil::sprintf("OSL_VERSION_PATCH=%d",
                                              OSL_LIBRARY_VERSION_PATCH).c_str());
-    preprocOpts.addMacroDef (OIIO::Strutil::format("OSL_VERSION=%d",
+    preprocOpts.addMacroDef (OIIO::Strutil::sprintf("OSL_VERSION=%d",
                                              OSL_LIBRARY_VERSION_CODE).c_str());
     for (auto&& d : defines) {
         if (d[1] == 'D')

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <map>
 
+#include <OSL/oslconfig.h>
 #include <OSL/oslcomp.h>
 #include "ast.h"
 #include "symtab.h"
@@ -102,10 +103,10 @@ public:
     /// Error reporting
     template<typename... Args>
     void error (ustring filename, int line,
-                string_view format, const Args&... args) const
+                const char* format, const Args&... args) const
     {
-        ASSERT (format.size());
-        std::string msg = OIIO::Strutil::format (format, args...);
+        DASSERT (format && format[0]);
+        std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
@@ -118,12 +119,12 @@ public:
     /// Warning reporting
     template<typename... Args>
     void warning (ustring filename, int line,
-                  string_view format, const Args&... args) const
+                  const char* format, const Args&... args) const
     {
-        ASSERT (format.size());
+        DASSERT (format && format[0]);
         if (nowarn(filename, line))
             return;    // skip if the filename/line is on the nowarn list
-        std::string msg = OIIO::Strutil::format (format, args...);
+        std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (m_err_on_warning) {
@@ -139,10 +140,10 @@ public:
     /// Info reporting
     template<typename... Args>
     void info (ustring filename, int line,
-                  string_view format, const Args&... args) const
+                  const char* format, const Args&... args) const
     {
-        ASSERT (format.size());
-        std::string msg = OIIO::Strutil::format (format, args...);
+        DASSERT (format && format[0]);
+        std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
@@ -154,10 +155,10 @@ public:
     /// message reporting
     template<typename... Args>
     void message (ustring filename, int line,
-                  string_view format, const Args&... args) const
+                  const char* format, const Args&... args) const
     {
-        ASSERT (format.size());
-        std::string msg = OIIO::Strutil::format (format, args...);
+        DASSERT (format && format[0]);
+        std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
@@ -402,8 +403,8 @@ private:
     void write_oso_metadata (const ASTNode *metanode) const;
 
     template<typename... Args>
-    inline void oso (string_view fmt, const Args&... args) const {
-        (*m_osofile) << OIIO::Strutil::format (fmt, args...);
+    inline void oso (const char* fmt, const Args&... args) const {
+        (*m_osofile) << OIIO::Strutil::sprintf (fmt, args...);
     }
 
     void track_variable_lifetimes () {

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -45,7 +45,7 @@ std::string
 Symbol::mangled () const
 {
     // FIXME: De-alias
-    return scope() ? Strutil::format ("___%d_%s", scope(), m_name.c_str())
+    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name.c_str())
         : m_name.string();
 }
 
@@ -65,7 +65,7 @@ Symbol::symtype_shortname (SymType s)
 std::string
 StructSpec::mangled () const
 {
-    return scope() ? Strutil::format ("___%d_%s", scope(), m_name.c_str())
+    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name.c_str())
         : m_name.string();
 }
 

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -738,8 +738,8 @@ ASTtype_constructor::typecheck (TypeSpec expected, bool report, bool bind)
 
     // If we made it this far, no match could be found.
     if (report) {
-        std::string err = Strutil::format ("Cannot construct %s (",
-                                           type_c_str(expected));
+        std::string err = OIIO::Strutil::sprintf ("Cannot construct %s (",
+                                                  type_c_str(expected));
         for (ref a = args();  a;  a = a->next()) {
             err += a->typespec().string();
             if (a->next())
@@ -1003,7 +1003,7 @@ private:
                          m_compiler->type_c_str(node->typespec()),
                          m_compiler->type_c_str(expected),
                          !spec ? "" :
-                         Strutil::format(" %s.%s", spec->name(), field->name));
+                         Strutil::sprintf(" %s.%s", spec->name(), field->name));
         }
         return true;
     }
@@ -1657,7 +1657,7 @@ public:
             comma = ", ";
         }
         argstr += ")";
-        return Strutil::format ("%s '%s'%s\n", msg, argstr,
+        return Strutil::sprintf ("%s '%s'%s\n", msg, argstr,
                                 candidateMsg ? "\n  Candidates are:" : "");
     }
 
@@ -1668,8 +1668,8 @@ public:
         formals += advance;
         std::string msg = "    ";
         if (ASTNode* decl = sym->node())
-            msg += Strutil::format("%s:%d\t", decl->sourcefile(), decl->sourceline());
-        msg += Strutil::format("%s %s (%s)\n", m_compiler->type_c_str(returntype),
+            msg += Strutil::sprintf("%s:%d\t", decl->sourcefile(), decl->sourceline());
+        msg += Strutil::sprintf("%s %s (%s)\n", m_compiler->type_c_str(returntype),
                                sym->name(), m_compiler->typelist_from_code(formals));
         return msg;
     }
@@ -1815,7 +1815,7 @@ public:
             std::string errmsg = reportAmbiguity (funcname, !warn /* "Candidates are" msg*/,
                                                   "Ambiguous call to");
             if (warn) {
-                errmsg += Strutil::format ("  Chosen function is:\n%s",
+                errmsg += Strutil::sprintf ("  Chosen function is:\n%s",
                                            reportFunction (c.first->sym));
                 errmsg += "  Other candidates are:\n";
                 for (auto& candidate : m_candidates)
@@ -2250,7 +2250,7 @@ OSLCompilerImpl::code_from_type (TypeSpec type) const
     std::string out;
     TypeDesc elem = type.elementtype().simpletype();
     if (type.is_structure() || type.is_structure_array()) {
-        out = Strutil::format ("S%d", type.structure());
+        out = Strutil::sprintf ("S%d", type.structure());
     } else if (type.is_closure() || type.is_closure_array()) {
         out = 'C';
     } else {
@@ -2280,7 +2280,7 @@ OSLCompilerImpl::code_from_type (TypeSpec type) const
         if (type.is_unsized_array())
             out += "[]";
         else
-            out += Strutil::format ("[%d]", type.arraylength());
+            out += Strutil::sprintf ("[%d]", type.arraylength());
     }
 
     return out;

--- a/src/liboslexec/automata.cpp
+++ b/src/liboslexec/automata.cpp
@@ -110,7 +110,7 @@ NdfAutomata::State::tostr()const
         for (IntSet::const_iterator j = dest.begin(); j != dest.end(); ++j) {
             if (s[s.size()-1] != '{')
                 s += ", ";
-            s += Strutil::format("%d", *j);
+            s += Strutil::sprintf("%d", *j);
         }
         s += "}";
     }
@@ -132,12 +132,12 @@ NdfAutomata::State::tostr()const
             }
             s += "]:";
         }
-        s += Strutil::format("%d", m_wildcard_trans);
+        s += Strutil::sprintf("%d", m_wildcard_trans);
     }
     // and finally the rule if we have it
     if (m_rule) {
         s += " | ";
-        s += Strutil::format("%lx", (long unsigned int)m_rule);
+        s += Strutil::sprintf("%lx", (long unsigned int)m_rule);
     }
     return s;
 }
@@ -361,7 +361,7 @@ DfAutomata::State::tostr()const
         else
             s += sym.c_str();
         s += ":";
-        s += Strutil::format("%d", dest);
+        s += Strutil::sprintf("%d", dest);
     }
     // wildcard
     if (m_wildcard_trans >= 0) {
@@ -379,7 +379,7 @@ DfAutomata::State::tostr()const
             }
             s += "}:";
         }
-        s += Strutil::format("%d", m_wildcard_trans);
+        s += Strutil::sprintf("%d", m_wildcard_trans);
     }
     // and the rules
     if (m_rules.size()) {
@@ -387,7 +387,7 @@ DfAutomata::State::tostr()const
         for (RuleSet::const_iterator i = m_rules.begin(); i != m_rules.end(); ++i) {
             if (s[s.size()-1] != '[')
                 s += ", ";
-            s += Strutil::format("%lx", (long unsigned int)*i);
+            s += Strutil::sprintf("%lx", (long unsigned int)*i);
         }
         s += "]";
     }

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -49,7 +49,7 @@ check_cwd (ShadingSystemImpl &shadingsys)
     char pathname[1024] = { "" };
     if (! getcwd (pathname, sizeof(pathname)-1)) {
         int e = errno;
-        err += Strutil::format ("Failed getcwd(), errno is %d: %s\n",
+        err += Strutil::sprintf ("Failed getcwd(), errno is %d: %s\n",
                                 errno, pathname);
         if (e == EACCES || e == ENOENT) {
             err += "Read/search permission problem or dir does not exist.\n";
@@ -57,10 +57,10 @@ check_cwd (ShadingSystemImpl &shadingsys)
             if (! pwdenv) {
                 err += "$PWD is not even found in the environment.\n";
             } else {
-                err += Strutil::format ("$PWD is \"%s\"\n", pwdenv);
-                err += Strutil::format ("That %s.\n",
+                err += Strutil::sprintf ("$PWD is \"%s\"\n", pwdenv);
+                err += Strutil::sprintf ("That %s.\n",
                           OIIO::Filesystem::exists(pwdenv) ? "exists" : "does NOT exist");
-                err += Strutil::format ("That %s a directory.\n",
+                err += Strutil::sprintf ("That %s a directory.\n",
                           OIIO::Filesystem::is_directory(pwdenv) ? "is" : "is NOT");
                 std::vector<std::string> pieces;
                 Strutil::split (pwdenv, pieces, "/");
@@ -70,7 +70,7 @@ check_cwd (ShadingSystemImpl &shadingsys)
                         continue;
                     p += "/";
                     p += pieces[i];
-                    err += Strutil::format ("  %s : %s and is%s a directory.\n", p,
+                    err += Strutil::sprintf ("  %s : %s and is%s a directory.\n", p,
                         OIIO::Filesystem::exists(p) ? "exists" : "does NOT exist",
                         OIIO::Filesystem::is_directory(p) ? "" : " NOT");
                 }
@@ -431,7 +431,7 @@ BackendLLVM::createOptixMetadata (const std::string& name, const std::string& ty
     ASSERT (use_optix() && "This function is only supported when using OptiX!");
 
     auto mangle_name = [](const std::string& name, const std::string& prefix) {
-        return OIIO::Strutil::format ("_ZN%drti_internal_%s%d%sE",
+        return OIIO::Strutil::sprintf ("_ZN%drti_internal_%s%d%sE",
                                       prefix.size()+13, prefix, name.size(), name);
     };
 

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -410,7 +410,7 @@ public:
     ///
     llvm::BasicBlock *llvm_exit_instance_block () {
         if (! m_exit_instance_block) {
-            std::string name = Strutil::format ("%s_%d_exit_", inst()->layername(), inst()->id());
+            std::string name = Strutil::sprintf ("%s_%d_exit_", inst()->layername(), inst()->id());
             m_exit_instance_block = ll.new_basic_block (name);
         }
         return m_exit_instance_block;

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1387,15 +1387,15 @@ DECLFOLDER(constfold_format)
         std::string formatted;
         const TypeSpec &argtype = Arg.typespec();
         if (argtype.is_int())
-            formatted = Strutil::format (mid.c_str(), *(int *)Arg.data());
+            formatted = Strutil::sprintf (mid.c_str(), *(int *)Arg.data());
         else if (argtype.is_float())
-            formatted = Strutil::format (mid.c_str(), *(float *)Arg.data());
+            formatted = Strutil::sprintf (mid.c_str(), *(float *)Arg.data());
         else if (argtype.is_triple())
-            formatted = Strutil::format (mid.c_str(), *(Vec3 *)Arg.data());
+            formatted = Strutil::sprintf (mid.c_str(), *(Vec3 *)Arg.data());
         else if (argtype.is_matrix())
-            formatted = Strutil::format (mid.c_str(), *(Matrix44 *)Arg.data());
+            formatted = Strutil::sprintf (mid.c_str(), *(Matrix44 *)Arg.data());
         else if (argtype.is_string())
-            formatted = Strutil::format (mid.c_str(), *(ustring *)Arg.data());
+            formatted = Strutil::sprintf (mid.c_str(), *(ustring *)Arg.data());
         else
             break;   // something else we don't handle -- we're done
 

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -537,9 +537,9 @@ std::string
 ConnectedParam::str (const ShaderInstance *inst)
 {
     const Symbol *s = inst->symbol(param);
-    return Strutil::format ("%s%s%s (%s)", s->name(),
-                            arrayindex >= 0 ? Strutil::format("[%d]", arrayindex) : std::string(),
-                            channel >= 0 ? Strutil::format("[%d]", channel) : std::string(),
+    return Strutil::sprintf ("%s%s%s (%s)", s->name(),
+                            arrayindex >= 0 ? Strutil::sprintf("[%d]", arrayindex) : std::string(),
+                            channel >= 0 ? Strutil::sprintf("[%d]", channel) : std::string(),
                             type);
 }
 
@@ -548,7 +548,7 @@ ConnectedParam::str (const ShaderInstance *inst)
 std::string
 Connection::str (const ShaderGroup &group, const ShaderInstance *dstinst)
 {
-    return Strutil::format ("%s -> %s", src.str (group[srclayer]),
+    return Strutil::sprintf ("%s -> %s", src.str (group[srclayer]),
                             dst.str (dstinst));
 }
 
@@ -868,7 +868,7 @@ ShaderGroup::serialize () const
                 bool lockgeom = dstsyms_exist ? s->lockgeom()
                                               : inst->instoverride(p)->lockgeom();
                 if (! lockgeom)
-                    out << Strutil::format (" [[int lockgeom=%d]]", lockgeom);
+                    out << Strutil::sprintf (" [[int lockgeom=%d]]", lockgeom);
                 out << " ;\n";
             }
         }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -405,9 +405,9 @@ LLVMGEN (llvm_gen_printf)
 
     // Some ops prepend things
     if (op.opname() == op_error || op.opname() == op_warning) {
-        std::string prefix = Strutil::format ("Shader %s [%s]: ",
-                                              op.opname().c_str(),
-                                              rop.inst()->shadername().c_str());
+        std::string prefix = Strutil::sprintf ("Shader %s [%s]: ",
+                                               op.opname(),
+                                               rop.inst()->shadername());
         s = prefix + s;
     }
 
@@ -3168,7 +3168,7 @@ LLVMGEN (llvm_gen_spline)
              Knots.typespec().is_array() &&  
              (!has_knot_count || (has_knot_count && Knot_count.typespec().is_int())));
 
-    std::string name = Strutil::format("osl_%s_", op.opname().c_str());
+    std::string name = Strutil::sprintf("osl_%s_", op.opname());
     std::vector<llvm::Value *> args;
     // only use derivatives for result if:
     //   result has derivs and (value || knots) have derivs
@@ -3270,7 +3270,7 @@ LLVMGEN (llvm_gen_closure)
 
     const ClosureRegistry::ClosureEntry * clentry = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-        rop.llvm_gen_error (Strutil::format("Closure '%s' is not supported by the current renderer, called from %s:%d in shader \"%s\", layer %d \"%s\", group \"%s\"",
+        rop.llvm_gen_error (Strutil::sprintf("Closure '%s' is not supported by the current renderer, called from %s:%d in shader \"%s\", layer %d \"%s\", group \"%s\"",
                                      closure_name, op.sourcefile(), op.sourceline(),
                                      rop.inst()->shadername(), rop.layer(),
                                      rop.inst()->layername(), rop.group().name()));
@@ -3744,7 +3744,7 @@ LLVMGEN (llvm_gen_blackbody)
 
     llvm::Value* args[3] = { rop.sg_void_ptr(), rop.llvm_void_ptr(Result),
                              rop.llvm_load_value(Temperature) };
-    rop.ll.call_function (Strutil::format("osl_%s_vf",op.opname().c_str()).c_str(), args, 3);
+    rop.ll.call_function (Strutil::sprintf("osl_%s_vf",op.opname()).c_str(), args, 3);
 
     // Punt, zero out derivs.
     // FIXME -- only of some day, someone truly needs blackbody() to

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -334,7 +334,7 @@ BackendLLVM::llvm_type_groupdata ()
         std::cout << " Group struct had " << order << " fields, total size "
                   << offset << "\n\n";
 
-    std::string groupdataname = Strutil::format("Groupdata_%llu",
+    std::string groupdataname = Strutil::sprintf("Groupdata_%llu",
                                                 (long long unsigned int)group().name().hash());
     m_llvm_type_groupdata = ll.type_struct (fields, groupdataname);
 
@@ -736,7 +736,7 @@ BackendLLVM::build_llvm_init ()
 {
     // Make a group init function: void group_init(ShaderGlobals*, GroupData*)
     // Note that the GroupData* is passed as a void*.
-    std::string unique_name = Strutil::format ("group_%d_init", group().id());
+    std::string unique_name = Strutil::sprintf ("group_%d_init", group().id());
     ll.current_function (
            ll.make_function (unique_name, false,
                              ll.type_void(), // return type
@@ -751,7 +751,7 @@ BackendLLVM::build_llvm_init ()
     ll.new_builder (entry_bb);
 #if 0 /* helpful for debugging */
     if (llvm_debug()) {
-        llvm_gen_debug_printf (Strutil::format("\n\n\n\nGROUP! %s",group().name()));
+        llvm_gen_debug_printf (Strutil::sprintf("\n\n\n\nGROUP! %s",group().name()));
         llvm_gen_debug_printf ("enter group initlayer %d %s %s");                               this->layer(), inst()->layername(), inst()->shadername()));
     }
 #endif
@@ -791,7 +791,7 @@ BackendLLVM::build_llvm_init ()
     // All done
 #if 0 /* helpful for debugging */
     if (llvm_debug())
-        llvm_gen_debug_printf (Strutil::format("exit group init %s",
+        llvm_gen_debug_printf (Strutil::sprintf("exit group init %s",
                                                group().name());
 #endif
     ll.op_return();
@@ -837,7 +837,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
         // ran. If it has, do an early return. Otherwise, set the 'ran' flag
         // and then run the layer.
         if (shadingsys().llvm_debug_layers())
-            llvm_gen_debug_printf (Strutil::format("checking for already-run layer %d %s %s",
+            llvm_gen_debug_printf (Strutil::sprintf("checking for already-run layer %d %s %s",
                                    this->layer(), inst()->layername(), inst()->shadername()));
         llvm::Value *executed = ll.op_eq (ll.op_load (layerfield), ll.constant_bool(true));
         llvm::BasicBlock *then_block = ll.new_basic_block();
@@ -846,14 +846,14 @@ BackendLLVM::build_llvm_instance (bool groupentry)
         // insert point is now then_block
         // we've already executed, so return early
         if (shadingsys().llvm_debug_layers())
-            llvm_gen_debug_printf (Strutil::format("  taking early exit, already executed layer %d %s %s",
+            llvm_gen_debug_printf (Strutil::sprintf("  taking early exit, already executed layer %d %s %s",
                                    this->layer(), inst()->layername(), inst()->shadername()));
         ll.op_return ();
         ll.set_insert_point (after_block);
     }
 
     if (shadingsys().llvm_debug_layers())
-        llvm_gen_debug_printf (Strutil::format("enter layer %d %s %s",
+        llvm_gen_debug_printf (Strutil::sprintf("enter layer %d %s %s",
                                this->layer(), inst()->layername(), inst()->shadername()));
     // Mark this layer as executed
     if (! group().is_last_layer(layer())) {
@@ -1014,7 +1014,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
 
     // All done
     if (shadingsys().llvm_debug_layers())
-        llvm_gen_debug_printf (Strutil::format("exit layer %d %s %s",
+        llvm_gen_debug_printf (Strutil::sprintf("exit layer %d %s %s",
                                this->layer(), inst()->layername(), inst()->shadername()));
     ll.op_return();
 
@@ -1221,8 +1221,8 @@ BackendLLVM::run ()
         // filename length limits.
         std::string safegroup = Strutil::replace (group().name(), "/", ".", true);
         if (safegroup.size() > 235)
-            safegroup = Strutil::format ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
-        std::string name = Strutil::format ("%s.ll", safegroup);
+            safegroup = Strutil::sprintf ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
+        std::string name = Strutil::sprintf ("%s.ll", safegroup);
         std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
         if (out.good()) {
             out << ll.bitcode_string (ll.module());
@@ -1250,8 +1250,8 @@ BackendLLVM::run ()
         // filename length limits.
         std::string safegroup = Strutil::replace (group().name(), "/", ".", true);
         if (safegroup.size() > 235)
-            safegroup = Strutil::format ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
-        std::string name = Strutil::format ("%s_opt.ll", safegroup);
+            safegroup = Strutil::sprintf ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
+        std::string name = Strutil::sprintf ("%s_opt.ll", safegroup);
         std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
         if (out.good()) {
             out << ll.bitcode_string (ll.module());
@@ -1270,7 +1270,7 @@ BackendLLVM::run ()
             ll.module_from_bitcode (static_cast<const char*>(bitcode.data()),
                                     bitcode.size(), "cuda_lib");
 
-        std::string name = Strutil::format ("%s_%d", group().name(), group().id());
+        std::string name = Strutil::sprintf ("%s_%d", group().name(), group().id());
         ll.ptx_compile_group (lib_module, name, group().m_llvm_ptx_compiled_version);
 
         if (group().m_llvm_ptx_compiled_version.empty()) {

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -57,7 +57,7 @@ getargs (int argc, char *argv[])
                 "--debug", &debug, "Debug mode",
                 "--memtest %d", &memtest, "Memory test mode (arg: iterations)",
                 // "--iters %d", &iterations,
-                //     Strutil::format("Number of iterations (default: %d)", iterations).c_str(),
+                //     Strutil::sprintf("Number of iterations (default: %d)", iterations).c_str(),
                 // "--trials %d", &ntrials, "Number of trials",
                 NULL);
     if (ap.parse (argc, (const char**)argv) < 0) {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -533,26 +533,26 @@ public:
     // Internal error, warning, info, and message reporting routines that
     // take printf-like arguments.
     template<typename T1, typename... Args>
-    inline void error (string_view fmt, const T1& v1, const Args&... args) const {
-        error (Strutil::format (fmt, v1, args...));
+    inline void error (const char* fmt, const T1& v1, const Args&... args) const {
+        error (Strutil::sprintf (fmt, v1, args...));
     }
     void error (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void warning (string_view fmt, const T1& v1, const Args&... args) const {
-        warning (Strutil::format (fmt, v1, args...));
+    inline void warning (const char* fmt, const T1& v1, const Args&... args) const {
+        warning (Strutil::sprintf (fmt, v1, args...));
     }
     void warning (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void info (string_view fmt, const T1& v1, const Args&... args) const {
-        info (Strutil::format (fmt, v1, args...));
+    inline void info (const char* fmt, const T1& v1, const Args&... args) const {
+        info (Strutil::sprintf (fmt, v1, args...));
     }
     void info (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void message (string_view fmt, const T1& v1, const Args&... args) const {
-        message (Strutil::format (fmt, v1, args...));
+    inline void message (const char* fmt, const T1& v1, const Args&... args) const {
+        message (Strutil::sprintf (fmt, v1, args...));
     }
     void message (const std::string &message) const;
 
@@ -1783,23 +1783,23 @@ public:
     void process_errors () const;
 
     template<typename... Args>
-    inline void error (string_view fmt, const Args&... args) const {
-        record_error(ErrorHandler::EH_ERROR, Strutil::format (fmt, args...));
+    inline void error (const char* fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_ERROR, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void warning (string_view fmt, const Args&... args) const {
-        record_error(ErrorHandler::EH_WARNING, Strutil::format (fmt, args...));
+    inline void warning (const char* fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_WARNING, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void info (string_view fmt, const Args&... args) const {
-        record_error(ErrorHandler::EH_INFO, Strutil::format (fmt, args...));
+    inline void info (const char* fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_INFO, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void message (string_view fmt, const Args&... args) const {
-        record_error(ErrorHandler::EH_MESSAGE, Strutil::format (fmt, args...));
+    inline void message (const char* fmt, const Args&... args) const {
+        record_error(ErrorHandler::EH_MESSAGE, Strutil::sprintf (fmt, args...));
     }
 
 private:
@@ -1998,7 +1998,7 @@ public:
     // Mangle the group and layer into a unique function name
     std::string layer_function_name (const ShaderGroup &group,
                                      const ShaderInstance &inst) {
-        return Strutil::format ("%s_%s_%d", group.name(),
+        return Strutil::sprintf ("%s_%s_%d", group.name(),
                                 inst.layername(), inst.id());
     }
     std::string layer_function_name () {

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -348,9 +348,9 @@ RuntimeOptimizer::debug_opt_ops (int opbegin, int opend, string_view message) co
     const Opcode &op (inst()->ops()[opbegin]);
     std::string oprange;
     if (opbegin >= 0 && opend-opbegin > 1)
-        oprange = Strutil::format ("ops %d-%d ", opbegin, opend);
+        oprange = Strutil::sprintf ("ops %d-%d ", opbegin, opend);
     else if (opbegin >= 0)
-        oprange = Strutil::format ("op %d ", opbegin);
+        oprange = Strutil::sprintf ("op %d ", opbegin);
     debug_opt ("%s%s (@ %s:%d)\n", oprange, message,
                op.sourcefile(), op.sourceline());
 }
@@ -366,18 +366,18 @@ RuntimeOptimizer::debug_turn_into (const Opcode &op, int numops,
     int opnum = &op - &(inst()->ops()[0]);
     std::string msg;
     if (numops == 1)
-        msg = Strutil::format ("turned '%s' to '%s", op_string(op), newop);
+        msg = Strutil::sprintf ("turned '%s' to '%s", op_string(op), newop);
     else
-        msg = Strutil::format ("turned to '%s", newop);
+        msg = Strutil::sprintf ("turned to '%s", newop);
     if (newarg0 >= 0)
-        msg += Strutil::format (" %s", inst()->symbol(newarg0)->name());
+        msg += Strutil::sprintf (" %s", inst()->symbol(newarg0)->name());
     if (newarg1 >= 0)
-        msg += Strutil::format (" %s", inst()->symbol(newarg1)->name());
+        msg += Strutil::sprintf (" %s", inst()->symbol(newarg1)->name());
     if (newarg2 >= 0)
-        msg += Strutil::format (" %s", inst()->symbol(newarg2)->name());
+        msg += Strutil::sprintf (" %s", inst()->symbol(newarg2)->name());
     msg += "'";
     if (why.size())
-        msg += Strutil::format (" : %s", why);
+        msg += Strutil::sprintf (" : %s", why);
     debug_opt_ops (opnum, opnum+numops, msg);
 }
 
@@ -1241,7 +1241,7 @@ RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
             Opcode &uselessop (inst()->ops()[i->second]);
             if (uselessop.opname() != u_nop)
                 turn_into_nop (uselessop,
-                           debug() > 1 ? Strutil::format("remove stale value assignment to %s, reassigned on op %d",
+                           debug() > 1 ? Strutil::sprintf("remove stale value assignment to %s, reassigned on op %d",
                                                          opargsym(uselessop,0)->name(), opnum).c_str() : "");
         }
     }
@@ -1434,9 +1434,9 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
         // replace its default value entirely and get rid of the assignment.
         if (R->firstread() > opnum && ! R->renderer_output() &&
                 m_opt_elide_unconnected_outputs) {
-            make_param_use_instanceval (R, Strutil::format("- written once, with a constant (%s), before any reads", const_value_as_string(*A)));
+            make_param_use_instanceval (R, Strutil::sprintf("- written once, with a constant (%s), before any reads", const_value_as_string(*A)));
             replace_param_value (R, A->data(), A->typespec());
-            turn_into_nop (op, debug() > 1 ? Strutil::format("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
+            turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
             return true;
         }
     }
@@ -1446,7 +1446,7 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
     // assignment at all. Note that unread_after() does take into
     // consideration whether it's a renderer output.
     if (unread_after(R,opnum)) {
-        turn_into_nop (op, debug() > 1 ? Strutil::format("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
+        turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
         return true;
     }
 
@@ -1723,7 +1723,7 @@ RuntimeOptimizer::peephole2 (int opnum, int op2num)
               equivalent (a->typespec(), c->typespec())) {
             if (debug() > 1)
                 debug_opt_ops (opnum, opnum+1,
-                               Strutil::format ("turned '%s %s...' to '%s %s...' as part of daisy-chain",
+                               Strutil::sprintf ("turned '%s %s...' to '%s %s...' as part of daisy-chain",
                                  op.opname(), a->name(), op.opname(), c->name()));
             inst()->args()[op.firstarg()] = inst()->args()[next.firstarg()];
             c->mark_rw (opnum, false, true);
@@ -1831,7 +1831,7 @@ RuntimeOptimizer::remove_unused_params ()
         if (param_never_used(s) && s.has_init_ops()) {
             std::string why;
             if (debug() > 1)
-                why = Strutil::format ("remove init ops of unused param %s %s", s.typespec().c_str(), s.name());
+                why = Strutil::sprintf ("remove init ops of unused param %s %s", s.typespec().c_str(), s.name());
             turn_into_nop (s.initbegin(), s.initend(), why);
             s.set_initrange (0, 0);
             s.clear_rw();   // mark as totally unused
@@ -2382,7 +2382,7 @@ RuntimeOptimizer::optimize_instance ()
         // Not needed.  Remove all its connections and ops.
         inst()->connections().clear ();
         turn_into_nop (0, (int)inst()->ops().size()-1,
-                       debug() > 1 ? Strutil::format("eliminate layer %s with no outward connections", inst()->layername().c_str()).c_str() : "");
+                       debug() > 1 ? Strutil::sprintf("eliminate layer %s with no outward connections", inst()->layername().c_str()).c_str() : "");
         for (auto&& s : inst()->symbols())
             s.clear_rw ();
     }
@@ -2992,7 +2992,7 @@ RuntimeOptimizer::printinst (std::ostream &out) const
             if (op.jump(j) >= 0)
                 out << " " << op.jump(j);
         out << "\t# ";
-//        out << "    rw " << Strutil::format("%x",op.argread_bits())
+//        out << "    rw " << Strutil::sprintf("%x",op.argread_bits())
 //            << ' ' << op.argwrite_bits();
         if (op.argtakesderivs_all())
             out << " %derivs(" << op.argtakesderivs_all() << ") ";

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -156,8 +156,8 @@ public:
     void debug_opt_impl (string_view message) const;
 
     template<typename... Args>
-    inline void debug_opt (string_view fmt, const Args&... args) const {
-        debug_opt_impl (Strutil::format (fmt, args...));
+    inline void debug_opt (const char* fmt, const Args&... args) const {
+        debug_opt_impl (OIIO::Strutil::sprintf (fmt, args...));
     }
 
     void debug_opt_ops (int opbegin, int opend, string_view message) const;

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -73,18 +73,18 @@ TypeSpec::string () const
         if (is_unsized_array())
             str += "[]";
         else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
+            str += Strutil::sprintf ("[%d]", arraylength());
     }
     else if (structure() > 0) {
         StructSpec *ss = structspec();
         if (ss)
-            str += Strutil::format ("struct %s", structspec()->name());
+            str += Strutil::sprintf ("struct %s", structspec()->name());
         else
-            str += Strutil::format ("struct %d", structure());
+            str += Strutil::sprintf ("struct %d", structure());
         if (is_unsized_array())
             str += "[]";
         else if (arraylength() > 0)
-            str += Strutil::format ("[%d]", arraylength());
+            str += Strutil::sprintf ("[%d]", arraylength());
     } else {
         str += simpletype().c_str();
     }

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -94,7 +94,7 @@ inline float abs (const Vec3& a) {
                     img.setpixel (x, y, &r[0]);                         \
                 }                                                       \
             }                                                           \
-            img.write (Strutil::format ("osl_%s_%d_%d.tif", #noisename, outdim, indim)); \
+            img.write (Strutil::sprintf ("osl_%s_%d_%d.tif", #noisename, outdim, indim)); \
         }                                                               \
     }
 

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -356,7 +356,7 @@ compile_buffer (const std::string &sourcecode,
         if (errhandler.haserror())
             errormessage = errhandler.geterror();
         else
-            errormessage = Strutil::format ("OSL: Could not compile \"%s\"", shadername);
+            errormessage = Strutil::sprintf ("OSL: Could not compile \"%s\"", shadername);
         return false;
     }
     // std::cout << "Compiled to oso:\n---\n" << osobuffer << "---\n\n";
@@ -364,7 +364,7 @@ compile_buffer (const std::string &sourcecode,
         if (errhandler.haserror())
             errormessage = errhandler.geterror();
         else
-            errormessage = Strutil::format ("OSL: Could not load compiled buffer from \"%s\"", shadername);
+            errormessage = Strutil::sprintf ("OSL: Could not load compiled buffer from \"%s\"", shadername);
         return false;
     }
     return true;
@@ -528,7 +528,7 @@ OSLInput::open (const std::string &name, ImageSpec &newspec,
         OIIO::lock_guard lock (shading_mutex);
         shadername.remove_suffix (8);
         static int exprcount = 0;
-        std::string exprname = OIIO::Strutil::format("expr_%d", exprcount++);
+        std::string exprname = OIIO::Strutil::sprintf("expr_%d", exprcount++);
         std::string sourcecode =
             "shader " + exprname + " (\n"
             "    float s = u [[ int lockgeom=0 ]],\n"

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -578,7 +578,7 @@ OSLToyMainWindow::ntabs () const
 void
 OSLToyMainWindow::update_statusbar_fps (float time, float fps)
 {
-    statusFPS->setText (OIIO::Strutil::format("  %.2f    FPS: %5.1f",
+    statusFPS->setText (OIIO::Strutil::sprintf("  %.2f    FPS: %5.1f",
                                               time, fps).c_str());
 }
 
@@ -628,7 +628,7 @@ OSLToyMainWindow::add_new_editor_window (const std::string &filename)
     if (filename.size()) {
         textTabs->addTab (editor_and_error_display, texteditor->brief_filename().c_str());
     } else {
-        std::string title = OIIO::Strutil::format ("untitled %d", n+1);
+        std::string title = OIIO::Strutil::sprintf ("untitled %d", n+1);
         textTabs->addTab (editor_and_error_display, title.c_str());
     }
     textTabs->setCurrentIndex (n);
@@ -733,7 +733,7 @@ OSLToyMainWindow::action_save ()
     }
 
     if (out.fail()) {
-        std::string msg = OIIO::Strutil::format ("Could not write %s", filename);
+        std::string msg = OIIO::Strutil::sprintf ("Could not write %s", filename);
         QErrorMessage err (nullptr);
         err.showMessage (msg.c_str());
         err.exec();
@@ -989,14 +989,14 @@ OSLToyMainWindow::make_param_adjustment_row (ParamRec *param,
 
     std::string typetext (param->type.c_str());
     if (param->isclosure)
-        typetext = OIIO::Strutil::format("closure %s", typetext);
+        typetext = OIIO::Strutil::sprintf("closure %s", typetext);
     if (param->isstruct)
-        typetext = OIIO::Strutil::format("struct %s", param->structname);
+        typetext = OIIO::Strutil::sprintf("struct %s", param->structname);
     if (param->isoutput)
-        typetext = OIIO::Strutil::format("output %s", typetext);
+        typetext = OIIO::Strutil::sprintf("output %s", typetext);
 //    auto typeLabel = QtUtils::make_qlabel ("<i>%s</i>", typetext);
 //    layout->addWidget (typeLabel, row, 1);
-    auto nameLabel = new QLabel (OIIO::Strutil::format("<i>%s</i>&nbsp;  <b>%s</b>",
+    auto nameLabel = new QLabel (OIIO::Strutil::sprintf("<i>%s</i>&nbsp;  <b>%s</b>",
                                                        typetext, param->name).c_str());
     nameLabel->setTextFormat (Qt::RichText);
     layout->addWidget (nameLabel, row, 1);
@@ -1034,7 +1034,7 @@ OSLToyMainWindow::make_param_adjustment_row (ParamRec *param,
                 labeltext = string_view(&("RGB"[c]), 1);
             else
                 labeltext = string_view(&("xyz"[c]), 1);
-            auto channellabel = QtUtils::make_qlabel(labeltext);
+            auto channellabel = QtUtils::make_qlabel("%s", labeltext);
             label_and_adjust_layout->addWidget (channellabel);
             auto adjustWidget = new QtUtils::DoubleSpinBox (param->fdefault[c]);
             if (param->type == TypeDesc::TypeColor) {
@@ -1182,7 +1182,7 @@ OSLToyMainWindow::rebuild_param_area ()
                       TypeDesc(TypeDesc::STRING, nlayers), &layernames[0]);
     for (int i = 0; i < nlayers; ++i) {
         OSLQuery oslquery (group.get(), i);
-        std::string desc = OIIO::Strutil::format ("layer %d %s  (%s)", i,
+        std::string desc = OIIO::Strutil::sprintf ("layer %d %s  (%s)", i,
                                             layernames[i], oslquery.shadername());
         paramLayout->addWidget (new QLabel (desc.c_str()), paramrow++, 0, 1, 2);
         for (auto&& p : m_shaderparams) {

--- a/src/osltoy/qtutils.h
+++ b/src/osltoy/qtutils.h
@@ -87,9 +87,9 @@ clear_layout (QLayout *lay)
 // render the 'blah' in italics.
 template<typename... Args>
 inline QLabel*
-make_qlabel (string_view fmt, const Args&... args)
+make_qlabel (const char* fmt, const Args&... args)
 {
-    std::string text = OIIO::Strutil::format (fmt, args...);
+    std::string text = OIIO::Strutil::sprintf (fmt, args...);
     auto label = new QLabel (text.c_str());
     label->setTextFormat (Qt::AutoText);
     return label;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -247,7 +247,7 @@ static void
 specify_expr (int argc, const char *argv[])
 {
     ASSERT (argc == 2);
-    std::string shadername = OIIO::Strutil::format("expr_%d", exprcount++);
+    std::string shadername = OIIO::Strutil::sprintf("expr_%d", exprcount++);
     std::string sourcecode =
         "shader " + shadername + " (\n"
         "    float s = u [[ int lockgeom=0 ]],\n"


### PR DESCRIPTION
This is related to OIIO 2.0 adding a new "sprintf" function that currently is a synonym for "format", but we anticipate that format will one day be modified to conform to an upcoming C++20 std::format that uses a different notation for formatting commands (more like python string formatting, quite nice).

In oslconfig.h, if the version of OSL is too old to have sprintf, define it as a synonym for format.

