### PR TITLE
Fix inadvertently missing SS::Parameter() implementation

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -459,9 +459,8 @@ public:
     // concurrently). If there is any doubt about that, use the versions
     // above that take an explicit `ShaderGroup&`, which are thread-safe
     // and re-entrant.
-    bool Parameter (string_view name, TypeDesc t, const void *val);
     bool Parameter (string_view name, TypeDesc t, const void *val,
-                    bool lockgeom);
+                    bool lockgeom=true);
     bool Shader (string_view shaderusage, string_view shadername,
                  string_view layername);
     bool ConnectShaders (string_view srclayer, string_view srcparam,


### PR DESCRIPTION
The implementation of #984 inadvertently lost one of the old
variants of the SS::Parameter() call. There was a 3-param version
and a 4-param version separately declared, but somehow in the code
that was merged, only the 4-param version has an implementation.
Fix by merging the declarations so that it's a 4-param method with
a default value for the last argument (which I think was my intent
all along).

Fixes #999 
