### PR TITLE
Improve oslc type error detection for variable declaration with init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,8 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             pnoise pnoise-cell pnoise-gabor pnoise-perlin
             operator-overloading
             oslc-comma oslc-D
-            oslc-err-arrayindex oslc-err-closuremul oslc-err-field
+            oslc-err-arrayindex oslc-err-assignmenttypes
+            oslc-err-closuremul oslc-err-field
             oslc-err-format oslc-err-funcoverload
             oslc-err-intoverflow oslc-err-write-nonoutput
             oslc-err-noreturn oslc-err-notfunc

--- a/testsuite/oslc-err-assignmenttypes/ref/out.txt
+++ b/testsuite/oslc-err-assignmenttypes/ref/out.txt
@@ -1,0 +1,6 @@
+test.osl:17: error: Cannot assign int i = float
+test.osl:18: error: Cannot assign int i = float
+test.osl:26: error: Cannot assign closure color cc = int
+test.osl:32: error: Cannot initialize struct vector4 v4 = struct vector2
+test.osl:34: error: Cannot assign struct vector2 v2 = struct vector4
+FAILED test.osl

--- a/testsuite/oslc-err-assignmenttypes/run.py
+++ b/testsuite/oslc-err-assignmenttypes/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-assignmenttypes/test.osl
+++ b/testsuite/oslc-err-assignmenttypes/test.osl
@@ -1,0 +1,36 @@
+// Test a variety of scenarios that should report type errors related to
+// assignments. We need to test both simple assignment as well as variable
+// declaration with initialization assignment, since they are different
+// grammatical constructs.
+
+#include "vector2.h"
+#include "vector4.h"
+
+
+
+shader
+test()
+{
+    // Assigning float to int is not allowed without a cast
+    {
+        float f = M_PI;
+        int i = f;                          // error
+        i = f;                              // error
+        i = (int)f;                         // ok
+    }
+
+    // Assigning scalar to closure, unless the scalar is 0
+    {
+        closure color cc = 0;               // ok
+        cc = 0;                             // ok
+        cc = 1;                             // error
+    }
+
+    // Assigning structs
+    {
+        vector2 v2 = {0.0};                 // ok
+        vector4 v4 = v2;                    // error -- incompatible structs
+        v4 = v4;                            // ok
+        v2 = v4;                            // error -- incompatible structs
+    }
+}

--- a/testsuite/oslc-err-closuremul/ref/out.txt
+++ b/testsuite/oslc-err-closuremul/ref/out.txt
@@ -1,3 +1,3 @@
 test.osl:6: error: Not allowed: 'closure color * closure color'
-test.osl:6: error: Cannot assign 'unknown' to 'closure color'
+test.osl:6: error: Cannot assign closure color Ci = unknown
 FAILED test.osl

--- a/testsuite/oslc-err-struct-ctr/ref/out.txt
+++ b/testsuite/oslc-err-struct-ctr/ref/out.txt
@@ -1,4 +1,4 @@
-test.osl:10: error: Cannot initialize structure 'A' with a scalar value
+test.osl:10: error: Cannot initialize struct rgba A = int
 test.osl:13: error: Constructor for 'rgba' has the wrong number of arguments (expected 2, got 1)
 test.osl:16: error: Constructor for 'rgba' has the wrong number of arguments (expected 2, got 3)
 test.osl:16: error: Too many initializers for struct 'rgba'

--- a/testsuite/struct-err/ref/out.txt
+++ b/testsuite/struct-err/ref/out.txt
@@ -1,4 +1,4 @@
-test.osl:29: error: Cannot assign 'struct Bstruct' to 'struct Astruct'
-test.osl:32: error: Cannot assign 'int' to 'struct Bstruct'
-test.osl:35: error: Cannot initialize structure 'c' with a scalar value
+test.osl:29: error: Cannot assign struct Astruct a = struct Bstruct
+test.osl:32: error: Cannot assign struct Bstruct b = int
+test.osl:35: error: Cannot initialize struct Astruct c = int
 FAILED test.osl


### PR DESCRIPTION
Turns out that some of the various type checking we do for simple
assignment,

    x = y

was not being checked at all for variable declaration with initialization,

    Type x = y

So this patch adds the necessary checks. And also goes back and improves
the error messages for regular variable assignment, changing from messages
like

    Cannot assign 'float' to 'int'

to the more clear (I think, because it names the variable, and looks
more like the grammatical construct being complained about)

    Cannot assign int i = float
