### PR TITLE
Change %.8g formatting to %.9g

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -657,7 +657,7 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
         if (islit && lit->typespec().is_int())
             out += Strutil::format ("%d", lit->intval());
         else if (islit && lit->typespec().is_float())
-            out += Strutil::format ("%.8g", lit->floatval());
+            out += Strutil::format ("%.9g", lit->floatval());
         else {
             out += "0";  // FIXME?
             completed = false;
@@ -665,10 +665,10 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
     } else if (type.is_triple()) {
         if (islit && lit->typespec().is_int()) {
             float f = lit->intval();
-            out += Strutil::format ("%.8g%s%.8g%s%.8g", f, sep, f, sep, f);
+            out += Strutil::format ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
         } else if (islit && lit->typespec().is_float()) {
             float f = lit->floatval();
-            out += Strutil::format ("%.8g%s%.8g%s%.8g", f, sep, f, sep, f);
+            out += Strutil::format ("%.9g%s%.9g%s%.9g", f, sep, f, sep, f);
         } else if (init && init->typespec() == type &&
                    (init->nodetype() == ASTNode::type_constructor_node ||
                    (init->nodetype() == ASTNode::compound_initializer_node &&
@@ -697,9 +697,9 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
                 }
             }
             if (nargs == 1)
-                out += Strutil::format ("%.8g%s%.8g%s%.8g", f[0], sep, f[0], sep, f[0]);
+                out += Strutil::format ("%.9g%s%.9g%s%.9g", f[0], sep, f[0], sep, f[0]);
             else
-                out += Strutil::format ("%.8g%s%.8g%s%.8g", f[0], sep, f[1], sep, f[2]);
+                out += Strutil::format ("%.9g%s%.9g%s%.9g", f[0], sep, f[1], sep, f[2]);
         } else {
             out += Strutil::format ("0%s0%s0", sep, sep);
             completed = false;
@@ -708,12 +708,12 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
         if (islit && lit->typespec().is_int()) {
             float f = lit->intval();
             for (int c = 0; c < 16; ++c)
-               out += Strutil::format ("%.8g%s", (c/4)==(c%4) ? f : 0.0f,
+               out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
                                        c<15 ? sep.c_str() : "");
         } else if (islit && lit->typespec().is_float()) {
             float f = lit->floatval();
             for (int c = 0; c < 16; ++c)
-               out += Strutil::format ("%.8g%s", (c/4)==(c%4) ? f : 0.0f,
+               out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f : 0.0f,
                                        c<15 ? sep.c_str() : "");
         } else if (init && init->typespec() == type &&
                    init->nodetype() == ASTNode::type_constructor_node) {
@@ -741,11 +741,11 @@ ASTNode::one_default_literal (const Symbol *sym, ASTNode *init,
             }
             if (nargs == 1) {
                 for (int c = 0; c < 16; ++c)
-                   out += Strutil::format ("%.8g%s", (c/4)==(c%4) ? f[0] : 0.0f,
+                   out += Strutil::format ("%.9g%s", (c/4)==(c%4) ? f[0] : 0.0f,
                                            c<15 ? sep.c_str() : "");
             } else {
                 for (int c = 0; c < 16; ++c)
-                    out += Strutil::format ("%.8g%s", f[c], c<15 ? sep.c_str() : "");
+                    out += Strutil::format ("%.9g%s", f[c], c<15 ? sep.c_str() : "");
             }
         } else {
             for (int c = 0; c < 16; ++c)

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -772,10 +772,10 @@ OSLCompilerImpl::write_oso_const_value (const ConstantSymbol *sym) const
             oso ("%d%s", sym->intval(i), nelements>1 ? " " : "");
     else if (elemtype == TypeDesc::FLOAT)
         for (int i = 0;  i < nelements;  ++i)
-            oso ("%.8g%s", sym->floatval(i), nelements>1 ? " " : "");
+            oso ("%.9g%s", sym->floatval(i), nelements>1 ? " " : "");
     else if (equivalent (elemtype, TypeDesc::TypeVector))
         for (int i = 0;  i < nelements;  ++i)
-            oso ("%.8g %.8g %.8g%s", sym->vecval(i)[0], sym->vecval(i)[1],
+            oso ("%.9g %.9g %.9g%s", sym->vecval(i)[0], sym->vecval(i)[1],
                  sym->vecval(i)[2], nelements>1 ? " " : "");
     else {
         ASSERT (0 && "Don't know how to output this constant type");


### PR DESCRIPTION
%.9g is needed to totally guarantee full precision preservation for all
possible float32 values.

