### PR TITLE
Overhaul OptiX variable creation

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -228,22 +228,15 @@ public:
     /// Allocate a CUDA variable for the given OSL symbol and return a pointer
     /// to the corresponding LLVM GlobalVariable, or return the pointer if it
     /// has already been allocated.
-    llvm::Value *getOrAllocateCUDAVariable (const Symbol& sym);
+    llvm::Value *getOrAllocateCUDAVariable (const Symbol& sym, bool addMetadata=false);
 
     /// Create a CUDA global variable and add it to the current Module
-    llvm::Value *addCUDAVariable (const std::string& name, int size,
-                                  int alignment, void* data,
+    llvm::Value *addCUDAVariable (const std::string& name, const Symbol& sym,
+                                  int size, int alignment, const void* data,
                                   const std::string& type="");
 
-    /// Create a CUDA variable, along with the extra semantic information needed
-    /// by OptiX.
-    llvm::Value *createOptixVariable (const std::string& name,
-                                      const std::string& type,
-                                      int size, void* data );
-
     /// Create the extra semantic information needed for OptiX variables
-    void createOptixMetadata (const std::string& name,
-                              const std::string& type, int size );
+    void createOptixMetadata (const std::string& name, const Symbol& sym );
 
     /// Retrieve an llvm::Value that is a pointer holding the start address
     /// of the specified symbol. This always works for globals and params;

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -231,9 +231,8 @@ public:
     llvm::Value *getOrAllocateCUDAVariable (const Symbol& sym, bool addMetadata=false);
 
     /// Create a CUDA global variable and add it to the current Module
-    llvm::Value *addCUDAVariable (const std::string& name, const Symbol& sym,
-                                  int size, int alignment, const void* data,
-                                  const std::string& type="");
+    llvm::Value *addCUDAVariable (const std::string& name, int size, int alignment,
+                                  const void* data, TypeDesc type=TypeDesc::UNKNOWN);
 
     /// Create the extra semantic information needed for OptiX variables
     void createOptixMetadata (const std::string& name, const Symbol& sym );

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -503,7 +503,12 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
     } else if (use_optix() && ! sym.typespec().is_closure() && ! sym.typespec().is_string()) {
         // If the call to osl_bind_interpolated_param returns 0, the default
         // value needs to be loaded from a CUDA variable.
-        llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym);
+        ustring var_name = ustring::format ("%s_%s_%s_%d", sym.name(),
+                                            inst()->layername(), group().name(), group().id());
+
+        // The "true" argument triggers the creation of the metadata needed to
+        // make the variable visible to OptiX.
+        llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym, true);
 
         // memcpy the initial value from the CUDA variable
         llvm::Value* src = ll.ptr_cast (ll.GEP (cuda_var, 0), ll.type_void_ptr());


### PR DESCRIPTION
## Description

There was [an issue](https://groups.google.com/forum/#!topic/osl-dev/qwymeCvdFOw) raised on the osl-dev group about variable updates no longer working in optix. This was due to a missing call to `createOptixMetadata`, which I had inadvertently removed in #973. I fixed that issue and squished out a bit of duplication in CUDA/OptiX variable creation.

I followed @fpsunflower's suggestion from #1057 and now use `TypeDesc` instead of `std::string` to communicate the type when creating a CUDA variable.

## Tests
No new tests added, but existing OptiX tests pass.

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

