### PR TITLE
oslc --embed-source : embed preprocessed source at end of oso file

### DIFF
--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -397,7 +397,8 @@ private:
     void initialize_globals ();
     void initialize_builtin_funcs ();
     std::string default_output_filename ();
-    void write_oso_file (const std::string &outfilename, string_view options);
+    void write_oso_file (const std::string &outfilename, string_view options,
+                         string_view preprocessed_source="");
     void write_oso_const_value (const ConstantSymbol *sym) const;
     void write_oso_symbol (const Symbol *sym);
     void write_oso_metadata (const ASTNode *metanode) const;
@@ -478,6 +479,7 @@ private:
     bool m_quiet;             ///< Quiet mode
     bool m_debug;             ///< Debug mode
     bool m_preprocess_only;   ///< Preprocess only?
+    bool m_embed_source = false; ///< Embed preprocessed source in oso?
     bool m_err_on_warning;    ///< Treat warnings as errors?
     int m_optimizelevel;      ///< Optimization level
     OpcodeVec m_ircode;       ///< Generated IR code

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -230,6 +230,10 @@ using namespace OSL::pvt;
                             return STRING_LITERAL;
                         }
 
+\%preprocessed_source\n(.*\n)* {
+                            /* skip remainder of file */
+                        }
+
 {HINTPATTERN}           {
                             ustring s (yytext);
                             yylval.s = s.c_str();

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -62,6 +62,7 @@ usage ()
         "\t-d             Debug mode\n"
         "\t-E             Only preprocess the input and output to stdout\n"
         "\t-Werror        Treat all warnings as errors\n"
+        "\t-embed-source  Embed preprocessed source in the oso file\n"
         "\t-buffer        (debugging) Force compile from buffer\n"
         ;
 }
@@ -147,7 +148,9 @@ main (int argc, const char *argv[])
                  ! strcmp (argv[a], "-E") ||
                  ! strcmp (argv[a], "-O") || ! strcmp (argv[a], "-O0") ||
                  ! strcmp (argv[a], "-O1") || ! strcmp (argv[a], "-O2") ||
-                 ! strcmp (argv[a], "-Werror")
+                 ! strcmp (argv[a], "-Werror") ||
+                 ! strcmp (argv[a], "-embed-source") ||
+                 ! strcmp (argv[a], "--embed-source")
                  ) {
             // Valid command-line argument
             args.emplace_back(argv[a]);


### PR DESCRIPTION
This can be useful in debugging situations, since the oso file would
completely contain a readable (though preprocessed) and recompilable
version of the source.

In the oso file, this is signified by the hint `%preprocessed_source`,
and following that the remainder of the file is assumed to be source
code or comments and will be ignored by the oso parser.

