### PR TITLE
Improve errors for badly formed serialized shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,8 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             debugnan debug-uninit
             derivs derivs-muldiv-clobber
             draw_string
-            error-dupes exit exponential
+            error-dupes error-serialized
+            exit exponential
             fprintf
             function-earlyreturn function-simple function-outputelem
             function-overloads function-redef

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1130,7 +1130,8 @@ test_shade (int argc, const char *argv[])
     // options change their values.
     set_shadingsys_options ();
 
-    shadingsys->attribute (shadergroup.get(), "groupname", groupname);
+    if (groupname.size())
+        shadingsys->attribute (shadergroup.get(), "groupname", groupname);
 
     // Now set up the connections
     for (size_t i = 0;  i < connections.size();  i += 4) {

--- a/testsuite/allowconnect-err/ref/out.txt
+++ b/testsuite/allowconnect-err/ref/out.txt
@@ -2,3 +2,4 @@ Compiled a.osl -> a.oso
 Compiled b.osl -> b.oso
 Connect alayer.f_out to blayer.f_in
 ERROR: ConnectShaders: cannot connect to blayer.f_in because it has metadata allowconnect=0
+        group: unnamed_group_1

--- a/testsuite/array-range/ref/out-alt.txt
+++ b/testsuite/array-range/ref/out-alt.txt
@@ -2,10 +2,10 @@ Compiled test.osl -> test.oso
 constant index:
  reading:
   array[1] = 1
-ERROR: Index [10] out of range $const1[0..4]: test.osl:8 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range $const1[0..4]: test.osl:8 (group unnamed_group_1, layer 0 test_0, shader test)
   array[10] = 4
  writing:
-ERROR: Index [10] out of range array[0..4]: test.osl:10 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range array[0..4]: test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test)
 variable index:
  reading:
   array[0] = 0
@@ -13,8 +13,8 @@ variable index:
   array[2] = 2
   array[3] = 3
   array[4] = 42
-ERROR: Index [5] out of range array[0..4]: test.osl:15 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [5] out of range array[0..4]: test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test)
   array[5] = 42
  writing:
-ERROR: Index [5] out of range array[0..4]: test.osl:19 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [5] out of range array[0..4]: test.osl:19 (group unnamed_group_1, layer 0 test_0, shader test)
 

--- a/testsuite/array-range/ref/out.txt
+++ b/testsuite/array-range/ref/out.txt
@@ -2,10 +2,10 @@ Compiled test.osl -> test.oso
 constant index:
  reading:
   array[1] = 1
-ERROR: Index [10] out of range array[0..4]: test.osl:8 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range array[0..4]: test.osl:8 (group unnamed_group_1, layer 0 test_0, shader test)
   array[10] = 4
  writing:
-ERROR: Index [10] out of range array[0..4]: test.osl:10 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range array[0..4]: test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test)
 variable index:
  reading:
   array[0] = 0
@@ -13,8 +13,8 @@ variable index:
   array[2] = 2
   array[3] = 3
   array[4] = 42
-ERROR: Index [5] out of range array[0..4]: test.osl:15 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [5] out of range array[0..4]: test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test)
   array[5] = 42
  writing:
-ERROR: Index [5] out of range array[0..4]: test.osl:19 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [5] out of range array[0..4]: test.osl:19 (group unnamed_group_1, layer 0 test_0, shader test)
 

--- a/testsuite/component-range/ref/out-alt.txt
+++ b/testsuite/component-range/ref/out-alt.txt
@@ -2,17 +2,17 @@ Compiled test.osl -> test.oso
 constant index:
  reading:
   V[1] = 1
-ERROR: Index [10] out of range $const1[0..2]: test.osl:8 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range $const1[0..2]: test.osl:8 (group unnamed_group_1, layer 0 test_0, shader test)
   V[10] = 2
  writing:
-ERROR: Index [10] out of range V[0..2]: test.osl:10 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range V[0..2]: test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test)
 variable index:
  reading:
   V[0] = 0
   V[1] = 1
   V[2] = 42
-ERROR: Index [3] out of range V[0..2]: test.osl:15 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [3] out of range V[0..2]: test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test)
   V[3] = 42
  writing:
-ERROR: Index [3] out of range V[0..2]: test.osl:19 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [3] out of range V[0..2]: test.osl:19 (group unnamed_group_1, layer 0 test_0, shader test)
 

--- a/testsuite/component-range/ref/out.txt
+++ b/testsuite/component-range/ref/out.txt
@@ -2,17 +2,17 @@ Compiled test.osl -> test.oso
 constant index:
  reading:
   V[1] = 1
-ERROR: Index [10] out of range V[0..2]: test.osl:8 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range V[0..2]: test.osl:8 (group unnamed_group_1, layer 0 test_0, shader test)
   V[10] = 2
  writing:
-ERROR: Index [10] out of range V[0..2]: test.osl:10 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [10] out of range V[0..2]: test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test)
 variable index:
  reading:
   V[0] = 0
   V[1] = 1
   V[2] = 42
-ERROR: Index [3] out of range V[0..2]: test.osl:15 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [3] out of range V[0..2]: test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test)
   V[3] = 42
  writing:
-ERROR: Index [3] out of range V[0..2]: test.osl:19 (group <unnamed group>, layer 0 test_0, shader test)
+ERROR: Index [3] out of range V[0..2]: test.osl:19 (group unnamed_group_1, layer 0 test_0, shader test)
 

--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 test_0, shader test, op 0 'assign', arg 1)
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 test_0, shader test, op 1 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 test_0, shader test, op 2 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test, op 0 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test, op 1 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group unnamed_group_1, layer 0 test_0, shader test, op 2 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,7 +1,7 @@
 Compiled test.osl -> test.oso
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group <unnamed group>, layer 0 test_0, shader test, op 3 'assign', arg 1)
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group <unnamed group>, layer 0 test_0, shader test, op 4 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group <unnamed group>, layer 0 test_0, shader test, op 5 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test, op 3 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test, op 4 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:11 (group unnamed_group_1, layer 0 test_0, shader test, op 5 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename

--- a/testsuite/error-serialized/ref/out.txt
+++ b/testsuite/error-serialized/ref/out.txt
@@ -1,0 +1,8 @@
+Compiled test.osl -> test.oso
+ERROR: ConnectShaders: source layer "a" not found
+        group: unnamed_group_2
+ERROR: ShaderGroupBegin: error parsing group description: 
+        group: unnamed_group_2
+        problem might be here: connect a.b c.d;
+
+ERROR: Invalid shader group. Exiting testshade.

--- a/testsuite/error-serialized/run.py
+++ b/testsuite/error-serialized/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+command += testshade("--group test.oslgroup")
+failureok = True
+outputs = [ "out.txt" ]

--- a/testsuite/error-serialized/test.osl
+++ b/testsuite/error-serialized/test.osl
@@ -1,0 +1,5 @@
+shader
+test ()
+{
+    // I am a totally harmless shader
+}

--- a/testsuite/error-serialized/test.oslgroup
+++ b/testsuite/error-serialized/test.oslgroup
@@ -1,0 +1,2 @@
+shader test;
+connect a.b c.d;

--- a/testsuite/groupstring/ref/out-noopt.txt
+++ b/testsuite/groupstring/ref/out-noopt.txt
@@ -13,7 +13,7 @@ connect alayer.c_out blayer.c_in ;
 
 ---
 
-Shader group "" layers are:
+Shader group "unnamed_group_2" layers are:
     alayer
 	float Kd
 	output float f_out

--- a/testsuite/groupstring/ref/out.txt
+++ b/testsuite/groupstring/ref/out.txt
@@ -13,7 +13,7 @@ connect alayer.c_out blayer.c_in ;
 
 ---
 
-Shader group "" layers are:
+Shader group "unnamed_group_2" layers are:
     alayer
 	float Kd
 	output float f_out

--- a/testsuite/missing-shader/ref/out.txt
+++ b/testsuite/missing-shader/ref/out.txt
@@ -1,6 +1,9 @@
 ERROR: No .oso file could be found for shader "foo"
 ERROR: Could not find shader "foo"
+        group: unnamed_group_1
 ERROR: No .oso file could be found for shader "bar"
 ERROR: Could not find shader "bar"
+        group: unnamed_group_1
 Connect lay1.x to lay2.y
 ERROR: ConnectShaders: source layer "lay1" not found
+        group: unnamed_group_1

--- a/testsuite/testshade-expr/ref/out.txt
+++ b/testsuite/testshade-expr/ref/out.txt
@@ -17,7 +17,7 @@ shader expr_0 expr_0_0 ;
 
 ---
 
-Shader group "" layers are:
+Shader group "unnamed_group_1" layers are:
     expr_0_0
 
 

--- a/testsuite/unknown-instruction/ref/out.txt
+++ b/testsuite/unknown-instruction/ref/out.txt
@@ -1,4 +1,5 @@
 ERROR: Parsing shader "test": instruction "blahblah" is not known. Maybe compiled with a too-new oslc?
 ERROR: Unable to read "data/test.oso"
 ERROR: Could not find shader "data/test"
+        group: unnamed_group_1
 


### PR DESCRIPTION
When using the variety of ShaderGroupBegin that takes a serialized
description of the group, errors in the individual 'shader', 'param',
or 'connect' commands were not bubbled up into a proper error message
for the ShaderGroupBegin call itself, nor caused it to return null
as the group.
