### PR TITLE
Fix bug in oslc loop code generation

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1414,7 +1414,8 @@ ASTloop_statement::codegen (Symbol *)
     codegen_list (init());
 
     int condlabel = m_compiler->next_op_label ();
-    Symbol *condvar = cond()->codegen_int ();
+    Symbol *condvar = cond()->codegen_int (/*dest=*/    nullptr,
+                                           /*boolify=*/ true);
 
     // Retroactively add the argument
     size_t argstart = m_compiler->add_op_args (1, &condvar);

--- a/testsuite/loop/ref/out.txt
+++ b/testsuite/loop/ref/out.txt
@@ -65,64 +65,9 @@ Varying do...while(i<5):
   i = 4.5
 After loop, i = 5.5
 
-Count 0 to 4 using 'while':
-  i = 0
-  i = 1
-  i = 2
-  i = 3
-  i = 4
-After loop, i = 5
-
-Varying 'while', count up until < 5:
- Start with i = 1.5
- iteration:
-  i = 1.5
- iteration:
-  i = 2.5
- iteration:
-  i = 3.5
- iteration:
-  i = 4.5
-After loop, i = 5.5
-
-Count 0 to 4 using 'for':
-  i = 0
-  i = 1
-  i = 2
-  i = 3
-  i = 4
-
-Varying 'for', count up until < 5:
- outer scope i = 15
- iteration:
-  i = 1.5
- iteration:
-  i = 2.5
- iteration:
-  i = 3.5
- iteration:
-  i = 4.5
- outer scope i = 15
-
-Count using 'do...while(i<5)':
-  i = 0
-  i = 1
-  i = 2
-  i = 3
-  i = 4
-After loop, i = 5
-
-Varying do...while(i<5):
- Start with i = 1.5
- iteration:
-  i = 1.5
- iteration:
-  i = 2.5
- iteration:
-  i = 3.5
- iteration:
-  i = 4.5
-After loop, i = 5.5
+Testing while(var) hit=1
+  first loop, i=0, hit=1
+  loop exited, hit is 0
 
 Count 0 to 4 using 'while':
   i = 0
@@ -182,6 +127,73 @@ Varying do...while(i<5):
  iteration:
   i = 4.5
 After loop, i = 5.5
+
+Testing while(var) hit=1
+  first loop, i=0, hit=1
+  loop exited, hit is 0
+
+Count 0 to 4 using 'while':
+  i = 0
+  i = 1
+  i = 2
+  i = 3
+  i = 4
+After loop, i = 5
+
+Varying 'while', count up until < 5:
+ Start with i = 1.5
+ iteration:
+  i = 1.5
+ iteration:
+  i = 2.5
+ iteration:
+  i = 3.5
+ iteration:
+  i = 4.5
+After loop, i = 5.5
+
+Count 0 to 4 using 'for':
+  i = 0
+  i = 1
+  i = 2
+  i = 3
+  i = 4
+
+Varying 'for', count up until < 5:
+ outer scope i = 15
+ iteration:
+  i = 1.5
+ iteration:
+  i = 2.5
+ iteration:
+  i = 3.5
+ iteration:
+  i = 4.5
+ outer scope i = 15
+
+Count using 'do...while(i<5)':
+  i = 0
+  i = 1
+  i = 2
+  i = 3
+  i = 4
+After loop, i = 5
+
+Varying do...while(i<5):
+ Start with i = 1.5
+ iteration:
+  i = 1.5
+ iteration:
+  i = 2.5
+ iteration:
+  i = 3.5
+ iteration:
+  i = 4.5
+After loop, i = 5.5
+
+Testing while(var) hit=1
+  first loop, i=0, hit=1
+  loop exited, hit is 0
 
 Count 0 to 4 using 'while':
   i = 0
@@ -235,4 +247,8 @@ Varying do...while(i<5):
  iteration:
   i = 4.5
 After loop, i = 5.5
+
+Testing while(var) hit=1
+  first loop, i=0, hit=1
+  loop exited, hit is 0
 

--- a/testsuite/loop/test.osl
+++ b/testsuite/loop/test.osl
@@ -64,5 +64,19 @@ test ()
     }
 
 
-    // FIXME -- try break/continue
+    // Regression test -- codegen problem made this an infinite loop, a
+    // problem when an int variable was directly used instead of a
+    // comparison.
+    {
+        int hit=1;
+        int i = 0;
+        printf ("\nTesting while(var) hit=%d\n", hit);
+        while (hit) {
+            printf ("  first loop, i=%d, hit=%d\n", i, hit);
+            hit = 0;
+            ++i;
+        }
+        printf ("  loop exited, hit is %d\n", hit);
+    }
+
 }


### PR DESCRIPTION
The problem was specific to using an integer variable directly as the
loop test, rather than a comparison. So for example, this would work
fine:

    i = 3;
    while (i > 0) {
        --i;
    }

But this would loop forever:

    i = 3;
    while (i) {
        --i;
    }

Because of a hilarious chain of events, this would eventually lead to
the optimizer thinking that since the value of i was nonzero at the
beginning of the loop, it must be equivalent to while(1). There was a
subtle assumption that the scope of the loop control variable would be
entirey inside the condition code. That was true of the the temporary
created to hold the result of "i > 0", but not true of the direct use of
i itself.  The solution is to force it to create a bool comparison
(which turns into the same machine code later anyway, so there is no
efficiency issue here).

Fixes #776

