### PR TITLE
Raise minimum LLVM to 6.0, drop LLVM 5

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -112,6 +112,29 @@ jobs:
             source src/build-scripts/gh-installdeps.bash
             source src/build-scripts/ci-build-and-test.bash
 
+  linux-oldest:
+    name: "Linux oldest everything: gcc6, C++11, llvm7, oiio 2.0, no simd, exr2.2"
+    # Unfortunately, this isn't the oldest of everything we support, but
+    # rather, the oldest of everything we can easily get on GH CI.
+    # Should be gcc 4.8 if we can figure out how to make that work.
+    # Should be llvm 6, but precompiled binaries for ubuntu 18 are llvm 7+.
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: all
+        env:
+          CXX: g++-6
+          USE_CPP: 11
+          CMAKE_CXX_STANDARD: 11
+          LLVM_VERSION: 7.0.1
+          USE_SIMD: 0
+          OPENEXR_BRANCH: v2.2.0
+          OPENIMAGEIO_BRANCH: RB-2.0
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps.bash
+            source src/build-scripts/ci-build-and-test.bash
+
   macos-py37:
     name: "Mac py37"
     runs-on: macOS-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ matrix:
               - *common-packages
               - *old-boost-packages
         env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.0 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=release BUILD_CMAKE=1
-      - name: "Older things: OIIO 2.0, llvm 5, boost 1.58"
+      - name: "Older things: OIIO 2.0, llvm 6, boost 1.58"
         os: linux
         dist: trusty
         compiler: gcc
@@ -126,7 +126,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=5.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
       - name: "gcc7, llvm7, C++14"
         os: linux
@@ -162,7 +162,7 @@ matrix:
               - *common-boost-packages
               - g++-6
         env: DEBUG=1 WHICHGCC=6 LLVM_VERSION=7.0.0 OPENIMAGEIO_BRANCH=master BUILD_CMAKE=1
-      - name: "Oldest everything: gcc4.8, LLVM 5, OIIO 2.0, no simd"
+      - name: "Oldest everything: gcc4.8, LLVM 6, OIIO 2.0, no simd"
         os: linux
         dist: trusty
         compiler: gcc
@@ -172,7 +172,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: USE_SIMD=0 LLVM_VERSION=5.0.1 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
+        env: USE_SIMD=0 LLVM_VERSION=6.0.1 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
 
 notifications:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,8 @@
 Release 1.11/2.0? -- ?? 2019 (compared to 1.10)
 --------------------------------------------------
 Dependency and standards changes:
-* **LLVM 5.0-9.0**: Support for LLVM 4 has been dropped. Support for LLVM 8
-  and 9 have been added. (Alert: we may also drop support for LLVM 5 by the
-  time we branch for the next major release.)
+* **LLVM 5.0-9.0**: Support for LLVM 4 and 5 have been dropped. Support for
+  LLVM 8 and 9 have been added.
 * OpenImageIO 2.0-2.1: Support for OIIO 1.8 has been dropped; a minimum
   of OIIO 2.0 is needed to build OSL. #1038 (1.11.0)
 * CMake minimum is now 3.12. #1072 (1.11.1)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X) and then OSL's build scripts will be able
     to find it.
 
-* **[LLVM](http://www.llvm.org) 5.0, 6.0, 7.0, 8.0, or 9.0**
+* **[LLVM](http://www.llvm.org) 6.0, 7.0, 8.0, or 9.0**
 
    Optionally, if Clang libraries are installed alongside LLVM, OSL will
    in most circumstances use Clang's internals for C-style preprocessing of

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ help:
 	@echo "      BOOST_ROOT=path          Custom Boost installation"
 	@echo "      USE_QT=0                 Skip anything that needs Qt"
 	@echo "  LLVM-related options:"
-	@echo "      LLVM_VERSION=6.0         Specify which LLVM version to use"
+	@echo "      LLVM_VERSION=7.0         Specify which LLVM version to use"
 	@echo "      LLVM_DIRECTORY=xx        Specify where LLVM lives"
 	@echo "      LLVM_NAMESPACE=xx        Specify custom LLVM namespace"
 	@echo "      LLVM_STATIC=1            Use static LLVM libraries"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_build:
     $OSL_INSTALL_BEGIN=Get-Date
     Write-Output "Configuration: $env:CONFIGURATION"
     Write-Output "Platform: $env:PLATFORM"
-    ls C:\Libraries\llvm-5.0.0
+    ls C:\Program Files\LLVM
     Get-ChildItem Env:
 
     [Array]$OSL_BUILD_FLAGS = "--", "/nologo", "/verbosity:minimal";
@@ -51,7 +51,7 @@ before_build:
     $DEP_DIR = "C:\projects\OSLdeps"
     $BOOST_ROOT = "C:\Libraries\boost_1_69_0"
     $PYTHON_DIR = "C:\Python27"
-    $LLVM_DIR = "C:\Libraries\llvm-5.0.0"
+    $LLVM_DIR = "C:\Program Files\LLVM\bin"
     #$LLVM_DIR = "$DEP_DIR"
     $env:Path += ";$DEP_DIR\lib;$DEP_DIR\bin"
     $OSL_INT_DIR = "build\windows$env:PLATFORM"

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -205,7 +205,7 @@ checked_find_package (PugiXML REQUIRED)
 
 
 # LLVM library setup
-checked_find_package (LLVM 5.0 REQUIRED
+checked_find_package (LLVM 6.0 REQUIRED
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/oslconfig.h>
 #include <OSL/llvm_util.h>
 
-#if OSL_LLVM_VERSION < 50
-#error "LLVM minimum version required for OSL is 5.0"
+#if OSL_LLVM_VERSION < 60
+#error "LLVM minimum version required for OSL is 6.0"
 #endif
 
 #include <llvm/IR/Constants.h>
@@ -94,11 +94,11 @@ typedef llvm::Error LLVMErr;
 
 namespace {
 
-#if OSL_LLVM_VERSION >= 60
-// NOTE: This is a COPY of something internal to LLVM, but since we destroy our LLVMMemoryManager
-//       via global variables we can't rely on the LLVM copy sticking around.
-//       Because of this, the variable must be declared _before_ jitmm_hold so that the object stays
-//       valid until after we have destroyed all our memory managers.
+// NOTE: This is a COPY of something internal to LLVM, but since we destroy
+// our LLVMMemoryManager via global variables we can't rely on the LLVM copy
+// sticking around. Because of this, the variable must be declared _before_
+// jitmm_hold so that the object stays valid until after we have destroyed
+// all our memory managers.
 struct DefaultMMapper final : public llvm::SectionMemoryManager::MemoryMapper {
     llvm::sys::MemoryBlock
     allocateMappedMemory(llvm::SectionMemoryManager::AllocationPurpose Purpose,
@@ -117,7 +117,6 @@ struct DefaultMMapper final : public llvm::SectionMemoryManager::MemoryMapper {
     }
 };
 static DefaultMMapper llvm_default_mapper;
-#endif
 
 static OIIO::spin_mutex llvm_global_mutex;
 static bool setup_done = false;
@@ -257,11 +256,7 @@ LLVM_Util::LLVM_Util (int debuglevel)
             m_thread->llvm_context = new llvm::LLVMContext();
 
         if (! m_thread->llvm_jitmm) {
-#if OSL_LLVM_VERSION >= 60
             m_thread->llvm_jitmm = new LLVMMemoryManager(&llvm_default_mapper);
-#else
-            m_thread->llvm_jitmm = new LLVMMemoryManager();
-#endif
             ASSERT (m_thread->llvm_jitmm);
             jitmm_hold.emplace_back (m_thread->llvm_jitmm);
         }


### PR DESCRIPTION
LLVM 9 is about to branch... supporting 6,7,8 and soon 9 is more than enough, we don't
need to support 5 versions back.

Also, LLVM 6 is the minimum that can be used with the new OptiX work, so 5 will soon be very undesirable if not already.
