### PR TITLE
LLVM 9 / clang 9 compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 * A suitable C++11 compiler to build OSL itself, which may be any of:
    - GCC 4.8.5 or newer (through gcc 8)
-   - Clang 3.4 or newer (through clang 8)
+   - Clang 3.4 or newer (through clang 9)
    - Microsoft Visual Studio 2015 or newer
    - Intel C++ compiler icc version 13 (?) or newer
 

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -57,7 +57,7 @@ ifeq ($(SP_OS), rhel7)
 
     ## If not overridden, here is our preferred LLVM installation
     ## (may be changed as new versions are rolled out to the facility)
-    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_7.0.1
+    LLVM_DIRECTORY ?= /shots/spi/home/lib/arnold/rhel7/llvm_8.0.0
 
     # A variety of tags can be used to try specific versions of gcc or
     # clang from the site-specific places we have installed them.
@@ -65,10 +65,30 @@ ifeq ($(SP_OS), rhel7)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.1/bin/clang \
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_6.0.1/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" \
+                          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr" \
+			  -DTOOLCHAIN_FLAGS="--gcc-toolchain=/usr"
     else ifeq (${COMPILER}, clang7)
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_7.0.1/bin/clang \
            -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_7.0.1/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" \
+                          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr" \
+			  -DTOOLCHAIN_FLAGS="--gcc-toolchain=/usr"
+    else ifeq (${COMPILER}, clang8)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_8.0.0/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_8.0.0/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" \
+                          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr" \
+			  -DTOOLCHAIN_FLAGS="--gcc-toolchain=/usr"
+    else ifeq (${COMPILER}, clang9)
+        MY_CMAKE_FLAGS += \
+           -DCMAKE_C_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_9.0.0_rc4/bin/clang \
+           -DCMAKE_CXX_COMPILER=/shots/spi/home/lib/arnold/rhel7/llvm_9.0.0_rc4/bin/clang++
+        MY_CMAKE_FLAGS += -DCMAKE_C_FLAGS="--gcc-toolchain=/usr" \
+                          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr" \
+			  -DTOOLCHAIN_FLAGS="--gcc-toolchain=/usr"
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc6)
@@ -159,6 +179,11 @@ else ifeq (${platform}, macosx)
         # default compiler is clang, taken from the LLVM directory
         MY_CMAKE_FLAGS += \
            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+    else ifeq (${COMPILER},llvm)
+        # "llvm" means "use the clang from our llvm"
+        MY_CMAKE_FLAGS += \
+            -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     endif
 
     # end generic OSX

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -64,6 +64,17 @@ find_library ( LLVM_MCJIT_LIBRARY
                NAMES LLVMMCJIT
                PATHS ${LLVM_LIB_DIR})
 
+if (NOT LLVM_LIBRARY)
+    # if no single library was found, use llvm-config to generate the list
+    # of what libraries we need, and substitute that in the right way for
+    # LLVM_LIBRARY.
+    execute_process (COMMAND ${LLVM_CONFIG} --libfiles
+                     OUTPUT_VARIABLE LLVM_LIBRARIES
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string (REPLACE " " ";" LLVM_LIBRARIES "${LLVM_LIBRARIES}")
+    set (LLVM_LIBRARY "${LLVM_LIBRARIES}")
+endif ()
+
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST clangBasic
                    clangEdit clangLex)

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -682,7 +682,12 @@ LLVM_Util::make_function (const std::string &name, bool fastcall,
                           bool varargs)
 {
     llvm::FunctionType *functype = type_function (rettype, params, varargs);
+#if OSL_LLVM_VERSION >= 90
+    auto funccallee = module()->getOrInsertFunction(name, functype);
+    llvm::Value* c = funccallee.getCallee();
+#else
     llvm::Constant *c = module()->getOrInsertFunction (name, functype);
+#endif
     ASSERT (c && "getOrInsertFunction returned NULL");
     ASSERT_MSG (llvm::isa<llvm::Function>(c),
                 "Declaration for %s is wrong, LLVM had to make a cast", name.c_str());


### PR DESCRIPTION
Only one extra `#if` this time to make it work with LLVM 9.0 (currently in release candidate), and compiling with clang9 seemed to work without changes. 

There are a few SPI-specific makefile fixes.