### PR TITLE
Make serialize-bc.py python 3 compatible

### DIFF
--- a/src/liboslexec/serialize-bc.py
+++ b/src/liboslexec/serialize-bc.py
@@ -2,6 +2,8 @@
 # bitcode is in a huge array.
 
 import sys
+import binascii
+
 in_name = sys.argv[1]
 out_name = sys.argv[2]
 prefix = sys.argv[3]
@@ -11,6 +13,6 @@ f_out.write('#include <cstddef>\n')
 f_out.write('unsigned char %s_block[] = {\n' % prefix)
 f_in.read
 for c in f_in.read():
-    f_out.write('0x%s,\n' % c.encode('hex'))
+    f_out.write('0x%s,\n' % binascii.hexlify(c))
 f_out.write('0x00 };\n')
 f_out.write('int %s_size = sizeof(%s_block)-1;\n' % (prefix, prefix))


### PR DESCRIPTION
Apparently string.encode() was deprecated in python 3.
