### PR TITLE
Forbid LPE repetitions inside groups

### DIFF
--- a/src/liboslexec/lpeparse.cpp
+++ b/src/liboslexec/lpeparse.cpp
@@ -396,6 +396,10 @@ LPexp *
 Parser::parseModifier(LPexp *e)
 {
     if (hasInput()) {
+        if (m_ingroup && (head() == '*' || head() == '{' || head() == '+')) {
+            m_error = std::string("Repetitions not allowed inside '<...>'");
+            return NULL;
+        }
         if (head() == '*') {
             next();
             return new lpexp::Repeat(e);


### PR DESCRIPTION
This is not useful in practice and we've seen a case of exponential DFA
state blowup in issue #971 because of its accidental use. This does not
make LPEs totally robust to ReDoS but prevents this particular mistake.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

