### PR TITLE
Warn about missed optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             noise-perlin noise-simplex
             pnoise pnoise-cell pnoise-gabor pnoise-perlin
             operator-overloading
+            opt-warnings
             oslc-comma oslc-D
             oslc-err-arrayindex oslc-err-assignmenttypes
             oslc-err-closuremul oslc-err-field

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -109,6 +109,10 @@ public:
     ///    int no_noise           Replace noise with constant value. (0)
     ///    int no_pointcloud      Skip pointcloud lookups. (0)
     ///    int exec_repeat        How many times to run each group (1).
+    ///    int opt_warnings       Warn on certain failure to runtime-optimize
+    ///                              cetain shader constructs. (0)
+    ///    int gpu_opt_error      Consider a hard error if certain shader
+    ///                              constructs cannot be optimized away. (0)
     /// 2. Attributes that should be set by applications/renderers that
     /// incorporate OSL:
     ///    string commonspace     Name of "common" coord system ("world")

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2987,6 +2987,7 @@ LLVMGEN (llvm_gen_gettextureinfo)
     /* Do not leave derivs uninitialized */
     if (Data.has_derivs())
         rop.llvm_zero_derivs (Data);
+    rop.generated_texture_call (texture_handle != NULL);
 
     return true;
 }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -802,6 +802,9 @@ private:
     bool m_force_derivs;                  ///< Force derivs on everything
     bool m_allow_shader_replacement;      ///< Allow shader masters to replace
     int m_exec_repeat;                    ///< How many times to execute group
+    int m_opt_warnings;                   ///< Warn on inability to optimize
+    int m_gpu_opt_error;                  ///< Error on inability to optimize
+                                          ///<   away things that can't GPU.
 
     // Derived/cached calculations from options:
     Color3 m_Red, m_Green, m_Blue;        ///< Color primaries (xyY)

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3300,19 +3300,21 @@ RuntimeOptimizer::run ()
 bool
 RuntimeOptimizer::police(const Opcode& op, string_view msg, int type)
 {
-    if (type == police_gpu_err && shadingsys().m_gpu_opt_error) {
+    if ((type & police_gpu_err) && shadingsys().m_gpu_opt_error) {
         shadingcontext()->error ("Optimization error for GPUs:\n"
-                                 "  group: %s\n"
-                                 "  layer: %s\n"
-                                 "  %s:%d: %s",
+                                 "  group:  %s\n"
+                                 "  layer:  %s\n"
+                                 "  source: %s:%d\n"
+                                 "  issue:  %s",
                                  group().name(), inst()->layername(),
                                  op.sourcefile(), op.sourceline(), msg);
         return true;
-    } else {
+    } else if ((type & police_opt_warn) && shadingsys().m_opt_warnings) {
         shadingcontext()->warning ("Optimization warning:\n"
-                                 "  group: %s\n"
-                                 "  layer: %s\n"
-                                 "  %s:%d: %s",
+                                 "  group:  %s\n"
+                                 "  layer:  %s\n"
+                                 "  source: %s:%d\n"
+                                 "  issue:  %s",
                                  group().name(), inst()->layername(),
                                  op.sourcefile(), op.sourceline(), msg);
     }

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3296,5 +3296,64 @@ RuntimeOptimizer::run ()
 }
 
 
+
+bool
+RuntimeOptimizer::police(const Opcode& op, string_view msg, int type)
+{
+    if (type == police_gpu_err && shadingsys().m_gpu_opt_error) {
+        shadingcontext()->error ("Optimization error for GPUs:\n"
+                                 "  group: %s\n"
+                                 "  layer: %s\n"
+                                 "  %s:%d: %s",
+                                 group().name(), inst()->layername(),
+                                 op.sourcefile(), op.sourceline(), msg);
+        return true;
+    } else {
+        shadingcontext()->warning ("Optimization warning:\n"
+                                 "  group: %s\n"
+                                 "  layer: %s\n"
+                                 "  %s:%d: %s",
+                                 group().name(), inst()->layername(),
+                                 op.sourcefile(), op.sourceline(), msg);
+    }
+    return false;
+}
+
+
+
+bool
+RuntimeOptimizer::police_failed_optimizations()
+{
+    using OIIO::Strutil::format;
+    bool err = false;
+    bool do_warn = shadingsys().m_opt_warnings;
+    bool do_gpu_err = shadingsys().m_gpu_opt_error;
+    if (!do_warn && !do_gpu_err)
+        return false;  // no need for any of this expense
+
+    int nlayers = (int) group().nlayers ();
+    for (int layer = 0;  layer < nlayers;  ++layer) {
+        set_inst (layer);
+        if (inst()->unused())
+            continue;  // no need to print or gather stats for unused layers
+        for (auto&& op : inst()->ops()) {
+            const OpDescriptor *opd = shadingsys().op_descriptor (op.opname());
+            if (! opd)
+                continue;
+            if (opd->flags & OpDescriptor::Tex) {
+                Symbol *sym = opargsym (op, 1);  // arg 1 is texture name
+                DASSERT (sym && sym->typespec().is_string());
+                if (! sym->is_constant()) {
+                    err |= police (op, format("%s(): texture name cannot be reduced to a constant.",
+                                              op.opname()),
+                                   police_gpu_err);
+                }
+            }
+            // FIXME: Will add more tests and warnings as we go
+        }
+    }
+    return err;
+}
+
 }; // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -411,8 +411,8 @@ public:
     /// After optimization, check for things that should not be left
     /// unoptimized.
     bool police_failed_optimizations ();
-    enum { police_warn_only = 0, police_gpu_err = 1 };
-    bool police(const Opcode& op, string_view msg, int type = police_warn_only);
+    enum { police_opt_warn = 1, police_gpu_err = 3, police_gpu_err_only = 2 };  // bit field
+    bool police(const Opcode& op, string_view msg, int type = police_opt_warn);
 
 private:
     int m_optimize;                   ///< Current optimization level

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -408,6 +408,12 @@ public:
                              const FastIntSet *excluded=NULL,
                              bool copy_temps=false);
 
+    /// After optimization, check for things that should not be left
+    /// unoptimized.
+    bool police_failed_optimizations ();
+    enum { police_warn_only = 0, police_gpu_err = 1 };
+    bool police(const Opcode& op, string_view msg, int type = police_warn_only);
+
 private:
     int m_optimize;                   ///< Current optimization level
     bool m_opt_simplify_param;            ///< Turn instance params into const?

--- a/testsuite/opt-warnings/ref/out.txt
+++ b/testsuite/opt-warnings/ref/out.txt
@@ -1,0 +1,11 @@
+Compiled test.osl -> test.oso
+WARNING: Optimization warning:
+  group: MyGroup
+  layer: TestLayer
+  test.osl:13: texture(): texture name cannot be reduced to a constant.
+WARNING: Optimization warning:
+  group: MyGroup
+  layer: TestLayer
+  test.osl:20: gettextureinfo(): texture name cannot be reduced to a constant.
+C = 1 0 0
+exists = 0

--- a/testsuite/opt-warnings/ref/out.txt
+++ b/testsuite/opt-warnings/ref/out.txt
@@ -1,11 +1,13 @@
 Compiled test.osl -> test.oso
 WARNING: Optimization warning:
-  group: MyGroup
-  layer: TestLayer
-  test.osl:13: texture(): texture name cannot be reduced to a constant.
+  group:  MyGroup
+  layer:  TestLayer
+  source: test.osl:13
+  issue:  texture(): texture name cannot be reduced to a constant.
 WARNING: Optimization warning:
-  group: MyGroup
-  layer: TestLayer
-  test.osl:20: gettextureinfo(): texture name cannot be reduced to a constant.
+  group:  MyGroup
+  layer:  TestLayer
+  source: test.osl:20
+  issue:  gettextureinfo(): texture name cannot be reduced to a constant.
 C = 1 0 0
 exists = 0

--- a/testsuite/opt-warnings/run.py
+++ b/testsuite/opt-warnings/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("-options opt_warnings=1 -groupname MyGroup -layer TestLayer test")

--- a/testsuite/opt-warnings/test.osl
+++ b/testsuite/opt-warnings/test.osl
@@ -1,0 +1,23 @@
+// This tests shader idioms that don't runtime-optimize well.
+
+
+shader test (
+    // Purposefully make a param that can't be constant-folded
+    int frame = 1 [[ int lockgeom = 0 ]],
+    output color Cout = 0)
+{
+    string varying_name = format("foo%04d.tif", frame);
+
+    // texture of a non-constant filename
+    {
+        color C = texture (varying_name, u, v, "missingcolor", color(1,0,0));
+        printf ("C = %g\n", C);
+    }
+
+    // gettextureinfo of a non-constant filename
+    {
+        int exists = 0;
+        gettextureinfo (varying_name, "exists", exists);
+        printf ("exists = %d", exists);
+    }
+}


### PR DESCRIPTION
* Properly track gettextureinfo handle use in the stats.

* New ShadingSystem option: "opt_warnings" enables warnings about
  things that couldn't be optimized and may be performance issues.

* New ShadingSystem option: "gpu_opt_error" enables full error status
  of the subset of those warnings that are also hard no-go's when
  executing on GPUs.

As an example, the first such warning/error is for texture calls where
the name of the texture cannot be fully resolved to a known string
constant during the course of runtime optimization. We will add other
warnings/errors over time.

The warnings/errors are sent back to the renderer's ErrorHandler,
and as an example they look like this:

    Optimization warning:
      group: bumpy_material_14
      layer: disp_texture_2
      shaders/tex.osl:58: texture(): texture name cannot be reduced to a constant


