### PR TITLE
Take advantage of proposed OIIO APIs to pass thread_info to texture related calls

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -200,16 +200,13 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle * get_texture_handle (ustring filename);
+    virtual TextureHandle * get_texture_handle (ustring filename,
+                                                ShadingContext *context);
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.
     virtual bool good (TextureHandle *texture_handle);
-
-    /// Return a thread-specific opaque pointer to the texture system.
-    /// Knowing the context may help this go faster.
-    virtual TexturePerthread * get_texture_perthread (ShadingContext *context=NULL);
 
     /// Filtered 2D texture lookup for a single point.
     ///
@@ -322,14 +319,20 @@ public:
     /// can) use that extra information to perform a less expensive texture
     /// lookup.
     ///
-    /// Note to renderers: if sg is NULL, that means get_texture_info is
-    /// being called speculatively by the runtime optimizer, and it doesn't
-    /// know which object the shader will be run on.
-    virtual bool get_texture_info (ShaderGlobals *sg, ustring filename,
+    /// If the errormessage parameter is NULL, this method is expected to
+    /// handle the errors fully, including forwarding them to the renderer
+    /// or shading system. If errormessage is non-NULL, any resulting error
+    /// messages (in case of failure, when the function returns false) will
+    /// be stored there, leaving it up to the caller/shader to handle the
+    /// error.
+    virtual bool get_texture_info (ustring filename,
                                    TextureHandle *texture_handle,
+                                   TexturePerthread *texture_thread_info,
+                                   ShadingContext *shading_context,
                                    int subimage,
                                    ustring dataname, TypeDesc datatype,
-                                   void *data);
+                                   void *data,
+                                   ustring *errormessage);
 
 
     /// Lookup nearest points in a point cloud. It will search for

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -388,7 +388,7 @@ DECL (osl_texture_set_missingcolor_alpha, "xXif")
 DECL (osl_texture, "iXXXXffffffiXXXXXXX")
 DECL (osl_texture3d, "iXXXXXXXiXXXXXXX")
 DECL (osl_environment, "iXXXXXXXiXXXXXXX")
-DECL (osl_get_textureinfo, "iXXXXiiiX")
+DECL (osl_get_textureinfo, "iXXXXiiiXX")
 
 DECL (osl_trace_set_mindist, "xXf")
 DECL (osl_trace_set_maxdist, "xXf")

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2417,9 +2417,7 @@ LLVMGEN (llvm_gen_texture)
     args.push_back (rop.sg_void_ptr());
     RendererServices::TextureHandle *texture_handle = NULL;
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
-        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data());
-        if (! rop.renderer()->good (texture_handle))
-            texture_handle = NULL;
+        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data(), rop.shadingcontext());
     }
     args.push_back (rop.llvm_load_value (Filename));
     args.push_back (rop.ll.constant_ptr (texture_handle));
@@ -2483,9 +2481,7 @@ LLVMGEN (llvm_gen_texture3d)
     args.push_back (rop.sg_void_ptr());
     RendererServices::TextureHandle *texture_handle = NULL;
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
-        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data());
-        if (! rop.renderer()->good (texture_handle))
-            texture_handle = NULL;
+        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data(), rop.shadingcontext());
     }
     args.push_back (rop.llvm_load_value (Filename));
     args.push_back (rop.ll.constant_ptr (texture_handle));
@@ -2543,9 +2539,7 @@ LLVMGEN (llvm_gen_environment)
     args.push_back (rop.sg_void_ptr());
     RendererServices::TextureHandle *texture_handle = NULL;
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
-        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data());
-        if (! rop.renderer()->good (texture_handle))
-            texture_handle = NULL;
+        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data(), rop.shadingcontext());
     }
     args.push_back (rop.llvm_load_value (Filename));
     args.push_back (rop.ll.constant_ptr (texture_handle));
@@ -2995,9 +2989,7 @@ LLVMGEN (llvm_gen_gettextureinfo)
     args.push_back (rop.sg_void_ptr());
     RendererServices::TextureHandle *texture_handle = NULL;
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
-        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data());
-        if (! rop.renderer()->good (texture_handle))
-            texture_handle = NULL;
+        texture_handle = rop.renderer()->get_texture_handle (*(ustring *)Filename.data(), rop.shadingcontext());
     }
     args.push_back (rop.llvm_load_value (Filename));
     args.push_back (rop.ll.constant_ptr (texture_handle));
@@ -3008,6 +3000,8 @@ LLVMGEN (llvm_gen_gettextureinfo)
     args.push_back (rop.ll.constant((int) Data.typespec().simpletype().aggregate));
     // destination
     args.push_back (rop.llvm_void_ptr (Data));
+    // errormessage
+    args.push_back (rop.ll.void_ptr_null());
 
     llvm::Value *r = rop.ll.call_function ("osl_get_textureinfo",
                                            &args[0], args.size());

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -403,7 +403,8 @@ osl_environment (void *sg_, const char *name, void *handle,
 OSL_SHADEOP int
 osl_get_textureinfo (void *sg_, const char *name, void *handle,
                      void *dataname,  int type,
-                     int arraylen, int aggregate, void *data)
+                     int arraylen, int aggregate, void *data,
+                     ustring *errormessage)
 {
     // recreate TypeDesc
     TypeDesc typedesc;
@@ -413,10 +414,13 @@ osl_get_textureinfo (void *sg_, const char *name, void *handle,
 
     ShaderGlobals *sg   = (ShaderGlobals *)sg_;
 
-    return sg->renderer->get_texture_info (sg, USTR(name),
+    return sg->renderer->get_texture_info (USTR(name),
                                            (RendererServices::TextureHandle *)handle,
+                                           sg->context->texture_thread_info(),
+                                           sg->context,
                                            0 /*FIXME-ptex*/,
-                                           USTR(dataname), typedesc, data);
+                                           USTR(dataname), typedesc, data,
+                                           errormessage);
 }
 
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -602,8 +602,8 @@ RuntimeOptimizer::insert_code (int opnum, ustring opname,
                                RecomputeRWRangesOption recompute_rw_ranges,
                                InsertRelation relation)
 {
-    const int *argsbegin = (args_to_add.size())? &args_to_add[0]: NULL;
-    const int *argsend = argsbegin + args_to_add.size();
+    const int *argsbegin = args_to_add.data();
+    const int *argsend   = argsbegin + args_to_add.size();
 
     insert_code (opnum, opname, argsbegin, argsend,
                  recompute_rw_ranges, relation);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -375,7 +375,7 @@ OptixRaytracer::good(TextureHandle *handle)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixRaytracer::get_texture_handle (ustring filename)
+OptixRaytracer::get_texture_handle (ustring filename, ShadingContext* shading_context)
 {
 #ifdef OSL_USE_OPTIX
     auto itr = m_samplers.find(filename);

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -79,7 +79,7 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle * get_texture_handle(ustring filename);
+    virtual TextureHandle * get_texture_handle(ustring filename, ShadingContext* shading_context);
 
     // Easy way to do Optix calls
     optix::Context& optix_ctx()            { return m_optix_ctx; }

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -304,7 +304,7 @@ OptixGridRenderer::good(TextureHandle *handle)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixGridRenderer::get_texture_handle (ustring filename)
+OptixGridRenderer::get_texture_handle (ustring filename, ShadingContext* shading_context)
 {
 #ifdef OSL_USE_OPTIX
     auto itr = m_samplers.find(filename);

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -80,7 +80,7 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle * get_texture_handle(ustring filename);
+    virtual TextureHandle * get_texture_handle(ustring filename, ShadingContext* shading_context);
 
     // Easy way to do Optix calls
     optix::Context& optix_ctx()            { return m_optix_ctx; }

--- a/testsuite/gettextureinfo/ref/out-opt.txt
+++ b/testsuite/gettextureinfo/ref/out-opt.txt
@@ -1,0 +1,56 @@
+Compiled test.osl -> test.oso
+Executing...
+../common/textures/grid.tx resolution: 1024 1024 (1)
+../common/textures/grid.tx channels: 4 (1)
+../common/textures/grid.tx texturetype: Plain Texture (1)
+../common/textures/grid.tx textureformat: Plain Texture (1)
+../common/textures/grid.tx datawindow: 0 0 1023 1023 (1)
+../common/textures/grid.tx displaywindow: 0 0 1023 1023 (1)
+../common/textures/grid.tx datetime: 2014:11:29 23:20:23 (1)
+../common/textures/grid.tx averagecolor: 0.608983 0.608434 0.608728
+../common/textures/grid.tx averagealpha: 1
+../common/textures/grid.tx unknown constantcolor
+../common/textures/grid.tx unknown constantalpha
+../common/textures/grid.tx foobar: not found (0)
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
+badfile data: not found (0)
+../common/textures/grid.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+
+Executing...
+win.exr resolution: 100 50 (1)
+win.exr channels: 3 (1)
+win.exr texturetype: Plain Texture (1)
+win.exr textureformat: Plain Texture (1)
+win.exr datawindow: 10 20 109 69 (1)
+win.exr displaywindow: 0 0 299 199 (1)
+win.exr averagecolor: 0 0 0
+win.exr unknown averagealpha
+win.exr unknown constantcolor
+win.exr unknown constantalpha
+win.exr foobar: not found (0)
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
+badfile data: not found (0)
+win.exr exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+
+Executing...
+green.tx resolution: 128 128 (1)
+green.tx channels: 4 (1)
+green.tx texturetype: Plain Texture (1)
+green.tx textureformat: Plain Texture (1)
+green.tx datawindow: 0 0 127 127 (1)
+green.tx displaywindow: 0 0 127 127 (1)
+green.tx averagecolor: 0.101961 0.501961 0.101961
+green.tx averagealpha: 1
+green.tx constantcolor: 0.101961 0.501961 0.101961
+green.tx constantalpha: 1
+green.tx foobar: not found (0)
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
+badfile data: not found (0)
+green.tx exists? 1 (return 1)
+badfile3 exists? 0 (return 1)
+


### PR DESCRIPTION
This goes together with https://github.com/OpenImageIO/oiio/pull/2277

I've also attempted to constant fold get_texture_info even if the call would fail (and generate an error message to maintain runtime behavior).

Remove unused function get_texture_perthread from RendererServices to reduce confusion. It was never getting called internally.