### PR TITLE
osl internals: be clear about printf style formatting

### DIFF
--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -404,7 +404,7 @@ private:
     void write_oso_metadata (const ASTNode *metanode) const;
 
     template<typename... Args>
-    inline void oso (const char* fmt, const Args&... args) const {
+    inline void osof(const char* fmt, const Args&... args) const {
         (*m_osofile) << OIIO::Strutil::sprintf (fmt, args...);
     }
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -352,7 +352,7 @@ RuntimeOptimizer::debug_opt_ops (int opbegin, int opend, string_view message) co
         oprange = Strutil::sprintf ("ops %d-%d ", opbegin, opend);
     else if (opbegin >= 0)
         oprange = Strutil::sprintf ("op %d ", opbegin);
-    debug_opt ("%s%s (@ %s:%d)\n", oprange, message,
+    debug_optf("%s%s (@ %s:%d)\n", oprange, message,
                op.sourcefile(), op.sourceline());
 }
 
@@ -932,7 +932,7 @@ RuntimeOptimizer::simplify_params ()
                     auto f = g.find (srcsym->name());
                     if (f != g.end()) {
                         if (debug() > 1)
-                            debug_opt ("Remapping %s.%s because it's connected to "
+                            debug_optf("Remapping %s.%s because it's connected to "
                                        "%s.%s, which is known to be %s\n",
                                        inst()->layername(), s->name(),
                                        uplayer->layername(), srcsym->name(),
@@ -1011,7 +1011,7 @@ RuntimeOptimizer::find_params_holding_globals ()
             continue;   // only interested in global assignments
 
         if (debug() > 1)
-            debug_opt ("I think that %s.%s will always be %s\n",
+            debug_optf("I think that %s.%s will always be %s\n",
                        inst()->layername(), s.name(), src->name());
         m_params_holding_globals[layer()][s.name()] = src->name();
     }
@@ -2304,7 +2304,7 @@ RuntimeOptimizer::optimize_instance ()
             break;
 
         if (debug() > 1)
-            debug_opt ("layer %d \"%s\", pass %d:\n",
+            debug_optf("layer %d \"%s\", pass %d:\n",
                        layer(), inst()->layername(), m_pass);
 
         // Track basic blocks and conditional states

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -156,7 +156,7 @@ public:
     void debug_opt_impl (string_view message) const;
 
     template<typename... Args>
-    inline void debug_opt (const char* fmt, const Args&... args) const {
+    inline void debug_optf (const char* fmt, const Args&... args) const {
         debug_opt_impl (OIIO::Strutil::sprintf (fmt, args...));
     }
 

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -998,7 +998,7 @@ OSLToyMainWindow::make_param_adjustment_row (ParamRec *param,
         typetext = OIIO::Strutil::sprintf("struct %s", param->structname);
     if (param->isoutput)
         typetext = OIIO::Strutil::sprintf("output %s", typetext);
-//    auto typeLabel = QtUtils::make_qlabel ("<i>%s</i>", typetext);
+//    auto typeLabel = QtUtils::make_qlabelf ("<i>%s</i>", typetext);
 //    layout->addWidget (typeLabel, row, 1);
     auto nameLabel = new QLabel (OIIO::Strutil::sprintf("<i>%s</i>&nbsp;  <b>%s</b>",
                                                        typetext, param->name).c_str());
@@ -1038,7 +1038,7 @@ OSLToyMainWindow::make_param_adjustment_row (ParamRec *param,
                 labeltext = string_view(&("RGB"[c]), 1);
             else
                 labeltext = string_view(&("xyz"[c]), 1);
-            auto channellabel = QtUtils::make_qlabel("%s", labeltext);
+            auto channellabel = QtUtils::make_qlabelf("%s", labeltext);
             label_and_adjust_layout->addWidget (channellabel);
             auto adjustWidget = new QtUtils::DoubleSpinBox (param->fdefault[c]);
             if (param->type == TypeDesc::TypeColor) {

--- a/src/osltoy/qtutils.h
+++ b/src/osltoy/qtutils.h
@@ -87,7 +87,7 @@ clear_layout (QLayout *lay)
 // render the 'blah' in italics.
 template<typename... Args>
 inline QLabel*
-make_qlabel (const char* fmt, const Args&... args)
+make_qlabelf (const char* fmt, const Args&... args)
 {
     std::string text = OIIO::Strutil::sprintf (fmt, args...);
     auto label = new QLabel (text.c_str());


### PR DESCRIPTION
Found a couple more internals to change the names to be extra sure we
keep straight which ones are "printf-style" formatting ("%6.2f"), versus
future C++ converstion of std::format (Python-like: "{:6.2}"). Currently
we use exclusively printf-style, but some day there may be a mix, so I'm
removing ambiguity in the names. This is strictly internal, does not
change any public APIs.

