### PR TITLE
Install crash handlers with stack trace dump

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ before_build:
 
     $DWN_DIR = "C:\projects\OSLdownloads"
     $DEP_DIR = "C:\projects\OSLdeps"
-    $BOOST_ROOT = "C:\Libraries\boost_1_63_0"
+    $BOOST_ROOT = "C:\Libraries\boost_1_69_0"
     $PYTHON_DIR = "C:\Python27"
     $LLVM_DIR = "C:\Libraries\llvm-5.0.0"
     #$LLVM_DIR = "$DEP_DIR"

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -117,6 +117,12 @@ main (int argc, const char *argv[])
     // internationalization, for the entire oslc application.
     std::locale::global (std::locale::classic());
 
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
+
     OIIO::Filesystem::convert_native_arguments (argc, (const char **)argv);
 
     if (argc <= 1) {

--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -51,10 +51,11 @@ Sony Pictures Imageworks terms, above.
 #include <string>
 #include <cstring>
 
-#include <OpenImageIO/strutil.h>
 #include <OpenImageIO/argparse.h>
-#include <OpenImageIO/timer.h>
 #include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/timer.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
 
 #include <OSL/oslquery.h>
 using namespace OSL;
@@ -255,6 +256,12 @@ main (int argc, char *argv[])
     // Globally force classic "C" locale, and turn off all formatting
     // internationalization, for the entire oslinfo application.
     std::locale::global (std::locale::classic());
+
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
 
     OIIO::Filesystem::convert_native_arguments (argc, (const char **)argv);
 

--- a/src/osltoy/osltoymain.cpp
+++ b/src/osltoy/osltoymain.cpp
@@ -101,6 +101,12 @@ getargs (int argc, char *argv[])
 int
 main (int argc, char* argv[])
 {
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
+
     OIIO::Filesystem::convert_native_arguments (argc, (const char **)argv);
 
     getargs (argc, argv);

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -178,6 +178,12 @@ void getargs(int argc, const char *argv[])
 int
 main (int argc, const char *argv[])
 {
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
+
     try {
         using namespace OIIO;
         Timer timer;

--- a/src/testshade/testshade_dso.cpp
+++ b/src/testshade/testshade_dso.cpp
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include <OpenImageIO/plugin.h>
+#include <OpenImageIO/sysutil.h>
 using namespace OIIO;
 
 
@@ -45,6 +46,12 @@ typedef int (*EntryPoint)(int argc, const char *argv[]);
 int
 main (int argc, const char *argv[])
 {
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
+
     std::string pluginname = std::string("libtestshade.") 
                              + Plugin::plugin_extension();
     Plugin::Handle handle = Plugin::open (pluginname, 

--- a/src/testshade/testshademain.cpp
+++ b/src/testshade/testshademain.cpp
@@ -31,6 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <exception>
 
+#include <OpenImageIO/sysutil.h>
+
 using namespace OSL;         // For OSL::optix when OSL_USE_OPTIX=0
 
 extern "C" int test_shade (int argc, const char *argv[]);
@@ -39,6 +41,12 @@ extern "C" int test_shade (int argc, const char *argv[]);
 int
 main (int argc, const char *argv[])
 {
+#ifdef OIIO_HAS_STACKTRACE
+    // Helpful for debugging to make sure that any crashes dump a stack
+    // trace.
+    OIIO::Sysutil::setup_crash_stacktrace("stdout");
+#endif
+
     int result = EXIT_FAILURE;
     try {
         result = test_shade (argc, argv);

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -254,6 +254,9 @@ def runtest (command, outputs, failureok=0, failthresh=0, failpercent=0) :
         if cmdret != 0 and failureok == 0 :
             print ("#### Error: this command failed: ", sub_command)
             print ("FAIL")
+            print ("Output was:\n--------")
+            print (open ("out.txt", 'rU').read())
+            print ("--------")
             return (1)
 
     err = 0


### PR DESCRIPTION
Recently, OIIO sysutil.h added a way to set up a stack trace dump in
case of crash. Use those in OSL binary commands (it does not
automatically happen from the library). This only work with a new
enough version of OIIO, and only if that OIIO was compiled with a new
enough boost to contain boost's stack trace library (>= 1.65).

This is primarily to help developers figure out what's going on with
CI tests fail on remote machines -- you can't catch it in the
debugger, but maybe the stack trace will give you the clue you need as
to what's going on. I definitely don't expect it to be very helpful if
the crash happens in the JITed shader. But if the crash is in our code,
maybe it will help the detective work.

To that end, we also change the testsuite runtest.py so that when a
command fails entirely, print its console output.

And bump appveyor boost to 1.69, so that it's new enough to support
the stack trace library.
