### PR TITLE
OptiX closure param fix

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -497,7 +497,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         ll.op_branch (cond_val, no_userdata_block, after_userdata_block);
     }
 
-    if (use_optix() && ! sym.typespec().is_string()) {
+    if (use_optix() && ! sym.typespec().is_closure() && ! sym.typespec().is_string()) {
         ASSERT (! sym.has_init_ops() && "Init ops are not currently supported in OptiX");
 
         // If the call to osl_bind_interpolated_param returns 0, the default
@@ -510,7 +510,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
 
         TypeDesc t = sym.typespec().simpletype();
         ll.op_memcpy (dst, src, t.size(), t.basesize());
-    } else if (use_optix()) {
+    } else if (use_optix() && ! sym.typespec().is_closure()) {
         // For convenience, we always pack string addresses into the groupdata
         // struct.
         int userdata_index = find_userdata_index (sym);

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -279,7 +279,7 @@ main (int argc, const char *argv[])
         rend->clear();
         delete shadingsys;
         delete rend;
-    } catch (const optix::Exception& e) {
+    } catch (const OSL::optix::Exception& e) {
         printf("Optix Error: %s\n", e.what());
     } catch (const std::exception& e) {
         printf("Unknown Error: %s\n", e.what());

--- a/src/testshade/testshademain.cpp
+++ b/src/testshade/testshademain.cpp
@@ -50,7 +50,7 @@ main (int argc, const char *argv[])
     int result = EXIT_FAILURE;
     try {
         result = test_shade (argc, argv);
-    } catch (const optix::Exception& e) {
+    } catch (const OSL::optix::Exception& e) {
         printf("Optix Error: %s\n", e.what());
     } catch (const std::exception& e) {
         printf("Unknown Error: %s\n", e.what());


### PR DESCRIPTION
## Description

As reported in #1025, ShaderGroup compilation fails when a shader uses closure parameters and OptiX is enabled. This is due to an improper type check that is only present in the OptiX path. The fix here is to check whether a parameter is of type closure before checking if it's a string.

## Tests

No new tests.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

