### PR TITLE
Uncomment old lines to fix rpath on macosx

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -290,8 +290,8 @@ ifeq (${SP_OS}, rhel7)
 ## Generic OSX machines (including LG's laptop)
 else ifeq (${platform}, macosx)
     USE_SIMD ?= sse4.2
-    # MY_CMAKE_FLAGS += -DCMAKE_BUILD_WITH_INSTALL_RPATH=1
-    # MY_CMAKE_FLAGS += -DCMAKE_INSTALL_NAME_DIR="${working_dir}/dist/${platform}${variant}/lib"
+    MY_CMAKE_FLAGS += -DCMAKE_BUILD_WITH_INSTALL_RPATH=1
+    MY_CMAKE_FLAGS += -DCMAKE_INSTALL_NAME_DIR="${working_dir}/dist/${platform}${variant}/lib"
 
     BOOSTVERSSP=${BOOSTVERS}${BOOSTSPSUFFIX}
     LLVM_DIRECTORY ?= /usr/local/opt/llvm


### PR DESCRIPTION
Build stopped working with rpath after latest overhaul. This seems to fix it.