### PR TITLE
Be more explicit about which string formatting convention we use

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -106,19 +106,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/span.h>
 
-// If we're using an old version of OIIO prior to the introduction of
-// Strutil::sprintf, define it ourselves to be a synonym for format.
-#ifndef OIIO_HAS_SPRINTF
-OIIO_NAMESPACE_BEGIN
-namespace Strutil {
-template<typename... Args>
-inline std::string sprintf (const char* fmt, const Args&... args) {
-    return Strutil::format (fmt, args...);
-}
-} // namespace strutil
-OIIO_NAMESPACE_END
-#endif
-
 
 OSL_NAMESPACE_ENTER
 

--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -218,7 +218,7 @@ private:
 
     // Internal error reporting routine, with printf-like arguments.
     template<typename... Args>
-    inline void error (const char* fmt, const Args&... args) const {
+    inline void errorf(const char* fmt, const Args&... args) const {
         append_error(OIIO::Strutil::sprintf (fmt, args...));
     }
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -190,7 +190,7 @@ public:
     void sourceline (int line) { m_sourceline = line; }
 
     template<typename... Args>
-    void error (const char* format, const Args&... args) const
+    void errorf (const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
         error_impl (OIIO::Strutil::sprintf (format, args...));
@@ -198,7 +198,7 @@ public:
 
     /// Warning reporting
     template<typename... Args>
-    void warning (const char* format, const Args&... args) const
+    void warningf (const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
         warning_impl (OIIO::Strutil::sprintf (format, args...));
@@ -206,7 +206,7 @@ public:
 
     /// info reporting
     template<typename... Args>
-    void info (const char* format, const Args&... args) const
+    void infof (const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
         info_impl (OIIO::Strutil::sprintf (format, args...));
@@ -214,7 +214,7 @@ public:
 
     /// message reporting
     template<typename... Args>
-    void message (const char* format, const Args&... args) const
+    void messagef (const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
         message_impl (OIIO::Strutil::sprintf (format, args...));

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -126,7 +126,7 @@ OSLCompilerImpl::insert_code (int opnum, const char *opname,
 Symbol *
 OSLCompilerImpl::make_temporary (const TypeSpec &type)
 {
-    ustring name = ustring::format ("$tmp%d", ++m_next_temp);
+    ustring name = ustring::sprintf ("$tmp%d", ++m_next_temp);
     Symbol *s = new Symbol (name, type, SymTypeTemp);
     symtab().insert (s);
 
@@ -157,14 +157,14 @@ OSLCompilerImpl::add_struct_fields (StructSpec *structspec,
     // arraylen is the length of the array of the surrounding data type
     for (int i = 0;  i < (int)structspec->numfields();  ++i) {
         const StructSpec::FieldSpec &field (structspec->field(i));
-        ustring fieldname = ustring::format ("%s.%s", basename, field.name);
+        ustring fieldname = ustring::sprintf ("%s.%s", basename, field.name);
         TypeSpec type = field.type;
         int arr = type.arraylength();
         if (arr && arraylen) {
-            error (node ? node->sourcefile() : ustring(),
+            errorf(node ? node->sourcefile() : ustring(),
                    node ? node->sourceline() : 1,
                    "Nested structs with >1 levels of arrays are not allowed: %s",
-                   structspec->name().c_str());
+                   structspec->name());
         }
         if (arraylen || arr) {
             // Translate an outer array into an inner array
@@ -199,7 +199,7 @@ OSLCompilerImpl::make_constant (ustring val)
             return sym;
     }
     // It's not a constant we've added before
-    ustring name = ustring::format ("$const%d", ++m_next_const);
+    ustring name = ustring::sprintf ("$const%d", ++m_next_const);
     ConstantSymbol *s = new ConstantSymbol (name, val);
     symtab().insert (s);
     m_const_syms.push_back (s);
@@ -218,7 +218,7 @@ OSLCompilerImpl::make_constant (TypeDesc type, const void *val)
             return sym;
     }
     // It's not a constant we've added before
-    ustring name = ustring::format ("$const%d", ++m_next_const);
+    ustring name = ustring::sprintf ("$const%d", ++m_next_const);
     ConstantSymbol *s = new ConstantSymbol (name, type);
     memcpy (s->data(), val, typesize);
     symtab().insert (s);
@@ -236,7 +236,7 @@ OSLCompilerImpl::make_constant (int val)
             return sym;
     }
     // It's not a constant we've added before
-    ustring name = ustring::format ("$const%d", ++m_next_const);
+    ustring name = ustring::sprintf ("$const%d", ++m_next_const);
     ConstantSymbol *s = new ConstantSymbol (name, val);
     symtab().insert (s);
     m_const_syms.push_back (s);
@@ -253,7 +253,7 @@ OSLCompilerImpl::make_constant (float val)
             return sym;
     }
     // It's not a constant we've added before
-    ustring name = ustring::format ("$const%d", ++m_next_const);
+    ustring name = ustring::sprintf ("$const%d", ++m_next_const);
     ConstantSymbol *s = new ConstantSymbol (name, val);
     symtab().insert (s);
     m_const_syms.push_back (s);
@@ -271,7 +271,7 @@ OSLCompilerImpl::make_constant (TypeDesc type, float x, float y, float z)
             return sym;
     }
     // It's not a constant we've added before
-    ustring name = ustring::format ("$const%d", ++m_next_const);
+    ustring name = ustring::sprintf ("$const%d", ++m_next_const);
     ConstantSymbol *s = new ConstantSymbol (name, type, x, y, z);
     symtab().insert (s);
     m_const_syms.push_back (s);
@@ -479,8 +479,8 @@ ASTcompound_initializer::codegen (Symbol *sym)
         return sym;
     }
 
-    error("Possible compiler bug: compound_initializer codegen does not "
-          "know how to handle type %s", typespec());
+    errorf("Possible compiler bug: compound_initializer codegen does not "
+           "know how to handle type %s", typespec());
     return nullptr;
 }
 
@@ -577,8 +577,8 @@ ASTNode::codegen_assign_struct (StructSpec *structspec,
             // struct within struct -- recurse
             ustring fieldname (structspec->field(i).name);
             codegen_assign_struct (fieldtype.structspec(),
-                                   ustring::format ("%s.%s", dstsym, fieldname),
-                                   ustring::format ("%s.%s", srcsym, fieldname),
+                                   ustring::sprintf ("%s.%s", dstsym, fieldname),
+                                   ustring::sprintf ("%s.%s", srcsym, fieldname),
                                    arrayindex, copywholearrays, 0, paraminit);
             continue;
         }
@@ -587,8 +587,8 @@ ASTNode::codegen_assign_struct (StructSpec *structspec,
             // struct array within struct -- loop over indices and recurse
             ASSERT (! arrayindex && "two levels of arrays not allowed");
             ustring fieldname (structspec->field(i).name);
-            ustring dstfield = ustring::format ("%s.%s", dstsym, fieldname);
-            ustring srcfield = ustring::format ("%s.%s", srcsym, fieldname);
+            ustring dstfield = ustring::sprintf ("%s.%s", dstsym, fieldname);
+            ustring srcfield = ustring::sprintf ("%s.%s", srcsym, fieldname);
             for (int i = 0;  i < fieldtype.arraylength();  ++i) {
                 codegen_assign_struct (fieldtype.structspec(),
                                        dstfield, srcfield,
@@ -920,7 +920,7 @@ ASTNode::codegen_initlist (ref init, TypeSpec type, Symbol *sym)
         StructSpec *structspec (type.structspec());
         for (int i = 0;  init && i < structspec->numfields();  init = init->next(), ++i) {
             const StructSpec::FieldSpec &field (structspec->field(i));
-            ustring fieldname = ustring::format ("%s.%s", sym->mangled(),
+            ustring fieldname = ustring::sprintf ("%s.%s", sym->mangled(),
                                                  field.name);
             Symbol *fieldsym = m_compiler->symtab().find_exact (fieldname);
             if (paraminit) {
@@ -939,7 +939,7 @@ ASTNode::codegen_initlist (ref init, TypeSpec type, Symbol *sym)
         // Warn early about struct array paramters.
         // Handling this will likely need changes to oso format.
         if (type.is_structure_array()) {
-            error ("array of struct are not allowed as parameters");
+            errorf("array of struct are not allowed as parameters");
             return;
         }
         // For parameter initialization, don't really generate ops if it
@@ -1088,8 +1088,8 @@ ASTNode::codegen_struct_initializers (ref init, Symbol *sym,
     for (int i = 0; init && i < structspec->numfields(); init = init->next(), ++i) {
         // Structure element -- assign to the i-th member field
         const StructSpec::FieldSpec &field (structspec->field(i));
-        ustring fieldname = ustring::format ("%s.%s", sym->mangled().c_str(),
-                                             field.name.c_str());
+        ustring fieldname = ustring::sprintf ("%s.%s", sym->mangled(),
+                                             field.name);
         Symbol *fieldsym = m_compiler->symtab().find_exact (fieldname);
         if (fieldsym->typespec().is_structure_based() &&
             (init->nodetype() == type_constructor_node ||
@@ -1249,10 +1249,9 @@ ASTindex::codegen_copy_struct_array_element (StructSpec *structspec,
         const TypeSpec &type (field.type);
         if (type.is_structure()) {
             // struct within struct -- recurse!
-            const char *fieldname = field.name.c_str();
             codegen_copy_struct_array_element (type.structspec(),
-                     ustring::format ("%s.%s", destname.c_str(), fieldname),
-                     ustring::format ("%s.%s", srcname.c_str(), fieldname),
+                     ustring::sprintf("%s.%s", destname, field.name),
+                     ustring::sprintf("%s.%s", srcname, field.name),
                      index);
         } else {
             ASSERT (! type.is_array());
@@ -1481,7 +1480,7 @@ ASTunary_expression::codegen (Symbol *dest)
     if (m_function_overload) {
         // A little crazy, but we temporarily construct an ASTfunction_call
         // in order to codegen this overloaded operator.
-        ustring funcname = ustring::format ("__operator__%s__", opword());
+        ustring funcname = ustring::sprintf ("__operator__%s__", opword());
         ASTfunction_call fc (m_compiler, funcname, expr().get(), m_function_overload);
         fc.typecheck (typespec());
         return dest = fc.codegen (dest);
@@ -1528,9 +1527,9 @@ ASTbinary_expression::codegen (Symbol *dest)
         // in order to codegen this overloaded operator. Slightly tricky
         // is that we need to concatenate our left and right arguments into
         // an arg list.
-        ustring funcname = ustring::format ("__operator__%s__", opword());
+        ustring funcname = ustring::sprintf ("__operator__%s__", opword());
         if (left()->nextptr() || right()->nextptr()) {
-            error ("Overloaded %s cannot be passed arguments %s and %s",
+            errorf("Overloaded %s cannot be passed arguments %s and %s",
                    funcname, left()->nodetypename(), right()->nodetypename());
             return dest;
         }
@@ -2007,11 +2006,10 @@ ASTfunction_call::codegen_arg (SymbolPtrVec &argdest, SymbolPtrVec &index1,
             ! equivalent (origarg->typespec(), form->typespec()) &&
             form->nodetype() == variable_declaration_node &&
             ((ASTvariable_declaration *)form)->is_output()) {
-            error ("Cannot pass '%s %s' as argument %d to %s\n\t"
+            errorf("Cannot pass '%s %s' as argument %d to %s\n\t"
                    "because it is an output parameter that must be a %s",
-                   origarg->typespec().c_str(), origarg->name().c_str(),
-                   argnum+1, user_function()->func()->name().c_str(),
-                   form->typespec().c_str());
+                   origarg->typespec(), origarg->name(), argnum+1,
+                   user_function()->func()->name(), form->typespec());
         }
     }
     if (thisarg) {
@@ -2020,7 +2018,7 @@ ASTfunction_call::codegen_arg (SymbolPtrVec &argdest, SymbolPtrVec &index1,
         index2.push_back (ind2);
         index3.push_back (ind3);
     } else
-        arg->error("Invalid argument to function");
+        arg->errorf("Invalid argument to function");
 }
 
 
@@ -2036,8 +2034,8 @@ ASTfunction_call::struct_pair_all_fields (StructSpec *structspec,
         if (type.is_structure() || type.is_structure_array()) {
             // struct within struct -- recurse!
             struct_pair_all_fields (type.structspec(),
-                                    ustring::format ("%s.%s", formal.c_str(), field.name.c_str()),
-                                    ustring::format ("%s.%s", actual.c_str(), field.name.c_str()),
+                                    ustring::sprintf ("%s.%s", formal, field.name),
+                                    ustring::sprintf ("%s.%s", actual, field.name),
                                     arrayindex);
         } else {
             Symbol *fsym, *asym;

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -102,7 +102,7 @@ public:
 
     /// Error reporting
     template<typename... Args>
-    void error (ustring filename, int line,
+    void errorf(ustring filename, int line,
                 const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
@@ -110,15 +110,15 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->error ("%s:%d: error: %s", filename, line, msg);
+            m_errhandler->errorf("%s:%d: error: %s", filename, line, msg);
         else
-            m_errhandler->error ("error: %s", msg);
+            m_errhandler->errorf("error: %s", msg);
         m_err = true;
     }
 
     /// Warning reporting
     template<typename... Args>
-    void warning (ustring filename, int line,
+    void warningf(ustring filename, int line,
                   const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
@@ -128,33 +128,33 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (m_err_on_warning) {
-            error (filename, line, "%s", msg);
+            errorf(filename, line, "%s", msg);
             return;
         }
         if (filename.size())
-            m_errhandler->warning ("%s:%d: warning: %s", filename, line, msg);
+            m_errhandler->warningf("%s:%d: warning: %s", filename, line, msg);
         else
-            m_errhandler->warning ("warning: %s", msg);
+            m_errhandler->warningf("warning: %s", msg);
     }
 
     /// Info reporting
     template<typename... Args>
-    void info (ustring filename, int line,
-                  const char* format, const Args&... args) const
+    void infof(ustring filename, int line,
+               const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
         std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->info ("%s:%d: info: %s", filename, line, msg);
+            m_errhandler->infof("%s:%d: info: %s", filename, line, msg);
         else
-            m_errhandler->info ("info: %s", msg);
+            m_errhandler->infof("info: %s", msg);
     }
 
     /// message reporting
     template<typename... Args>
-    void message (ustring filename, int line,
+    void messagef(ustring filename, int line,
                   const char* format, const Args&... args) const
     {
         DASSERT (format && format[0]);
@@ -162,9 +162,9 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->message ("%s:%d: %s", filename, line, msg);
+            m_errhandler->messagef("%s:%d: %s", filename, line, msg);
         else
-            m_errhandler->message ("%s", msg);
+            m_errhandler->messagef("%s", msg);
     }
 
     /// Have we hit an error?

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -266,7 +266,7 @@ formal_param
                     // Grab the current declaration type, modify it to be array
                     TypeSpec t = oslcompiler->current_typespec();
                     if (! t.is_structure() && ! t.is_triple() && ! t.is_matrix())
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Can't use '= {...}' initializer "
                                             "except with arrays, structs, vectors, "
@@ -312,7 +312,7 @@ metadatum
                     TypeDesc simple = osllextype ($1);
                     simple.arraylen = $3;
                     if (simple.arraylen < 1)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length for %s", $2);
                     TypeSpec t (simple, false);
@@ -356,12 +356,12 @@ struct_declaration
                     ustring name ($2);
                     Symbol *s = oslcompiler->symtab().clash (name);
                     if (s) {
-                        oslcompiler->error (oslcompiler->filename(), oslcompiler->lineno(),
+                        oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
                                             "\"%s\" already declared in this scope", name);
                         // FIXME -- print the file and line of the other definition
                     }
                     if (OIIO::Strutil::starts_with (name, "___")) {
-                        oslcompiler->error (oslcompiler->filename(), oslcompiler->lineno(),
+                        oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
                                             "\"%s\" : sorry, can't start with three underscores", name);
                     }
                     oslcompiler->symtab().new_struct (name);
@@ -393,7 +393,7 @@ typed_field
                     TypeSpec t = oslcompiler->current_typespec();
                     StructSpec *s = oslcompiler->symtab().current_struct();
                     if (s->lookup_field (name) >= 0)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Field \"%s\" already exists in struct \"%s\"",
                                             name, s->name());
@@ -408,12 +408,12 @@ typed_field
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
                     if (t.arraylength() < 1)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length for %s", name);
                     StructSpec *s = oslcompiler->symtab().current_struct();
                     if (s->lookup_field (name) >= 0)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Field \"%s\" already exists in struct \"%s\"",
                                             name, s->name());
@@ -452,7 +452,7 @@ def_expression
                     TypeSpec t = oslcompiler->current_typespec();
                     t.make_array ($2);
                     if ($2 < 1)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length for %s", $1);
                     $$ = new ASTvariable_declaration (oslcompiler, t,
@@ -463,7 +463,7 @@ def_expression
                 {
                     TypeSpec t = oslcompiler->current_typespec();
                     if (! t.is_structure() && ! t.is_triple() && ! t.is_matrix())
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Can't use '= {...}' initializer "
                                             "except with arrays, struct, vectors, "
@@ -501,7 +501,7 @@ compound_initializer
         | '{' '}'
                 {
                     if (!oslcompiler->declaring_shader_formals())
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Empty compound initializers '{ }' "
                                             "only allowed for shader parameters.");
@@ -584,7 +584,7 @@ arrayspec
         : '[' INT_LITERAL ']'
                 {
                     if ($2 < 1)
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Invalid array length (%d)", $2);
                     $$ = $2;
@@ -612,7 +612,7 @@ typespec
                         oslcompiler->current_typespec (TypeSpec ("", s->typespec().structure()));
                     else {
                         oslcompiler->current_typespec (TypeSpec (TypeDesc::UNKNOWN));
-                        oslcompiler->error (oslcompiler->filename(),
+                        oslcompiler->errorf(oslcompiler->filename(),
                                             oslcompiler->lineno(),
                                             "Unknown struct name: %s", $1);
                     }
@@ -653,7 +653,7 @@ typespec_or_shadertype
                             oslcompiler->current_typespec (TypeSpec ("", s->typespec().structure()));
                         else {
                             oslcompiler->current_typespec (TypeSpec (TypeDesc::UNKNOWN));
-                            oslcompiler->error (oslcompiler->filename(),
+                            oslcompiler->errorf(oslcompiler->filename(),
                                                 oslcompiler->lineno(),
                                                 "Unknown struct name: %s", $1);
                         }
@@ -815,9 +815,9 @@ expression
                         //     color x = Cd * (a, b, c); // same as:  x = Cd * c
                         // when they really meant
                         //     color x = Cd * color(a, b, c);
-                        oslcompiler->warning(oslcompiler->filename(),
-                                             @1.first_line,
-                                             "Comma operator inside parenthesis is probably an error -- it is not a vector/color.");
+                        oslcompiler->warningf(oslcompiler->filename(),
+                                              @1.first_line,
+                                              "Comma operator inside parenthesis is probably an error -- it is not a vector/color.");
                     }
                     $$ = $2;
                 }
@@ -1112,7 +1112,7 @@ string_literal_group
 void
 yyerror (const char *err)
 {
-    oslcompiler->error (oslcompiler->filename(), oslcompiler->lineno(),
+    oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
                         "Syntax error: %s", err);
 }
 

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -186,7 +186,7 @@ void preprocess (const char *yytext);
 "protected"|"short"|"signed"|"sizeof"|"static"|"struct" |    \
 "switch"|"template"|"this"|"true"|"typedef"|"uniform" |      \
 "union"|"unsigned"|"varying"|"virtual" {
-                            oslcompiler->error (oslcompiler->filename(),
+                            oslcompiler->errorf(oslcompiler->filename(),
                                                 oslcompiler->lineno(),
                                                 "'%s' is a reserved word",
                                                 yytext);
@@ -208,7 +208,7 @@ void preprocess (const char *yytext);
                             // we do not detect overflow when the value is INT_MAX+1,
                             // because negation happens later and -(INT_MAX+1) == INT_MIN
                             if (llval > ((long long)INT_MAX)+1) {
-                                oslcompiler->error (oslcompiler->filename(),
+                                oslcompiler->errorf(oslcompiler->filename(),
                                                     oslcompiler->lineno(),
                                                     "integer overflow, value must be between %d and %d.",
                                                     INT_MIN, INT_MAX);
@@ -222,7 +222,7 @@ void preprocess (const char *yytext);
                             // we do not detect overflow when the value is INT_MAX+1,
                             // because negation happens later and -(INT_MAX+1) == INT_MIN
                             if (llval > ((long long)UINT_MAX)+1) {
-                                oslcompiler->error (oslcompiler->filename(),
+                                oslcompiler->errorf(oslcompiler->filename(),
                                                     oslcompiler->lineno(),
                                                     "integer overflow, value must be between %d and %d.",
                                                     INT_MIN, INT_MAX);
@@ -308,7 +308,7 @@ preprocess (const char *yytext)
     while (*p == ' ' || *p == '\t')
         p++;
     if (*p != '#') {
-        oslcompiler->error (oslcompiler->filename(), oslcompiler->lineno(),
+        oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
                             "Possible bug in shader preprocess");
         SETLINE;
         return;
@@ -325,7 +325,7 @@ preprocess (const char *yytext)
             if (pragmaname == "nowarn") {
                 oslcompiler->pragma_nowarn ();
             } else {
-                oslcompiler->warning (oslcompiler->filename(), oslcompiler->lineno(),
+                oslcompiler->warningf(oslcompiler->filename(), oslcompiler->lineno(),
                                       "Unknown pragma '%s'", pragmaname);
             }
         }
@@ -377,7 +377,7 @@ preprocess (const char *yytext)
             }
             oslcompiler->lineno (line);
         } else {
-            oslcompiler->error (oslcompiler->filename(), oslcompiler->lineno(),
+            oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
                                 "Unrecognized preprocessor command: #%s", p);
         }
     }

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -283,8 +283,8 @@ BackendLLVM::getLLVMSymbolBase (const Symbol &sym)
     std::string mangled_name = dealiased->mangled();
     AllocationMap::iterator map_iter = named_values().find (mangled_name);
     if (map_iter == named_values().end()) {
-        shadingcontext()->error ("Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
-                            mangled_name.c_str(), dealiased->name().c_str());
+        shadingcontext()->errorf("Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
+                                 mangled_name, dealiased->name());
         return 0;
     }
     return (llvm::Value*) map_iter->second;

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1338,7 +1338,7 @@ DECLFOLDER(constfold_concat)
             return 0;  // something non-constant
         ustring old = result;
         ustring s = *(ustring *)S.data();
-        result = ustring::format ("%s%s", old.c_str() ? old.c_str() : "",
+        result = ustring::sprintf ("%s%s", old.c_str() ? old.c_str() : "",
                                   s.c_str() ? s.c_str() : "");
     }
     // If we made it this far, all args were constants, and the

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -98,8 +98,8 @@ ShadingContext::execute_init (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
     size_t heap_size_needed = sgroup.llvm_groupdata_size();
     if (heap_size_needed > m_heap.size()) {
         if (shadingsys().debug())
-            info ("  ShadingContext %p growing heap to %llu",
-                  this, (unsigned long long) heap_size_needed);
+            infof("  ShadingContext %p growing heap to %d",
+                  this, heap_size_needed);
         m_heap.resize (heap_size_needed);
     }
     // Zero out the heap memory we will be using
@@ -162,7 +162,7 @@ bool
 ShadingContext::execute_cleanup ()
 {
     if (! group()) {
-        error ("execute_cleanup called again on a cleaned-up context");
+        errorf("execute_cleanup called again on a cleaned-up context");
         return false;
     }
 

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -182,7 +182,7 @@ Dictionary::get_document_index (ustring dictionaryname)
                                              dictionaryname.length());
         }
         if (! parse_result) {
-            m_context->error ("XML parsed with errors: %s, at offset %d",
+            m_context->errorf("XML parsed with errors: %s, at offset %d",
                               parse_result.description(),
                               parse_result.offset);
             m_document_map[dictionaryname] = -1;
@@ -221,7 +221,7 @@ Dictionary::dict_find (ustring dictionaryname, ustring query)
         matches = doc->select_nodes (query.c_str());
     }
     catch (const pugi::xpath_exception& e) {
-        m_context->error ("Invalid dict_find query '%s': %s",
+        m_context->errorf("Invalid dict_find query '%s': %s",
                           query.c_str(), e.what());
         return 0;
     }
@@ -268,7 +268,7 @@ Dictionary::dict_find (int nodeID, ustring query)
         matches = m_nodes[nodeID].node.select_nodes (query.c_str());
     }
     catch (const pugi::xpath_exception& e) {
-        m_context->error ("Invalid dict_find query '%s': %s",
+        m_context->errorf("Invalid dict_find query '%s': %s",
                           query.c_str(), e.what());
         return 0;
     }

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -230,7 +230,7 @@ ShaderInstance::parameters (const ParamValueList &params)
             TypeSpec sm_typespec = sm->typespec(); // Type of the master's param
             if (sm_typespec.is_closure_based()) {
                 // Can't assign a closure instance value.
-                shadingsys().warning ("skipping assignment of closure: %s", sm->name());
+                shadingsys().warningf("skipping assignment of closure: %s", sm->name());
                 continue;
             }
             if (sm_typespec.is_structure())
@@ -250,7 +250,7 @@ ShaderInstance::parameters (const ParamValueList &params)
                     int val = *static_cast<const int*>(p.data());
                     float conv = float(val);
                     if (val != int(conv))
-                        shadingsys().error ("attempting to set parameter from wrong type would change the value: %s (set %.9g from %d)",
+                        shadingsys().errorf("attempting to set parameter from wrong type would change the value: %s (set %.9g from %d)",
                             sm->name(), conv, val);
                     tmpdata[0] = conv;
                     data = tmpdata;
@@ -271,12 +271,12 @@ ShaderInstance::parameters (const ParamValueList &params)
                        ( paramtype.is_vec3()          && valuetype == TypeDesc::FLOAT) ) )) {
                     // We are being very relaxed in this mode, so if the user _still_ got it wrong
                     // something more serious is at play and we should treat it as an error.
-                    shadingsys().error ("attempting to set parameter from incompatible type: %s (expected '%s', received '%s')",
+                    shadingsys().errorf("attempting to set parameter from incompatible type: %s (expected '%s', received '%s')",
                                           sm->name(), paramtype, valuetype);
                     continue;
                 }
             } else if (!compatible_param(paramtype, valuetype)) {
-                shadingsys().warning ("attempting to set parameter with wrong type: %s (expected '%s', received '%s')",
+                shadingsys().warningf("attempting to set parameter with wrong type: %s (expected '%s', received '%s')",
                                       sm->name(), paramtype, valuetype);
                 continue;
             }
@@ -355,7 +355,7 @@ ShaderInstance::parameters (const ParamValueList &params)
             memcpy (param_storage(i), data, valuetype.size());
         }
         else {
-            shadingsys().warning ("attempting to set nonexistent parameter: %s", p.name());
+            shadingsys().warningf("attempting to set nonexistent parameter: %s", p.name());
         }
     }
 
@@ -736,7 +736,7 @@ ShaderGroup::ShaderGroup (string_view name)
         m_name = name;
     } else {
         // No name -- make one up using the unique
-        m_name = ustring::format ("unnamed_group_%d", m_id);
+        m_name = ustring::sprintf ("unnamed_group_%d", m_id);
     }
 }
 

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -385,7 +385,7 @@ OSOReaderToMaster::hint (string_view hintstring)
         string_view str = Strutil::parse_until (h, "}");
         Strutil::parse_string (str, str, false, Strutil::DeleteQuotes);
         if (str.size() != m_nargs) {
-            m_shadingsys.error ("Parsing shader %s: malformed hint '%s' on op %s line %d",
+            m_shadingsys.errorf("Parsing shader %s: malformed hint '%s' on op %s line %d",
                                 m_master->shadername(), hintstring,
                                 m_master->m_ops.back().opname(), m_sourceline);
             m_errors = true;
@@ -461,8 +461,8 @@ OSOReaderToMaster::codemarker (const char *name)
     if (m_codesection == "___main___") {
         m_master->m_maincodebegin = nextop;
     } else if (m_codesym < 0) {
-        m_shadingsys.error ("Parsing shader %s: don't know what to do with code section \"%s\"",
-                            m_master->shadername().c_str(), name);
+        m_shadingsys.errorf("Parsing shader %s: don't know what to do with code section \"%s\"",
+                            m_master->shadername(), name);
         m_errors = true;
     }
 }
@@ -500,8 +500,8 @@ OSOReaderToMaster::instruction (int label, const char *opcode)
         // Replace the name in case it was aliased for compatibility
         uopcode = od->name;
     } else {
-        m_shadingsys.error ("Parsing shader \"%s\": instruction \"%s\" is not known. Maybe compiled with a too-new oslc?",
-                            m_master->shadername().c_str(), opcode);
+        m_shadingsys.errorf("Parsing shader \"%s\": instruction \"%s\" is not known. Maybe compiled with a too-new oslc?",
+                            m_master->shadername(), opcode);
         m_errors = true;
     }
 }
@@ -518,8 +518,8 @@ OSOReaderToMaster::instruction_arg (const char *name)
         ++m_nargs;
         return;
     }
-    m_shadingsys.error ("Parsing shader %s: unknown arg %s",
-                        m_master->shadername().c_str(), name);
+    m_shadingsys.errorf("Parsing shader %s: unknown arg %s",
+                        m_master->shadername(), name);
     m_errors = true;
 }
 
@@ -558,7 +558,7 @@ ShadingSystemImpl::loadshader (string_view cname)
     ShaderNameMap::const_iterator found = m_shader_masters.find (name);
     if (found != m_shader_masters.end()) {
         // if (debug())
-        //     info ("Found %s in shader_masters", name.c_str());
+        //     infof("Found %s in shader_masters", name);
         // Already loaded this shader, return its reference
         return (*found).second;
     }
@@ -570,7 +570,7 @@ ShadingSystemImpl::loadshader (string_view cname)
                                                         m_searchpath_dirs,
                                                         testcwd);
     if (filename.empty ()) {
-        error ("No .oso file could be found for shader \"%s\"", name);
+        errorf("No .oso file could be found for shader \"%s\"", name);
         return NULL;
     }
     OIIO::Timer timer;
@@ -584,17 +584,17 @@ ShadingSystemImpl::loadshader (string_view cname)
     }
     if (ok) {
         ++m_stat_shaders_loaded;
-        info ("Loaded \"%s\" (took %s)", filename.c_str(),
-              Strutil::timeintervalformat(loadtime, 2).c_str());
+        infof("Loaded \"%s\" (took %s)", filename,
+              Strutil::timeintervalformat(loadtime, 2));
         ASSERT (r);
         r->resolve_syms ();
         // if (debug()) {
         //     std::string s = r->print ();
         //     if (s.length())
-        //         info ("%s", s.c_str());
+        //         infof("%s", s);
         // }
     } else {
-        error ("Unable to read \"%s\"", filename.c_str());
+        errorf("Unable to read \"%s\"", filename);
     }
 
     return r;
@@ -611,7 +611,7 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
         return false;
     }
     if (! buffer.size()) {
-        error ("Attempt to load shader \"%s\" with empty OSO data.", shadername);
+        errorf ("Attempt to load shader \"%s\" with empty OSO data.", shadername);
         return false;
     }
 
@@ -620,7 +620,7 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
     ShaderNameMap::const_iterator found = m_shader_masters.find (name);
     if (found != m_shader_masters.end() && ! allow_shader_replacement()) {
         if (debug())
-            info ("Preload shader %s already exists in shader_masters", name);
+            infof("Preload shader %s already exists in shader_masters", name);
         return false;
     }
 
@@ -637,17 +637,17 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
     }
     if (ok) {
         ++m_stat_shaders_loaded;
-        info ("Loaded \"%s\" (took %s)", shadername,
-              Strutil::timeintervalformat(loadtime, 2).c_str());
+        infof("Loaded \"%s\" (took %s)", shadername,
+              Strutil::timeintervalformat(loadtime, 2));
         ASSERT (r);
         r->resolve_syms ();
         // if (debug()) {
         //     std::string s = r->print ();
         //     if (s.length())
-        //         info ("%s", s.c_str());
+        //         infof ("%s", s);
         // }
     } else {
-        error ("Unable to parse preloaded shader \"%s\"", shadername);
+        errorf("Unable to parse preloaded shader \"%s\"", shadername);
     }
 
     return true;

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -619,8 +619,8 @@ ColorSystem::set_colorspace (StringParam colorspace)
 #else
     void
     ColorSystem::error(StringParam src, StringParam dst, Context context) {
-        context->error("Unknown color space transformation"
-                       " \"%s\" -> \"%s\"", src, dst);
+        context->errorf("Unknown color space transformation"
+                        " \"%s\" -> \"%s\"", src, dst);
     }
 
     static inline ColorSystem& op_color_colorsystem (void *sg) {

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -179,7 +179,7 @@ osl_get_matrix (void *sg_, void *r, const char *from)
         MAT(r).makeIdentity();
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->error ("Unknown transformation \"%s\"", from);
+            ctx->errorf("Unknown transformation \"%s\"", from);
     }
     return ok;
 }
@@ -209,7 +209,7 @@ osl_get_inverse_matrix (void *sg_, void *r, const char *to)
         MAT(r).makeIdentity ();
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->error ("Unknown transformation \"%s\"", to);
+            ctx->errorf("Unknown transformation \"%s\"", to);
     }
     return ok;
 }
@@ -235,7 +235,7 @@ osl_prepend_matrix_from (void *sg, void *r, const char *from)
     else {
         ShadingContext *ctx = (ShadingContext *)((ShaderGlobals *)sg)->context;
         if (ctx->shadingsys().unknown_coordsys_error())
-            ctx->error ("Unknown transformation \"%s\"", from);
+            ctx->errorf("Unknown transformation \"%s\"", from);
     }
 #endif
     return ok;

--- a/src/liboslexec/opmessage.cpp
+++ b/src/liboslexec/opmessage.cpp
@@ -67,23 +67,15 @@ osl_setmessage (ShaderGlobals *sg, const char *name_, long long type_, void *val
         if (m->name == name) {
             // message already exists?
             if (m->has_data())
-                sg->context->error(
+                sg->context->errorf(
                    "message \"%s\" already exists (created here: %s:%d)"
                    " cannot set again from %s:%d",
-                   name.c_str(),
-                   m->sourcefile.c_str(),
-                   m->sourceline,
-                   sourcefile.c_str(),
-                   sourceline);
+                   name, m->sourcefile, m->sourceline, sourcefile, sourceline);
             else // NOTE: this cannot be triggered when strict_messages=false because we won't record "failed" getmessage calls
-               sg->context->error(
+               sg->context->errorf(
                    "message \"%s\" was queried before being set (queried here: %s:%d)"
                    " setting it now (%s:%d) would lead to inconsistent results",
-                   name.c_str(),
-                   m->sourcefile.c_str(),
-                   m->sourceline,
-                   sourcefile.c_str(),
-                   sourceline);
+                   name, m->sourcefile, m->sourceline, sourcefile, sourceline);
             return;
         }
     }
@@ -120,17 +112,14 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
         if (m->name == name) {
             if (m->type != type) {
                 // found message, but types don't match
-                sg->context->error(
+                sg->context->errorf(
                     "type mismatch for message \"%s\" (%s as %s here: %s:%d)"
                     " cannot fetch as %s from %s:%d",
-                    name.c_str(),
-                    m->has_data() ? "created" : "queried",
+                    name, m->has_data() ? "created" : "queried",
                     m->type == TypeDesc::PTR ? "closure color" : m->type.c_str(),
-                    m->sourcefile.c_str(),
-                    m->sourceline,
+                    m->sourcefile, m->sourceline,
                     is_closure ? "closure color" : type.c_str(),
-                    sourcefile.c_str(),
-                    sourceline);
+                    sourcefile, sourceline);
                 return 0;
             }
             if (!m->has_data()) {
@@ -139,18 +128,13 @@ osl_getmessage (ShaderGlobals *sg, const char *source_, const char *name_,
             }
             if (m->layeridx > layeridx) {
                 // found message, but was set by a layer deeper than the one querying the message
-                sg->context->error(
+                sg->context->errorf(
                     "message \"%s\" was set by layer #%d (%s:%d)"
                     " but is being queried by layer #%d (%s:%d)"
                     " - messages may only be transfered from nodes "
                     "that appear earlier in the shading network",
-                    name.c_str(),
-                    m->layeridx,
-                    m->sourcefile.c_str(),
-                    m->sourceline,
-                    layeridx,
-                    sourcefile.c_str(),
-                    sourceline);
+                    name, m->layeridx, m->sourcefile, m->sourceline,
+                    layeridx, sourcefile, sourceline);
                 return 0;
             }
             // Message found!

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -724,7 +724,7 @@ struct GenericNoise {
             result.clear_d();
         } else {
 #ifndef __CUDA_ARCH__
-            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->errorf("Unknown noise type \"%s\"", name);
 #else
             // TODO: find a way to signal this error on the GPU
             result.clear_d();
@@ -766,7 +766,7 @@ struct GenericNoise {
             result.clear_d();
         } else {
 #ifndef __CUDA_ARCH__
-            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->errorf("Unknown noise type \"%s\"", name);
 #else
             // TODO: find a way to signal this error on the GPU
             result.clear_d();
@@ -809,7 +809,7 @@ struct GenericPNoise {
             result.clear_d();
         } else {
 #ifndef __CUDA_ARCH__
-            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->errorf("Unknown noise type \"%s\"", name);
 #else
             // TODO: find a way to signal this error on the GPU
             result.clear_d();
@@ -841,7 +841,7 @@ struct GenericPNoise {
             result.clear_d();
         } else {
 #ifndef __CUDA_ARCH__
-            ((ShadingContext *)sg->context)->error ("Unknown noise type \"%s\"", name.c_str());
+            ((ShadingContext *)sg->context)->errorf("Unknown noise type \"%s\"", name);
 #else
             // TODO: find a way to signal this error on the GPU
             result.clear_d();

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdarg>
 
 #include <OpenImageIO/strutil.h>
+#include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 
 #include "oslexec_pvt.h"
@@ -52,7 +53,7 @@ namespace pvt {
 OSL_SHADEOP const char *
 osl_concat_sss (const char *s, const char *t)
 {
-    return ustring::format("%s%s", s, t).c_str();
+    return ustring::sprintf("%s%s", s, t).c_str();
 }
 
 OSL_SHADEOP int
@@ -184,7 +185,7 @@ osl_printf (ShaderGlobals *sg, const char* format_str, ...)
 #endif
     std::string s = Strutil::vformat (format_str, args);
     va_end (args);
-    sg->context->message ("%s", s);
+    sg->context->messagef("%s", s);
 }
 
 
@@ -195,7 +196,7 @@ osl_error (ShaderGlobals *sg, const char* format_str, ...)
     va_start (args, format_str);
     std::string s = Strutil::vformat (format_str, args);
     va_end (args);
-    sg->context->error ("%s", s);
+    sg->context->errorf("%s", s);
 }
 
 
@@ -207,7 +208,7 @@ osl_warning (ShaderGlobals *sg, const char* format_str, ...)
         va_start (args, format_str);
         std::string s = Strutil::vformat (format_str, args);
         va_end (args);
-        sg->context->warning ("%s", s);
+        sg->context->warningf("%s", s);
     }
 }
 
@@ -224,7 +225,7 @@ osl_fprintf (ShaderGlobals *sg, const char *filename,
 
     static OIIO::mutex fprintf_mutex;
     OIIO::lock_guard lock (fprintf_mutex);
-    FILE *file = fopen (filename, "a");
+    FILE *file = OIIO::Filesystem::fopen (filename, "a");
     fputs (s.c_str(), file);
     fclose (file);
 }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -510,25 +510,25 @@ public:
     // Internal error, warning, info, and message reporting routines that
     // take printf-like arguments.
     template<typename T1, typename... Args>
-    inline void error (const char* fmt, const T1& v1, const Args&... args) const {
+    inline void errorf (const char* fmt, const T1& v1, const Args&... args) const {
         error (Strutil::sprintf (fmt, v1, args...));
     }
     void error (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void warning (const char* fmt, const T1& v1, const Args&... args) const {
+    inline void warningf (const char* fmt, const T1& v1, const Args&... args) const {
         warning (Strutil::sprintf (fmt, v1, args...));
     }
     void warning (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void info (const char* fmt, const T1& v1, const Args&... args) const {
+    inline void infof (const char* fmt, const T1& v1, const Args&... args) const {
         info (Strutil::sprintf (fmt, v1, args...));
     }
     void info (const std::string &message) const;
 
     template<typename T1, typename... Args>
-    inline void message (const char* fmt, const T1& v1, const Args&... args) const {
+    inline void messagef (const char* fmt, const T1& v1, const Args&... args) const {
         message (Strutil::sprintf (fmt, v1, args...));
     }
     void message (const std::string &message) const;
@@ -1742,22 +1742,22 @@ public:
     void process_errors () const;
 
     template<typename... Args>
-    inline void error (const char* fmt, const Args&... args) const {
+    inline void errorf(const char* fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_ERROR, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void warning (const char* fmt, const Args&... args) const {
+    inline void warningf(const char* fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_WARNING, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void info (const char* fmt, const Args&... args) const {
+    inline void infof(const char* fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_INFO, Strutil::sprintf (fmt, args...));
     }
 
     template<typename... Args>
-    inline void message (const char* fmt, const Args&... args) const {
+    inline void messagef(const char* fmt, const Args&... args) const {
         record_error(ErrorHandler::EH_MESSAGE, Strutil::sprintf (fmt, args...));
     }
 

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -242,13 +242,13 @@ RendererServices::pointcloud_search (ShaderGlobals *sg,
         return 0;
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_search: could not open \"%s\"", filename.c_str());
+        sg->context->errorf("pointcloud_search: could not open \"%s\"", filename);
         return 0;
     }
 
     const Partio::ParticlesData *cloud = pc->read_access();
     if (cloud == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_search: could not open \"%s\"", filename.c_str());
+        sg->context->errorf("pointcloud_search: could not open \"%s\"", filename);
         return 0;
     }
 
@@ -346,20 +346,20 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
 
     PointCloud *pc = PointCloud::get(filename);
     if (pc == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_get: could not open \"%s\"", filename);
+        sg->context->errorf("pointcloud_get: could not open \"%s\"", filename);
         return 0;
     }
 
     const Partio::ParticlesData *cloud = pc->read_access();
     if (cloud == NULL) { // The file failed to load
-        sg->context->error ("pointcloud_get: could not open \"%s\"", filename);
+        sg->context->errorf("pointcloud_get: could not open \"%s\"", filename);
         return 0;
     }
 
     // lookup the ParticleAttribute pointer needed for a query
     Partio::ParticleAttribute *attr = pc->m_attributes[attr_name].get();
     if (! attr) {
-        sg->context->error ("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name, filename);
+        sg->context->errorf("Accessing unexisting attribute %s in pointcloud \"%s\"", attr_name, filename);
         return 0;
     }
 
@@ -370,7 +370,7 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
 
     // Finally check for some equivalent types like float3 and vector
     if (!compatiblePartioType(partio_type, element_type)) {
-        sg->context->error ("Type of attribute \"%s\" : %s not compatible with OSL's %s in \"%s\" pointcloud",
+        sg->context->errorf("Type of attribute \"%s\" : %s not compatible with OSL's %s in \"%s\" pointcloud",
                             attr_name, partio_type, element_type, filename);
         return 0;
     }
@@ -378,7 +378,7 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
     // For safety, clamp the count to the most that will fit in the output
     int maxn = basevals(attr_type) / basevals(partio_type);
     if (maxn < count) {
-        sg->context->error ("Point cloud attribute \"%s\" : %s with retrieval count %d will not fit in %s",
+        sg->context->errorf("Point cloud attribute \"%s\" : %s with retrieval count %d will not fit in %s",
                             attr_name, partio_type, count, attr_type);
         count = maxn;
     }

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -159,7 +159,7 @@ RendererServices::texture (ustring filename, TextureHandle *texture_handle,
             if (errormessage) {
                 *errormessage = ustring(err);
             } else {
-                context->error ("[RendererServices::texture] %s", err);
+                context->errorf("[RendererServices::texture] %s", err);
             }
         } else if (errormessage) {
             *errormessage = Strings::unknown;
@@ -195,7 +195,7 @@ RendererServices::texture3d (ustring filename, TextureHandle *texture_handle,
             if (errormessage) {
                 *errormessage = ustring(err);
             } else {
-                sg->context->error ("[RendererServices::texture3d] %s", err);
+                sg->context->errorf("[RendererServices::texture3d] %s", err);
             }
         } else if (errormessage) {
             *errormessage = Strings::unknown;
@@ -229,7 +229,7 @@ RendererServices::environment (ustring filename, TextureHandle *texture_handle,
             if (errormessage) {
                 *errormessage = ustring(err);
             } else {
-                sg->context->error ("[RendererServices::environment] %s", err);
+                sg->context->errorf("[RendererServices::environment] %s", err);
             }
         } else if (errormessage) {
             *errormessage = Strings::unknown;
@@ -261,7 +261,7 @@ RendererServices::get_texture_info (ustring filename,
             if (errormessage) {
                 *errormessage = ustring(err);
             } else {
-                shading_context->error ("[RendererServices::get_texture_info] %s", err);
+                shading_context->errorf("[RendererServices::get_texture_info] %s", err);
             }
         } else if (errormessage) {
             // gettextureinfo failed but did not provide an error, so none should be emitted

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -244,7 +244,7 @@ RuntimeOptimizer::add_constant (const TypeSpec &type, const void *data,
         if (type.is_unsized_array())
             newtype.make_array (datatype.numelements());
 
-        Symbol newconst (ustring::format ("$newconst%d", m_next_newconst++),
+        Symbol newconst (ustring::sprintf ("$newconst%d", m_next_newconst++),
                          newtype, SymTypeConst);
         void *newdata;
         TypeDesc t (newtype.simpletype());
@@ -299,7 +299,7 @@ RuntimeOptimizer::add_constant (const TypeSpec &type, const void *data,
 int
 RuntimeOptimizer::add_temp (const TypeSpec &type)
 {
-    return add_symbol (Symbol (ustring::format ("$opttemp%d", m_next_newtemp++),
+    return add_symbol (Symbol (ustring::sprintf ("$opttemp%d", m_next_newtemp++),
                                type, SymTypeTemp));
 }
 
@@ -3021,7 +3021,7 @@ RuntimeOptimizer::run ()
     Timer rop_timer;
     int nlayers = (int) group().nlayers ();
     if (debug())
-        shadingcontext()->info ("About to optimize shader group %s (%d layers):",
+        shadingcontext()->infof("About to optimize shader group %s (%d layers):",
                            group().name(), nlayers);
     if (debug())
         std::cout << "About to optimize shader group " << group().name() << "\n";
@@ -3248,33 +3248,33 @@ RuntimeOptimizer::run ()
             ss.m_stat_empty_groups += 1;
     }
     if (shadingsys().m_compile_report) {
-        shadingcontext()->info ("Optimized shader group %s:", group().name());
-        shadingcontext()->info (" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
+        shadingcontext()->infof("Optimized shader group %s:", group().name());
+        shadingcontext()->infof(" spec %1.2fs, New syms %llu/%llu (%5.1f%%), ops %llu/%llu (%5.1f%%)",
               m_stat_specialization_time, new_nsyms, old_nsyms,
               100.0*double((long long)new_nsyms-(long long)old_nsyms)/double(old_nsyms),
               new_nops, old_nops,
               100.0*double((long long)new_nops-(long long)old_nops)/double(old_nops));
         if (does_nothing)
-            shadingcontext()->info ("Group does nothing");
+            shadingcontext()->infof("Group does nothing");
         if (m_textures_needed.size()) {
-            shadingcontext()->info ("Group needs textures:");
+            shadingcontext()->infof("Group needs textures:");
             for (auto&& f : m_textures_needed)
-                shadingcontext()->info ("    %s", f);
+                shadingcontext()->infof("    %s", f);
             if (m_unknown_textures_needed)
-                shadingcontext()->info ("    Also may construct texture names on the fly.");
+                shadingcontext()->infof("    Also may construct texture names on the fly.");
         }
         if (m_userdata_needed.size()) {
-            shadingcontext()->info ("Group potentially needs userdata:");
+            shadingcontext()->infof("Group potentially needs userdata:");
             for (auto&& f : m_userdata_needed)
-                shadingcontext()->info ("    %s %s %s", f.name, f.type,
+                shadingcontext()->infof("    %s %s %s", f.name, f.type,
                                         f.derivs ? "(derivs)" : "");
         }
         if (m_attributes_needed.size()) {
-            shadingcontext()->info ("Group needs attributes:");
+            shadingcontext()->infof("Group needs attributes:");
             for (auto&& f : m_attributes_needed)
-                shadingcontext()->info ("    %s %s", f.name, f.scope);
+                shadingcontext()->infof("    %s %s", f.name, f.scope);
             if (m_unknown_attributes_needed)
-                shadingcontext()->info ("    Also may construct attribute names on the fly.");
+                shadingcontext()->infof("    Also may construct attribute names on the fly.");
         }
     }
 }
@@ -3285,7 +3285,7 @@ bool
 RuntimeOptimizer::police(const Opcode& op, string_view msg, int type)
 {
     if ((type & police_gpu_err) && shadingsys().m_gpu_opt_error) {
-        shadingcontext()->error ("Optimization error for GPUs:\n"
+        shadingcontext()->errorf("Optimization error for GPUs:\n"
                                  "  group:  %s\n"
                                  "  layer:  %s\n"
                                  "  source: %s:%d\n"
@@ -3294,13 +3294,13 @@ RuntimeOptimizer::police(const Opcode& op, string_view msg, int type)
                                  op.sourcefile(), op.sourceline(), msg);
         return true;
     } else if ((type & police_opt_warn) && shadingsys().m_opt_warnings) {
-        shadingcontext()->warning ("Optimization warning:\n"
-                                 "  group:  %s\n"
-                                 "  layer:  %s\n"
-                                 "  source: %s:%d\n"
-                                 "  issue:  %s",
-                                 group().name(), inst()->layername(),
-                                 op.sourcefile(), op.sourceline(), msg);
+        shadingcontext()->warningf("Optimization warning:\n"
+                                   "  group:  %s\n"
+                                   "  layer:  %s\n"
+                                   "  source: %s:%d\n"
+                                   "  issue:  %s",
+                                   group().name(), inst()->layername(),
+                                   op.sourcefile(), op.sourceline(), msg);
     }
     return false;
 }
@@ -3310,7 +3310,6 @@ RuntimeOptimizer::police(const Opcode& op, string_view msg, int type)
 bool
 RuntimeOptimizer::police_failed_optimizations()
 {
-    using OIIO::Strutil::format;
     bool err = false;
     bool do_warn = shadingsys().m_opt_warnings;
     bool do_gpu_err = shadingsys().m_gpu_opt_error;
@@ -3330,7 +3329,7 @@ RuntimeOptimizer::police_failed_optimizations()
                 Symbol *sym = opargsym (op, 1);  // arg 1 is texture name
                 DASSERT (sym && sym->typespec().is_string());
                 if (! sym->is_constant()) {
-                    err |= police (op, format("%s(): texture name cannot be reduced to a constant.",
+                    err |= police (op, OIIO::Strutil::sprintf("%s(): texture name cannot be reduced to a constant.",
                                               op.opname()),
                                    police_gpu_err);
                 }

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -388,7 +388,7 @@ getargs (int argc, const char *argv[])
                 "-v", &verbose, "Verbose mode",
                 "--img", &make_images, "Make test images",
                 "--iterations %d", &iterations,
-                    ustring::format("Number of iterations (default: %d)", iterations).c_str(),
+                    ustring::sprintf("Number of iterations (default: %d)", iterations).c_str(),
                 "--trials %d", &ntrials, "Number of trials",
                 NULL);
     if (ap.parse (argc, (const char**)argv) < 0) {

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -440,7 +440,7 @@ OSLQuery::open (string_view shadername,
         filename = Filesystem::searchpath_find (filename, dirs);
     }
     if (filename.empty()) {
-        error ("File \"%s\" could not be found.", shadername);
+        errorf("File \"%s\" could not be found.", shadername);
         return false;
     }
 

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -516,7 +516,7 @@ OSLInput::open (const std::string &name, ImageSpec &newspec,
                                    pv.interp() == ParamValue::INTERP_CONSTANT);
         }
         if (! shadingsys->Shader ("surface", shadername, "" /*layername*/ )) {
-            error ("y %s", errhandler.haserror() ? errhandler.geterror() : std::string("OSL error"));
+            errorf("y %s", errhandler.haserror() ? errhandler.geterror() : std::string("OSL error"));
             ok = false;
         }
         shadingsys->ShaderGroupEnd ();
@@ -544,7 +544,7 @@ OSLInput::open (const std::string &name, ImageSpec &newspec,
         //           << sourcecode << "---\n";
         std::string err;
         if (! compile_buffer (sourcecode, exprname, err)) {
-            error ("%s", err);
+            errorf("%s", err);
             return false;
         }
         m_group = shadingsys->ShaderGroupBegin ();


### PR DESCRIPTION
With OIIO 2.0 as our minimum, change all the internal error reporting
functions taking printf-style arguments to use the errorf() convention,
thus reserving the name error() for an eventual future where we use
C++20 format conventions.

Also make sure that we are consistently using the right OIIO functions
themselves -- sprintf, not format, for example.

This doesn't affect any of OSL's public APIs, this is all strictly
internal and does not break public API compatibility.
