### PR TITLE
Fix custom namespace vs symbol hiding clash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,13 @@ else ()
 endif ()
 
 
-# Set the default namespace
+# Set the default namespace. For symbol hiding reasons, it's important that
+# the project name is a subset of the namespace name.
 set (PROJ_NAMESPACE "${${PROJ_NAME}_NAMESPACE}")
+string(REGEX MATCH ${PROJECT_NAME} NAMESPACE_HAS_PROJECT_NAME ${PROJ_NAMESPACE})
+if (NOT NAMESPACE_HAS_PROJECT_NAME)
+    set (PROJ_NAMESPACE ${PROJECT_NAME}_${PROJ_NAMESPACE})
+endif ()
 set (PROJ_NAMESPACE_V "${PROJ_NAMESPACE}_v${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
 message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
 

--- a/src/build-scripts/hidesymbols.map
+++ b/src/build-scripts/hidesymbols.map
@@ -1,4 +1,4 @@
 {
     global: *OSL*; test_shade; *osl*imageio*; *osl_input_extensions;
-    local: osl_*; *;
+    local: osl_*; *pvt*; *;
 };


### PR DESCRIPTION
I guess everbody who builds with NAMESPACE=... to customize OSL's namespace
must (like we do) pick a name that include the substring "OSL".
Because if they don't... a bunch of public API symbols will be improperly
hidden!

Oops. Seems like the most foolproof solution is that if a custom namespace
is supplied that doesn't include the substring "OSL", have the build
script prepend "OSL_". Then the symbol hiding regex will work.

(You may object: "But then you're not using exactly what they asked for!"
Correct, but remember we are already overriding their literal choice by
automatically appending the OSL version number as well.)

While there, also take care to hide symbols containing "pvt", which I
think should not be exposed, despite the fact that they're in the main
OSL namespace.
