### PR TITLE
Make initialization of ShaderGlobals C++ compliant

### DIFF
--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -78,8 +78,8 @@ OSLToyRenderer::OSLToyRenderer ()
     m_attr_getters[ustring("camera:shutter_close")] = &OSLToyRenderer::get_camera_shutter_close;
 
     // Set up default shaderglobals
-    ShaderGlobals &sg (m_shaderglobals_template);
-    memset (&sg, 0, sizeof(ShaderGlobals));
+    ShaderGlobals &sg = m_shaderglobals_template;
+    sg = {};
     Matrix44 Mshad, Mobj;  // just let these be identity for now
     // Set "shader" space to be Mshad.  In a real renderer, this may be
     // different for each shader group.


### PR DESCRIPTION
ShaderGlobals aggregates several non POD types, GCC warns when these
are initialized using memset:
error: ‘void* memset(void*, int, size_t)’ clearing an object of type
‘struct OSL_v1_11::ShaderGlobals’ with no trivial copy-assignment;
use assignment or value-initialization instead [-Werror=class-memaccess]
     memset (&sg, 0, sizeof(ShaderGlobals));

Use value-initilization instead.

Fix for #964.


## Description

See #964 

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

