### PR TITLE
Optix: support array and va_args printing

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -235,6 +235,7 @@ public:
     llvm::PointerType *type_longlong_ptr() const { return m_llvm_type_longlong_ptr; }
     llvm::PointerType *type_triple_ptr() const { return m_llvm_type_triple_ptr; }
     llvm::PointerType *type_matrix_ptr() const { return m_llvm_type_matrix_ptr; }
+    llvm::PointerType *type_double_ptr() const { return m_llvm_type_double_ptr; }
 
     /// Generate the appropriate llvm type definition for a TypeDesc
     /// (this is the actual type, for example when we allocate it).
@@ -543,6 +544,7 @@ private:
     llvm::PointerType *m_llvm_type_longlong_ptr;
     llvm::PointerType *m_llvm_type_triple_ptr;
     llvm::PointerType *m_llvm_type_matrix_ptr;
+    llvm::PointerType *m_llvm_type_double_ptr;
 
 };
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -363,7 +363,8 @@ LLVMGEN (llvm_gen_printf)
                     if (rop.use_optix() && simpletype.basetype == TypeDesc::STRING) {
                         // In the OptiX case, we register each string separately.
                         if (simpletype.arraylen >= 1) {
-                            ustring name = ustring::format("%s[%d]", sym.name(), a);
+                            // Mangle the element's name in case llvm_load_device_string calls getOrAllocateLLVMSymbol
+                            ustring name = ustring::format("__symname__%s[%d]", sym.mangled(), a);
                             Symbol lsym(name, TypeDesc::TypeString, sym.symtype());
                             lsym.data(&((ustring*)sym.data())[a]);
                             loaded = rop.llvm_load_device_string (lsym);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1060,6 +1060,10 @@ BackendLLVM::initialize_llvm_group ()
             }
             types += advance;
         }
+        if (varargs && use_optix()) {
+            varargs = false;
+            params.push_back (ll.type_void_ptr());
+        }
         llvm::Function *f = ll.make_function (funcname, false, llvm_type(rettype), params, varargs);
 
         // Skipping this in the non-JIT OptiX case suppresses an LLVM warning

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -288,6 +288,7 @@ LLVM_Util::LLVM_Util (int debuglevel)
     m_llvm_type_ustring_ptr = (llvm::PointerType *) llvm::PointerType::get (m_llvm_type_char_ptr, 0);
     m_llvm_type_longlong_ptr = (llvm::PointerType *) llvm::Type::getInt64PtrTy (*m_llvm_context);
     m_llvm_type_void_ptr = m_llvm_type_char_ptr;
+    m_llvm_type_double_ptr = llvm::Type::getDoublePtrTy (*m_llvm_context);
 
     // A triple is a struct composed of 3 floats
     std::vector<llvm::Type*> triplefields(3, m_llvm_type_float);

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -225,7 +225,10 @@ extern "C" {
     __device__
     void osl_printf (void* sg_, char* fmt_str, void* args)
     {
-        printf (fmt_str, args);
+        // FIXME: This is to limit printing to one Cuda thread
+        //        Mainly to keep the testsuite happy.
+        if (launch_index.x == 0 && launch_index.y == 0)
+            vprintf(fmt_str, (const char*) args);
     }
 
 

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -225,10 +225,10 @@ extern "C" {
     __device__
     void osl_printf (void* sg_, char* fmt_str, void* args)
     {
-        // FIXME: This is to limit printing to one Cuda thread
-        //        Mainly to keep the testsuite happy.
-        if (launch_index.x == 0 && launch_index.y == 0)
-            vprintf(fmt_str, (const char*) args);
+        // This can be used to limit printing to one Cuda thread for debugging
+        // if (launch_index.x == 0 && launch_index.y == 0)
+        //
+        vprintf(fmt_str, (const char*) args);
     }
 
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -169,8 +169,11 @@ OptixGridRenderer::make_optix_materials ()
         shadingsys->optimize_group (groupref.get(), nullptr);
 
         if (!shadingsys->find_symbol (*groupref.get(), ustring(outputs[0]))) {
-            errhandler().warning ("Requested output '%s', which wasn't found",
-                                  outputs[0]);
+            // Asume a 1 x 1 image maybe testing things other than Cout 
+            if (m_xres > 1 || m_yres > 1) {
+                errhandler().warning ("Requested output '%s', which wasn't found",
+                                      outputs[0]);
+            }
         }
 
         std::string group_name, init_name, entry_name;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -169,7 +169,8 @@ OptixGridRenderer::make_optix_materials ()
         shadingsys->optimize_group (groupref.get(), nullptr);
 
         if (!shadingsys->find_symbol (*groupref.get(), ustring(outputs[0]))) {
-            // Asume a 1 x 1 image maybe testing things other than Cout 
+            // FIXME: This is for cases where testshade is run with 1x1 resolution
+            //        Those tests may not have a Cout parameter to write to.
             if (m_xres > 1 || m_yres > 1) {
                 errhandler().warning ("Requested output '%s', which wasn't found",
                                       outputs[0]);

--- a/testsuite/printf-whole-array/ref/out.txt
+++ b/testsuite/printf-whole-array/ref/out.txt
@@ -2,7 +2,7 @@ Compiled test.osl -> test.oso
 iarray = 1 2 3 4 5
 sarray = a b c d e
 farray = 1.000000 2.000000 3.000000 4.000000 5.000000
-ielems = 5 4 3 2 1
-selems = e d c b a
-felems = 5.000000 4.000000 3.000000 2.000000 1.000000
+ielems reversed = 5 4 3 2 1
+selems reversed = e d c b a
+felems reversed = 5.000000 4.000000 3.000000 2.000000 1.000000
 

--- a/testsuite/printf-whole-array/ref/out.txt
+++ b/testsuite/printf-whole-array/ref/out.txt
@@ -2,4 +2,7 @@ Compiled test.osl -> test.oso
 iarray = 1 2 3 4 5
 sarray = a b c d e
 farray = 1.000000 2.000000 3.000000 4.000000 5.000000
+ielems = 5 4 3 2 1
+selems = e d c b a
+felems = 5.000000 4.000000 3.000000 2.000000 1.000000
 

--- a/testsuite/printf-whole-array/test.osl
+++ b/testsuite/printf-whole-array/test.osl
@@ -7,5 +7,9 @@ shader test (
     printf ("iarray = %i\n", iarray);
     printf ("sarray = %s\n", sarray);
     printf ("farray = %f\n", farray);
-}
 
+    // Make sure the elements are reachable
+    printf ("ielems = %d %d %d %d %d\n", iarray[4], iarray[3], iarray[2], iarray[1], iarray[0]);
+    printf ("selems = %s %s %s %s %s\n", sarray[4], sarray[3], sarray[2], sarray[1], sarray[0]);
+    printf ("felems = %f %f %f %f %f\n", farray[4], farray[3], farray[2], farray[1], farray[0]);
+}

--- a/testsuite/printf-whole-array/test.osl
+++ b/testsuite/printf-whole-array/test.osl
@@ -9,7 +9,7 @@ shader test (
     printf ("farray = %f\n", farray);
 
     // Make sure the elements are reachable
-    printf ("ielems = %d %d %d %d %d\n", iarray[4], iarray[3], iarray[2], iarray[1], iarray[0]);
-    printf ("selems = %s %s %s %s %s\n", sarray[4], sarray[3], sarray[2], sarray[1], sarray[0]);
-    printf ("felems = %f %f %f %f %f\n", farray[4], farray[3], farray[2], farray[1], farray[0]);
+    printf ("ielems reversed = %d %d %d %d %d\n", iarray[4], iarray[3], iarray[2], iarray[1], iarray[0]);
+    printf ("selems reversed = %s %s %s %s %s\n", sarray[4], sarray[3], sarray[2], sarray[1], sarray[0]);
+    printf ("felems reversed = %f %f %f %f %f\n", farray[4], farray[3], farray[2], farray[1], farray[0]);
 }


### PR DESCRIPTION
## Description
Hopefully this'll make picking off tests a bit easier.
I haven't found much documentation about Cuda's vprintf, but it seems to be supported back to at least v6 ?

## Tests
Enabled printf-whole-array for Optix, and added some lines.
