### PR TITLE
oslc: Fix crash when encountering `for (;;)`

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -859,6 +859,18 @@ ASTconditional_statement::childname (size_t i) const
 
 
 
+ASTloop_statement::ASTloop_statement (OSLCompilerImpl *comp, LoopType looptype,
+                                      ASTNode *init, ASTNode *cond,
+                                      ASTNode *iter, ASTNode *stmt)
+    : ASTNode (loop_statement_node, comp, looptype, init, cond, iter, stmt)
+{
+    // Handle empty comparison, for(;;), is same as for(;1;)
+    if (!cond)
+        m_children[1] = new ASTliteral(comp, 1);
+}
+
+
+
 const char *
 ASTloop_statement::childname (size_t i) const
 {

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -655,9 +655,7 @@ public:
     };
 
     ASTloop_statement (OSLCompilerImpl *comp, LoopType looptype, ASTNode *init,
-                       ASTNode *cond, ASTNode *iter, ASTNode *stmt)
-        : ASTNode (loop_statement_node, comp, looptype, init, cond, iter, stmt)
-    { }
+                       ASTNode *cond, ASTNode *iter, ASTNode *stmt);
 
     const char *nodetypename () const { return "loop_statement"; }
     const char *childname (size_t i) const;

--- a/testsuite/breakcont/ref/out.txt
+++ b/testsuite/breakcont/ref/out.txt
@@ -43,3 +43,6 @@ start of outer, j=3
   i = 3
   i = 4
 
+Testing break in an infinite for loop:
+worked
+

--- a/testsuite/breakcont/test.osl
+++ b/testsuite/breakcont/test.osl
@@ -31,5 +31,11 @@ shader test ()
             break;
     }
 
+    printf ("\nTesting break in an infinite for loop:\n");
+    for ( ; ; ) {
+        break;
+        // N.B. This used to crash oslc, if this compiles, it's fine.
+    }
+    printf ("worked\n");
 }
 


### PR DESCRIPTION
An empty conditional clause of a `for` statement was leading to bad
things. It's understood that `for (;;)` means `for (;1;)`, so just
make sure that happens when parsing.

Fixes #688
