### PR TITLE
Add remaining matrix ops to optix

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -143,7 +143,7 @@ public:
     llvm::Value *llvm_load_value (const Symbol& sym, int deriv = 0,
                                   int component = 0,
                                   TypeDesc cast=TypeDesc::UNKNOWN) {
-        return llvm_load_value (sym, deriv, NULL, component, cast);
+        return (use_optix() && ! sym.typespec().is_closure() && sym.typespec().is_string()) ? llvm_load_device_string(sym) : llvm_load_value (sym, deriv, NULL, component, cast);
     }
 
     /// Load the address of a global device-side string pointer, which may

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1516,7 +1516,7 @@ LLVMGEN (llvm_gen_construct_triple)
         llvm::Value *args[] = { rop.sg_void_ptr(),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
-            rop.llvm_load_value(Space), rop.ll.constant(Strings::common),
+            rop.llvm_load_string(Space), rop.ll.constant(Strings::common),,
             rop.ll.constant((int)vectype) };
         RendererServices *rend (rop.shadingsys().renderer());
         if (rend->transform_points (NULL, from, to, 0.0f, NULL, NULL, 0, vectype)) {
@@ -1556,8 +1556,8 @@ LLVMGEN (llvm_gen_matrix)
         llvm::Value *args[] = {
                 rop.sg_void_ptr(),  // shader globals
                 rop.llvm_void_ptr(Result),  // result
-                rop.llvm_load_value(*rop.opargsym (op, 1)),  // from
-                rop.llvm_load_value(*rop.opargsym (op, 2)),  // to
+                rop.llvm_load_string(*rop.opargsym (op, 1)),  // from
+                rop.llvm_load_string(*rop.opargsym (op, 2)),  // to
         };
         rop.ll.call_function ("osl_get_from_to_matrix", args);
     } else {
@@ -1580,7 +1580,7 @@ LLVMGEN (llvm_gen_matrix)
             llvm::Value *args[] = {
                 rop.sg_void_ptr(),  // shader globals
                 rop.llvm_void_ptr(Result),  // result
-                rop.llvm_load_value(*rop.opargsym (op, 1)),  // from
+                rop.llvm_load_string(*rop.opargsym (op, 1)),  // from
             };
             rop.ll.call_function ("osl_prepend_matrix_from", args);
         }
@@ -1606,8 +1606,8 @@ LLVMGEN (llvm_gen_getmatrix)
     llvm::Value *args[] = {
         rop.sg_void_ptr(),  // shader globals
         rop.llvm_void_ptr(M),  // matrix result
-        rop.llvm_load_value(From),
-        rop.llvm_load_value(To),
+        rop.llvm_load_string(From),
+        rop.llvm_load_string(To),
     };
     llvm::Value *result = rop.ll.call_function ("osl_get_from_to_matrix", args);
     rop.llvm_store_value (result, Result);
@@ -1661,7 +1661,7 @@ LLVMGEN (llvm_gen_transform)
     llvm::Value *args[] = { rop.sg_void_ptr(),
         rop.llvm_void_ptr(*P), rop.ll.constant(P->has_derivs()),
         rop.llvm_void_ptr(*Result), rop.ll.constant(Result->has_derivs()),
-        rop.llvm_load_value(*From), rop.llvm_load_value(*To),
+        rop.llvm_load_string(*From), rop.llvm_load_string(*To),
         rop.ll.constant((int)vectype) };
     RendererServices *rend (rop.shadingsys().renderer());
     if (rend->transform_points (NULL, from, to, 0.0f, NULL, NULL, 0, vectype)) {

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1516,7 +1516,7 @@ LLVMGEN (llvm_gen_construct_triple)
         llvm::Value *args[] = { rop.sg_void_ptr(),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
-            rop.llvm_load_string(Space), rop.ll.constant(Strings::common),,
+            rop.llvm_load_string(Space), rop.ll.constant(Strings::common),
             rop.ll.constant((int)vectype) };
         RendererServices *rend (rop.shadingsys().renderer());
         if (rend->transform_points (NULL, from, to, 0.0f, NULL, NULL, 0, vectype)) {

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1516,7 +1516,7 @@ LLVMGEN (llvm_gen_construct_triple)
         llvm::Value *args[] = { rop.sg_void_ptr(),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
             rop.llvm_void_ptr(Result), rop.ll.constant(Result.has_derivs()),
-            rop.llvm_load_string(Space), rop.ll.constant(Strings::common),
+            rop.llvm_load_value(Space), rop.ll.constant(Strings::common),
             rop.ll.constant((int)vectype) };
         RendererServices *rend (rop.shadingsys().renderer());
         if (rend->transform_points (NULL, from, to, 0.0f, NULL, NULL, 0, vectype)) {
@@ -1556,8 +1556,8 @@ LLVMGEN (llvm_gen_matrix)
         llvm::Value *args[] = {
                 rop.sg_void_ptr(),  // shader globals
                 rop.llvm_void_ptr(Result),  // result
-                rop.llvm_load_string(*rop.opargsym (op, 1)),  // from
-                rop.llvm_load_string(*rop.opargsym (op, 2)),  // to
+                rop.llvm_load_value(*rop.opargsym (op, 1)),  // from
+                rop.llvm_load_value(*rop.opargsym (op, 2)),  // to
         };
         rop.ll.call_function ("osl_get_from_to_matrix", args);
     } else {
@@ -1580,7 +1580,7 @@ LLVMGEN (llvm_gen_matrix)
             llvm::Value *args[] = {
                 rop.sg_void_ptr(),  // shader globals
                 rop.llvm_void_ptr(Result),  // result
-                rop.llvm_load_string(*rop.opargsym (op, 1)),  // from
+                rop.llvm_load_value(*rop.opargsym (op, 1)),  // from
             };
             rop.ll.call_function ("osl_prepend_matrix_from", args);
         }
@@ -1606,8 +1606,8 @@ LLVMGEN (llvm_gen_getmatrix)
     llvm::Value *args[] = {
         rop.sg_void_ptr(),  // shader globals
         rop.llvm_void_ptr(M),  // matrix result
-        rop.llvm_load_string(From),
-        rop.llvm_load_string(To),
+        rop.llvm_load_value(From),
+        rop.llvm_load_value(To),
     };
     llvm::Value *result = rop.ll.call_function ("osl_get_from_to_matrix", args);
     rop.llvm_store_value (result, Result);
@@ -1661,7 +1661,7 @@ LLVMGEN (llvm_gen_transform)
     llvm::Value *args[] = { rop.sg_void_ptr(),
         rop.llvm_void_ptr(*P), rop.ll.constant(P->has_derivs()),
         rop.llvm_void_ptr(*Result), rop.ll.constant(Result->has_derivs()),
-        rop.llvm_load_string(*From), rop.llvm_load_string(*To),
+        rop.llvm_load_value(*From), rop.llvm_load_value(*To),
         rop.ll.constant((int)vectype) };
     RendererServices *rend (rop.shadingsys().renderer());
     if (rend->transform_points (NULL, from, to, 0.0f, NULL, NULL, 0, vectype)) {

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -330,4 +330,58 @@ extern "C" {
         }
         return indexvalue;
     }
+
+#define MAT(m) (*(OSL::Matrix44 *)m)
+    __device__
+    int osl_get_matrix (void *sg_, void *r, const char *from)
+    {
+        ShaderGlobals *sg = (ShaderGlobals *)sg_;
+        //ShadingContext *ctx = (ShadingContext *)sg->context;
+        if (HDSTR(from) == StringParams::common ||
+            //HDSTR(from) == ctx->shadingsys().commonspace_synonym() ||
+            HDSTR(from) == StringParams::shader)
+        {
+            MAT(r).makeIdentity ();
+            return true;
+        }
+        if (HDSTR(from) == StringParams::object)
+        {
+            // TODO: Implement transform
+            return false;
+        }
+        int ok = false; // TODO: Implement transform
+        if (!ok)
+        {
+            MAT(r).makeIdentity();
+            // TBR: OSL would throw an error here, what should we do?
+        }
+        return ok;
+    }
+
+    __device__
+    int osl_get_inverse_matrix (void *sg_, void *r, const char *to)
+    {
+        ShaderGlobals *sg = (ShaderGlobals *)sg_;
+        //ShadingContext *ctx = (ShadingContext *)sg->context;
+        if (HDSTR(to) == StringParams::common ||
+            //HDSTR(to) == ctx->shadingsys().commonspace_synonym() ||
+            HDSTR(to) == StringParams::shader)
+        {
+            MAT(r).makeIdentity ();
+            return true;
+        }
+        if (HDSTR(to) == StringParams::object)
+        {
+            // TODO: Implement transform
+            return false;
+        }
+        int ok = false; // TODO: Implement transform
+        if (!ok)
+        {
+            MAT(r).makeIdentity();
+            // TBR: OSL would throw an error here, what should we do?
+        }
+        return ok;
+    }
+#undef MAT
 }


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
In this pull request I have ported the remaining matrix ops to OptiX. This therefore allows renderers to add support for transforms (camera, raster, screen space etc..) in the OptiX runtime. The majority of this PR was just adding the device decorations for the correct functions and using `llvm_load_string` in stead of `llvm_load_value` in the correct places so that device strings are dealt with correctly. Notice that I have left the `osl_get_matrix` and `osl_get_inverse_matrix` functions as extern functions. The design of this is because they need some kind of renderer callback. As extern this allows the renderer to directly implement these ops in the same way we do with such ops as `osl_allocate_closure_component`. I have created the basic functions for these in the rend_lib.cu file but have left the actual implementation of the OSL transforms for another enthusiastic contributor as to not take all the fun.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

