### PR TITLE
Allow shader params (arrays/structs) empty brace initialization lists

### DIFF
--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -968,7 +968,7 @@ ASTNode::codegen_initlist (ref init, TypeSpec type, Symbol *sym)
                 break;
             }
         }
-        if (all_const) {
+        if (all_const && init) {
             std::vector<char> arrayvals (type.simpletype().size());
             for (int i = 0;  init;  init = init->next(), ++i) {
                 ASTliteral *lit = (ASTliteral *)init.get();

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -498,6 +498,16 @@ compound_initializer
                     $$ = new ASTcompound_initializer (oslcompiler, $2);
                     $$->sourceline (@1.first_line);
                 }
+        | '{' '}'
+                {
+                    if (!oslcompiler->declaring_shader_formals())
+                        oslcompiler->error (oslcompiler->filename(),
+                                            oslcompiler->lineno(),
+                                            "Empty compound initializers '{ }' "
+                                            "only allowed for shader parameters.");
+                    $$ = new ASTcompound_initializer (oslcompiler, nullptr);
+                    $$->sourceline (@1.first_line);
+                }
         ;
 
 init_expression_list

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -116,8 +116,9 @@ ASTvariable_declaration::typecheck (TypeSpec expected)
     if (init->nodetype() == compound_initializer_node) {
         if (init->nextptr())
             error ("compound_initializer should be the only initializer");
-        // init = ((ASTcompound_initializer *)init)->initlist().get();
-        return m_typespec;  // done
+        init = ((ASTcompound_initializer *)init)->initlist().get();
+        if (!init)
+            return m_typespec;
     }
 
     // Special case: ok to assign a literal 0 to a closure to
@@ -831,6 +832,8 @@ public:
     // Adjust the type for every element of an array
     void
     typecheck_array(ASTcompound_initializer* init, TypeSpec expected) {
+        if (! init->initlist())
+            return;    // early out for empty initializer { }
         ASSERT (expected.is_array());
         // Every element of the array is the same type
         TypeSpec elemtype = expected.elementtype();
@@ -955,8 +958,8 @@ public:
 
     TypeSpec type() const {
         // If succeeded, root type is at end of m_adjust
-        return (m_success || m_debug_successful) ? std::get<1>(m_adjust.back())
-                                                 : TypeSpec(TypeDesc::NONE);
+        return (m_success || m_debug_successful) && m_adjust.size()
+            ? std::get<1>(m_adjust.back()) : TypeSpec(TypeDesc::NONE);
     }
 
     bool success() const { return m_success; }

--- a/testsuite/oslc-err-initlist-return/ref/out.txt
+++ b/testsuite/oslc-err-initlist-return/ref/out.txt
@@ -4,5 +4,9 @@ test.osl:14: warning: Function 'struct bcolor badreturn ()' redefined in the sam
   Previous definitions:
     test.osl:13
 test.osl:14: error: Cannot return a 'struct acolor' from 'struct bcolor badreturn()'
-test.osl:17: error: Syntax error: syntax error
+test.osl:17: error: Empty compound initializers '{ }' only allowed for shader parameters.
+test.osl:17: warning: Function 'struct bcolor badreturn ()' redefined in the same scope
+  Previous definitions:
+    test.osl:14
+    test.osl:13
 FAILED test.osl

--- a/testsuite/struct/ref/out.txt
+++ b/testsuite/struct/ref/out.txt
@@ -5,6 +5,7 @@ a == { 3.14159, 42, [0 1 2], foobar }
 constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
+Default init eparam == { 0 0 0, 0 }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
 
@@ -32,6 +33,7 @@ a == { 3.14159, 42, [0 1 2], foobar }
 constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
+Default init eparam == { 0 0 0, 0 }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
 
@@ -59,6 +61,7 @@ a == { 3.14159, 42, [0 1 2], foobar }
 constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
+Default init eparam == { 0 0 0, 0 }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
 
@@ -86,6 +89,7 @@ a == { 3.14159, 42, [0 1 2], foobar }
 constructed x == { 6.28319, 21, [1 2 3], constructed }
 
 struct param:  aparam == { 1, 0, [3 4 5], foo! }
+Default init eparam == { 0 0 0, 0 }
 
 after c=a, c == { 3.14159, 42, [0 1 2], foobar }
 

--- a/testsuite/struct/test.osl
+++ b/testsuite/struct/test.osl
@@ -36,7 +36,8 @@ void func_with_struct_output_param (output Astruct ap)
 
 shader
 test (
-    Astruct aparam = { 1.0, 0, point(3,4,5), "foo!" }
+    Astruct aparam = { 1.0, 0, point(3,4,5), "foo!" },
+    Bstruct eparam = {}
 )
 {
     printf ("test struct\n");
@@ -64,6 +65,9 @@ test (
     printf ("\n");
     printf ("struct param:  aparam == { %g, %i, [%g], %s }\n",
             aparam.f, aparam.i, aparam.p, aparam.s);
+
+    // Test that empty default initializer for eparam
+    printf ("Default init eparam == { %g, %g }\n", eparam.v, eparam.i);
 
     Bstruct b;
 

--- a/testsuite/vararray-default/ref/out.txt
+++ b/testsuite/vararray-default/ref/out.txt
@@ -6,4 +6,6 @@ a array length 3
 b array length 2
   [0] = (9 9 9)
   [1] = (1 2.3 4)
+c array length 1
+  [0] = (0 0 0)
 

--- a/testsuite/vararray-default/test.osl
+++ b/testsuite/vararray-default/test.osl
@@ -12,8 +12,11 @@ void print_array_contents (string name, vector v[])
         printf ("  [%d] = (%g)\n", i, v[i]);
 }
 
-shader test (float a[] = {0,1,2.3}, vector b[] = {9, vector(1,2.3,4)})
+shader test (float a[] = {0,1,2.3},
+             vector b[] = {9, vector(1,2.3,4)},
+             vector c[] = {})
 {
     print_array_contents ("a", a);
     print_array_contents ("b", b);
+    print_array_contents ("c", c);
 }


### PR DESCRIPTION
Still gets length 1 (we don't allow 0-length arrays, that's a whole
other can of worms), but this is now treated as equivalent to
`= { default_value }` (0 for int or float, "" for string).

It's syntactic sugar, but it removes some clutter for people who want to
have shader parameters that are arrays of undetermined length (and thus are
probably expected to have a runtime-assigned instance value or be
conntected to an output of an earlier layer within the shader group),
removes the requirement for spelling out an initializing value that
won't be used anyway.

