### PR TITLE
Optix simplification / cleanup

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -79,6 +79,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  endif
 #endif
 
+#ifndef OSL_CONSTANT_DATA
+#  ifdef __CUDA_ARCH__
+#    define OSL_CONSTANT_DATA __constant__
+#  else
+#    define OSL_CONSTANT_DATA
+#  endif
+#endif
+
 // Symbol export defines
 #include "export.h"
 

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -150,6 +150,15 @@ public:
     /// reside in a global variable, the groupdata struct, or a local value.
     llvm::Value *llvm_load_device_string (const Symbol& sym);
 
+    /// Convenience function to load a string for CPU or GPU device
+    llvm::Value *llvm_load_string (const Symbol& sym) {
+        if (!use_optix())
+            return llvm_load_value (sym);
+
+        ASSERT(sym.typespec().is_string());
+        return llvm_load_device_string(sym);
+    }
+
     /// Legacy version
     ///
     llvm::Value *loadLLVMValue (const Symbol& sym, int component=0,

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -152,11 +152,8 @@ public:
 
     /// Convenience function to load a string for CPU or GPU device
     llvm::Value *llvm_load_string (const Symbol& sym) {
-        if (!use_optix())
-            return llvm_load_value (sym);
-
-        ASSERT(sym.typespec().is_string());
-        return llvm_load_device_string(sym);
+        DASSERT(sym.typespec().is_string());
+        return use_optix() ? llvm_load_device_string(sym) : llvm_load_value(sym);
     }
 
     /// Legacy version

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2817,12 +2817,7 @@ LLVMGEN (llvm_gen_noise)
     std::string funcname = "osl_" + name.string() + "_" + arg_typecode(&Result,derivs);
     std::vector<llvm::Value *> args;
     if (pass_name) {
-        if (! rop.use_optix()) {
-            args.push_back (rop.llvm_load_value(*Name));
-        }
-        else {
-            args.push_back (rop.llvm_load_device_string (*Name));
-        }
+        args.push_back (rop.llvm_load_string (*Name));
     }
     llvm::Value *tmpresult = NULL;
     // triple return, or float return with derivs, passes result pointer
@@ -3191,12 +3186,7 @@ LLVMGEN (llvm_gen_spline)
         name += "v";
 
     args.push_back (rop.llvm_void_ptr (Result));
-    if (rop.use_optix() && Spline.typespec().is_string()) {
-        args.push_back (rop.llvm_load_device_string (Spline));
-    }
-    else {
-        args.push_back (rop.llvm_load_value (Spline));
-    }
+    args.push_back (rop.llvm_load_string (Spline));
     args.push_back (rop.llvm_void_ptr (Value)); // make things easy
     args.push_back (rop.llvm_void_ptr (Knots));
     if (has_knot_count)

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1220,8 +1220,16 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
         return true;
     }
     if (name == "lib_bitcode" && type.basetype == TypeDesc::UINT8) {
+        if (type.arraylen < 0) {
+            error ("Invalid bitcode size: %d", type.arraylen);
+            return false;
+        }
         m_lib_bitcode.clear();
-        m_lib_bitcode = *static_cast<const std::vector<char>*>(val);
+        if (type.arraylen) {
+            const char* bytes = static_cast<const char*>(val);
+            std::copy(bytes, bytes + type.arraylen,
+                      back_inserter(m_lib_bitcode));
+        }
         return true;
     }
     if (name == "error_repeats") {

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -28,15 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#ifdef __CUDACC__
-  #include <optix.h>
-#endif
-
-// avoid naming conflict with MSVC macro
-#ifdef BTYPE
-#undef BTYPE
-#endif
-
 OSL_NAMESPACE_ENTER
 
 namespace pvt {
@@ -70,54 +61,50 @@ enum {
     kNumSplineTypes
 };
 
-#ifdef __CUDACC__
-    rtBuffer<SplineBasis> gBasisSet;
-#else
-    const static SplineBasis gBasisSet[kNumSplineTypes] = {
-    //
-    // catmullrom
-    //
-       { 1, { {(-1.0f/2.0f),  ( 3.0f/2.0f), (-3.0f/2.0f), ( 1.0f/2.0f)},
-              {( 2.0f/2.0f),  (-5.0f/2.0f), ( 4.0f/2.0f), (-1.0f/2.0f)},
-              {(-1.0f/2.0f),  ( 0.0f/2.0f), ( 1.0f/2.0f), ( 0.0f/2.0f)},
-              {( 0.0f/2.0f),  ( 2.0f/2.0f), ( 0.0f/2.0f), ( 0.0f/2.0f)}  } },
-    //
-    // bezier
-    //
-       { 3, { {-1,  3, -3,  1},
-              { 3, -6,  3,  0},
-              {-3,  3,  0,  0},
-              { 1,  0,  0,  0} } },
-    //
-    // bspline
-    //
-       { 1, { {(-1.0f/6.0f), ( 3.0f/6.0f),  (-3.0f/6.0f),  (1.0f/6.0f)},
-              {( 3.0f/6.0f), (-6.0f/6.0f),  ( 3.0f/6.0f),  (0.0f/6.0f)},
-              {(-3.0f/6.0f), ( 0.0f/6.0f),  ( 3.0f/6.0f),  (0.0f/6.0f)},
-              {( 1.0f/6.0f), ( 4.0f/6.0f),  ( 1.0f/6.0f),  (0.0f/6.0f)} } },
-    //
-    // hermite
-    //
-       { 2, { { 2,  1, -2,  1},
-              {-3, -2,  3, -1},
-              { 0,  1,  0,  0},
-              { 1,  0,  0,  0} } },
-    //
-    // linear
-    //
-       { 1, { {0,  0,  0,  0},
-              {0,  0,  0,  0},
-              {0, -1,  1,  0},
-              {0,  1,  0,  0} } },
-    //
-    // constant
-    //
-       { 1, { {0,  0,  0,  0},
-              {0,  0,  0,  0},
-              {0,  0,  0,  0},
-              {0,  0,  0,  0} } }
-    };
-#endif
+OSL_CONSTANT_DATA const static SplineBasis gBasisSet[kNumSplineTypes] = {
+//
+// catmullrom
+//
+   { 1, { {(-1.0f/2.0f),  ( 3.0f/2.0f), (-3.0f/2.0f), ( 1.0f/2.0f)},
+          {( 2.0f/2.0f),  (-5.0f/2.0f), ( 4.0f/2.0f), (-1.0f/2.0f)},
+          {(-1.0f/2.0f),  ( 0.0f/2.0f), ( 1.0f/2.0f), ( 0.0f/2.0f)},
+          {( 0.0f/2.0f),  ( 2.0f/2.0f), ( 0.0f/2.0f), ( 0.0f/2.0f)}  } },
+//
+// bezier
+//
+   { 3, { {-1,  3, -3,  1},
+          { 3, -6,  3,  0},
+          {-3,  3,  0,  0},
+          { 1,  0,  0,  0} } },
+//
+// bspline
+//
+   { 1, { {(-1.0f/6.0f), ( 3.0f/6.0f),  (-3.0f/6.0f),  (1.0f/6.0f)},
+          {( 3.0f/6.0f), (-6.0f/6.0f),  ( 3.0f/6.0f),  (0.0f/6.0f)},
+          {(-3.0f/6.0f), ( 0.0f/6.0f),  ( 3.0f/6.0f),  (0.0f/6.0f)},
+          {( 1.0f/6.0f), ( 4.0f/6.0f),  ( 1.0f/6.0f),  (0.0f/6.0f)} } },
+//
+// hermite
+//
+   { 2, { { 2,  1, -2,  1},
+          {-3, -2,  3, -1},
+          { 0,  1,  0,  0},
+          { 1,  0,  0,  0} } },
+//
+// linear
+//
+   { 1, { {0,  0,  0,  0},
+          {0,  0,  0,  0},
+          {0, -1,  1,  0},
+          {0,  1,  0,  0} } },
+//
+// constant
+//
+   { 1, { {0,  0,  0,  0},
+          {0,  0,  0,  0},
+          {0,  0,  0,  0},
+          {0,  0,  0,  0} } }
+};
 
 struct SplineInterp {
     const SplineBasis& spline;

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/oslconfig.h>
 
 #include "optixraytracer.h"
-#include "../liboslexec/splineimpl.h"
 
 // The pre-compiled renderer support library LLVM bitcode is embedded
 // into the executable and made available through these variables.
@@ -112,17 +111,6 @@ OptixRaytracer::init_optix_context (int xres, int yres)
     // Create the OptiX programs and set them on the optix::Context
     m_program = m_optix_ctx->createProgramFromPTXString(renderer_ptx, "raygen");
     m_optix_ctx->setRayGenerationProgram(0, m_program);
-
-    {
-        optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
-        buffer->setElementSize(sizeof(pvt::Spline::SplineBasis));
-        buffer->setSize(sizeof(pvt::Spline::gBasisSet)/sizeof(pvt::Spline::SplineBasis));
-
-        pvt::Spline::SplineBasis* basis = (pvt::Spline::SplineBasis*) buffer->map();
-        ::memcpy(basis, &pvt::Spline::gBasisSet[0], sizeof(pvt::Spline::gBasisSet));
-        buffer->unmap();
-        m_optix_ctx[OSL_NAMESPACE_STRING "::pvt::Spline::gBasisSet"]->setBuffer(buffer);
-    }
 
     if (scene.num_prims()) {
         m_optix_ctx["radiance_ray_type"]->setUint  (0u);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -82,11 +82,8 @@ bool
 OptixRaytracer::init_optix_context (int xres, int yres)
 {
 #ifdef OSL_USE_OPTIX
-    std::vector<char> lib_bitcode;
-    std::copy (&rend_llvm_compiled_ops_block[0],
-               &rend_llvm_compiled_ops_block[rend_llvm_compiled_ops_size],
-               back_inserter(lib_bitcode));
-    shadingsys->attribute ("lib_bitcode", OSL::TypeDesc::UINT8, &lib_bitcode);
+    shadingsys->attribute ("lib_bitcode", {OSL::TypeDesc::UINT8, rend_llvm_compiled_ops_size},
+                           rend_llvm_compiled_ops_block);
 
     // Set up the OptiX context
     m_optix_ctx = optix::Context::create();

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/oslconfig.h>
 
 #include "optixgridrender.h"
-#include "../liboslexec/splineimpl.h"
 
 
 // The pre-compiled renderer support library LLVM bitcode is embedded
@@ -129,17 +128,6 @@ OptixGridRenderer::init_optix_context (int xres, int yres)
     // Create the OptiX programs and set them on the optix::Context
     m_program = m_optix_ctx->createProgramFromPTXString(renderer_ptx, "raygen");
     m_optix_ctx->setRayGenerationProgram(0, m_program);
-
-    {
-        optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
-        buffer->setElementSize(sizeof(pvt::Spline::SplineBasis));
-        buffer->setSize(sizeof(pvt::Spline::gBasisSet)/sizeof(pvt::Spline::SplineBasis));
-
-        pvt::Spline::SplineBasis* basis = (pvt::Spline::SplineBasis*) buffer->map();
-        ::memcpy(basis, &pvt::Spline::gBasisSet[0], sizeof(pvt::Spline::gBasisSet));
-        buffer->unmap();
-        m_optix_ctx[OSL_NAMESPACE_STRING "::pvt::Spline::gBasisSet"]->setBuffer(buffer);
-    }
 #endif
     return true;
 }

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -203,30 +203,8 @@ OptixGridRenderer::finalize_scene()
 #ifdef OSL_USE_OPTIX
     make_optix_materials();
 
-    // Create a GeometryGroup to contain the scene geometry
-    optix::GeometryGroup geom_group = m_optix_ctx->createGeometryGroup();
-
-    m_optix_ctx["top_object"  ]->set (geom_group);
-    m_optix_ctx["top_shadower"]->set (geom_group);
-
-    // NB: Since the scenes in the test suite consist of only a few primitives,
-    //     using 'NoAccel' instead of 'Trbvh' might yield a slight performance
-    //     improvement. For more complex scenes (e.g., scenes with meshes),
-    //     using 'Trbvh' is recommended to achieve maximum performance.
-    geom_group->setAcceleration (m_optix_ctx->createAcceleration ("Trbvh"));
-
-    // Set the camera variables on the OptiX Context, to be used by the ray gen program
-#if 0
-    m_optix_ctx["eye" ]->setFloat (vec3_to_float3 (camera.eye));
-    m_optix_ctx["dir" ]->setFloat (vec3_to_float3 (camera.dir));
-    m_optix_ctx["cx"  ]->setFloat (vec3_to_float3 (camera.cx));
-    m_optix_ctx["cy"  ]->setFloat (vec3_to_float3 (camera.cy));
-    m_optix_ctx["invw"]->setFloat (camera.invw);
-    m_optix_ctx["invh"]->setFloat (camera.invh);
-#else
     m_optix_ctx["invw"]->setFloat (1.0f/m_xres);
     m_optix_ctx["invh"]->setFloat (1.0f/m_yres);
-#endif
 
     // Create the output buffer
     optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_OUTPUT, RT_FORMAT_FLOAT3, m_xres, m_yres);

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -102,11 +102,8 @@ OptixGridRenderer::init_shadingsys (ShadingSystem *ss)
     shadingsys = ss;
 
 #ifdef OSL_USE_OPTIX
-    std::vector<char> lib_bitcode;
-    std::copy (&rend_llvm_compiled_ops_block[0],
-               &rend_llvm_compiled_ops_block[rend_llvm_compiled_ops_size],
-               back_inserter(lib_bitcode));
-    shadingsys->attribute ("lib_bitcode", OSL::TypeDesc::UINT8, &lib_bitcode);
+    shadingsys->attribute ("lib_bitcode", {OSL::TypeDesc::UINT8, rend_llvm_compiled_ops_size},
+                           rend_llvm_compiled_ops_block);
 #endif
 }
 


### PR DESCRIPTION
## Description
Trying to simplify / cleanup portions of the current implementation.

Make OSL::pvt::gSplineData constant which can avoid avoid CPU->GPU upload.
Introduce BackendLLVM::llvm_load_string to localize the branching done when uploading strings.
Send actual bitcode bytes vs a point to std::vector (which is currently incurring a temporary allocation penalty)