### PR TITLE
Fix group_name, group_init_name, group_entry_name

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1424,6 +1424,7 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
 {
     if (! group)
         return false;
+
     if (name == "groupname" && type == TypeDesc::TypeString) {
         *(ustring *)val = group->name();
         return true;
@@ -1468,6 +1469,18 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
                 ((ustring *)val)[n++] = (*group)[i]->layername();
         for (size_t i = n;  i < type.numelements();  ++i)
             ((ustring *)val)[i] = ustring();
+        return true;
+    }
+    if (name == "group_init_name" && type.basetype == TypeDesc::STRING) {
+        *(ustring *)val = ustring::format ("group_%d_init", group->id());
+        return true;
+    }
+    if (name == "group_entry_name" && type.basetype == TypeDesc::STRING) {
+        int nlayers = group->nlayers ();
+        ShaderInstance *inst = (*group)[nlayers-1];
+        // This formuation mirrors OSOProcessorBase::layer_function_name()
+        *(ustring *)val = ustring::format ("%s_%s_%d", group->name(),
+                                           inst->layername(), inst->id());
         return true;
     }
     if (name == "num_textures_needed" && type == TypeDesc::TypeInt) {
@@ -1626,26 +1639,10 @@ ShadingSystemImpl::getattribute (ShaderGroup *group, string_view name,
         *(std::string *)val = exists ? group->m_llvm_ptx_compiled_version : "";
         return true;
     }
-    if (name == "group_name" && type.basetype == TypeDesc::PTR) {
-        *(std::string *)val = group->name().string();
-        return true;
-    }
     if (name == "group_id" && type == TypeDesc::TypeInt) {
         if (! group->optimized())
             optimize_group (*group);
         *(int *)val = (int) group->id();
-        return true;
-    }
-    if (name == "group_init_name" && type.basetype == TypeDesc::PTR) {
-        *(std::string *)val = Strutil::format ("group_%d_init", group->id());
-        return true;
-    }
-    if (name == "group_entry_name" && type.basetype == TypeDesc::PTR) {
-        int nlayers = group->nlayers ();
-        ShaderInstance *inst = (*group)[nlayers-1];
-        // This formuation mirrors OSOProcessorBase::layer_function_name()
-        *(std::string *)val = Strutil::format ("%s_%s_%d", group->name(),
-                                               inst->layername(), inst->id());
         return true;
     }
     if (name == "layer_osofiles" && type.basetype == TypeDesc::STRING) {

--- a/src/testoptix/testoptix.cpp
+++ b/src/testoptix/testoptix.cpp
@@ -481,10 +481,9 @@ void make_optix_materials ()
         shadingsys->optimize_group (groupref.get());
 
         std::string group_name, init_name, entry_name;
-
-        shadingsys->getattribute (groupref.get(), "group_name",       OSL::TypeDesc::PTR, &group_name);
-        shadingsys->getattribute (groupref.get(), "group_init_name",  OSL::TypeDesc::PTR, &init_name);
-        shadingsys->getattribute (groupref.get(), "group_entry_name", OSL::TypeDesc::PTR, &entry_name);
+        shadingsys->getattribute (groupref.get(), "groupname",        group_name);
+        shadingsys->getattribute (groupref.get(), "group_init_name",  init_name);
+        shadingsys->getattribute (groupref.get(), "group_entry_name", entry_name);
 
         // Retrieve the compiled ShaderGroup PTX
         std::string osl_ptx;


### PR DESCRIPTION
I didn't notice this in Tim's code before today, but he made the
retrieval of these group attributes more complex than they needed to be.
Instead of messing with pointers (which we avoid), you can just directly
getattribute(name,string&). So now we use that. Also eliminate group_name
entirely, since it's redundant with the existing groupname.

