### PR TITLE
Improve thread safety of OSLCompiler

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -381,9 +381,8 @@ namespace pvt {   // OSL::pvt
 bool
 OSLCompilerImpl::osl_parse_buffer (const std::string &preprocessed_buffer)
 {
-    // Thread safety with the lexer/parser
-    static std::mutex oslcompiler_mutex;
-    std::lock_guard<std::mutex> lock (oslcompiler_mutex);
+    // N.B. This should only be called if oslcompiler_mutex is held.
+    ASSERT (oslcompiler == this);
 
 #ifndef OIIO_STRUTIL_HAS_STOF
     // Force classic "C" locale for correct '.' decimal parsing.
@@ -395,7 +394,6 @@ OSLCompilerImpl::osl_parse_buffer (const std::string &preprocessed_buffer)
 #endif
 
     osl_switch_to_buffer (osl_scan_string (preprocessed_buffer.c_str()));
-    oslcompiler = this;
     oslparse ();
     bool parseerr = error_encountered();
     osl_delete_buffer (YY_CURRENT_BUFFER);


### PR DESCRIPTION
Fixes #654.

There's a problem with the lock we use to protect the global
`oslcompiler` pointer -- it's locked for the duration `osl_parse_buffer`
(where it's assigned), but it is used and also cleared to NULL after the
lock is released (in particular, the clearing that happens in compile()
and compile_buffer().

The solution is to move the lock itself to compile/compile_buffer, and
do all of the assignment, use, and clear within the scope of that lock.

I think this went unnoticed for so long because most of us highly
multithread the shader execution (and runtime optimization), but not the
initial compilation -- except for Issue #654, and my sincere apologies for
letting that slip through the cracks.
