### PR TITLE
Allow aggregate component access with .[xyzrgb]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Dependency and standards changes:
   we may drop support for OIIO 1.x.
 
 OSL Language and oslc compiler:
+* New syntax to reference color and point/vector/normal components as
+  named struct components, such as C.r, C.g, C.b, or P.x, P.y, P.z.
+  #1049 (1.11.0)
 * oslc compilation speed-ups with faster retrieval of source lines when
   pasted into oso output. #938 (1.11.0)
 * Writing to function parameters not marked as `output` was only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             logic loop matrix message
             mergeinstances-nouserdata mergeinstances-vararray
             metadata-braces miscmath missing-shader
+            named-components
             noise noise-cell
             noise-gabor noise-gabor2d-filter noise-gabor3d-filter
             noise-perlin noise-simplex
@@ -343,6 +344,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             oslc-err-intoverflow oslc-err-write-nonoutput
             oslc-err-noreturn oslc-err-notfunc
             oslc-err-initlist-args oslc-err-initlist-return
+            oslc-err-named-components
             oslc-err-outputparamvararray oslc-err-paramdefault
             oslc-err-struct-array-init oslc-err-struct-ctr
             oslc-err-struct-dup oslc-err-struct-print

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -60,8 +60,8 @@ Language Specification
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 31 Mar 2018 \\
- (with corrections, 23 Jul 2019)
+\date{{\large Date: 3 Aug 2019 \\
+% (with corrections, 23 Jul 2019)
 }
 \bigskip
 \bigskip
@@ -1620,6 +1620,16 @@ Colors can have their individual components examined and set using the
 It is an error to access a color component with an index outside the
 $[0...2]$ range.
 
+Color variables may also have their components referenced using
+``named components'' that look like accessing structure fields named
+{\cf r}, {\cf g}, and {\cf b}, as synonyms for {\cf [0]}, {\cf [1]}, and
+{\cf [2]}, respectively:
+
+\begin{code}
+    float green = C.g;   // get the green component
+    C.r = 0.5;           // set the red component
+\end{code}
+
 The following operators may be used with \color values (in order of
 decreasing precedence, with each box holding operators of the same
 precedence):
@@ -1780,6 +1790,16 @@ the {\cf []} array access notation.  For example:
 \noindent Components 0, 1, and 2 are $x$, $y$, and $z$, respectively.
 It is an error to access a point component with an index outside the
 $[0...2]$ range.
+
+Point-like variables may also have their components referenced using
+``named components'' that look like accessing structure fields named
+{\cf x}, {\cf y}, and {\cf z}, as synonyms for {\cf [0]}, {\cf [1]}, and
+{\cf [2]}, respectively:
+
+\begin{code}
+    float yval = P.y;    // get the [1] or y component
+    P.x = 0.5;           // set the [0] or x component
+\end{code}
 
 The following operators may be used with point-like values (in order of
 decreasing precedence, with each box holding operators of the same
@@ -5462,6 +5482,13 @@ nothing (empty, no token).
 \alt <variable_lvalue> "." <identifier>
 
 <variable-ref> ::= <identifier> <array-deref-opt> 
+
+<array-deref> ::= "[" <expression> "]"
+
+<component-deref> ::= "[" <expression> "]"
+\alt "." <component-field>
+
+<component-field> ::= "x" | "y" | "z" | "r" | "g" | "b"
 
 <binary-op> ::= "*" | "/" | "\%"
 \alt "+" | "-" 

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -134,6 +134,11 @@ public:
     /// reliable if it's not a struct, a struct will return an UNKNOWN type.
     const TypeDesc &simpletype () const { return m_simple; }
 
+    /// Is the type unknown/uninitialized?
+    bool is_unknown () const noexcept {
+        return m_simple == OIIO::TypeUnknown && !m_structure && !m_closure;
+    }
+
     /// Is this typespec a closure?  (N.B. if so, you can find out what
     /// kind of closure it is with simpletype()).
     bool is_closure () const { return m_closure && !is_array(); }

--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -244,6 +244,11 @@ ASTindex::typecheck (TypeSpec expected)
 TypeSpec
 ASTstructselect::typecheck (TypeSpec expected)
 {
+    if (compindex()) {
+        // Redirected codegen to ASTIndex for named component (e.g., point.x)
+        return compindex()->typecheck(expected);
+    }
+
     // The ctr already figured out if this was a valid structure selection
     if (m_fieldid < 0 || m_fieldsym == NULL) {
         return TypeSpec();
@@ -338,8 +343,7 @@ ASTassign_expression::typecheck (TypeSpec expected)
                 return m_typespec;
             }
         }
-        error ("Cannot assign %s %s = %s", type_c_str(vt), varname,
-               type_c_str(et));
+        error ("Cannot assign %s %s = %s", vt, varname, et);
         return m_typespec;
     }
 
@@ -359,8 +363,7 @@ ASTassign_expression::typecheck (TypeSpec expected)
         if (vts == ets)
             return m_typespec = vt;
         // Otherwise, a structure mismatch
-        error ("Cannot assign %s %s = %s", type_c_str(vt), varname,
-               type_c_str(et));
+        error ("Cannot assign %s %s = %s", vt, varname, et);
         return m_typespec;
     }
 
@@ -369,10 +372,9 @@ ASTassign_expression::typecheck (TypeSpec expected)
         // Special case: for int=float, it's just a warning.
         if (vt.is_int() && et.is_float())
             warning ("Assignment may lose precision: %s %s = %s",
-                     type_c_str(vt), varname, type_c_str(et));
+                     vt, varname, et);
         else
-            error ("Cannot assign %s %s = %s",
-                   type_c_str(vt), varname, type_c_str(et));
+            error ("Cannot assign %s %s = %s", vt, varname, et);
         return m_typespec;
     }
 

--- a/testsuite/color/ref/out.txt
+++ b/testsuite/color/ref/out.txt
@@ -4,6 +4,13 @@ Compiled test.osl -> test.oso
 
   color (0.1) = 0.1 0.1 0.1
   color (0.1, 0.2, 0.5) = 0.1 0.2 0.5
+  C = color (0 1 2) has components 0, 1, 2
+  After C[1] = 8, V = (0 8 2)
+  After C[2] = 0.5, V = (0 8 0.5)
+  C = color (0 8 0.5) has rgb components 0, 8, 0.5
+  After C.r = 14.5, C = (14.5 8 0.5)
+  After C.g = 15.5, C = (14.5 15.5 0.5)
+  After C.b = 16.5, C = (14.5 15.5 16.5)
 
 testing with spaces:
   color ("rgb", 0.1, 0.2, 0.5) = 0.1 0.2 0.5

--- a/testsuite/color/test.osl
+++ b/testsuite/color/test.osl
@@ -13,7 +13,25 @@ test (color cparam = color (.1, .7, .2),
         printf ("  color (%g, %g, %g) = %g\n", a, b, c, color(a,b,c));
     }
 
-    { 
+    {
+        color C = color (0, 1, 2);
+        printf ("  C = color (%g) has components %g, %g, %g\n",
+                C, C[0], C[1], C[2]);
+        C[1] = 8;
+        printf ("  After C[1] = 8, V = (%g)\n", C);
+        C[2] = 0.5;
+        printf ("  After C[2] = 0.5, V = (%g)\n", C);
+        printf ("  C = color (%g) has rgb components %g, %g, %g\n",
+                C, C.r, C.g, C.b);
+        C.r = 14.5;
+        printf ("  After C.r = 14.5, C = (%g)\n", C);
+        C.g = 15.5;
+        printf ("  After C.g = 15.5, C = (%g)\n", C);
+        C.b = 16.5;
+        printf ("  After C.b = 16.5, C = (%g)\n", C);
+    }
+
+    {
         float a = 0.1, b = 0.2, c = 0.5;
         printf ("\ntesting with spaces:\n");
         printf ("  color (\"rgb\", %g, %g, %g) = %g\n",

--- a/testsuite/named-components/ref/out.txt
+++ b/testsuite/named-components/ref/out.txt
@@ -1,0 +1,34 @@
+Compiled test.osl -> test.oso
+point:
+  R = point(0 1 2) has components 0, 1, 2
+  After R.x = 0.25, R = (0.25 1 2)
+  After R.y = 0.50, R = (0.25 0.5 2)
+  After R.z = 0.75, R = (0.25 0.5 0.75)
+  Via function params, R comps = 0.25 0.5 0.75
+  After function params, R = 42 0.5 0.75
+  Setting array components separately, arr[1] = 1.5 2 2.5
+vector:
+  R = vector(0 1 2) has components 0, 1, 2
+  After R.x = 0.25, R = (0.25 1 2)
+  After R.y = 0.50, R = (0.25 0.5 2)
+  After R.z = 0.75, R = (0.25 0.5 0.75)
+  Via function params, R comps = 0.25 0.5 0.75
+  After function params, R = 42 0.5 0.75
+  Setting array components separately, arr[1] = 1.5 2 2.5
+normal:
+  R = normal(0 1 2) has components 0, 1, 2
+  After R.x = 0.25, R = (0.25 1 2)
+  After R.y = 0.50, R = (0.25 0.5 2)
+  After R.z = 0.75, R = (0.25 0.5 0.75)
+  Via function params, R comps = 0.25 0.5 0.75
+  After function params, R = 42 0.5 0.75
+  Setting array components separately, arr[1] = 1.5 2 2.5
+color:
+  R = color(0 1 2) has components 0, 1, 2
+  After R.r = 0.25, R = (0.25 1 2)
+  After R.g = 0.50, R = (0.25 0.5 2)
+  After R.b = 0.75, R = (0.25 0.5 0.75)
+  Via function params, R comps = 0.25 0.5 0.75
+  After function params, R = 42 0.5 0.75
+  Setting array components separately, arr[1] = 1.5 2 2.5
+

--- a/testsuite/named-components/run.py
+++ b/testsuite/named-components/run.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+command = testshade("test")

--- a/testsuite/named-components/test.osl
+++ b/testsuite/named-components/test.osl
@@ -1,0 +1,34 @@
+float retrieve(float q) { return q; }
+
+void set(output float q, float r) { q = r; }
+
+
+// Rather than replicate test functions for each type, we put the test
+// function in test_named_comp.h, but it relies on TYPE being defined
+// (and also has X, Y, Z macros defaulting to x, y, z). So we make multipe
+// functions by including the header several times with different macro
+// definitions. (The header clears the macro defs at its end.)
+
+#define TYPE point
+#include "test_named_comp.h"
+
+#define TYPE vector
+#include "test_named_comp.h"
+
+#define TYPE normal
+#include "test_named_comp.h"
+
+#define TYPE color
+#define X r
+#define Y g
+#define Z b
+#include "test_named_comp.h"
+
+shader
+test ()
+{
+    test_named_comp(point(0));
+    test_named_comp(vector(0));
+    test_named_comp(normal(0));
+    test_named_comp(color(0));
+}

--- a/testsuite/named-components/test_named_comp.h
+++ b/testsuite/named-components/test_named_comp.h
@@ -1,0 +1,63 @@
+// A test for named components. Use TYPE, X, Y, Z macros to customize for
+// different types.
+
+
+#ifndef TYPE
+#  error "Must define TYPE, X, Y, Z"
+#endif
+
+// If X hasn't been defined, use X,Y,Z = x,y,z. So it only needs to be
+// defined for colors.
+#ifndef X
+#  define X x
+#  define Y y
+#  define Z z
+#endif
+
+// Helper macro to turn symbols into strings.
+#ifndef STRINGIZE
+#  define STRINGIZE2(a) #a
+#  define STRINGIZE(a) STRINGIZE2(a)
+#endif
+
+
+
+void
+test_named_comp(TYPE dummy)
+{
+    printf (STRINGIZE(TYPE) ":\n");
+
+    // Test retrieval of components by name
+    TYPE R = TYPE (0, 1, 2);
+    printf ("  R = " STRINGIZE(TYPE) "(%g) has components %g, %g, %g\n",
+            R, R.X, R.Y, R.Z);
+
+    // Test setting of components by name
+    R.X = 0.25;
+    printf ("  After R." STRINGIZE(X) " = 0.25, R = (%g)\n", R);
+    R.Y = 0.5;
+    printf ("  After R." STRINGIZE(Y) " = 0.50, R = (%g)\n", R);
+    R.Z = 0.75;
+    printf ("  After R." STRINGIZE(Z) " = 0.75, R = (%g)\n", R);
+
+    // Make sure we can use components as parameters to functions
+    printf ("  Via function params, R comps = %g %g %g\n",
+            retrieve(R.X), retrieve(R.Y), retrieve(R.Z));
+    set(R.X, 42.0);
+    printf ("  After function params, R = %g\n", R);
+
+    // Test array
+    TYPE arr[2] = { TYPE(0), TYPE(0) };
+    arr[1].X = 1.5;
+    arr[1].Y = 2.0;
+    arr[1].Z = 2.5;
+    printf ("  Setting array components separately, arr[1] = %g %g %g\n",
+            arr[1].X, arr[1].Y, arr[1].Z);
+}
+
+
+// Clear the macro definitions so we can include this header multiple times.
+#undef TYPE
+#undef X
+#undef Y
+#undef Z

--- a/testsuite/oslc-err-named-components/NOOPTIMIZE
+++ b/testsuite/oslc-err-named-components/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-named-components/NOOPTIX
+++ b/testsuite/oslc-err-named-components/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-named-components/ref/out.txt
+++ b/testsuite/oslc-err-named-components/ref/out.txt
@@ -1,0 +1,6 @@
+test.osl:11: error: type 'color' does not have a member 'x'
+test.osl:12: error: type 'color' does not have a member 'err'
+test.osl:16: error: type 'vector' does not have a member 'r'
+test.osl:17: error: type 'vector' does not have a member 'oops'
+test.osl:21: error: struct type 'Foo' does not have a member 'r'
+FAILED test.osl

--- a/testsuite/oslc-err-named-components/run.py
+++ b/testsuite/oslc-err-named-components/run.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-named-components/test.osl
+++ b/testsuite/oslc-err-named-components/test.osl
@@ -1,0 +1,22 @@
+struct Foo {
+   color alice;
+   float bob;
+};
+
+
+shader test ()
+{
+    color C;
+    C.r = 1;  // ok
+    C.x = 1;  // not ok
+    C.err = 1; // not ok
+
+    vector V;
+    V.x = 1;  // ok
+    V.r = 1;  // not ok
+    V.oops = 1;  // not ok
+
+    Foo foo;
+    foo.bob = 1;  // ok
+    foo.r = 1;  // not ok
+}

--- a/testsuite/vector/ref/out-alt.txt
+++ b/testsuite/vector/ref/out-alt.txt
@@ -1,9 +1,19 @@
 Compiled test.osl -> test.oso
+  parameter initialization test: vparam = 0.1 0.7 0.2
+  parameter initialization test2: vparam2 = 0.1 0.1 0.1
+
 Test vector functions
 
+  vector (0.1) = 0.1 0.1 0.1
+  vector (0.1, 0.2, 0.5) = 0.1 0.2 0.5
   V = vector (0 1 2) has components 0, 1, 2
   After V[1] = 8, V = (0 8 2)
   After V[2] = 0.5, V = (0 8 0.5)
+  V = vector (0 8 0.5) has xyz components 0, 8, 0.5
+  After V.x = 14.5, V = (14.5 8 0.5)
+  After V.y = 15.5, V = (14.5 15.5 0.5)
+  After V.z = 16.5, V = (14.5 15.5 16.5)
+ V = 0 8 0.5
   dot ((0 8 0.5), (0 8 0.5)) = 64.25
   dot ((0 8 0.5), (0 1 0)) = 8
   cross ((1 0 0), (0 1 0)) = 0 0 1

--- a/testsuite/vector/ref/out.txt
+++ b/testsuite/vector/ref/out.txt
@@ -1,9 +1,19 @@
 Compiled test.osl -> test.oso
+  parameter initialization test: vparam = 0.1 0.7 0.2
+  parameter initialization test2: vparam2 = 0.1 0.1 0.1
+
 Test vector functions
 
+  vector (0.1) = 0.1 0.1 0.1
+  vector (0.1, 0.2, 0.5) = 0.1 0.2 0.5
   V = vector (0 1 2) has components 0, 1, 2
   After V[1] = 8, V = (0 8 2)
   After V[2] = 0.5, V = (0 8 0.5)
+  V = vector (0 8 0.5) has xyz components 0, 8, 0.5
+  After V.x = 14.5, V = (14.5 8 0.5)
+  After V.y = 15.5, V = (14.5 15.5 0.5)
+  After V.z = 16.5, V = (14.5 15.5 16.5)
+ V = 0 8 0.5
   dot ((0 8 0.5), (0 8 0.5)) = 64.25
   dot ((0 8 0.5), (0 1 0)) = 8
   cross ((1 0 0), (0 1 0)) = 0 0 1

--- a/testsuite/vector/test.osl
+++ b/testsuite/vector/test.osl
@@ -1,11 +1,25 @@
 shader
-test ()
+test (vector vparam = vector (.1, .7, .2),
+      vector vparam2 = vector (.1),
+      vector vparam3 = vector ("object", .1, .2, .3))
 {
-    printf ("Test vector functions\n\n");
     vector X = vector (1, 0, 0);
+
+    printf ("  parameter initialization test: vparam = %g\n", vparam);
+    printf ("  parameter initialization test2: vparam2 = %g\n", vparam2);
+    printf ("\n");
+
+    printf ("Test vector functions\n\n");
     vector Y = vector (0, 1, 0);
     vector XY = X + Y;
     vector Zero = 0;
+
+    {
+        float a = 0.1, b = 0.2, c = 0.5;
+        printf ("  vector (%g) = %g\n", a, vector(a));
+        printf ("  vector (%g, %g, %g) = %g\n", a, b, c, vector(a,b,c));
+    }
+
     {
         vector V = vector (0, 1, 2);
         printf ("  V = vector (%g) has components %g, %g, %g\n",
@@ -14,6 +28,19 @@ test ()
         printf ("  After V[1] = 8, V = (%g)\n", V);
         V[2] = 0.5;
         printf ("  After V[2] = 0.5, V = (%g)\n", V);
+        printf ("  V = vector (%g) has xyz components %g, %g, %g\n",
+                V, V.x, V.y, V.z);
+        V.x = 14.5;
+        printf ("  After V.x = 14.5, V = (%g)\n", V);
+        V.y = 15.5;
+        printf ("  After V.y = 15.5, V = (%g)\n", V);
+        V.z = 16.5;
+        printf ("  After V.z = 16.5, V = (%g)\n", V);
+    }
+
+    {
+        vector V = vector (0, 8, 0.5);
+        printf (" V = %g\n", V);
         printf ("  dot ((%g), (%g)) = %g\n", V, V, dot(V,V));
         printf ("  dot ((%g), (%g)) = %g\n", V, Y, dot(V,Y));
         printf ("  cross ((%g), (%g)) = %g\n", X, Y, cross(X,Y));


### PR DESCRIPTION
Spatial geometry triples (point, vector, normal) now support A.x, A.y,
A.z as synonyms for A[0], A[1], A[2], respectively. It's not the
notation I prefer (obviously, or I would have done it 25 years ago),
but other people really dig it, so fine by me.

Colors now support A.r, A.g, A.b as synonyms for A[0], A[1], A[2],
respectively.  To be honest, this worries me a little because I fear
we will regret it if we ever shift to supporting spectral rendering
(and the components will not necessarily represent red, green, and
blue, and may have arbitrary number). But again, people really seem to
like this, so fine, but don't come complaining to me in a few years
when your shaders all need rewriting for your new spectral renderer.

In both cases, it's for direct reference to lvalues (variables, including
references passed as arguments to functions):

    val = P.x;   // yes
    P.y = val;   // yes
    function_with_float_param (P.z);   // yes

But you can't use this notations on arbitrary expressions:

    val = function_returning_color().r;   // no
    val = (P + N).y;                      // no, double ick

We are also NOT supporting "swizzling."

