### PR TITLE
Respect lockgeom default for 'GroupSpecs' and remove ASSERT from ReParameter

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2396,7 +2396,7 @@ ShadingSystemImpl::ShaderGroupBegin (string_view groupname,
             }
         }
         string_view paramname (paramname_string);
-        int lockgeom = true;
+        int lockgeom = m_lockgeom_default;
         // For speed, reserve space. Note that for "unsized" arrays, we only
         // preallocate 1 slot and let it grow as needed. That's ok. For
         // everything else, we will reserve the right amount up front.
@@ -2587,8 +2587,13 @@ ShadingSystemImpl::ReParameter (ShaderGroup &group, string_view layername_,
     int paramindex = layer->findparam (ustring(paramname));
     if (paramindex < 0)
         return false;   // could not find the named parameter
+
     Symbol *sym = layer->symbol (paramindex);
-    ASSERT (sym != NULL);
+    if (!sym) {
+        // Can have a paramindex >= 0, but no symbol when it's a master-symbol
+        DASSERT(layer->mastersymbol(paramindex) && "No symbol for paramindex");
+        return false;
+    }
 
     // Check for mismatch versus previously-declared type
     if (!equivalent(sym->typespec(), type))


### PR DESCRIPTION
Respect 'lockgeom' default when building from commands.

ReParameter was asserting after parameter lookup, if the symbol was not on the instance.
Since the call already has a return value to signal success, use that instead.

