### PR TITLE
oslc can generate dependency files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             pnoise pnoise-cell pnoise-gabor pnoise-perlin
             operator-overloading
             opt-warnings
-            oslc-comma oslc-D
+            oslc-comma oslc-D oslc-M
             oslc-err-arrayindex oslc-err-assignmenttypes
             oslc-err-closuremul oslc-err-field
             oslc-err-format oslc-err-funcoverload

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -84,7 +84,10 @@ public:
 
     /// Set the name of the file we're currently parsing (should only
     /// be called by the lexer!)
-    void filename (ustring f) { m_filename = f; }
+    void filename (ustring f) {
+        m_filename = f;
+        m_file_dependencies.emplace(f);
+    }
 
     /// The line we're currently parsing
     ///
@@ -371,7 +374,7 @@ public:
                                           std::vector<int> *bblock_ids=NULL);
     static void coalesce_temporaries (SymbolPtrVec &symtab);
 
-    const std::string main_filename () const { return m_main_filename; }
+    ustring main_filename () const { return m_main_filename; }
     const std::string cwd () const { return m_cwd; }
 
     bool debug () const { return m_debug; }
@@ -402,6 +405,7 @@ private:
     void write_oso_const_value (const ConstantSymbol *sym) const;
     void write_oso_symbol (const Symbol *sym);
     void write_oso_metadata (const ASTNode *metanode) const;
+    void write_dependency_file (string_view filename);
 
     template<typename... Args>
     inline void osof(const char* fmt, const Args&... args) const {
@@ -466,7 +470,7 @@ private:
     ustring m_filename;       ///< Current file we're parsing
     int m_lineno;             ///< Current line we're parsing
     std::string m_output_filename; ///< Output filename
-    std::string m_main_filename; ///< Main input filename
+    ustring m_main_filename;  ///< Main input filename
     std::string m_cwd;        ///< Current working directory
     ASTNode::ref m_shader;    ///< The shader's syntax tree
     ErrorHandler *m_errhandler; ///< Error handler
@@ -479,6 +483,8 @@ private:
     bool m_quiet;             ///< Quiet mode
     bool m_debug;             ///< Debug mode
     bool m_preprocess_only;   ///< Preprocess only?
+    bool m_generate_deps = false; ///< Generate dependencies? -MD or -MMD?
+    bool m_generate_system_deps = false; ///< Generate system header deps? -MD
     bool m_embed_source = false; ///< Embed preprocessed source in oso?
     bool m_err_on_warning;    ///< Treat warnings as errors?
     int m_optimizelevel;      ///< Optimization level
@@ -503,6 +509,8 @@ private:
     std::string* m_last_filecontents = nullptr; //< Last file contents
     int m_last_sourceline;
     size_t m_last_sourceline_offset;
+    std::string m_deps_filename; ///< Where to write deps? -MF
+    std::set<ustring> m_file_dependencies; ///< All include file dependencies
 };
 
 

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -336,11 +336,11 @@ preprocess (const char *yytext)
             p += 4;
         int line = atoi (p);
         if (line > 0) {
-            const char *f = strchr (yytext, '\"');
+            const char *f = strchr (yytext, '\"'); // " undo syntax highlight
             if (f) {
                 ++f;  // increment to past the quote
                 int len = 0;  // count of chars within quotes
-                while (f[len] && f[len] != '\"')
+                while (f[len] && f[len] != '\"') // " undo syntax highlight
                     ++len;
                 std::string filename (f, len);
 #if defined(_WIN32) && defined(USE_BOOST_WAVE) && (USE_BOOST_WAVE != 0)
@@ -365,14 +365,15 @@ preprocess (const char *yytext)
                         (filename[0] == '/' || filename[0] == '\\'))
                         filename.erase (0, 1);
                 }
-                oslcompiler->filename (ustring (filename));
+                ustring ufilename(filename);
+                oslcompiler->filename (ufilename);
                 // Spooky workaround for Boost Wave bug: force_include
                 // is broken and doesn't give us the right lines/files, so
                 // instead we forcefully insert a '#include "stdosl.h"' into
                 // the stream ourselves, but this in turn makes the rest
                 // of the main file all have line counts one line off!
                 // So we fix it here, ugh.
-                if (filename == oslcompiler->main_filename())
+                if (ufilename == oslcompiler->main_filename())
                     --line;
             }
             oslcompiler->lineno (line);

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -64,6 +64,9 @@ usage ()
         "\t-Werror        Treat all warnings as errors\n"
         "\t-embed-source  Embed preprocessed source in the oso file\n"
         "\t-buffer        (debugging) Force compile from buffer\n"
+        "\t-MD, -MMD      Write a depfile containing headers used, to a file\n"
+        "\t-M, -MM        Like -MD, but write depfile to stdout\n"
+        "\t-MF<file>      Specify the name of the depfile to output (for -MD, -MMD)\n"
         ;
 }
 
@@ -142,19 +145,29 @@ main (int argc, const char *argv[])
             usage ();
             return EXIT_SUCCESS;
         }
-        else if (! strcmp (argv[a], "-v") ||
-                 ! strcmp (argv[a], "-q") ||
-                 ! strcmp (argv[a], "-d") ||
-                 ! strcmp (argv[a], "-E") ||
-                 ! strcmp (argv[a], "-O") || ! strcmp (argv[a], "-O0") ||
-                 ! strcmp (argv[a], "-O1") || ! strcmp (argv[a], "-O2") ||
-                 ! strcmp (argv[a], "-Werror") ||
-                 ! strcmp (argv[a], "-embed-source") ||
-                 ! strcmp (argv[a], "--embed-source")
+        else if (!strcmp(argv[a], "-q") || !strcmp(argv[a], "-v")) {
+            args.emplace_back(argv[a]);
+            quiet = (strcmp(argv[a], "-q") == 0);
+        }
+        else if (!strcmp(argv[a], "-E")
+                 || ! strcmp(argv[a], "-M") || !strcmp(argv[a], "--dependencies")
+                 || ! strcmp(argv[a], "-MM") || !strcmp(argv[a], "--user-dependencies")) {
+            args.emplace_back(argv[a]);
+            quiet = true;
+        }
+        else if (!strcmp(argv[a], "-v")
+                 || ! strcmp(argv[a], "-d")
+                 || ! strcmp(argv[a], "-O") || !strcmp(argv[a], "-O0")
+                 || ! strcmp(argv[a], "-O1") || !strcmp(argv[a], "-O2")
+                 || ! strcmp(argv[a], "-Werror")
+                 || ! strcmp(argv[a], "-embed-source")
+                 || ! strcmp(argv[a], "--embed-source")
+                 || ! strcmp(argv[a], "-MD") || !strcmp(argv[a], "--write-dependencies")
+                 || ! strcmp(argv[a], "-MMD") || !strcmp(argv[a], "--write-user-dependencies")
+                 || OIIO::Strutil::starts_with(argv[a], "-MF")
                  ) {
             // Valid command-line argument
             args.emplace_back(argv[a]);
-            quiet |= (strcmp (argv[a], "-q") == 0);
         }
         else if (! strcmp (argv[a], "-o") && a < argc-1) {
             // Output filepath

--- a/testsuite/oslc-M/myheader.h
+++ b/testsuite/oslc-M/myheader.h
@@ -1,0 +1,4 @@
+int foo(int x)
+{
+    return x*2;
+}

--- a/testsuite/oslc-M/ref/mydep.d
+++ b/testsuite/oslc-M/ref/mydep.d
@@ -1,0 +1,2 @@
+test.oso: test.osl \
+  myheader.h

--- a/testsuite/oslc-M/ref/out.txt
+++ b/testsuite/oslc-M/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+test.oso: test.osl \
+  myheader.h

--- a/testsuite/oslc-M/ref/test.d
+++ b/testsuite/oslc-M/ref/test.d
@@ -1,0 +1,2 @@
+test.oso: test.osl \
+  myheader.h

--- a/testsuite/oslc-M/run.py
+++ b/testsuite/oslc-M/run.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+# Use -MMD instead of -MD to cause it to not list stdosl.h, which with its
+# absolute path is very hard to have match across CI platforms and test
+# exactly.
+
+# Test deps to default test.d
+command = oslc ("-q -MMD test.osl")
+
+# Test deps to custom file location
+command += oslc ("-q -MMD -MFmydep.d test.osl")
+
+# Test deps to stdout
+command += oslc ("-MM test.osl")
+
+outputs = [ "test.d", "mydep.d", "out.txt" ]
+

--- a/testsuite/oslc-M/test.osl
+++ b/testsuite/oslc-M/test.osl
@@ -1,0 +1,8 @@
+#include "myheader.h"
+
+shader test ()
+{
+    int bar = 42;
+    printf ("foo is %d\n", foo(bar));
+}
+


### PR DESCRIPTION
This patch adds support for `-M`, `-MM`, `-MD`, `-MMD`, `-MF` flags,
akin to how they are used in gcc or clang, to generate dependency
files that can be used by make, ninja, etc., to express header
dependencies of osl files.  For example, output might look like:

    $ oslc -MMD test.osl
    Compiled test.osl -> test.oso
    $ cat test.d
    test.oso: test.osl \
      dist/macosx/share/OSL/shaders/color2.h \
      dist/macosx/share/OSL/shaders/stdosl.h

`-MD` and `-MMD` output a dependency file (all headers for `-MD`, just
user headers for `-MMD`), by default to `<inputbasename>.d`, but
overrideable by `-MF<filename>`.

`-M` and `-MM` are versions of `-MD` and `-MMD` but that print the
resulting dependency list to stdout.

We also adjust the printing of "Compiled foo.osl -> foo.oso" so that
it does not happen in the case of `-E`, `-M`, and `-MM` when other
specific output is expected to comprise the whole of stdout.

Also, I *think* that we now no longer use Boost Wave at all on any
platforms, so I put in an `#error` compiler directive to verify. If
nobody complains, I'll soon excise all of the Boost Wave specific
code.
