### PR TITLE
Build test projects on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,7 @@ macro ( TESTSUITE )
             NOT _testname MATCHES "optix" AND
             NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
             set (_env TESTSHADE_OPT=0
+                      PATH=${PATH}${PNG_LIBRARIES}
                       OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
                       OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                       OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )
@@ -261,6 +262,7 @@ macro ( TESTSUITE )
         if (NOT _testname MATCHES "optix"
             AND NOT EXISTS "${_testsrcdir}/NOOPTIMIZE")
             set (_env TESTSHADE_OPT=2
+                      PATH=${PATH}${PNG_LIBRARIES}
                       OPENIMAGEIO_ROOT_DIR=${OPENIMAGEIO_ROOT_DIR}
                       OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                       OSL_BUILD_DIR=${CMAKE_BINARY_DIR} )

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -67,6 +67,67 @@ message (STATUS "Using OpenImageIO ${OPENIMAGEIO_VERSION}")
 
 
 ###########################################################################
+# OpenColorIO Setup
+
+if (OSL_BUILD_TESTS)
+
+    find_package (OpenColorIO REQUIRED)
+
+    if (OCIO_FOUND AND LINKSTATIC)
+        find_library (TINYXML_LIBRARY NAMES tinyxml PATHS ${OCIO_PATH}/lib/)
+        if (TINYXML_LIBRARY)
+            set (OCIO_LIBRARIES ${OCIO_LIBRARIES} ${TINYXML_LIBRARY})
+        endif ()
+        find_library (YAML_LIBRARY NAMES yaml-cpp libyaml-cppmd libyaml-cppmdd PATHS ${OCIO_PATH}/lib/)
+        if (YAML_LIBRARY)
+            set (OCIO_LIBRARIES ${OCIO_LIBRARIES} ${YAML_LIBRARY})
+        endif ()
+    endif ()
+endif ()
+
+# end OpenColorIO setup
+###########################################################################
+
+###########################################################################
+# TIFF
+
+if (OSL_BUILD_TESTS)
+    find_package (TIFF 3.9 REQUIRED)
+endif ()
+
+###########################################################################
+
+
+###########################################################################
+# PNG
+
+if (OSL_BUILD_TESTS)
+    find_package (PNG REQUIRED)
+endif ()
+
+###########################################################################
+
+
+###########################################################################
+# JPEG
+
+if (OSL_BUILD_TESTS)
+    if (USE_JPEGTURBO)
+        find_package (JPEGTurbo)
+    endif ()
+    if (JPEG_FOUND)
+        add_definitions ("-DUSE_JPEG_TURBO=1")
+        set (JPEG_TURBO_FOUND 1)
+    else ()
+        find_package (JPEG REQUIRED)
+    endif ()
+endif ()
+
+# end JPEG
+###########################################################################
+
+
+###########################################################################
 # LLVM library setup
 
 find_package (LLVM 5.0 REQUIRED)

--- a/src/cmake/modules/FindOpenColorIO.cmake
+++ b/src/cmake/modules/FindOpenColorIO.cmake
@@ -1,0 +1,46 @@
+# Module to find OpenColorIO
+#
+# This module will first look into the directories defined by the variables:
+#   - OCIO_PATH, OCIO_LIBRARY_PATH
+#
+# This module defines the following variables:
+#
+# OCIO_FOUND       - True if OpenColorIO was found.
+# OCIO_LIBRARIES   - list of libraries to link against when using OpenColorIO
+
+# Other standard issue macros
+include (FindPackageHandleStandardArgs)
+include (FindPackageMessage)
+message(STATUS "Looking for library: OpenColorIO")
+
+if (NOT OpenColorIO_FIND_QUIETLY)
+    if (OCIO_PATH)
+        message(STATUS "OCIO path explicitly specified: ${OCIO_PATH}")
+    endif()
+    if (OCIO_LIBRARY_PATH)
+        message(STATUS "OCIO LIBRARY_PATH explicitly specified: ${OCIO_LIBRARY_PATH}")
+    endif()
+endif ()
+FIND_LIBRARY(OCIO_LIBRARIES
+    NAMES OCIO OpenColorIO
+    PATHS
+    ${OCIO_LIBRARY_PATH}
+    ${OCIO_PATH}/lib/
+    /usr/lib64
+    /usr/lib
+    /usr/local/lib64
+    /usr/local/lib
+    /sw/lib
+    /opt/local/lib
+    DOC "The OCIO library")
+
+if(OCIO_LIBRARIES)
+    set(OCIO_FOUND TRUE)
+    if (NOT OpenColorIO_FIND_QUIETLY)
+        message(STATUS "Found OCIO library ${OCIO_LIBRARIES}")
+    endif ()
+else()
+    set(OCIO_FOUND FALSE)
+    message(STATUS "OCIO not found. Specify OCIO_PATH to locate it")
+endif()
+

--- a/src/liboslnoise/CMakeLists.txt
+++ b/src/liboslnoise/CMakeLists.txt
@@ -16,7 +16,11 @@ set_target_properties (oslnoise
                        OUTPUT_NAME oslnoise${OSL_LIBNAME_SUFFIX}
                        )
 
-TARGET_LINK_LIBRARIES ( oslnoise ${OPENIMAGEIO_LIBRARIES} ${ILMBASE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
+TARGET_LINK_LIBRARIES ( oslnoise 
+                        ${OPENIMAGEIO_LIBRARIES} ${ILMBASE_LIBRARIES}
+                        ${OPENEXR_ILMIMF_LIBRARY}
+                        ${TIFF_LIBRARIES} ${JPEG_LIBRARIES} ${PNG_LIBRARIES}
+                        ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
 
 install_targets (oslnoise)
 

--- a/src/osltoy/CMakeLists.txt
+++ b/src/osltoy/CMakeLists.txt
@@ -6,7 +6,9 @@ set (osltoy_srcs
      osltoymain.cpp osltoyapp.cpp codeeditor.cpp osltoyrenderer.cpp)
 add_executable (osltoy ${osltoy_srcs})
 set_target_properties (osltoy PROPERTIES FOLDER "Tools")
-target_link_libraries (osltoy oslexec
+target_link_libraries (osltoy oslexec oslquery oslcomp
                        Qt5::Core Qt5::Gui Qt5::Widgets
-                       ${OPENIMAGEIO_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+                       ${OPENIMAGEIO_LIBRARIES} ${OCIO_LIBRARIES} ${OPENEXR_ILMIMF_LIBRARY}
+                       ${TIFF_LIBRARIES} ${JPEG_LIBRARIES} ${PNG_LIBRARIES}
+                       ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 install_targets (osltoy)

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -38,7 +38,9 @@ endif()
 add_definitions ("-DPTX_PATH=\"${OSL_PTX_INSTALL_DIR}\"")
 
 ADD_EXECUTABLE ( testrender ${testrender_srcs} )
-TARGET_LINK_LIBRARIES ( testrender oslexec oslquery
-                       ${CUDA_LIBRARIES} ${OPTIX_LIBRARIES} ${OPTIX_EXTRA_LIBS}
-                       ${OPENIMAGEIO_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+TARGET_LINK_LIBRARIES ( testrender oslexec oslquery oslcomp
+                        ${OPENEXR_ILMIMF_LIBRARY} ${OCIO_LIBRARIES}
+                        ${TIFF_LIBRARIES} ${JPEG_LIBRARIES} ${PNG_LIBRARIES}
+                        ${CUDA_LIBRARIES} ${OPTIX_LIBRARIES} ${OPTIX_EXTRA_LIBS}
+                        ${OPENIMAGEIO_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 INSTALL ( TARGETS testrender RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -37,10 +37,13 @@ endif()
 add_definitions ("-DPTX_PATH=\"${OSL_PTX_INSTALL_DIR}\"")
 
 ADD_EXECUTABLE ( testshade ${testshade_srcs} testshademain.cpp )
-TARGET_LINK_LIBRARIES (testshade oslexec oslquery
-                       ${OPENIMAGEIO_LIBRARIES} ${OPENEXR_LIBRARIES}
-                       ${CUDA_LIBRARIES} ${OPTIX_LIBRARIES} ${OPTIX_EXTRA_LIBS}
-                       ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+TARGET_LINK_LIBRARIES (testshade oslexec oslquery oslcomp
+                       ${OPENIMAGEIO_LIBRARIES} ${OCIO_LIBRARIES}
+                       ${OPENEXR_LIBRARIES} ${CUDA_LIBRARIES}
+                       ${OPTIX_LIBRARIES} ${OPTIX_EXTRA_LIBS}
+                       ${Boost_LIBRARIES}
+                       ${TIFF_LIBRARIES} ${JPEG_LIBRARIES} ${PNG_LIBRARIES}
+                       ${CMAKE_DL_LIBS})
 INSTALL ( TARGETS testshade RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
 # The 'libtestshade' library


### PR DESCRIPTION
This change allows to build and run test projects on windows.
PR adds several link libraries such as OCIO, jpg, png, tiff and few others to test projects.

I didn't test the change on any other OS. It's probably not needed on Linux.

## Tests

Cmake target RUN_TESTS runs successfully after the build. Also I'm able to run osltoy.exe, testrender.exe and testshader.exe.

## Checklist:

- [ x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ x ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ x ] My code follows the prevailing code style of this project.

P.S. This is my first PR on OSL project. I didn't submit CLA yet, but will do if PR makes sense.
Thanks for review.