### PR TITLE
Some fixes for mingw compiler

### DIFF
--- a/src/cmake/modules/FindPugiXML.cmake
+++ b/src/cmake/modules/FindPugiXML.cmake
@@ -12,12 +12,12 @@ find_path (PUGIXML_INCLUDE_DIR
            NAMES pugixml.hpp
            PATHS ${PUGIXML_HOME}/include
            /usr/local/include
-           /usr/local/include/pugixml-1.8)
+           PATH_SUFFIXES pugixml-1.8 pugixml-1.9)
 find_library (PUGIXML_LIBRARY
               NAMES pugixml
               PATHS ${PUGIXML_HOME}/lib
               /usr/local/lib
-              /usr/local/lib/pugixml-1.8)
+              PATH_SUFFIXES pugixml-1.8 pugixml-1.9)
 
 # Second chance -- if not found, look in the OIIO distro
 if (NOT PUGIXML_INCLUDE_DIR AND OPENIMAGEIO_INCLUDE_DIR)

--- a/src/include/OSL/export.h
+++ b/src/include/OSL/export.h
@@ -86,7 +86,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-#if defined(oslcomp_EXPORTS)
+#if defined(oslcomp_EXPORTS) || defined(oslexec_EXPORTS)
 #  define OSLCOMPPUBLIC OSL_DLL_EXPORT
 #else
 #  define OSLCOMPPUBLIC OSL_DLL_IMPORT

--- a/src/include/OSL/export.h
+++ b/src/include/OSL/export.h
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// dependencies, and so what is exported for one may be imported for
 /// another.
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   #if defined(OSL_STATIC_BUILD)
     #define OSL_DLL_IMPORT
     #define OSL_DLL_EXPORT


### PR DESCRIPTION
1. Allow to use pugixml-1.9
2. MIngw compiler use ````__declspec```` macroses too for export symbols
3. Fix export symbols by liboslexec to allow properly link osltoy