### PR TITLE
Modify testsuite to run optix tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ macro ( TESTSUITE )
     if (_ats_FOUNDVAR AND NOT ${_ats_FOUNDVAR})
         set (_ats_LABEL "broken")
     endif ()
+    set (test_all_optix $ENV{TESTSUITE_OPTIX})
     # Add the tests if all is well.
     set (ALL_TEST_LIST "")
     foreach (_testname ${_ats_UNPARSED_ARGUMENTS})
@@ -239,30 +240,59 @@ macro ( TESTSUITE )
                                       --solution-path "${CMAKE_BINARY_DIR}" )
         endif ()
 
+        set (ALL_TEST_LIST "${ALL_TEST_LIST} ${_testname}")
         file (MAKE_DIRECTORY "${_testdir}")
 
-        # Run the test unoptimized, unless it's a "render_*" or "oslinfo_*"
-        # test, which we don't bother testing unoptimized.
-        if (NOT _testname MATCHES "^render" AND
-            NOT _testname MATCHES "^oslinfo" AND
-            NOT _testname MATCHES "^getattribute-shader" AND
+        # Run the test unoptimized, unless it matches a few patterns that
+        # we don't test unoptimized (or has an OPTIMIZEONLY marker file).
+        if (NOT _testname MATCHES "^getattribute-shader" AND
+            NOT _testname MATCHES "optix" AND
             NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
-          set (_env TESTSHADE_OPT=0
-                    OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
-                    OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-                    OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
-          add_test ( NAME ${_testname}
-                     COMMAND env ${_env} ${_runtest} )
+            set (_env TESTSHADE_OPT=0
+                      OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
+                      OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                      OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
+            add_test ( NAME ${_testname}
+                       COMMAND env ${_env} ${_runtest} )
         endif ()
-        set (ALL_TEST_LIST "${ALL_TEST_LIST} ${_testname}")
         # Run the same test again with aggressive -O2 runtime
-        # optimization, triggered by setting TESTSHADE_OPT env variable
-        set (_env TESTSHADE_OPT=2
-                  OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
-                  OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-                  OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
-        add_test ( NAME ${_testname}.opt
-                   COMMAND env ${_env} ${_runtest} )
+        # optimization, triggered by setting TESTSHADE_OPT env variable.
+        # Skip OptiX-only tests and those with a NOOPTIMIZE marker file.
+        if (NOT _testname MATCHES "optix"
+            AND NOT EXISTS "${_testsrcdir}/NOOPTIMIZE")
+            set (_env TESTSHADE_OPT=2
+                      OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
+                      OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                      OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
+            add_test ( NAME ${_testname}.opt
+                       COMMAND env ${_env} ${_runtest} )
+        endif ()
+        # When building for OptiX support, also run it in OptiX mode
+        # if there is an OPTIX marker file in the directory.
+        # If an environment variable $TESTSUITE_OPTIX is nonzero, then
+        # run all tests with OptiX, even if there's no OPTIX marker.
+        if (USE_OPTIX
+            AND (EXISTS "${_testsrcdir}/OPTIX" OR test_all_optix OR _testname MATCHES "optix")
+            AND NOT EXISTS "${_testsrcdir}/NOOPTIX"
+            AND NOT EXISTS "${_testsrcdir}/NOOPTIX-FIXME")
+            # FIXME! Don't run unoptimized yet because we know optix tests
+            # almost all fail on anything with init ops. Will fix soon.
+            #if (NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
+            #    set (_env TESTSHADE_OPT=0 TESTSHADE_OPTIX=1
+            #              OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
+            #              OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+            #              OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
+            #    add_test ( NAME ${_testname}.optix
+            #               COMMAND env ${_env} ${_runtest} )
+            #endif ()
+            # and optimized
+            set (_env TESTSHADE_OPT=2 TESTSHADE_OPTIX=1
+                      OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
+                      OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                      OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
+            add_test ( NAME ${_testname}.optix.opt
+                       COMMAND env ${_env} ${_runtest} )
+        endif ()
     endforeach ()
     if (VERBOSE)
         message (STATUS "Added tests: ${ALL_TEST_LIST}")

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/parallel.h>
+#include <OpenImageIO/sysutil.h>
 
 #include <OSL/oslexec.h>
 #include "optixraytracer.h"
@@ -73,7 +74,7 @@ static int iters = 1;
 static std::string scenefile, imagefile;
 static std::string shaderpath;
 static bool shadingsys_options_set = false;
-static bool use_optix = false;
+static bool use_optix = OIIO::Strutil::stoi(OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
 
 
 

--- a/testsuite/Werror/NOOPTIMIZE
+++ b/testsuite/Werror/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/Werror/NOOPTIX
+++ b/testsuite/Werror/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/allowconnect-err/NOOPTIMIZE
+++ b/testsuite/allowconnect-err/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing error detection, no execution, no need to optimize

--- a/testsuite/allowconnect-err/NOOPTIX
+++ b/testsuite/allowconnect-err/NOOPTIX
@@ -1,0 +1,1 @@
+Testing error detection, no execution, no need to run with OptiX

--- a/testsuite/missing-shader/NOOPTIMIZE
+++ b/testsuite/missing-shader/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing error detection, no execution, no need to optimize

--- a/testsuite/missing-shader/NOOPTIX
+++ b/testsuite/missing-shader/NOOPTIX
@@ -1,0 +1,1 @@
+Testing error detection, no execution, no need to run with OptiX

--- a/testsuite/osl-imageio/NOOPTIX
+++ b/testsuite/osl-imageio/NOOPTIX
@@ -1,0 +1,1 @@
+Test uses OIIO to generate pixels -- skip OptiX

--- a/testsuite/oslc-err-arrayindex/NOOPTIMIZE
+++ b/testsuite/oslc-err-arrayindex/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-arrayindex/NOOPTIX
+++ b/testsuite/oslc-err-arrayindex/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-assignmenttypes/NOOPTIMIZE
+++ b/testsuite/oslc-err-assignmenttypes/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-assignmenttypes/NOOPTIX
+++ b/testsuite/oslc-err-assignmenttypes/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-closuremul/NOOPTIMIZE
+++ b/testsuite/oslc-err-closuremul/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-closuremul/NOOPTIX
+++ b/testsuite/oslc-err-closuremul/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-field/NOOPTIMIZE
+++ b/testsuite/oslc-err-field/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-field/NOOPTIX
+++ b/testsuite/oslc-err-field/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-format/NOOPTIMIZE
+++ b/testsuite/oslc-err-format/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-format/NOOPTIX
+++ b/testsuite/oslc-err-format/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-funcoverload/NOOPTIMIZE
+++ b/testsuite/oslc-err-funcoverload/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-funcoverload/NOOPTIX
+++ b/testsuite/oslc-err-funcoverload/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-initlist-args/NOOPTIMIZE
+++ b/testsuite/oslc-err-initlist-args/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-initlist-args/NOOPTIX
+++ b/testsuite/oslc-err-initlist-args/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-initlist-return/NOOPTIMIZE
+++ b/testsuite/oslc-err-initlist-return/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-initlist-return/NOOPTIX
+++ b/testsuite/oslc-err-initlist-return/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-initlist/NOOPTIMIZE
+++ b/testsuite/oslc-err-initlist/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-initlist/NOOPTIX
+++ b/testsuite/oslc-err-initlist/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-intoverflow/NOOPTIMIZE
+++ b/testsuite/oslc-err-intoverflow/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-intoverflow/NOOPTIX
+++ b/testsuite/oslc-err-intoverflow/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-noreturn/NOOPTIMIZE
+++ b/testsuite/oslc-err-noreturn/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-noreturn/NOOPTIX
+++ b/testsuite/oslc-err-noreturn/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-notfunc/NOOPTIMIZE
+++ b/testsuite/oslc-err-notfunc/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-notfunc/NOOPTIX
+++ b/testsuite/oslc-err-notfunc/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-outputparamvararray/NOOPTIMIZE
+++ b/testsuite/oslc-err-outputparamvararray/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-outputparamvararray/NOOPTIX
+++ b/testsuite/oslc-err-outputparamvararray/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-paramdefault/NOOPTIMIZE
+++ b/testsuite/oslc-err-paramdefault/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-paramdefault/NOOPTIX
+++ b/testsuite/oslc-err-paramdefault/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-struct-array-init/NOOPTIMIZE
+++ b/testsuite/oslc-err-struct-array-init/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-struct-array-init/NOOPTIX
+++ b/testsuite/oslc-err-struct-array-init/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-struct-ctr/NOOPTIMIZE
+++ b/testsuite/oslc-err-struct-ctr/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-struct-ctr/NOOPTIX
+++ b/testsuite/oslc-err-struct-ctr/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-struct-dup/NOOPTIMIZE
+++ b/testsuite/oslc-err-struct-dup/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-struct-dup/NOOPTIX
+++ b/testsuite/oslc-err-struct-dup/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-struct-print/NOOPTIMIZE
+++ b/testsuite/oslc-err-struct-print/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-struct-print/NOOPTIX
+++ b/testsuite/oslc-err-struct-print/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-unknown-ctr/NOOPTIMIZE
+++ b/testsuite/oslc-err-unknown-ctr/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-unknown-ctr/NOOPTIX
+++ b/testsuite/oslc-err-unknown-ctr/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-write-nonoutput/NOOPTIMIZE
+++ b/testsuite/oslc-err-write-nonoutput/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-write-nonoutput/NOOPTIX
+++ b/testsuite/oslc-err-write-nonoutput/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-warn-commainit/NOOPTIMIZE
+++ b/testsuite/oslc-warn-commainit/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-warn-commainit/NOOPTIX
+++ b/testsuite/oslc-warn-commainit/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslinfo-arrayparams/NOOPTIMIZE
+++ b/testsuite/oslinfo-arrayparams/NOOPTIMIZE
@@ -1,0 +1,1 @@
+oslinfo only test, no need to optimize

--- a/testsuite/oslinfo-arrayparams/NOOPTIX
+++ b/testsuite/oslinfo-arrayparams/NOOPTIX
@@ -1,0 +1,1 @@
+oslinfo only, no need to test optix

--- a/testsuite/oslinfo-colorctrfloat/NOOPTIMIZE
+++ b/testsuite/oslinfo-colorctrfloat/NOOPTIMIZE
@@ -1,0 +1,1 @@
+oslinfo only test, no need to optimize

--- a/testsuite/oslinfo-colorctrfloat/NOOPTIX
+++ b/testsuite/oslinfo-colorctrfloat/NOOPTIX
@@ -1,0 +1,1 @@
+oslinfo only, no need to test optix

--- a/testsuite/oslinfo-metadata/NOOPTIMIZE
+++ b/testsuite/oslinfo-metadata/NOOPTIMIZE
@@ -1,0 +1,1 @@
+oslinfo only test, no need to optimize

--- a/testsuite/oslinfo-metadata/NOOPTIX
+++ b/testsuite/oslinfo-metadata/NOOPTIX
@@ -1,0 +1,1 @@
+oslinfo only, no need to test optix

--- a/testsuite/oslinfo-noparams/NOOPTIMIZE
+++ b/testsuite/oslinfo-noparams/NOOPTIMIZE
@@ -1,0 +1,1 @@
+oslinfo only test, no need to optimize

--- a/testsuite/oslinfo-noparams/NOOPTIX
+++ b/testsuite/oslinfo-noparams/NOOPTIX
@@ -1,0 +1,1 @@
+oslinfo only, no need to test optix

--- a/testsuite/render-background/NOOPTIMIZE
+++ b/testsuite/render-background/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-bumptest/NOOPTIMIZE
+++ b/testsuite/render-bumptest/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-cornell/NOOPTIMIZE
+++ b/testsuite/render-cornell/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-furnace-diffuse/NOOPTIMIZE
+++ b/testsuite/render-furnace-diffuse/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-material-layer/NOOPTIMIZE
+++ b/testsuite/render-material-layer/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-microfacet/NOOPTIMIZE
+++ b/testsuite/render-microfacet/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-oren-nayar/NOOPTIMIZE
+++ b/testsuite/render-oren-nayar/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-veachmis/NOOPTIMIZE
+++ b/testsuite/render-veachmis/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/render-ward/NOOPTIMIZE
+++ b/testsuite/render-ward/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Render too expensive without optimization

--- a/testsuite/struct-err/NOOPTIMIZE
+++ b/testsuite/struct-err/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/struct-err/NOOPTIX
+++ b/testsuite/struct-err/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX


### PR DESCRIPTION
We previously had each test run twice: once with -O0 and again with
-O2. Because one tests the actual literal code specified in the shader
(without the possibility of being optimized away) and the other tests
the optimization to make sure it still matches.

This patch extends the logic to allow the possibility of every test
running in optix mode as well, if the code base is built with
USE_OPTIX=1.

For now, it only runs optix mode if the individual test has "optix"
in its name, or if the test directory has a file called "OPTIX" present.
Also, if environment variable TESTSUITE_OPTIX=1, it will try to run
*all* tests with optix mode (that's just for me... most of them fail
at the moment).

The eventual goal is for these conditions to change, so that in a
USE_OPTIX=1 build, *all* tests run optix flavors unless not marked
with a NOOPTIX file in their directory.

At the moment, *6* tests pass for me in OptiX mode. Now we can start
attacking the features to get more and more tests to pass identically
on CPU and GPU.

I realized that there were many tests that are only trying to test
that oslc issues the right error or warning for various malformed
code, or that are only compiling the shader to test oslinfo, or a few
other such cases that run oslc only and never try to execute their
shaders. So I also liberally sprinkled NOOPTIX as well as NOOPTIMIZE
marker files in those test directories, to skip optix tests, and also
skip a second "optimized" run of the same test (which was pointless,
because it wasn't executing at all).
