### PR TITLE
Avoid creating tiny std::vectors during constant folding where possible

### DIFF
--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -284,12 +284,7 @@ public:
     /// subsequent instruction; NoRelation means we have no information,
     /// so don't copy that info from anywhere.
     void insert_code (int opnum, ustring opname,
-                      const std::vector<int> &args_to_add,
-                      RecomputeRWRangesOption recompute_rw_ranges,
-                      InsertRelation relation=GroupWithNext);
-    /// insert_code with begin/end arg array pointers.
-    void insert_code (int opnum, ustring opname,
-                      const int *argsbegin, const int *argsend,
+                      const OIIO::cspan<int> args_to_add,
                       RecomputeRWRangesOption recompute_rw_ranges,
                       InsertRelation relation=GroupWithNext);
     /// insert_code with explicit arguments (up to 4, a value of -1 means


### PR DESCRIPTION
Noticed we were making a bunch of tiny `std::vector`s while working on the `gettextureinfo` patch.

Probably a drop in the bucket compared to everything else that goes on during runtime optimization, but every little bit helps.

Also `rop.insert_code` also makes a fresh `Opcode` struct, so there's no need to tweak the read/write flags if they are the same as the default.