### PR TITLE
Fix private header inclusion of opcolor.h

### DIFF
--- a/src/liboslexec/opcolor.h
+++ b/src/liboslexec/opcolor.h
@@ -110,7 +110,7 @@ public:
     template <typename Color> OSL_HOSTDEVICE Color
     ocio_transform (StringParam fromspace, StringParam tospace, const Color& C, Context);
 
-    OSL_HOSTDEVICE StringParam colorspace() const { return m_colorspace; }
+    OSL_HOSTDEVICE const StringParam& colorspace() const { return m_colorspace; }
 
     OSL_HOSTDEVICE void error(StringParam src, StringParam dst, Context);
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1252,6 +1252,23 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
 #undef ATTR_SET_STRING
 }
 
+    
+
+template <typename T> static bool
+getAttributePtr (T* obj, void** val, int arraylen = 1) {
+    using DataType = typename std::remove_pointer<T>::type;
+    static_assert(!std::is_pointer<DataType>::value, "Requesting a pointer to a pointer!");
+
+    // arraylen is TypeDesc:arraylen which means 0 and 1 are [kind-of] the same
+    DASSERT(arraylen >= 0 && arraylen <= 2 && "Invalid pointer request");
+
+    val[0] = obj;
+    // Interpret array len of two as a request for the data and size
+    if (arraylen == 2)
+        ((uintptr_t*)val)[1] = sizeof(DataType);
+    return true;
+}
+
 
 
 bool
@@ -1398,9 +1415,10 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("stat:mem_inst_connections_current", long long, m_stat_mem_inst_connections.current());
     ATTR_DECODE ("stat:mem_inst_connections_peak", long long, m_stat_mem_inst_connections.peak());
 
-    if (name == "colorsystem" && type.basetype == TypeDesc::PTR) {
-        *(void**)val = &colorsystem();
-        return true;
+    ATTR_DECODE_STRING ("colorsystem:colorspace", colorsystem().colorspace());
+    if (type.basetype == TypeDesc::PTR) {
+        if (name == "colorsystem")
+            return getAttributePtr(&colorsystem(), (void**)val, type.arraylen);
     }
 
     return false;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1402,8 +1402,20 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
         *(void**)val = &colorsystem();
         return true;
     }
-    ATTR_DECODE ("colorsystem:size", long long, sizeof(colorsystem()));
-    ATTR_DECODE_STRING ("colorsystem:colorspace", colorsystem().colorspace());
+    if (name == "colorsystem:sizes" && type.basetype == TypeDesc::LONGLONG) {
+        if (type.arraylen != 2) {
+            error ("Must request two colorsystem:sizes, [sizeof(pvt::ColorSystem), num-strings]");
+            return false;
+        }
+        long long* lptr = (long long*) val;
+        lptr[0] = sizeof(pvt::ColorSystem);
+        lptr[1] = 1; // 1 string (pvt::ColorSystem::m_colorspace)
+
+        // Make sure everything adds up!
+        ASSERT((((char*)&colorsystem() + lptr[0]) - sizeof(ustring)*lptr[1]) ==
+               (char*)&colorsystem().colorspace());
+        return true;
+    }
 
     return false;
 #undef ATTR_DECODE

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -160,29 +160,21 @@ OptixRaytracer::synch_attributes ()
     m_optix_ctx["test_str_2"]->setUserData (sizeof(char*), &addr2);
 
     {
-        // FIXME -- This requires knowing the last field of osl::pvt::ColorSystem is a StringParam so the CPU->GPU:
-        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(DeviceString)
-        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(DeviceString))
-        
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
-
-        ustring colorspace;
-        if (!shadingsys->getattribute("colorsystem:colorspace", colorspace)) {
-            errhandler().error ("No colorspace available.");
-            return false;
-        }
-
-        void* colorSys = nullptr;
-        long long cpuDataSize = 0;
+        
+        char* colorSys = nullptr;
+        long long cpuDataSizes[2] = {0,0};
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
-            !shadingsys->getattribute("colorsystem:size", TypeDesc::LONGLONG, (void*)&cpuDataSize) ||
-            !colorSys || !cpuDataSize) {
+            !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
+            !colorSys || !cpuDataSizes[0]) {
             errhandler().error ("No colorsystem available.");
             return false;
         }
+        auto cpuDataSize = cpuDataSizes[0];
+        auto numStrings = cpuDataSizes[1];
         
         // Get the size data-size, minus the ustring size
-        const size_t podDataSize = cpuDataSize - sizeof(StringParam);
+        const size_t podDataSize = cpuDataSize - sizeof(StringParam)*numStrings;
         
         optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
         if (!buffer) {
@@ -194,23 +186,27 @@ OptixRaytracer::synch_attributes ()
         buffer->setElementSize(sizeof(char));
         
         // and number of elements to the actual size needed.
-        buffer->setSize(podDataSize + sizeof(DeviceString));
+        buffer->setSize(podDataSize + sizeof(DeviceString)*numStrings);
         
         // copy the base data
         char* gpuData = (char*) buffer->map();
         if (!gpuData) {
             errhandler().error ("Could not map buffer for '%s' (size: %lu).",
-                                name, podDataSize + sizeof(DeviceString));
+                                name, podDataSize + sizeof(DeviceString)*numStrings);
             return false;
         }
         ::memcpy(gpuData, colorSys, podDataSize);
         
-        // convert the ustring to a device string
-        uint64_t devStr = register_string (colorspace.string(), "");
-        
+        // then copy the device string to the end, first strings starting at dataPtr - (numStrings)
         // FIXME -- Should probably handle alignment better.
-        // then copy the device string to the end
-        ::memcpy(gpuData+podDataSize, &devStr, sizeof(devStr));
+        const ustring* cpuString = (const ustring*)(colorSys + (cpuDataSize - sizeof(StringParam)*numStrings));
+        char* gpuStrings = gpuData + podDataSize;
+        for (const ustring* end = cpuString + numStrings; cpuString < end; ++cpuString) {
+            // convert the ustring to a device string
+            uint64_t devStr = register_string (cpuString->string(), "");
+            ::memcpy(gpuStrings, &devStr, sizeof(devStr));
+            gpuStrings += sizeof(DeviceString);
+        }
         
         buffer->unmap();
         m_optix_ctx[name]->setBuffer(buffer);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/oslconfig.h>
 
 #include "optixraytracer.h"
-#include "../liboslexec/opcolor.h"
 
 // The pre-compiled renderer support library LLVM bitcode is embedded
 // into the executable and made available through these variables.
@@ -161,46 +160,58 @@ OptixRaytracer::synch_attributes ()
     m_optix_ctx["test_str_2"]->setUserData (sizeof(char*), &addr2);
 
     {
+        // FIXME -- This requires knowing the last field of osl::pvt::ColorSystem is a StringParam so the CPU->GPU:
+        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(StringParam)
+        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(StringParam))
+        
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
 
-        pvt::ColorSystem* colorSys = nullptr;
-        shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys);
-        if (colorSys == nullptr) {
-            errhandler().error ("No colorsystem available.");
+        ustring colorspace;
+        if (!shadingsys->getattribute("colorsystem:colorspace", colorspace)) {
+            errhandler().error ("No colorspace available.");
             return false;
         }
 
+        void* colorSysData[2] = { nullptr, nullptr };
+        shadingsys->getattribute("colorsystem", TypeDesc(TypeDesc::PTR, 2), (void*)&colorSysData);
+        if (!colorSysData[0] || !colorSysData[1]) {
+            errhandler().error ("No colorsystem available.");
+            return false;
+        }
+        void* colorSys = colorSysData[0];
+        uintptr_t cpuDataSize = (uintptr_t) colorSysData[1];
+        
         // Get the size data-size, minus the ustring size
-        const size_t dataSize = sizeof(pvt::ColorSystem) - sizeof(StringParam);
-
+        const size_t podDataSize = cpuDataSize - sizeof(StringParam);
+        
         optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
         if (!buffer) {
             errhandler().error ("Could not create buffer for '%s'.", name);
             return false;
         }
-
+        
         // set the elemet size to char
         buffer->setElementSize(sizeof(char));
-
+        
         // and number of elements to the actual size needed.
-        buffer->setSize(dataSize + sizeof(DeviceString));
-
+        buffer->setSize(podDataSize + sizeof(DeviceString));
+        
         // copy the base data
-        char* dstData = (char*) buffer->map();
-        if (!dstData) {
+        char* gpuData = (char*) buffer->map();
+        if (!gpuData) {
             errhandler().error ("Could not map buffer for '%s' (size: %lu).",
-                                 name, dataSize);
+                                name, podDataSize + sizeof(DeviceString));
             return false;
         }
-        ::memcpy(dstData, colorSys, dataSize);
-
+        ::memcpy(gpuData, colorSys, podDataSize);
+        
         // convert the ustring to a device string
-        uint64_t devStr = register_string (colorSys->colorspace().string(), "");
-
+        uint64_t devStr = register_string (colorspace.string(), "");
+        
         // FIXME -- Should probably handle alignment better.
         // then copy the device string to the end
-        ::memcpy(dstData+dataSize, &devStr, sizeof(devStr));
-
+        ::memcpy(gpuData+podDataSize, &devStr, sizeof(devStr));
+        
         buffer->unmap();
         m_optix_ctx[name]->setBuffer(buffer);
     }

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -161,8 +161,8 @@ OptixRaytracer::synch_attributes ()
 
     {
         // FIXME -- This requires knowing the last field of osl::pvt::ColorSystem is a StringParam so the CPU->GPU:
-        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(StringParam)
-        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(StringParam))
+        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(DeviceString)
+        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(DeviceString))
         
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
 
@@ -172,14 +172,14 @@ OptixRaytracer::synch_attributes ()
             return false;
         }
 
-        void* colorSysData[2] = { nullptr, nullptr };
-        shadingsys->getattribute("colorsystem", TypeDesc(TypeDesc::PTR, 2), (void*)&colorSysData);
-        if (!colorSysData[0] || !colorSysData[1]) {
+        void* colorSys = nullptr;
+        long long cpuDataSize = 0;
+        if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
+            !shadingsys->getattribute("colorsystem:size", TypeDesc::LONGLONG, (void*)&cpuDataSize) ||
+            !colorSys || !cpuDataSize) {
             errhandler().error ("No colorsystem available.");
             return false;
         }
-        void* colorSys = colorSysData[0];
-        uintptr_t cpuDataSize = (uintptr_t) colorSysData[1];
         
         // Get the size data-size, minus the ustring size
         const size_t podDataSize = cpuDataSize - sizeof(StringParam);

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -146,29 +146,21 @@ OptixGridRenderer::synch_attributes ()
     m_optix_ctx["test_str_2"]->setUserData (sizeof(char*), &addr2);
 
     {
-        // FIXME -- This requires knowing the last field of osl::pvt::ColorSystem is a StringParam so the CPU->GPU:
-        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(DeviceString)
-        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(DeviceString))
-        
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
         
-        ustring colorspace;
-        if (!shadingsys->getattribute("colorsystem:colorspace", colorspace)) {
-            errhandler().error ("No colorspace available.");
-            return false;
-        }
-        
-        void* colorSys = nullptr;
-        long long cpuDataSize = 0;
+        char* colorSys = nullptr;
+        long long cpuDataSizes[2] = {0,0};
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
-            !shadingsys->getattribute("colorsystem:size", TypeDesc::LONGLONG, (void*)&cpuDataSize) ||
-            !colorSys || !cpuDataSize) {
+            !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
+            !colorSys || !cpuDataSizes[0]) {
             errhandler().error ("No colorsystem available.");
             return false;
         }
-        
+        auto cpuDataSize = cpuDataSizes[0];
+        auto numStrings = cpuDataSizes[1];
+
         // Get the size data-size, minus the ustring size
-        const size_t podDataSize = cpuDataSize - sizeof(StringParam);
+        const size_t podDataSize = cpuDataSize - sizeof(StringParam)*numStrings;
         
         optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
         if (!buffer) {
@@ -180,23 +172,27 @@ OptixGridRenderer::synch_attributes ()
         buffer->setElementSize(sizeof(char));
         
         // and number of elements to the actual size needed.
-        buffer->setSize(podDataSize + sizeof(DeviceString));
+        buffer->setSize(podDataSize + sizeof(DeviceString)*numStrings);
         
         // copy the base data
         char* gpuData = (char*) buffer->map();
         if (!gpuData) {
             errhandler().error ("Could not map buffer for '%s' (size: %lu).",
-                                name, podDataSize + sizeof(DeviceString));
+                                name, podDataSize + sizeof(DeviceString)*numStrings);
             return false;
         }
         ::memcpy(gpuData, colorSys, podDataSize);
         
-        // convert the ustring to a device string
-        uint64_t devStr = register_string (colorspace.string(), "");
-        
+        // then copy the device string to the end, first strings starting at dataPtr - (numStrings)
         // FIXME -- Should probably handle alignment better.
-        // then copy the device string to the end
-        ::memcpy(gpuData+podDataSize, &devStr, sizeof(devStr));
+        const ustring* cpuString = (const ustring*)(colorSys + (cpuDataSize - sizeof(StringParam)*numStrings));
+        char* gpuStrings = gpuData + podDataSize;
+        for (const ustring* end = cpuString + numStrings; cpuString < end; ++cpuString) {
+            // convert the ustring to a device string
+            uint64_t devStr = register_string (cpuString->string(), "");
+            ::memcpy(gpuStrings, &devStr, sizeof(devStr));
+            gpuStrings += sizeof(DeviceString);
+        }
         
         buffer->unmap();
         m_optix_ctx[name]->setBuffer(buffer);

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -147,8 +147,8 @@ OptixGridRenderer::synch_attributes ()
 
     {
         // FIXME -- This requires knowing the last field of osl::pvt::ColorSystem is a StringParam so the CPU->GPU:
-        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(StringParam)
-        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(StringParam))
+        //  1. Uploads the pod-data of size (osl::pvt::ColorSystem) - sizeof(DeviceString)
+        //  2. Then registers the string at *((osl::pvt::ColorSystem) - sizeof(DeviceString))
         
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
         
@@ -158,14 +158,14 @@ OptixGridRenderer::synch_attributes ()
             return false;
         }
         
-        void* colorSysData[2] = { nullptr, nullptr };
-        shadingsys->getattribute("colorsystem", TypeDesc(TypeDesc::PTR, 2), (void*)&colorSysData);
-        if (!colorSysData[0] || !colorSysData[1]) {
+        void* colorSys = nullptr;
+        long long cpuDataSize = 0;
+        if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
+            !shadingsys->getattribute("colorsystem:size", TypeDesc::LONGLONG, (void*)&cpuDataSize) ||
+            !colorSys || !cpuDataSize) {
             errhandler().error ("No colorsystem available.");
             return false;
         }
-        void* colorSys = colorSysData[0];
-        uintptr_t cpuDataSize = (uintptr_t) colorSysData[1];
         
         // Get the size data-size, minus the ustring size
         const size_t podDataSize = cpuDataSize - sizeof(StringParam);


### PR DESCRIPTION
## Description
Fixes reliance on liboslexec/opcolor.h in client code.
There isn't a super-great simple-solution here while still keeping liboptix out of liboslexec.

Final version seem like it should be extensible enough to at least handle other data upload that needs to convert device strings...but uploading OCIO transforms will probably change all of this anyway?

