### PR TITLE
Improve FindOptiX.cmake logic

### DIFF
--- a/src/cmake/modules/FindOptiX.cmake
+++ b/src/cmake/modules/FindOptiX.cmake
@@ -39,13 +39,14 @@ macro(OPTIX_find_api_library name version)
     find_library(${name}_LIBRARY
         NAMES ${name}.${version} ${name}
         )
+    if (${name}_LIBRARY STREQUAL "${name}_LIBRARY-NOTFOUND")
+        if (WIN32)
+            set (${name}_LIBRARY "${OPTIXHOME}/lib64/${name}.${version}.lib")
+        else ()
+            set (${name}_LIBRARY "${OPTIXHOME}/lib64/lib${name}.so")
+        endif ()
+    endif()
 endmacro()
-
-OPTIX_find_api_library(optix 1)
-OPTIX_find_api_library(optixu 1)
-OPTIX_find_api_library(optix_prime 1)
-
-set (OPTIX_LIBRARIES ${optix_LIBRARY} ${optixu_LIBRARY} ${optix_prime_LIBRARY})
 
 # Pull out the API version from optix.h
 file(STRINGS ${OPTIX_INCLUDE_DIR}/optix.h OPTIX_VERSION_LINE LIMIT_COUNT 1 REGEX OPTIX_VERSION)
@@ -54,6 +55,12 @@ math(EXPR OPTIX_VERSION_MAJOR "${OPTIX_VERSION_STRING}/10000")
 math(EXPR OPTIX_VERSION_MINOR "(${OPTIX_VERSION_STRING}%10000)/100")
 math(EXPR OPTIX_VERSION_MICRO "${OPTIX_VERSION_STRING}%100")
 set(OPTIX_VERSION "${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR}.${OPTIX_VERSION_MICRO}")
+
+OPTIX_find_api_library(optix ${OPTIX_VERSION})
+OPTIX_find_api_library(optixu ${OPTIX_VERSION})
+OPTIX_find_api_library(optix_prime ${OPTIX_VERSION})
+
+set (OPTIX_LIBRARIES ${optix_LIBRARY})
 
 message (STATUS "OptiX version = ${OPTIX_VERSION}")
 if (NOT OptiX_FIND_QUIETLY)


### PR DESCRIPTION
## Description

Improves the logic for finding the OptiX libraries in two ways. Firstly, a fallback has been added to the OPTIX_find_api_library macro to set the library version based on the OPTIXHOME variable and our knowledge of the default directory structure of an OptiX install. Secondly, the logic now uses the version number that is already being fetched from the OptiX headers to correctly match the versioned OptiX libraries. 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

