### PR TITLE
Bump minimum OIIO version to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ matrix:
               - libboost-thread1.55
               - libboost-wave1.55
         env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OIIOBRANCH=release
-      - name: "Older things: OIIO 1.9, llvm 5, boost 1.55"
+      - name: "Older things: OIIO 2.0, llvm 5, boost 1.55"
         os: linux
         compiler: gcc
         addons:
@@ -163,7 +163,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=5.0.0 USE_SIMD=sse4.2 OIIOBRANCH=RB-1.9
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=5.0.0 USE_SIMD=sse4.2 OIIOBRANCH=RB-2.0
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
       - name: "gcc7, llvm7, C++14"
         os: linux
@@ -214,7 +214,7 @@ matrix:
               - libboost-thread1.55
               - libboost-wave1.55
         env: DEBUG=1 LLVM_VERSION=7.0.0 OIIOBRANCH=master
-      - name: "Oldest everything: LLVM 5, OIIO 1.8, no simd"
+      - name: "Oldest everything: LLVM 5, OIIO 2.0, no simd"
         os: linux
         compiler: gcc
         addons:
@@ -229,7 +229,7 @@ matrix:
               - libboost-system1.55
               - libboost-thread1.55
               - libboost-wave1.55
-        env: USE_SIMD=0 LLVM_VERSION=5.0.0 OIIOBRANCH=RB-1.8
+        env: USE_SIMD=0 LLVM_VERSION=5.0.0 OIIOBRANCH=RB-2.0
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
 
 notifications:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
   OSL should compile also properly with C++14 or C++17, but they are not
   required.
 
-* **[OpenImageIO](http://openimageio.org) 1.8.5 or newer**
+* **[OpenImageIO](http://openimageio.org) 2.0 or newer**
 
     OSL uses OIIO both for its texture mapping functionality as well as
     numerous utility classes.  If you are integrating OSL into an existing

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -57,7 +57,7 @@ endif ()
 
 set (OIIO_LIBNAME_SUFFIX "" CACHE STRING
      "Optional name appended to OIIO libraries that are built")
-find_package (OpenImageIO 1.8.5 REQUIRED)
+find_package (OpenImageIO 2.0 REQUIRED)
 include_directories ("${OPENIMAGEIO_INCLUDE_DIR}")
 link_directories ("${OPENIMAGEIO_LIBRARY_DIRS}")
 message (STATUS "Using OpenImageIO ${OPENIMAGEIO_VERSION}")

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -104,13 +104,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
 #include <OpenImageIO/platform.h>
-
-// Make sure we can use OIIO::cspan
-#if OIIO_VERSION >= 10904
-#  include <OpenImageIO/span.h>
-#else
-#  include <OpenImageIO/array_view.h>
-#endif
+#include <OpenImageIO/span.h>
 
 // If we're using an old version of OIIO prior to the introduction of
 // Strutil::sprintf, define it ourselves to be a synonym for format.
@@ -166,13 +160,8 @@ using OIIO::TypeDesc;
 using OIIO::ustring;
 using OIIO::ustringHash;
 using OIIO::string_view;
-
-// Make sure we can use OIIO::cspan
-#if OIIO_VERSION >= 10904
-  using OIIO::cspan;
-#else
-  template<typename T> using cspan = OIIO::array_view<const T>;
-#endif
+using OIIO::span;
+using OIIO::cspan;
 
 
 // In C++20 (and some compilers before that), __has_cpp_attribute can

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -36,9 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/refcnt.h>
 #include <OpenImageIO/ustring.h>
-#if OPENIMAGEIO_VERSION <= 10902
-#include <OpenImageIO/imagebufalgo_util.h>
-#endif
+
 
 OSL_NAMESPACE_ENTER
 

--- a/src/liboslexec/dual_test.cpp
+++ b/src/liboslexec/dual_test.cpp
@@ -37,11 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace OSL;
 
-// Fix namespace problem with OIIO unit tests in older versions.
-#if OIIO_VERSION < 10901
-using namespace OIIO;
-#endif
-
 typedef Dual<float,1> Dualf;
 typedef Dual2<float> Dual2f;
 

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -174,7 +174,6 @@ test_perlin ()
         OIIO_CHECK_EQUAL_THRESH (vs4, vresults_4d[i], eps);
     }
 
-#if OPENIMAGEIO_VERSION >= 10904
     // Make sure the right thing happens at integer cell boundaries.
     // Perlin noise should be continuous everywhere.
     OIIO_CHECK_EQUAL_APPROX (noise( 0.9999f), noise( 1.0f));
@@ -185,7 +184,6 @@ test_perlin ()
     OIIO_CHECK_EQUAL_APPROX (noise(-0.9999f), noise(-1.0f));
     Strutil::printf ("noise around -1: %g %g %g\n", 
                      noise(-0.9999f), noise(-1.0f), noise(-1.0001f));
-#endif
 
     if (make_images) {
         MAKE_IMAGE (noise);
@@ -262,7 +260,6 @@ test_cell ()
         OIIO_CHECK_EQUAL_THRESH (vs4, vresults_4d[i], eps);
     }
 
-#if OPENIMAGEIO_VERSION >= 10904
     // Make sure the right thing happens at integer cell boundaries
     OIIO_CHECK_EQUAL (cellnoise( 1.0001f), cellnoise( 1.0f));
     OIIO_CHECK_NE    (cellnoise( 0.9999f), cellnoise( 1.0f));
@@ -272,7 +269,6 @@ test_cell ()
     OIIO_CHECK_EQUAL (cellnoise(-0.0001f), cellnoise(-1.0f));
     OIIO_CHECK_EQUAL (cellnoise(-0.9999f), cellnoise(-1.0f));
     OIIO_CHECK_EQUAL (cellnoise(-1.0001f), cellnoise(-2.0f));
-#endif
 
     if (make_images) {
         MAKE_IMAGE (cellnoise);
@@ -350,7 +346,6 @@ test_hash ()
         OIIO_CHECK_EQUAL_THRESH (vs4, vresults_4d[i], eps);
     }
 
-#if OPENIMAGEIO_VERSION >= 10904
     // Make sure the right thing happens at integer cell boundaries.
     // hashnoise should be discontinuous everywhere!
     OIIO_CHECK_NE (hashnoise( 0.9999f), hashnoise( 1.0f));
@@ -359,7 +354,6 @@ test_hash ()
     OIIO_CHECK_NE (hashnoise( 0.0001f), hashnoise( 0.0f));
     OIIO_CHECK_NE (hashnoise(-1.0001f), hashnoise(-1.0f));
     OIIO_CHECK_NE (hashnoise(-0.9999f), hashnoise(-1.0f));
-#endif
 
     if (make_images) {
         MAKE_IMAGE (hashnoise);

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -1123,13 +1123,7 @@ OSLToyMainWindow::set_param_diddle (ParamRec *param, int diddle)
 void
 OSLToyMainWindow::set_param_instance_value (ParamRec *param)
 {
-#if OPENIMAGEIO_VERSION >= 10903
     m_shaderparam_instvalues.remove (param->name);
-#else
-    auto&& found = m_shaderparam_instvalues.find (param->name);
-    if (found != m_shaderparam_instvalues.end())
-        m_shaderparam_instvalues.erase (found);
-#endif
 
     if (param->type == TypeDesc::INT) {
         int v = reinterpret_cast<QSpinBox*>(param->widgets[0])->value();

--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -127,11 +127,9 @@ OSLToyRenderer::render_image ()
     static ustring outputs[] = { ustring("Cout") };
 //    OIIO::Timer timer;
     OIIO::ImageBufAlgo::parallel_image_options popt;
-#if OPENIMAGEIO_VERSION > 10902
     popt.minitems = 4096;
     popt.splitdir = OIIO::Split_Tile;
     popt.recursive = true;
-#endif
     shade_image (*shadingsys(), *shadergroup(), &m_shaderglobals_template,
                  m_framebuffer, outputs, ShadePixelCenters, OIIO::ROI(), popt);
 //    std::cout << timer() << "\n";

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1320,7 +1320,6 @@ test_shade (int argc, const char *argv[])
     delete shadingsys;
     int retcode = EXIT_SUCCESS;
 
-#if OPENIMAGEIO_VERSION >= 10904
     // Double check that there were no uncaught errors in the texture
     // system and image cache.
     std::string err = texturesys->geterror();
@@ -1334,7 +1333,6 @@ test_shade (int argc, const char *argv[])
         std::cout << "ERRORS left in ImageCache:\n" << err << "\n";
         retcode = EXIT_FAILURE;
     }
-#endif
 
     delete rend;
 


### PR DESCRIPTION
We've been talking about this for a long time.
This is only in master. The 1.10 family of releases will always retain compatibility with OIIO 1.8.
