### PR TITLE
Constant fold array access even if they are out-of-bounds

### DIFF
--- a/testsuite/array-range/ref/out-opt.txt
+++ b/testsuite/array-range/ref/out-opt.txt
@@ -1,0 +1,20 @@
+Compiled test.osl -> test.oso
+constant index:
+ reading:
+  array[1] = 1
+ERROR: Shader error [test]: Index [10] out of range $const1[0..4]: test.osl:8 (group unnamed_group_1, layer 0 test_0, shader test)
+  array[10] = 4
+ writing:
+ERROR: Index [10] out of range array[0..4]: test.osl:10 (group unnamed_group_1, layer 0 test_0, shader test)
+variable index:
+ reading:
+  array[0] = 0
+  array[1] = 1
+  array[2] = 2
+  array[3] = 3
+  array[4] = 42
+ERROR: Index [5] out of range array[0..4]: test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test)
+  array[5] = 42
+ writing:
+ERROR: Index [5] out of range array[0..4]: test.osl:19 (group unnamed_group_1, layer 0 test_0, shader test)
+


### PR DESCRIPTION
This extends constant folding for `aref` even in the cases where the array index is out of bounds. If the user asked for range checking, we will generate an error instruction in the event that control flow reaches there, but the array index will be clamped regardless.