### PR TITLE
Improve warnings about ill-advised use of comma operator

### DIFF
--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -796,7 +796,21 @@ expression
                         $$->sourceline (@1.first_line);
                     }
                 }
-        | '(' compound_expression ')'           { $$ = $2; }
+        | '(' compound_expression ')'
+                {
+                    if ($2->nodetype() == ASTNode::comma_operator_node) {
+                        // Warning for comma operator ïn parenthesized
+                        // expressions, which sometimes happens when somebody
+                        // forgets the proper syntax for triple constructors:
+                        //     color x = Cd * (a, b, c); // same as:  x = Cd * c
+                        // when they really meant
+                        //     color x = Cd * color(a, b, c);
+                        oslcompiler->warning(oslcompiler->filename(),
+                                             @1.first_line,
+                                             "Comma operator inside parenthesis is probably an error -- it is not a vector/color.");
+                    }
+                    $$ = $2;
+                }
         | function_call
         | assign_expression
         | ternary_expression

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -113,19 +113,6 @@ ASTvariable_declaration::typecheck (TypeSpec expected)
         init = ((ASTcompound_initializer *)init.get())->initlist();
     }
 
-    // Warning to catch confusing comma operator in variable initializers.
-    // One place this comes up is when somebody forgets the proper syntax
-    // for constructors, for example
-    //     color x = (a, b, c);   // Sets x to (c,c,c)!
-    // when they really meant
-    //     color x = color(a, b, c);
-    if (init->nodetype() == comma_operator_node && !typespec().is_closure() &&
-        (typespec().is_triple() || typespec().is_matrix())) {
-        warning ("Comma operator is very confusing here. "
-                 "Did you mean to use a constructor: %s = %s(...)?",
-                 m_name.c_str(), typespec().c_str());
-    }
-
     return m_typespec;
 }
 
@@ -347,19 +334,6 @@ ASTassign_expression::typecheck (TypeSpec expected)
         error ("Cannot assign '%s' to '%s'", type_c_str(et), type_c_str(vt));
         // FIXME - can we print the variable in question?
         return TypeSpec();
-    }
-
-    // Warning to catch confusing comma operator in assignment.
-    // One place this comes up is when somebody forgets the proper syntax
-    // for constructors, for example
-    //     color x = (a, b, c);   // Sets x to (c,c,c)!
-    // when they really meant
-    //     color x = color(a, b, c);
-    if (expr()->nodetype() == comma_operator_node && !vt.is_closure() &&
-        (vt.is_triple() || vt.is_matrix())) {
-        warning ("Comma operator is very confusing here. "
-                 "Did you mean to use a constructor: = %s(...)?",
-                 vt.c_str());
     }
 
     return m_typespec = vt;

--- a/testsuite/oslc-comma/comma.osl
+++ b/testsuite/oslc-comma/comma.osl
@@ -19,6 +19,7 @@ shader comma ()
     printf ("Lo = %d, hi = %d   (expect: 0,1)\n", lo, hi);
 
     // Test the return value of a commma expression
+    // Note: this will make a warning, because it's stupid.
     float x = 3.14;
     int y = 5;
     int z = (x, y);

--- a/testsuite/oslc-comma/ref/out.txt
+++ b/testsuite/oslc-comma/ref/out.txt
@@ -1,3 +1,4 @@
+comma.osl:25: warning: Comma operator inside parenthesis is probably an error -- it is not a vector/color.
 Compiled comma.osl -> comma.oso
 for loop: amp = 0.03125, freq = 16, sum = 0
 Lo = 0, hi = 1   (expect: 0,1)

--- a/testsuite/oslc-warn-commainit/ref/out.txt
+++ b/testsuite/oslc-warn-commainit/ref/out.txt
@@ -1,3 +1,4 @@
-test.osl:3: warning: Comma operator is very confusing here. Did you mean to use a constructor: x = vector(...)?
-test.osl:4: warning: Comma operator is very confusing here. Did you mean to use a constructor: = color(...)?
+test.osl:3: warning: Comma operator inside parenthesis is probably an error -- it is not a vector/color.
+test.osl:4: warning: Comma operator inside parenthesis is probably an error -- it is not a vector/color.
+test.osl:5: warning: Comma operator inside parenthesis is probably an error -- it is not a vector/color.
 Compiled test.osl -> test.oso

--- a/testsuite/oslc-warn-commainit/test.osl
+++ b/testsuite/oslc-warn-commainit/test.osl
@@ -2,4 +2,5 @@ shader test ( output color Cout = 0 )
 {
     vector x = (1, 2, 3);
     Cout = (u, v, 0);
+    Cout *= (0, 1, 2);
 }


### PR DESCRIPTION
We previously had warnings that attempted to catch mistakes in using
the "comma operator" when the user intended an "aggregate type
constructor", for example:

    color x = (a, b, c);    // comma operator! equivalent to: x = c;
    color x = color(a,b,c); // this is what they probably meant

However, the way we implemented the warning was specific to assignment:

    x = (a, b, c);

and variable declaration with initialization:

    color x = (a, b, c);

But it missed similar bugs in other constructs, for example

    color x = Cdiffuse * (a, b, c);

Here the user surely intends to multiply Cdiffuse channel-by-channel
with color(a,b,c), but what they will actually get is Cfiffuse scaled
by float c.

This patch changes the strategy for this warning, no longer tied to
variable declaration or assignment, but more generally any time the
comma operator is used inside expression parentheses, it will give a
warning.

