### PR TITLE
ShadingSystem: allow for thread-safe/reentrant shader specification

### DIFF
--- a/src/testoptix/testoptix.cpp
+++ b/src/testoptix/testoptix.cpp
@@ -368,17 +368,23 @@ void parse_scene() {
                     for (pugi::xml_attribute attr = gnode.first_attribute(); attr; attr = attr.next_attribute()) {
                         int i = 0; float x = 0, y = 0, z = 0;
                         if (sscanf(attr.value(), " int %d ", &i) == 1)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeInt, store.Int(i));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeInt, store.Int(i));
                         else if (sscanf(attr.value(), " float %f ", &x) == 1)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeFloat, store.Float(x));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeFloat, store.Float(x));
                         else if (sscanf(attr.value(), " vector %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeVector, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeVector, store.Vec(x, y, z));
                         else if (sscanf(attr.value(), " point %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypePoint, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypePoint, store.Vec(x, y, z));
                         else if (sscanf(attr.value(), " color %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeColor, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeColor, store.Vec(x, y, z));
                         else
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeString, store.Str(attr.value()));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeString, store.Str(attr.value()));
                     }
                 } else if (strcmp(gnode.name(), "Shader") == 0) {
                     pugi::xml_attribute  type_attr = gnode.attribute("type");
@@ -386,7 +392,8 @@ void parse_scene() {
                     pugi::xml_attribute layer_attr = gnode.attribute("layer");
                     const char* type = type_attr ? type_attr.value() : "surface";
                     if (name_attr && layer_attr)
-                        shadingsys->Shader(type, name_attr.value(), layer_attr.value());
+                        shadingsys->Shader(group, type, name_attr.value(),
+                                           layer_attr.value());
                 } else if (strcmp(gnode.name(), "ConnectShaders") == 0) {
                     // FIXME: find a more elegant way to encode this
                     pugi::xml_attribute  sl = gnode.attribute("srclayer");
@@ -394,13 +401,13 @@ void parse_scene() {
                     pugi::xml_attribute  dl = gnode.attribute("dstlayer");
                     pugi::xml_attribute  dp = gnode.attribute("dstparam");
                     if (sl && sp && dl && dp)
-                        shadingsys->ConnectShaders(sl.value(), sp.value(),
+                        shadingsys->ConnectShaders(group, sl.value(), sp.value(),
                                                    dl.value(), dp.value());
                 } else {
                     // unknow element?
                 }
             }
-            shadingsys->ShaderGroupEnd();
+            shadingsys->ShaderGroupEnd(*group);
             shaders.push_back (group);
         } else {
             // unknown element?

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -352,17 +352,23 @@ void parse_scene() {
                     for (pugi::xml_attribute attr = gnode.first_attribute(); attr; attr = attr.next_attribute()) {
                         int i = 0; float x = 0, y = 0, z = 0;
                         if (sscanf(attr.value(), " int %d ", &i) == 1)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeInt, store.Int(i));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeInt, store.Int(i));
                         else if (sscanf(attr.value(), " float %f ", &x) == 1)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeFloat, store.Float(x));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeFloat, store.Float(x));
                         else if (sscanf(attr.value(), " vector %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeVector, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeVector, store.Vec(x, y, z));
                         else if (sscanf(attr.value(), " point %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypePoint, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypePoint, store.Vec(x, y, z));
                         else if (sscanf(attr.value(), " color %f %f %f", &x, &y, &z) == 3)
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeColor, store.Vec(x, y, z));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeColor, store.Vec(x, y, z));
                         else
-                            shadingsys->Parameter(attr.name(), TypeDesc::TypeString, store.Str(attr.value()));
+                            shadingsys->Parameter(*group, attr.name(),
+                                                  TypeDesc::TypeString, store.Str(attr.value()));
                     }
                 } else if (strcmp(gnode.name(), "Shader") == 0) {
                     pugi::xml_attribute  type_attr = gnode.attribute("type");
@@ -370,7 +376,8 @@ void parse_scene() {
                     pugi::xml_attribute layer_attr = gnode.attribute("layer");
                     const char* type = type_attr ? type_attr.value() : "surface";
                     if (name_attr && layer_attr)
-                        shadingsys->Shader(type, name_attr.value(), layer_attr.value());
+                        shadingsys->Shader(*group, type, name_attr.value(),
+                                           layer_attr.value());
                 } else if (strcmp(gnode.name(), "ConnectShaders") == 0) {
                     // FIXME: find a more elegant way to encode this
                     pugi::xml_attribute  sl = gnode.attribute("srclayer");
@@ -378,13 +385,14 @@ void parse_scene() {
                     pugi::xml_attribute  dl = gnode.attribute("dstlayer");
                     pugi::xml_attribute  dp = gnode.attribute("dstparam");
                     if (sl && sp && dl && dp)
-                        shadingsys->ConnectShaders(sl.value(), sp.value(),
+                        shadingsys->ConnectShaders(*group,
+                                                   sl.value(), sp.value(),
                                                    dl.value(), dp.value());
                 } else {
                     // unknow element?
                 }
             }
-            shadingsys->ShaderGroupEnd();
+            shadingsys->ShaderGroupEnd(*group);
             shaders.push_back (group);
         } else {
             // unknown element?


### PR DESCRIPTION
The ShaderGroupBegin / ShaderGroupEnd (with interspersed Parameter,
Shader, and ConnectShaders calls between them) relied on hidden state
indicating which shader group was the single one undergoing
specification.  This made the shader declaration process unable to
occur concurrenty for different shaders by different threads.

This patch introduces new versions of Parameter(), Shader(), and
ConnectShaders() that take an explicit `ShaderGroup&` parameter and
don't depend on any saved state. Remember that ShaderGroupBegin
returns a ShaderGroupRef, it's this dereferenced object that is passed
to the other functions that help specify the contents of the group.
This allows multithreaded apps to be building the scene, including
shader specification, from many threads concurrently.

The old stateful versions remain, and are fine to continue using for
any apps that are sure that all shader declaration will be done
serially (though we will perhaps mull over whether to eventually
deprecate it entirely).  Though internally, the amount of saved state
is now reduced to merely the one shared pointer that designates which
is the single active group being specified, the other former bits of
state either being entirely redundant or moving to be local to the
group itself.

