### PR TITLE
QFontMetrics.width() is marked as deprecated in new Qt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     -   export EXRREPO=https://github.com/lgritz/openexr.git ;
     -   export EXRBRANCH=lg-cpp11 ;
     - if [ $TRAVIS_OS_NAME == osx ] ; then
-          src/build-scripts/install_homebrew_deps.bash ;
+          source src/build-scripts/install_homebrew_deps.bash ;
       elif [ $TRAVIS_OS_NAME == linux ] ; then
           CXX="ccache $CXX" CCACHE_CPP2=1 src/build-scripts/build_openexr.bash ;
           export ILMBASE_ROOT_DIR=$PWD/ext/openexr-install ;

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -32,3 +32,7 @@ brew install qt
 echo ""
 echo "After brew installs:"
 brew list --versions
+
+# Set up paths. These will only affect the caller if this script is
+# run with 'source' rather than in a separate shell.
+export PATH=/usr/local/opt/qt5/bin:$PATH

--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -97,7 +97,12 @@ CodeEditor::text_string () const
 int
 CodeEditor::char_width_pixels () const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+    return fontMetrics().horizontalAdvance(QLatin1Char('M'));
+#else
+    // QFontMetric.width() deprecated from 5.11, marked as such in 5.13
     return fontMetrics().width(QLatin1Char('M'));
+#endif
 }
 
 

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -447,8 +447,13 @@ OSLToyMainWindow::OSLToyMainWindow (OSLToyRenderer *rend, int xr, int yr)
 
     auto editorarea = new QWidget;
     QFontMetrics fontmetrics (CodeEditor::fixedFont());
-    editorarea->setMinimumSize (85*fontmetrics.width(QLatin1Char('M')),
-                                40*fontmetrics.lineSpacing());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+    int Mwidth = fontmetrics.horizontalAdvance(QLatin1Char('M'));
+#else
+    // QFontMetric.width() deprecated from 5.11, marked as such in 5.13
+    int Mwidth = fontmetrics.width(QLatin1Char('M'));
+#endif
+    editorarea->setMinimumSize (85*Mwidth, 40*fontmetrics.lineSpacing());
     auto editorarea_layout = new QVBoxLayout;
     editorarea->setLayout (editorarea_layout);
     editorarea_layout->addWidget (textTabs);


### PR DESCRIPTION
Keep warnings about marked-as-deprecated methods from breaking the OSL build.

On OSX, Homebrew just upgraded to a new enough Qt to see this breakage.

Also fix install_homebrew_deps to make sure Travis OSX test can find
Qt so it builds osltoy. (It wasn't before, so this build break would
not have been found by Travis-CI.)

