### PR TITLE
Fix a subtle issue with parameter arrays

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -312,8 +312,7 @@ ShaderInstance::parameters (const ParamValueList &params)
                 // END of the ordinary param storage, since when we assigned
                 // data offsets to each parameter, we didn't know the length
                 // needed to allocate this param in its proper spot.
-                ASSERT (valuetype.arraylen > 0);
-                int nelements = valuetype.arraylen * valuetype.aggregate;
+                int nelements = valuetype.basevalues();
                 // Store the actual length in the shader instance parameter
                 // override info. Compute the length this way to account for relaxed
                 // parameter checking (for example passing an array of floats to an array of colors)


### PR DESCRIPTION
When specifying a parameter value for an unbounded array, supplying a scalar parameter would lead to a failed assert.

For example, shader declares: `string[] foo`, but the user provides the parameter type: `string` instead of `string[1]`.

It seems ok to me to allow this (at the very least, it shouldn't be an assert).