### PR TITLE
OptiX Fixes - or - How I Spent My Summer Vacation

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -509,7 +509,7 @@ BackendLLVM::getOrAllocateCUDAVariable (const Symbol& sym, bool addMetadata)
 
     // TODO: Figure out the actual CUDA alignment requirements for the various
     //       OSL types. For now, be somewhat conservative and assume 8 for
-    //       non-scalar types. See: createOptixVariable()
+    //       non-scalar types.
     int alignment = (sym.typespec().is_scalarnum()) ? 4 : 8;
 
     llvm::Value* cuda_var = addCUDAVariable (name, sym, sym.size(), alignment, sym.data(),
@@ -663,7 +663,7 @@ BackendLLVM::llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
 
 
 llvm::Value *
-BackendLLVM::llvm_load_device_string (const Symbol& sym)
+BackendLLVM::llvm_load_device_string (const Symbol& sym, bool follow)
 {
     // TODO: need to make this work with arrays of strings
     ASSERT (use_optix() && "This is only intended to be used with CUDA");
@@ -688,8 +688,12 @@ BackendLLVM::llvm_load_device_string (const Symbol& sym)
                            ll.type_longlong_ptr());
     }
 
-    // Follow the pointer value to get to the char*.
-    val = ll.int_to_ptr_cast (ll.op_load (val));
+    // It's preferable to deal with device strings "symbolically" through the
+    // CUDA variable (essentially a char**), which helps keep the code
+    // portable. But sometimes it's necessary to handle the underlying char*
+    // directly, e.g. when printing or writing out a closure param.
+    if (follow)
+        val = ll.int_to_ptr_cast (ll.op_load (val));
 
     return val;
 }
@@ -731,7 +735,7 @@ BackendLLVM::llvm_load_constant_value (const Symbol& sym,
     }
     if (sym.typespec().is_string() && use_optix()) {
         ASSERT ((arrayindex == 0) && "String arrays are not currently supported in OptiX");
-        return llvm_load_device_string (sym);
+        return llvm_load_device_string (sym, /*follow*/ false);
     }
     if (sym.typespec().is_string()) {
         const ustring *val = (const ustring *)sym.data();
@@ -945,7 +949,7 @@ BackendLLVM::llvm_call_function (const char *name,
         if (s.typespec().is_closure())
             valargs[i] = llvm_load_value (s);
         else if (use_optix() && s.typespec().is_string())
-            valargs[i] = llvm_load_device_string (s);
+            valargs[i] = llvm_load_device_string (s, /*follow*/ true);
         else if (s.typespec().simpletype().aggregate > 1 ||
                  (deriv_ptrs && s.has_derivs()))
             valargs[i] = llvm_void_ptr (s);
@@ -1048,7 +1052,7 @@ BackendLLVM::llvm_assign_impl (Symbol &Result, Symbol &Src,
     const int num_components = rt.aggregate;
     const bool singlechan = (srccomp != -1) || (dstcomp != -1);
     if (use_optix() && Src.typespec().is_string()) {
-        llvm::Value* src = llvm_load_device_string (Src);
+        llvm::Value* src = llvm_load_device_string (Src, /*follow*/ true);
         llvm_store_value (ll.ptr_cast (src, ll.type_void_ptr()), Result);
     }
     else if (!singlechan) {

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -394,11 +394,10 @@ BackendLLVM::createOptixVariable (const std::string& name, const std::string& ty
         return it->second;
     }
 
-    int alignment =
-        (type == "float" ) ? 4 :
-        (type == "int"   ) ? 4 :
-        (type == "color" ) ? 8 :
-        (type == "string") ? 8 : 8;
+    // TODO: Figure out the actual CUDA alignment requirements for the various
+    //       OSL types. For now, be somewhat conservative and assume 8 for
+    //       non-scalar types. See: getOrAllocateCUDAVariable()
+    int alignment = (type == "float" || type == "int" ) ? 4 : 8;
 
     // Create a global variable with the name, type, and initializer. This is
     // the value that will be accessed when the shader executes.
@@ -525,16 +524,10 @@ BackendLLVM::getOrAllocateCUDAVariable (const Symbol& sym)
         return it->second;
     }
 
-    int alignment =
-        (sym.typespec().is_scalarnum()) ? 4 :
-        (sym.typespec().is_triple()   ) ? 8 :
-        (sym.typespec().is_array()    ) ? 8 :
-        (sym.typespec().is_matrix()   ) ? 8 :
-        (sym.typespec().is_string()   ) ? 8 : -1;
-
-    if (alignment < 1) {
-        return nullptr;
-    }
+    // TODO: Figure out the actual CUDA alignment requirements for the various
+    //       OSL types. For now, be somewhat conservative and assume 8 for
+    //       non-scalar types. See: createOptixVariable()
+    int alignment = (sym.typespec().is_scalarnum()) ? 4 : 8;
 
     return addCUDAVariable (name, sym.size(), alignment, sym.data(),
                             sym.typespec().string());

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -143,17 +143,21 @@ public:
     llvm::Value *llvm_load_value (const Symbol& sym, int deriv = 0,
                                   int component = 0,
                                   TypeDesc cast=TypeDesc::UNKNOWN) {
-        return (use_optix() && ! sym.typespec().is_closure() && sym.typespec().is_string()) ? llvm_load_device_string(sym) : llvm_load_value (sym, deriv, NULL, component, cast);
+        return (use_optix() && ! sym.typespec().is_closure() && sym.typespec().is_string())
+            ? llvm_load_device_string (sym, /*follow*/ true)
+            : llvm_load_value (sym, deriv, NULL, component, cast);
     }
 
     /// Load the address of a global device-side string pointer, which may
     /// reside in a global variable, the groupdata struct, or a local value.
-    llvm::Value *llvm_load_device_string (const Symbol& sym);
+    llvm::Value *llvm_load_device_string (const Symbol& sym, bool follow);
 
     /// Convenience function to load a string for CPU or GPU device
     llvm::Value *llvm_load_string (const Symbol& sym) {
         DASSERT(sym.typespec().is_string());
-        return use_optix() ? llvm_load_device_string(sym) : llvm_load_value(sym);
+        return use_optix()
+            ? llvm_load_device_string(sym, /*follow*/ true)
+            : llvm_load_value(sym);
     }
 
     /// Legacy version

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -228,22 +228,15 @@ public:
     /// Allocate a CUDA variable for the given OSL symbol and return a pointer
     /// to the corresponding LLVM GlobalVariable, or return the pointer if it
     /// has already been allocated.
-    llvm::Value *getOrAllocateCUDAVariable (const Symbol& sym);
+    llvm::Value *getOrAllocateCUDAVariable (const Symbol& sym, bool addMetadata=false);
 
     /// Create a CUDA global variable and add it to the current Module
-    llvm::Value *addCUDAVariable (const std::string& name, int size,
-                                  int alignment, void* data,
+    llvm::Value *addCUDAVariable (const std::string& name, const Symbol& sym,
+                                  int size, int alignment, const void* data,
                                   const std::string& type="");
 
-    /// Create a CUDA variable, along with the extra semantic information needed
-    /// by OptiX.
-    llvm::Value *createOptixVariable (const std::string& name,
-                                      const std::string& type,
-                                      int size, void* data );
-
     /// Create the extra semantic information needed for OptiX variables
-    void createOptixMetadata (const std::string& name,
-                              const std::string& type, int size );
+    void createOptixMetadata (const std::string& name, const Symbol& sym );
 
     /// Retrieve an llvm::Value that is a pointer holding the start address
     /// of the specified symbol. This always works for globals and params;

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -751,9 +751,7 @@ BackendLLVM::build_llvm_init ()
         ll.op_memset (ll.void_ptr(layer_run_ref(0)), 0, sz, 4 /*align*/);
     }
     int num_userdata = (int) group().m_userdata_names.size();
-    if (num_userdata && ! use_optix()) {
-        // NB: we don't need these flags in the OptiX case because userdata is
-        //     accessed through rtVariables, which are guaranteed to be initialized
+    if (num_userdata) {
         int sz = (num_userdata + 3) & (~3);  // round up to 32 bits
         ll.op_memset (ll.void_ptr(userdata_initialized_ref(0)), 0, sz, 4 /*align*/);
     }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -503,7 +503,12 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
     } else if (use_optix() && ! sym.typespec().is_closure() && ! sym.typespec().is_string()) {
         // If the call to osl_bind_interpolated_param returns 0, the default
         // value needs to be loaded from a CUDA variable.
-        llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym);
+        ustring var_name = ustring::format ("%s_%s_%s_%d", sym.name(),
+                                            inst()->layername(), group().name(), group().id());
+
+        // The "true" argument triggers the creation of the metadata needed to
+        // make the variable visible to OptiX.
+        llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym, true);
 
         // memcpy the initial value from the CUDA variable
         llvm::Value* src = ll.ptr_cast (ll.GEP (cuda_var, 0), ll.type_void_ptr());

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -457,7 +457,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
 #endif
             Symbol symname_const (arg_name, TypeDesc::TypeString, SymTypeConst);
             symname_const.data (&symname);
-            name_arg = llvm_load_device_string (symname_const);
+            name_arg = llvm_load_device_string (symname_const, /*follow*/ true);
         } else {
             name_arg = ll.constant (symname);
         }
@@ -520,7 +520,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         // struct.
         int userdata_index = find_userdata_index (sym);
         llvm::Value* init_val = getOrAllocateCUDAVariable (sym);
-        init_val = ll.ptr_cast (ll.GEP (init_val, 0), ll.type_void_ptr());
+        init_val = ll.ptr_cast (init_val, ll.type_void_ptr());
         ll.op_memcpy (groupdata_field_ptr (2 + userdata_index), init_val, 8, 4);
     } else if (! sym.lockgeom() && ! sym.typespec().is_closure()) {
         // geometrically-varying param; memcpy its default value

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -152,13 +152,13 @@ float3 process_closure(const OSL::ClosureColor* closure_tree)
 
         case MICROFACET_ID: {
 #if 0
-            const char* mem = ((OSL::ClosureComponent*) cur)->mem;
+            const char* mem = (const char*)((OSL::ClosureComponent*) cur)->data();
             const char* dist_str = *(const char**) &mem[0];
             if (launch_index.x == launch_dim.x / 2 && launch_index.y == launch_dim.y / 2) {
                 printf ("microfacet, dist: %s\n", HDSTR(dist_str).c_str());
                 // Comparisons between the closure variable and "standard"
                 // strings are possible
-                if (HDSTR(dist_str) == OSLDeviceStrings::default_)
+                if (HDSTR(dist_str) == OSL::DeviceStrings::default_)
                     printf("dist is default\n");
             }
 #endif


### PR DESCRIPTION
## Description
This is a handful of small fixes that have built up over the last several months. Apologies for their somewhat wide-ranging nature, we can break them into several PRs if that would be helpful.

Issue #1040 is addressed by allowing init ops in the OptiX path. This had been conservatively disallowed, but there aren't any obvious reasons that init ops won't Just Work™.

Issue #1027 highlighted some shortcomings in userdata initialization. I've made `rend_get_userdata` look and behave more like the host version. This issue also flushed out a bug in a little-used corner of rtVariable initialization which has been patched in recent drivers.

There was [an issue](https://groups.google.com/forum/#!topic/osl-dev/qwymeCvdFOw) raised on the osl-dev group about variable updates no longer working. This was due to metadata for OptiX variables not being created. I fixed that issue and squished out a bit of duplication in CUDA/OptiX variable creation. I also relaxed the constraints on the types and the alignment of CUDA variables. This is to allow a wider range of parameter types to be initialized.

Lastly, it was discovered that closure capture was not working properly for strings. DeviceStrings are essentially a `char**`, and sometimes it is convenient to copy the `char*` (like when writing a closure param) and sometimes it's better to handle the `char**` (like when assigning a temporary variable). I added a bool to `llvm_load_device_string` to determine the semantics.

## Tests
I have not added any new tests. If the existing testsuite does not cover init ops and userdata initialization in OptiX, can it be easily extended?

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

