### PR TITLE
FindLLVM: Make more robust to library configuration of llvm

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -52,19 +52,10 @@ execute_process (COMMAND ${LLVM_CONFIG} --includedir
 execute_process (COMMAND ${LLVM_CONFIG} --targets-built
        OUTPUT_VARIABLE LLVM_TARGETS
        OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (NOT ${LLVM_VERSION} VERSION_LESS 3.8)
-    execute_process (COMMAND ${LLVM_CONFIG} --system-libs
-                     OUTPUT_VARIABLE LLVM_SYSTEM_LIBRARIES
-                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string (REPLACE " " ";" LLVM_SYSTEM_LIBRARIES "${LLVM_SYSTEM_LIBRARIES}")
-else ()
-    # Older LLVM did not have llvm-config --system-libs, but we know that
-    # on Linux, we'll need curses.
-    find_package (Curses)
-    if (CURSES_FOUND)
-        list (APPEND LLVM_SYSTEM_LIBRARIES ${CURSES_LIBRARIES})
-    endif ()
-endif ()
+execute_process (COMMAND ${LLVM_CONFIG} --system-libs
+                 OUTPUT_VARIABLE LLVM_SYSTEM_LIBRARIES
+                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+string (REPLACE " " ";" LLVM_SYSTEM_LIBRARIES "${LLVM_SYSTEM_LIBRARIES}")
 
 find_library ( LLVM_LIBRARY
                NAMES LLVM-${LLVM_VERSION} LLVM
@@ -72,7 +63,6 @@ find_library ( LLVM_LIBRARY
 find_library ( LLVM_MCJIT_LIBRARY
                NAMES LLVMMCJIT
                PATHS ${LLVM_LIB_DIR})
-
 
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST clangBasic
@@ -85,12 +75,6 @@ foreach (COMPONENT clangFrontend clangDriver clangSerialization
     endif ()
 endforeach ()
 
-
-# if (NOT LLVM_LIBRARY)
-#     execute_process (COMMAND ${LLVM_CONFIG} --libfiles engine
-#                      OUTPUT_VARIABLE LLVM_LIBRARIES
-#                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-# endif ()
 
 # shared llvm library may not be available, this is not an error if we use LLVM_STATIC.
 if ((LLVM_LIBRARY OR LLVM_LIBRARIES OR LLVM_STATIC) AND LLVM_INCLUDES AND LLVM_DIRECTORY AND LLVM_LIB_DIR)

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -220,7 +220,6 @@ TARGET_LINK_LIBRARIES ( oslexec
                         ${PARTIO_LIBRARIES} ${ZLIB_LIBRARIES}
                         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
                         ${CLANG_LIBRARIES}
-                        ${LLVM_LIBRARY} ${LLVM_MCJIT_LIBRARY}
                         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
                         ${LLVM_SYSTEM_LIBRARIES})
 ADD_DEPENDENCIES (oslexec "${CMAKE_SOURCE_DIR}/src/build-scripts/hidesymbols.map")

--- a/src/shaders/MaterialX/CMakeLists.txt
+++ b/src/shaders/MaterialX/CMakeLists.txt
@@ -61,7 +61,7 @@ macro (mx_oslc_compile)
         get_filename_component(mxfile_justname ${mxfile} NAME)
         get_filename_component(oslfile_justname ${oslfile} NAME)
         get_filename_component(osofile_justname ${osofile} NAME)
-        message (STATUS "oslc will make ${mxfile_justname} -> ${oslfile_justname} -> ${osofile_justname}")
+        # message (STATUS "oslc will make ${mxfile_justname} -> ${oslfile_justname} -> ${osofile_justname}")
     endif ()
     add_custom_command (OUTPUT ${osofile}
         COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/build_materialX_osl.py"


### PR DESCRIPTION
In particular, some system distributions bundle everything in one
libLLVM, without a separate libLLVMMCJIT.

