### PR TITLE
Ensure locale independence

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -188,6 +188,7 @@ OSLCompilerImpl::preprocess_buffer (const std::string &buffer,
                                     std::string &result)
 {
     std::ostringstream ss;
+    ss.imbue (std::locale::classic());  // force C locale
     boost::wave::util::file_position_type current_position;
 
     std::string instring;

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -447,7 +447,8 @@ BackendLLVM::getOrAllocateCUDAVariable (const Symbol& sym, bool addMetadata)
 {
     ASSERT (use_optix() && "This function is only supported when using OptiX!");
 
-    std::stringstream ss;
+    std::ostringstream ss;
+    ss.imbue (std::locale::classic());  // force C locale
     if (sym.typespec().is_string()) {
         // Use the ustring hash to create a name for the symbol that's based on
         // the string contents

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -676,6 +676,7 @@ void
 BackendLLVM::llvm_generate_debug_op_printf (const Opcode &op)
 {
     std::ostringstream msg;
+    msg.imbue (std::locale::classic());  // force C locale
     msg << op.sourcefile() << ':' << op.sourceline() << ' ' << op.opname();
     for (int i = 0;  i < op.nargs();  ++i)
         msg << ' ' << opargsym (op, i)->mangled();

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -222,7 +222,8 @@ ShaderMaster::resolve_syms ()
 std::string
 ShaderMaster::print ()
 {
-    std::stringstream out;
+    std::ostringstream out;
+    out.imbue (std::locale::classic());  // force C locale
     out << "Shader " << m_shadername << " type=" 
               << shadertypename() << "\n";
     out << "  path = " << m_osofilename << "\n";

--- a/src/liboslexec/opclosure.cpp
+++ b/src/liboslexec/opclosure.cpp
@@ -92,7 +92,8 @@ OSL_SHADEOP const char *
 osl_closure_to_string (ShaderGlobals *sg, ClosureColor *c)
 {
     // Special case for printing closures
-    std::stringstream stream;
+    std::ostringstream stream;
+    stream.imbue (std::locale::classic());  // force C locale
     print_closure(stream, c, &sg->context->shadingsys());
     return ustring(stream.str ()).c_str();
 }

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <locale>
 #include <memory>
 #include <string>
 #include <vector>
@@ -108,6 +109,7 @@ static bool shadingsys_options_set = false;
 static float uscale = 1, vscale = 1;
 static float uoffset = 0, voffset = 0;
 static std::vector<const char*> shader_setup_args;
+static std::string localename = OIIO::Sysutil::getenv("TESTSHADE_LOCALE");
 
 
 
@@ -520,6 +522,7 @@ getargs (int argc, const char *argv[])
                 "--scaleuv %f %f", &uscale, &vscale, "Scale s & t texture lookups (default: 1, 1)",
                 "--scalest %f %f", &uscale, &vscale, "", // old name
                 "--userdata_isconnected", &userdata_isconnected, "Consider lockgeom=0 to be isconnected()",
+                "--locale %s", &localename, "Set a different locale",
                 NULL);
     if (ap.parse(argc, argv) < 0 /*|| (shadernames.empty() && groupspec.empty())*/) {
         std::cerr << ap.geterror() << std::endl;
@@ -1030,6 +1033,14 @@ test_shade (int argc, const char *argv[])
     // Get the command line arguments.  Those that set up the shader
     // instances are queued up in shader_setup_args for later handling.
     getargs (argc, argv);
+
+    // For testing purposes, allow user to set global locale
+    if (localename.size()) {
+        std::locale::global (std::locale(localename));
+        if (debug1 || verbose)
+            printf("testshade: locale '%s', floats look like: %g\n",
+                   localename.c_str(), 3.5);
+    }
 
     SimpleRenderer *rend = nullptr;
 #ifdef OSL_USE_OPTIX

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1036,7 +1036,7 @@ test_shade (int argc, const char *argv[])
 
     // For testing purposes, allow user to set global locale
     if (localename.size()) {
-        std::locale::global (std::locale(localename));
+        std::locale::global (std::locale(localename.c_str()));
         if (debug1 || verbose)
             printf("testshade: locale '%s', floats look like: %g\n",
                    localename.c_str(), 3.5);


### PR DESCRIPTION
I found several additional places where we were not being locale
independent, so if run in a locale with "," as the decimal separators,
output would change or bad things would happen.
