### PR TITLE
__attribute__((aligned())) does not work on Windows (no error is give…

### DIFF
--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -188,8 +188,8 @@ RT_PROGRAM void closest_hit_osl()
     //       networks, so there should be (at least) some mechanism to issue a
     //       warning or error if the closure or param storage can possibly be
     //       exceeded.
-    __attribute__((aligned(8))) char closure_pool[256];
-    __attribute__((aligned(8))) char params      [256];
+    alignas(8) char closure_pool[256];
+    alignas(8) char params      [256];
 
     ShaderGlobals sg;
     globals_from_hit (sg);

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -60,8 +60,8 @@ RT_PROGRAM void raygen()
     //       networks, so there should be (at least) some mechanism to issue a
     //       warning or error if the closure or param storage can possibly be
     //       exceeded.
-    __attribute__((aligned(8))) char closure_pool[256];
-    __attribute__((aligned(8))) char params      [256];
+    alignas(8) char closure_pool[256];
+    alignas(8) char params      [256];
 
     ShaderGlobals sg;
     // Setup the ShaderGlobals


### PR DESCRIPTION
…n even though alignment never happens). Use C++11 alignas for cross-platform compatibility.

As we know from ```OIIO_ALIGN```, windows and linux use different mechanisms for specifying alignment before c++11. The cuda code is using the linux version and works on linux but on Windows it would compile without warning and then fail at runtime with alignment errors. The simplest fix is to just switch over to the C++11 ```alignas```, which is what we already do with ```OSL_ALIGNAS```. Note that this is cuda code so no need for the gcc fix in ```OSL_ALIGNAS```, but I suppose that could be safely substituted in if consistency is desired? 

## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

