### PR TITLE
oslc: slight adjustment to assignment typechecking

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -131,8 +131,13 @@ ASTvariable_declaration::typecheck (TypeSpec expected)
 
     // Expression must be of a type assignable to the lvalue
     if (! assignable (vt, et)) {
-        error ("Cannot assign %s %s = %s",
-               type_c_str(vt), name(), type_c_str(et));
+        // Special case: for int=float, it's just a warning.
+        if (vt.is_int() && et.is_float())
+            warning ("Assignment may lose precision: %s %s = %s",
+                     type_c_str(vt), name(), type_c_str(et));
+        else
+            error ("Cannot assign %s %s = %s",
+                   type_c_str(vt), name(), type_c_str(et));
         return m_typespec;
     }
 
@@ -360,8 +365,13 @@ ASTassign_expression::typecheck (TypeSpec expected)
 
     // Expression must be of a type assignable to the lvalue
     if (! assignable (vt, et)) {
-        error ("Cannot assign %s %s = %s", type_c_str(vt), varname,
-               type_c_str(et));
+        // Special case: for int=float, it's just a warning.
+        if (vt.is_int() && et.is_float())
+            warning ("Assignment may lose precision: %s %s = %s",
+                     type_c_str(vt), varname, type_c_str(et));
+        else
+            error ("Cannot assign %s %s = %s",
+                   type_c_str(vt), varname, type_c_str(et));
         return m_typespec;
     }
 

--- a/testsuite/oslc-err-assignmenttypes/ref/out.txt
+++ b/testsuite/oslc-err-assignmenttypes/ref/out.txt
@@ -1,5 +1,5 @@
-test.osl:17: error: Cannot assign int i = float
-test.osl:18: error: Cannot assign int i = float
+test.osl:17: warning: Assignment may lose precision: int i = float
+test.osl:18: warning: Assignment may lose precision: int i = float
 test.osl:26: error: Cannot assign closure color cc = int
 test.osl:32: error: Cannot initialize struct vector4 v4 = struct vector2
 test.osl:34: error: Cannot assign struct vector2 v2 = struct vector4


### PR DESCRIPTION
Consider int=float to be a warning, not an error.
This is partly because C allows it and we ran accross some
examples where it seems more strict than necessary.
(Of course it works without warning if you use a cast, showing
that any trucation is intentional.)

