### PR TITLE
Add support for native OSL closures in OptiX

### DIFF
--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <cstring>
-#include <OpenImageIO/ustring.h>
 #include <OSL/oslconfig.h>
+#include <OpenImageIO/ustring.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -94,17 +94,17 @@ struct OSLEXECPUBLIC ClosureColor {
 
     int id;
 
-    const ClosureComponent* as_comp() const {
+    OSL_HOSTDEVICE const ClosureComponent* as_comp() const {
         DASSERT(id >= COMPONENT_BASE_ID);
         return reinterpret_cast<const ClosureComponent*>(this);
     }
 
-    const ClosureMul* as_mul() const {
+    OSL_HOSTDEVICE const ClosureMul* as_mul() const {
         DASSERT(id == MUL);
         return reinterpret_cast<const ClosureMul*>(this);
     }
 
-    const ClosureAdd* as_add() const {
+    OSL_HOSTDEVICE const ClosureAdd* as_add() const {
         DASSERT(id == ADD);
         return reinterpret_cast<const ClosureAdd*>(this);
     }
@@ -120,20 +120,26 @@ struct OSLEXECPUBLIC ClosureColor {
 /// scaled to add parameters after the end of the struct. Alignment is
 /// set to 16 bytes so that 64 bit pointers and 128 bit SSE types in user
 /// structs have the required alignment.
+#ifdef __CUDACC__
+/// Notice in the OptiX implementation we align this to 8 bytes
+/// so that it matches the alignment of the memory pools.
+struct OSLEXECPUBLIC OSL_ALIGNAS(8) ClosureComponent : public ClosureColor
+#else
 struct OSLEXECPUBLIC OSL_ALIGNAS(16) ClosureComponent : public ClosureColor
+#endif
 {
     Vec3 w;                     ///< Weight of this component
 
     /// Handy method for getting the parameter memory as a void*.
-    void *data () { return (char*)(this + 1); }
-    const void *data () const { return (const char*)(this + 1); }
+    OSL_HOSTDEVICE void *data () { return (char*)(this + 1); }
+    OSL_HOSTDEVICE const void *data () const { return (const char*)(this + 1); }
 
     /// Handy methods for extracting the underlying parameters as a struct
     template <typename T>
-    const T* as() const { return reinterpret_cast<const T*>(data()); }
+    OSL_HOSTDEVICE const T* as() const { return reinterpret_cast<const T*>(data()); }
 
     template <typename T>
-    T* as() { return reinterpret_cast<const T*>(data()); }
+    OSL_HOSTDEVICE T* as() { return reinterpret_cast<const T*>(data()); }
 };
 
 

--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstring>
 #include <OSL/oslconfig.h>
-#include <OpenImageIO/ustring.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -1,9 +1,9 @@
 #include <optix.h>
 #include <optix_device.h>
 #include <optix_math.h>
+#include <OSL/oslclosure.h>
 
 #include "rend_lib.h"
-#include <OSL/oslclosure.h>
 
 
 rtDeclareVariable (uint2, launch_index, rtLaunchIndex, );

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -3,6 +3,7 @@
 #include <optix_math.h>
 
 #include "rend_lib.h"
+#include <OSL/oslclosure.h>
 
 
 rtDeclareVariable (uint2, launch_index, rtLaunchIndex, );
@@ -20,12 +21,12 @@ OSL_NAMESPACE_EXIT
 extern "C" {
 
     __device__
-    void* closure_component_allot (void* pool, int id, size_t prim_size, const float3& w)
+    void* closure_component_allot (void* pool, int id, size_t prim_size, const OSL::Color3& w)
     {
-        ((ClosureComponent*) pool)->id = id;
-        ((ClosureComponent*) pool)->w  = w;
+        ((OSL::ClosureComponent*) pool)->id = id;
+        ((OSL::ClosureComponent*) pool)->w  = w;
 
-        size_t needed   = (sizeof(ClosureComponent) - sizeof(void*) + prim_size + 0x7) & ~0x7;
+        size_t needed   = (sizeof(OSL::ClosureComponent) - sizeof(void*) + prim_size + 0x7) & ~0x7;
         char*  char_ptr = (char*) pool;
 
         return (void*) &char_ptr[needed];
@@ -33,13 +34,13 @@ extern "C" {
 
 
     __device__
-    void* closure_mul_allot (void* pool, const float3& w, ClosureColor* c)
+    void* closure_mul_allot (void* pool, const OSL::Color3& w, OSL::ClosureColor* c)
     {
-        ((ClosureMul*) pool)->id      = ClosureColor::MUL;
-        ((ClosureMul*) pool)->weight  = w;
-        ((ClosureMul*) pool)->closure = c;
+        ((OSL::ClosureMul*) pool)->id      = OSL::ClosureColor::MUL;
+        ((OSL::ClosureMul*) pool)->weight  = w;
+        ((OSL::ClosureMul*) pool)->closure = c;
 
-        size_t needed   = (sizeof(ClosureMul) + 0x7) & ~0x7;
+        size_t needed   = (sizeof(OSL::ClosureMul) + 0x7) & ~0x7;
         char*  char_ptr = (char*) pool;
 
         return &char_ptr[needed];
@@ -47,15 +48,15 @@ extern "C" {
 
 
     __device__
-    void* closure_mul_float_allot (void* pool, const float& w, ClosureColor* c)
+    void* closure_mul_float_allot (void* pool, const float& w, OSL::ClosureColor* c)
     {
-        ((ClosureMul*) pool)->id       = ClosureColor::MUL;
-        ((ClosureMul*) pool)->weight.x = w;
-        ((ClosureMul*) pool)->weight.y = w;
-        ((ClosureMul*) pool)->weight.z = w;
-        ((ClosureMul*) pool)->closure  = c;
+        ((OSL::ClosureMul*) pool)->id       = OSL::ClosureColor::MUL;
+        ((OSL::ClosureMul*) pool)->weight.x = w;
+        ((OSL::ClosureMul*) pool)->weight.y = w;
+        ((OSL::ClosureMul*) pool)->weight.z = w;
+        ((OSL::ClosureMul*) pool)->closure  = c;
 
-        size_t needed   = (sizeof(ClosureMul) + 0x7) & ~0x7;
+        size_t needed   = (sizeof(OSL::ClosureMul) + 0x7) & ~0x7;
         char*  char_ptr = (char*) pool;
 
         return &char_ptr[needed];
@@ -63,13 +64,13 @@ extern "C" {
 
 
     __device__
-    void* closure_add_allot (void* pool, ClosureColor* a, ClosureColor* b)
+    void* closure_add_allot (void* pool, OSL::ClosureColor* a, OSL::ClosureColor* b)
     {
-        ((ClosureAdd*) pool)->id       = ClosureColor::ADD;
-        ((ClosureAdd*) pool)->closureA = a;
-        ((ClosureAdd*) pool)->closureB = b;
+        ((OSL::ClosureAdd*) pool)->id       = OSL::ClosureColor::ADD;
+        ((OSL::ClosureAdd*) pool)->closureA = a;
+        ((OSL::ClosureAdd*) pool)->closureB = b;
 
-        size_t needed   = (sizeof(ClosureAdd) + 0x7) & ~0x7;
+        size_t needed   = (sizeof(OSL::ClosureAdd) + 0x7) & ~0x7;
         char*  char_ptr = (char*) pool;
 
         return &char_ptr[needed];
@@ -81,7 +82,7 @@ extern "C" {
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
-        float3 w   = make_float3 (1.0f);
+        OSL::Color3 w   = OSL::Color3 (1, 1, 1);
         void*  ret = sg_ptr->renderstate;
 
         size = max (4, size);
@@ -93,7 +94,7 @@ extern "C" {
 
 
     __device__
-    void* osl_allocate_weighted_closure_component (void* sg_, int id, int size, const float3* w)
+    void* osl_allocate_weighted_closure_component (void* sg_, int id, int size, const OSL::Color3* w)
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
@@ -111,7 +112,7 @@ extern "C" {
 
 
     __device__
-    void* osl_mul_closure_color (void* sg_, ClosureColor* a, float3* w)
+    void* osl_mul_closure_color (void* sg_, OSL::ClosureColor* a, const OSL::Color3* w)
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
@@ -135,7 +136,7 @@ extern "C" {
 
 
     __device__
-    void* osl_mul_closure_float (void* sg_, ClosureColor* a, float w)
+    void* osl_mul_closure_float (void* sg_, OSL::ClosureColor* a, float w)
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 
@@ -155,7 +156,7 @@ extern "C" {
 
 
     __device__
-    void* osl_add_closure_closure (void* sg_, ClosureColor* a, ClosureColor* b)
+    void* osl_add_closure_closure (void* sg_, OSL::ClosureColor* a, OSL::ClosureColor* b)
     {
         ShaderGlobals* sg_ptr = (ShaderGlobals*) sg_;
 

--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -126,29 +126,4 @@ enum ClosureIDs {
     HOLDOUT_ID,
 };
 
-
-struct ClosureColor {
-    enum ClosureID { COMPONENT_BASE_ID = 0, MUL = -1, ADD = -2 };
-    int id;
-};
-
-
-struct ClosureComponent : public ClosureColor {
-    float3 w;
-    char   mem[8];
-};
-
-
-struct ClosureMul : public ClosureColor {
-    float3        weight;
-    ClosureColor* closure;
-};
-
-
-struct ClosureAdd : public ClosureColor {
-    ClosureColor* closureA;
-    ClosureColor* closureB;
-};
-
-
 }  // anonymous namespace

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -31,9 +31,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optixu/optixu_math_namespace.h>
 
 #include <OSL/device_string.h>
+#include <OSL/oslclosure.h>
 
 #include "rend_lib.h"
-#include <OSL/oslclosure.h>
 #include "util.h"
 
 // Ray payload

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/device_string.h>
 
 #include "rend_lib.h"
+#include <OSL/oslclosure.h>
 #include "util.h"
 
 // Ray payload
@@ -95,12 +96,12 @@ void globals_from_hit(ShaderGlobals& sg)
 
 
 static __device__
-float3 process_closure(const ClosureColor* closure_tree)
+float3 process_closure(const OSL::ClosureColor* closure_tree)
 {
-    float3 result = make_float3 (0.0f);
+    OSL::Color3 result = OSL::Color3 (0.0f);
 
     if (!closure_tree) {
-        return result;
+        return make_float3(result.x, result.y, result.z);
     }
 
     // The depth of the closure tree must not exceed the stack size.
@@ -110,25 +111,25 @@ float3 process_closure(const ClosureColor* closure_tree)
 
     // Non-recursive traversal stack
     int    stack_idx = 0;
-    void*  ptr_stack   [STACK_SIZE];
-    float3 weight_stack[STACK_SIZE];
+    const OSL::ClosureColor* ptr_stack[STACK_SIZE];
+    OSL::Color3 weight_stack[STACK_SIZE];
 
     // Shading accumlator
-    float3 weight = make_float3(1.0f);
+    OSL::Color3 weight = OSL::Color3(1.0f);
 
     const void* cur = closure_tree;
     while (cur) {
-        switch (((ClosureColor*)cur)->id) {
-        case ClosureColor::ADD: {
-            ptr_stack   [stack_idx  ] = ((ClosureAdd*) cur)->closureB;
+        switch (((OSL::ClosureColor*)cur)->id) {
+        case OSL::ClosureColor::ADD: {
+            ptr_stack   [stack_idx  ] = ((OSL::ClosureAdd*) cur)->closureB;
             weight_stack[stack_idx++] = weight;
-            cur = ((ClosureAdd*) cur)->closureA;
+            cur = ((OSL::ClosureAdd*) cur)->closureA;
             break;
         }
 
-        case ClosureColor::MUL: {
-            weight *= ((ClosureMul*) cur)->weight;
-            cur     = ((ClosureMul*) cur)->closure;
+        case OSL::ClosureColor::MUL: {
+            weight *= ((OSL::ClosureMul*) cur)->weight;
+            cur     = ((OSL::ClosureMul*) cur)->closure;
             break;
         }
 
@@ -144,14 +145,14 @@ float3 process_closure(const ClosureColor* closure_tree)
         case REFLECTION_ID:
         case REFRACTION_ID:
         case FRESNEL_REFLECTION_ID: {
-            result += ((ClosureComponent*) cur)->w * weight;
+            result += ((OSL::ClosureComponent*) cur)->w * weight;
             cur = NULL;
             break;
         }
 
         case MICROFACET_ID: {
 #if 0
-            const char* mem = ((ClosureComponent*) cur)->mem;
+            const char* mem = ((OSL::ClosureComponent*) cur)->mem;
             const char* dist_str = *(const char**) &mem[0];
             if (launch_index.x == launch_dim.x / 2 && launch_index.y == launch_dim.y / 2) {
                 printf ("microfacet, dist: %s\n", HDSTR(dist_str).c_str());
@@ -162,7 +163,7 @@ float3 process_closure(const ClosureColor* closure_tree)
             }
 #endif
 
-            result += ((ClosureComponent*) cur)->w * weight;
+            result += ((OSL::ClosureComponent*) cur)->w * weight;
             cur = NULL;
             break;
         }
@@ -178,7 +179,7 @@ float3 process_closure(const ClosureColor* closure_tree)
         }
     }
 
-    return result;
+    return make_float3(result.x, result.y, result.z);
 }
 
 
@@ -216,5 +217,5 @@ RT_PROGRAM void closest_hit_osl()
     osl_init_func (&sg, params);
     osl_group_func(&sg, params);
 
-    prd_radiance.result = process_closure ((ClosureColor*) sg.Ci);
+    prd_radiance.result = process_closure ((OSL::ClosureColor*) sg.Ci);
 }


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
The current implementation of the OptiX run time defines its own closure structures that replicate that of the native OSL closure structures. This is likely just legacy code as it was easier to use OptiX types like float3 than add support the native OSL types. Removing this duplication and using the native OSL closures improves the maintainability of the code as you will no longer need duplicate logic if the structures ever change.

Some notes regarding this PR that are worth thinking about:
* In OSL/oslclosure.h I have to align the ClosureComponent struct to 8 bytes instead of 16. This is because the memory pools we use to store these structs are aligned to 8 bytes and we need to align them in a compatible way to avoid misalignment issues.
* ~~There is an order dependency when including headers like OSL/oslclosure.h in device code. If OSL/oslconfig.h is not included prior, such defines as OSL_HOSTDEVICE will not be defined correctly and can causes compiler errors. You can avoid this by defining these defines in the build instead which I have found makes things a little nicer in other projects. Whether this is an issue or not is up for discussion, but I thought it was worth mentioning. This is likely outside of the scope of this PR anyway.~~

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

