### PR TITLE
Make rend_get_userdata behave more like the host version

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -751,9 +751,7 @@ BackendLLVM::build_llvm_init ()
         ll.op_memset (ll.void_ptr(layer_run_ref(0)), 0, sz, 4 /*align*/);
     }
     int num_userdata = (int) group().m_userdata_names.size();
-    if (num_userdata && ! use_optix()) {
-        // NB: we don't need these flags in the OptiX case because userdata is
-        //     accessed through rtVariables, which are guaranteed to be initialized
+    if (num_userdata) {
         int sz = (num_userdata + 3) & (~3);  // round up to 32 bits
         ll.op_memset (ll.void_ptr(userdata_initialized_ref(0)), 0, sz, 4 /*align*/);
     }


### PR DESCRIPTION
## Description
Issue #1027 highlighted some shortcomings in userdata initialization. This patch makes `rend_get_userdata` match the host version more closely, especially with regard to the `userdata_initialized` flags.

This issue also flushed out a bug in rtVariable initialization that has since been patched. In some cases, only the first member of an aggregate type was correctly initialized with a default value.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests
No new tests.
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

