### PR TITLE
Replace ASSERT -> OSL_ASSERT and DASSERT -> OSL_DASSERT.

### DIFF
--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -94,17 +94,17 @@ struct OSLEXECPUBLIC ClosureColor {
     int id;
 
     OSL_HOSTDEVICE const ClosureComponent* as_comp() const {
-        DASSERT(id >= COMPONENT_BASE_ID);
+        OSL_DASSERT(id >= COMPONENT_BASE_ID);
         return reinterpret_cast<const ClosureComponent*>(this);
     }
 
     OSL_HOSTDEVICE const ClosureMul* as_mul() const {
-        DASSERT(id == MUL);
+        OSL_DASSERT(id == MUL);
         return reinterpret_cast<const ClosureMul*>(this);
     }
 
     OSL_HOSTDEVICE const ClosureAdd* as_add() const {
-        DASSERT(id == ADD);
+        OSL_DASSERT(id == ADD);
         return reinterpret_cast<const ClosureAdd*>(this);
     }
 };

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <memory>
-#include <OpenImageIO/dassert.h>
 
 #include <OSL/oslconfig.h>
 
@@ -202,7 +201,7 @@ public:
 
     /// Returns the length of the array, or 0 if not an array.
     int arraylength () const {
-        DASSERT_MSG (m_simple.arraylen >= 0, "Called arraylength() on "
+        OSL_DASSERT_MSG (m_simple.arraylen >= 0, "Called arraylength() on "
                      "TypeSpec of array with unspecified length (%d)", m_simple.arraylen);
         return m_simple.arraylen;
     }
@@ -210,7 +209,7 @@ public:
     /// Number of elements
     ///
     int numelements() const {
-        DASSERT_MSG (m_simple.arraylen >= 0, "Called numelements() on "
+        OSL_DASSERT_MSG (m_simple.arraylen >= 0, "Called numelements() on "
                      "TypeSpec of array with unspecified length (%d)", m_simple.arraylen);
         return std::max (1, m_simple.arraylen);
     }
@@ -520,7 +519,7 @@ public:
     /// Establish that this symbol is really an alias for another symbol.
     ///
     void alias (Symbol *other) {
-        DASSERT (other != this);  // circular alias would be bad
+        OSL_DASSERT(other != this);  // circular alias would be bad
         m_alias = other;
     }
 
@@ -671,21 +670,21 @@ public:
     bool is_constant () const { return symtype() == SymTypeConst; }
     bool is_temp () const { return symtype() == SymTypeTemp; }
 
-    // Retrieve the const float value (will ASSERT if not a const float!)
+    // Retrieve the const float value (must be a const float!)
     float get_float (int index = 0) const {
-        ASSERT (data() && typespec().is_float_based());
+        OSL_DASSERT (data() && typespec().is_float_based());
         return ((const float *)data())[index];
     }
 
-    // Retrieve the const int value (will ASSERT if not a const int!)
+    // Retrieve the const int value (must be a const int!)
     int get_int (int index = 0) const {
-        ASSERT (data() && typespec().is_int_based());
+        OSL_DASSERT (data() && typespec().is_int_based());
         return ((const int *)data())[index];
     }
 
-    // Retrieve the const string value (will ASSERT if not a const string!)
+    // Retrieve the const string value (must be a const string!)
     ustring get_string (int index = 0) const {
-        ASSERT (data() && typespec().is_string());
+        OSL_DASSERT (data() && typespec().is_string());
         return ((const ustring *)data())[index];
     }
 

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -192,7 +192,7 @@ public:
     template<typename... Args>
     void errorf (const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         error_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
@@ -200,7 +200,7 @@ public:
     template<typename... Args>
     void warningf (const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         warning_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
@@ -208,7 +208,7 @@ public:
     template<typename... Args>
     void infof (const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         info_impl (OIIO::Strutil::sprintf (format, args...));
     }
 
@@ -216,7 +216,7 @@ public:
     template<typename... Args>
     void messagef (const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         message_impl (OIIO::Strutil::sprintf (format, args...));
     }
 

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenImageIO/platform.h>
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/thread.h>
 
@@ -584,13 +583,13 @@ OSLCompilerImpl::compile (string_view filename,
                        m_output_filename);
                 return false;
             }
-            ASSERT (m_osofile == NULL);
+            OSL_DASSERT (m_osofile == nullptr);
             m_osofile = &oso_output;
 
             write_oso_file (m_output_filename,
                             OIIO::Strutil::join(options," "),
                             preprocess_result);
-            ASSERT (m_osofile == NULL);
+            OSL_DASSERT (m_osofile == nullptr);
         }
 
         oslcompiler = nullptr;
@@ -667,14 +666,14 @@ OSLCompilerImpl::compile_buffer (string_view sourcecode,
 
             std::ostringstream oso_output;
             oso_output.imbue (std::locale::classic());  // force C locale
-            ASSERT (m_osofile == NULL);
+            OSL_DASSERT (m_osofile == nullptr);
             m_osofile = &oso_output;
 
             write_oso_file (m_output_filename,
                             OIIO::Strutil::join(options," "),
                             preprocess_result);
             osobuffer = oso_output.str();
-            ASSERT (m_osofile == NULL);
+            OSL_DASSERT (m_osofile == nullptr);
         }
 
         oslcompiler = nullptr;
@@ -736,10 +735,10 @@ OSLCompilerImpl::default_output_filename ()
 void
 OSLCompilerImpl::write_oso_metadata (const ASTNode *metanode) const
 {
-    ASSERT (metanode->nodetype() == ASTNode::variable_declaration_node);
+    OSL_DASSERT (metanode->nodetype() == ASTNode::variable_declaration_node);
     const ASTvariable_declaration *metavar = static_cast<const ASTvariable_declaration *>(metanode);
     Symbol *metasym = metavar->sym();
-    ASSERT (metasym);
+    OSL_DASSERT (metasym);
     TypeSpec ts = metasym->typespec();
     std::string pdl;
     bool ok = metavar->param_default_literals (metasym, metavar->init().get(), pdl, ",");
@@ -757,7 +756,7 @@ OSLCompilerImpl::write_oso_metadata (const ASTNode *metanode) const
 void
 OSLCompilerImpl::write_oso_const_value (const ConstantSymbol *sym) const
 {
-    ASSERT (sym);
+    OSL_ASSERT (sym);
     TypeDesc type = sym->typespec().simpletype();
     TypeDesc elemtype = type.elementtype();
     int nelements = std::max (1, type.arraylen);
@@ -776,7 +775,7 @@ OSLCompilerImpl::write_oso_const_value (const ConstantSymbol *sym) const
             osof("%.9g %.9g %.9g%s", sym->vecval(i)[0], sym->vecval(i)[1],
                  sym->vecval(i)[2], nelements>1 ? " " : "");
     else {
-        ASSERT (0 && "Don't know how to output this constant type");
+        OSL_ASSERT (0 && "Don't know how to output this constant type");
     }
 }
 
@@ -814,7 +813,6 @@ OSLCompilerImpl::write_oso_symbol (const Symbol *sym)
 
     // %meta{} encodes metadata (handled by write_oso_metadata)
     if (v) {
-        ASSERT (v);
         for (ASTNode::ref m = v->meta();  m;  m = m->next()) {
             if (hints++ == 0)
                 osof("\t");
@@ -905,7 +903,7 @@ OSLCompilerImpl::write_oso_file (const std::string &outfilename,
                                  string_view options,
                                  string_view preprocessed_source)
 {
-    ASSERT (m_osofile != NULL && m_osofile->good());
+    OSL_DASSERT (m_osofile && m_osofile->good());
     osof("OpenShadingLanguage %d.%02d\n",
          OSO_FILE_VERSION_MAJOR, OSO_FILE_VERSION_MINOR);
     osof("# Compiled by oslc %s\n", OSL_LIBRARY_VERSION_STRING);
@@ -1151,11 +1149,11 @@ void
 OSLCompilerImpl::struct_field_pair (Symbol *sym1, Symbol *sym2, int fieldnum,
                                     Symbol * &field1, Symbol * &field2)
 {
-    ASSERT (sym1 && sym2 && sym1->typespec().is_structure() &&
-            sym1->typespec().structure() && sym2->typespec().structure());
+    OSL_DASSERT (sym1 && sym2 && sym1->typespec().is_structure() &&
+                 sym1->typespec().structure() && sym2->typespec().structure());
     // Find the StructSpec for the type of struct that the symbols are
     StructSpec *structspec (sym1->typespec().structspec());
-    ASSERT (structspec && fieldnum < (int)structspec->numfields());
+    OSL_DASSERT (structspec && fieldnum < (int)structspec->numfields());
     // Find the FieldSpec for the field we are interested in
     const StructSpec::FieldSpec &field (structspec->field(fieldnum));
     // Construct mangled names that describe the symbols for the
@@ -1165,7 +1163,7 @@ OSLCompilerImpl::struct_field_pair (Symbol *sym1, Symbol *sym2, int fieldnum,
     // Retrieve the symbols
     field1 = symtab().find_exact (name1);
     field2 = symtab().find_exact (name2);
-    ASSERT (field1 && field2);
+    OSL_DASSERT (field1 && field2);
 }
 
 
@@ -1182,7 +1180,7 @@ OSLCompilerImpl::struct_field_pair (const StructSpec *structspec, int fieldnum,
     // Retrieve the symbols
     field1 = symtab().find_exact (name1);
     field2 = symtab().find_exact (name2);
-    ASSERT (field1 && field2);
+    OSL_ASSERT (field1 && field2);
 }
 
 
@@ -1255,7 +1253,7 @@ OSLCompilerImpl::track_variable_lifetimes (const OpcodeVec &code,
                 op.opname() == op_dowhile) {
             // If this is a loop op, we need to mark its control variable
             // (the only arg) as used for the duration of the loop!
-            ASSERT (op.nargs() == 1);  // loops should have just one arg
+            OSL_DASSERT (op.nargs() == 1);  // loops should have just one arg
             SymbolPtr s = opargs[op.firstarg()];
             int loopcond = op.jump (0); // after initialization, before test
             int loopend = op.farthest_jump() - 1;   // inclusive end
@@ -1268,7 +1266,7 @@ OSLCompilerImpl::track_variable_lifetimes (const OpcodeVec &code,
         // Some work to do for each argument to the op...
         for (int a = 0;  a < op.nargs();  ++a) {
             SymbolPtr s = opargs[op.firstarg()+a];
-            ASSERT (s->dealias() == s);  // Make sure it's de-aliased
+            OSL_DASSERT (s->dealias() == s);  // Make sure it's de-aliased
 
             // Mark that it's read and/or written for this op
             bool readhere = op.argread(a);
@@ -1280,7 +1278,7 @@ OSLCompilerImpl::track_variable_lifetimes (const OpcodeVec &code,
             for (auto oprange : loop_bounds) {
                 int loopcond = oprange.first;
                 int loopend = oprange.second;
-                DASSERT (s->firstuse() <= loopend);
+                OSL_DASSERT(s->firstuse() <= loopend);
                 // Special case: a temp or local, even if written inside a
                 // loop, if it's entire lifetime is within one basic block
                 // and it's strictly written before being read, then its

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -105,7 +105,7 @@ public:
     void errorf(ustring filename, int line,
                 const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
@@ -121,7 +121,7 @@ public:
     void warningf(ustring filename, int line,
                   const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         if (nowarn(filename, line))
             return;    // skip if the filename/line is on the nowarn list
         std::string msg = OIIO::Strutil::sprintf (format, args...);
@@ -142,7 +142,7 @@ public:
     void infof(ustring filename, int line,
                const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
@@ -157,7 +157,7 @@ public:
     void messagef(ustring filename, int line,
                   const char* format, const Args&... args) const
     {
-        DASSERT (format && format[0]);
+        OSL_DASSERT(format && format[0]);
         std::string msg = OIIO::Strutil::sprintf (format, args...);
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -394,7 +394,7 @@ bool
 OSLCompilerImpl::osl_parse_buffer (const std::string &preprocessed_buffer)
 {
     // N.B. This should only be called if oslcompiler_mutex is held.
-    ASSERT (oslcompiler == this);
+    OSL_ASSERT (oslcompiler == this);
 
 #ifndef OIIO_STRUTIL_HAS_STOF
     // Force classic "C" locale for correct '.' decimal parsing.

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "oslcomp_pvt.h"
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 namespace Strutil = OIIO::Strutil;
 
 
@@ -45,7 +44,7 @@ std::string
 Symbol::mangled () const
 {
     // FIXME: De-alias
-    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name.c_str())
+    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name)
         : m_name.string();
 }
 
@@ -54,7 +53,7 @@ Symbol::mangled () const
 const char *
 Symbol::symtype_shortname (SymType s)
 {
-    ASSERT ((int)s >= 0 && (int)s < (int)SymTypeType);
+    OSL_DASSERT ((int)s >= 0 && (int)s < (int)SymTypeType);
     static const char *names[] = { "param", "oparam", "local", "temp",
                                    "global", "const", "func" };
     return names[(int)s];
@@ -65,7 +64,7 @@ Symbol::symtype_shortname (SymType s)
 std::string
 StructSpec::mangled () const
 {
-    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name.c_str())
+    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name)
         : m_name.string();
 }
 
@@ -91,7 +90,7 @@ Symbol::valuesourcename (ValueSource v)
     case GeomVal      : return "geom";
     case ConnectedVal : return "connected";
     }
-    ASSERT(0 && "unknown valuesource");
+    OSL_DASSERT(0 && "unknown valuesource");
     return NULL;
 }
 
@@ -225,7 +224,7 @@ SymbolTable::clash (ustring name) const
 void
 SymbolTable::insert (Symbol *sym)
 {
-    DASSERT (sym != NULL);
+    OSL_DASSERT(sym != NULL);
     sym->scope (scopeid ());
     m_scopetables.back()[sym->name()] = sym;
     m_allsyms.push_back (sym);
@@ -256,7 +255,7 @@ void
 SymbolTable::add_struct_field (const TypeSpec &type, ustring name)
 {
     StructSpec *s = current_struct();
-    ASSERT (s && "add_struct_field couldn't find a current struct");
+    OSL_DASSERT (s && "add_struct_field couldn't find a current struct");
     s->add_field (type, name);
 }
 
@@ -276,7 +275,7 @@ void
 SymbolTable::pop ()
 {
     m_scopetables.resize (m_scopetables.size()-1);
-    ASSERT (! m_scopestack.empty());
+    OSL_DASSERT (! m_scopestack.empty());
     m_scopeid = m_scopestack.top ();
     m_scopestack.pop ();
 }

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -162,7 +162,7 @@ public:
         else if (equivalent(type,TypeDesc::TypeVector))
             m_data = &m_val.v;
         else {
-            ASSERT (m_data == NULL);
+            OSL_DASSERT (m_data == nullptr);
             m_data = new char [type.size()];
             m_free_data = true;
         }

--- a/src/liboslexec/accum.cpp
+++ b/src/liboslexec/accum.cpp
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/accum.h>
 #include <OSL/oslclosure.h>
 #include "lpeparse.h"
-#include <OpenImageIO/dassert.h>
 
 
 OSL_NAMESPACE_ENTER
@@ -147,7 +146,7 @@ Accumulator::Accumulator(const AccumAutomata *accauto):m_accum_automata(accauto)
 void
 Accumulator::setAov(int outidx, Aov *aov, bool neg_color, bool neg_alpha)
 {
-    ASSERT (0 <= outidx && outidx < (int) m_outputs.size());
+    OSL_ASSERT (0 <= outidx && outidx < (int) m_outputs.size());
     m_outputs[outidx].aov = aov;
     m_outputs[outidx].neg_color = neg_color;
     m_outputs[outidx].neg_alpha = neg_alpha;
@@ -158,7 +157,7 @@ Accumulator::setAov(int outidx, Aov *aov, bool neg_color, bool neg_alpha)
 void
 Accumulator::pushState()
 {
-    ASSERT (m_state >= 0);
+    OSL_ASSERT (m_state >= 0);
     m_stack.push(m_state);
 }
 
@@ -167,7 +166,7 @@ Accumulator::pushState()
 void
 Accumulator::popState()
 {
-    ASSERT (m_stack.size());
+    OSL_ASSERT (m_stack.size());
     m_state = m_stack.top();
     m_stack.pop();
 }

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OSL/accum.h>
 #include <OSL/oslclosure.h>
+#include <OpenImageIO/unittest.h>
 
 using namespace OSL;
 
@@ -156,16 +157,16 @@ int main()
     automata.addEventType(ustring("U"));
     automata.addScatteringType(ustring("Y"));
 
-    ASSERT(automata.addRule("C[SG]*D*L",        beauty));
-    ASSERT(automata.addRule("C[SG]*D{2,3}L",    diffuse2_3));
-    ASSERT(automata.addRule("C[SG]*D*<L.'3'>",  light3));
-    ASSERT(automata.addRule("C[SG]*<.D'1'>D*L", object_1));
-    ASSERT(automata.addRule("C<.[SG]>+D*L",     specular));
-    ASSERT(automata.addRule("CD+L",             diffuse));
-    ASSERT(automata.addRule("CD+<Ts>L",         transpshadow));
-    ASSERT(automata.addRule("C<R[^D]>+D*L",     reflections));
-    ASSERT(automata.addRule("C([SG]*D){1,2}L",  nocaustic));
-    ASSERT(automata.addRule("CDY+U",            custom));
+    OIIO_CHECK_ASSERT(automata.addRule("C[SG]*D*L",        beauty));
+    OIIO_CHECK_ASSERT(automata.addRule("C[SG]*D{2,3}L",    diffuse2_3));
+    OIIO_CHECK_ASSERT(automata.addRule("C[SG]*D*<L.'3'>",  light3));
+    OIIO_CHECK_ASSERT(automata.addRule("C[SG]*<.D'1'>D*L", object_1));
+    OIIO_CHECK_ASSERT(automata.addRule("C<.[SG]>+D*L",     specular));
+    OIIO_CHECK_ASSERT(automata.addRule("CD+L",             diffuse));
+    OIIO_CHECK_ASSERT(automata.addRule("CD+<Ts>L",         transpshadow));
+    OIIO_CHECK_ASSERT(automata.addRule("C<R[^D]>+D*L",     reflections));
+    OIIO_CHECK_ASSERT(automata.addRule("C([SG]*D){1,2}L",  nocaustic));
+    OIIO_CHECK_ASSERT(automata.addRule("CDY+U",            custom));
 
     automata.compile();
 
@@ -182,15 +183,16 @@ int main()
 
     // And check. We unroll this loop for boost to give us a useful
     // error in case they fail
-    ASSERT(aovs[beauty      ].check());
-    ASSERT(aovs[diffuse2_3  ].check());
-    ASSERT(aovs[light3      ].check());
-    ASSERT(aovs[object_1    ].check());
-    ASSERT(aovs[specular    ].check());
-    ASSERT(aovs[diffuse     ].check());
-    ASSERT(aovs[transpshadow].check());
-    ASSERT(aovs[reflections ].check());
-    ASSERT(aovs[nocaustic   ].check());
+    OIIO_CHECK_ASSERT(aovs[beauty      ].check());
+    OIIO_CHECK_ASSERT(aovs[diffuse2_3  ].check());
+    OIIO_CHECK_ASSERT(aovs[light3      ].check());
+    OIIO_CHECK_ASSERT(aovs[object_1    ].check());
+    OIIO_CHECK_ASSERT(aovs[specular    ].check());
+    OIIO_CHECK_ASSERT(aovs[diffuse     ].check());
+    OIIO_CHECK_ASSERT(aovs[transpshadow].check());
+    OIIO_CHECK_ASSERT(aovs[reflections ].check());
+    OIIO_CHECK_ASSERT(aovs[nocaustic   ].check());
 
     std::cout << "Light expressions check OK" << std::endl;
+    return unit_test_failures;
 }

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -154,7 +154,7 @@ public:
 
     /// Convenience function to load a string for CPU or GPU device
     llvm::Value *llvm_load_string (const Symbol& sym) {
-        DASSERT(sym.typespec().is_string());
+        OSL_DASSERT(sym.typespec().is_string());
         return use_optix()
             ? llvm_load_device_string(sym, /*follow*/ true)
             : llvm_load_value(sym);

--- a/src/liboslexec/closure.cpp
+++ b/src/liboslexec/closure.cpp
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstdio>
 
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/sysutil.h>
 
 #include <OSL/oslconfig.h>
@@ -86,9 +85,9 @@ print_component_value(std::ostream &out, ShadingSystemImpl *ss,
 static void
 print_component (std::ostream &out, const ClosureComponent *comp, ShadingSystemImpl *ss, const Color3 &weight)
 {
-    out << "(" << weight[0]*comp->w[0] << ", " << weight[1]*comp->w[1] << ", " << weight[2]*comp->w[2] << ") * ";
     const ClosureRegistry::ClosureEntry *clentry = ss->find_closure(comp->id);
-    ASSERT(clentry);
+    OSL_ASSERT(clentry);
+    out << "(" << weight[0]*comp->w[0] << ", " << weight[1]*comp->w[1] << ", " << weight[2]*comp->w[2] << ") * ";
     out << clentry->name.c_str() << " (";
     for (int i = 0, nparams = clentry->params.size() - 1; i < nparams; ++i) {
         if (i) out << ", ";

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -351,7 +351,7 @@ DECLFOLDER(constfold_dot)
 
     // dot(const,const) -> const
     if (A.is_constant() && B.is_constant()) {
-        DASSERT (A.typespec().is_triple() && B.typespec().is_triple());
+        OSL_DASSERT(A.typespec().is_triple() && B.typespec().is_triple());
         float result = (*(Vec3 *)A.data()).dot (*(Vec3 *)B.data());
         int cind = rop.add_constant (TypeDesc::TypeFloat, &result);
         rop.turn_into_assign (op, cind, "dot(const,const)");
@@ -610,7 +610,7 @@ DECLFOLDER(constfold_or)
     Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &B (*rop.inst()->argsymbol(op.firstarg()+2));
     if (A.is_constant() && B.is_constant()) {
-        DASSERT (A.typespec().is_int() && B.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int() && B.typespec().is_int());
         bool val = *(int *)A.data() || *(int *)B.data();
         // Turn the 'or R A B' into 'assign R X' where X is 0 or 1.
         static const int int_zero = 0, int_one = 1;
@@ -631,7 +631,7 @@ DECLFOLDER(constfold_and)
     Symbol &B (*rop.inst()->argsymbol(op.firstarg()+2));
     if (A.is_constant() && B.is_constant()) {
         // Turn the 'and R A B' into 'assign R X' where X is 0 or 1.
-        DASSERT (A.typespec().is_int() && B.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int() && B.typespec().is_int());
         bool val = *(int *)A.data() && *(int *)B.data();
         static const int int_zero = 0, int_one = 1;
         int cind = rop.add_constant (TypeDesc::TypeInt,
@@ -651,7 +651,7 @@ DECLFOLDER(constfold_bitand)
     Symbol &B (*rop.opargsym(op, 2));
     if (A.is_constant() && B.is_constant()) {
         // Turn the 'bitand R A B' into 'assign R X'.
-        DASSERT (A.typespec().is_int() && B.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int() && B.typespec().is_int());
         int cind = rop.add_constant (A.get_int() & B.get_int());
         rop.turn_into_assign (op, cind, "const & const");
         return 1;
@@ -668,7 +668,7 @@ DECLFOLDER(constfold_bitor)
     Symbol &B (*rop.opargsym(op, 2));
     if (A.is_constant() && B.is_constant()) {
         // Turn the 'bitor R A B' into 'assign R X'.
-        DASSERT (A.typespec().is_int() && B.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int() && B.typespec().is_int());
         int cind = rop.add_constant (A.get_int() | B.get_int());
         rop.turn_into_assign (op, cind, "const | const");
         return 1;
@@ -685,7 +685,7 @@ DECLFOLDER(constfold_xor)
     Symbol &B (*rop.opargsym(op, 2));
     if (A.is_constant() && B.is_constant()) {
         // Turn the 'xor R A B' into 'assign R X'.
-        DASSERT (A.typespec().is_int() && B.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int() && B.typespec().is_int());
         int cind = rop.add_constant (A.get_int() ^ B.get_int());
         rop.turn_into_assign (op, cind, "const ^ const");
         return 1;
@@ -701,7 +701,7 @@ DECLFOLDER(constfold_compl)
     Symbol &A (*rop.opargsym(op, 1));
     if (A.is_constant()) {
         // Turn the 'compl R A' into 'assign R X'.
-        DASSERT (A.typespec().is_int());
+        OSL_DASSERT(A.typespec().is_int());
         int cind = rop.add_constant (~(A.get_int()));
         rop.turn_into_assign (op, cind, "~const");
         return 1;
@@ -773,15 +773,15 @@ DECLFOLDER(constfold_aref)
     Symbol &R (*rop.inst()->argsymbol(op.firstarg()+0));
     Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &Index (*rop.inst()->argsymbol(op.firstarg()+2));
-    DASSERT (A.typespec().is_array() && Index.typespec().is_int());
+    OSL_DASSERT(A.typespec().is_array() && Index.typespec().is_int());
 
     // Try to turn R=A[I] into R=C if A and I are const.
     if (A.is_constant() && Index.is_constant()) {
         TypeSpec elemtype = A.typespec().elementtype();
-        ASSERT (equivalent(elemtype, R.typespec()));
+        OSL_ASSERT (equivalent(elemtype, R.typespec()));
         const int length = A.typespec().arraylength();
         const int orig_index = *(int *)Index.data(), index = OIIO::clamp(orig_index, 0, length - 1);
-        DASSERT(index >=0 && index < length);
+        OSL_DASSERT(index >=0 && index < length);
         int cind = rop.add_constant (elemtype,
                         (char *)A.data() + index*elemtype.simpletype().size());
         rop.turn_into_assign (op, cind, "aref const fold: const_array[const]");
@@ -811,7 +811,7 @@ DECLFOLDER(constfold_aref)
     // the array elements are equal!
     if (A.is_constant() && array_all_elements_equal(A)) {
         TypeSpec elemtype = A.typespec().elementtype();
-        ASSERT (equivalent(elemtype, R.typespec()));
+        OSL_ASSERT (equivalent(elemtype, R.typespec()));
         int cind = rop.add_constant (elemtype, (char *)A.data());
         rop.turn_into_assign (op, cind, "aref of elements-equal array");
         return 1;
@@ -826,7 +826,7 @@ DECLFOLDER(constfold_arraylength)
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol &R (*rop.inst()->argsymbol(op.firstarg()+0));
     Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
-    ASSERT (R.typespec().is_int() && A.typespec().is_array());
+    OSL_DASSERT (R.typespec().is_int() && A.typespec().is_array());
 
     // Try to turn R=arraylength(A) into R=C if the array length is known
     int len = A.typespec().is_unsized_array() ? A.initializers()
@@ -850,7 +850,7 @@ DECLFOLDER(constfold_aassign)
     Symbol *C (rop.inst()->argsymbol(op.firstarg()+2));
     if (! I->is_constant() || !C->is_constant())
         return 0;  // not much we can do if not assigning constants
-    ASSERT (R->typespec().is_array() && I->typespec().is_int());
+    OSL_DASSERT (R->typespec().is_array() && I->typespec().is_int());
 
     TypeSpec elemtype = R->typespec().elementtype();
     if (elemtype.is_closure())
@@ -927,8 +927,8 @@ DECLFOLDER(constfold_compassign)
     Symbol *C (rop.inst()->argsymbol(op.firstarg()+2));
     if (! I->is_constant() || !C->is_constant())
         return 0;  // not much we can do if not assigning constants
-    ASSERT (R->typespec().is_triple() && I->typespec().is_int() &&
-            (C->typespec().is_float() || C->typespec().is_int()));
+    OSL_DASSERT (R->typespec().is_triple() && I->typespec().is_int() &&
+                 (C->typespec().is_float() || C->typespec().is_int()));
 
     // We are obviously not assigning to a constant, but it could be
     // that at this point in our current block, the value of A is known,
@@ -943,7 +943,7 @@ DECLFOLDER(constfold_compassign)
     // and thus the assignment doesn't change A's value, we can eliminate
     // the assignment entirely.
     if (AA && AA->is_constant()) {
-        ASSERT (AA->typespec().is_triple());
+        OSL_DASSERT (AA->typespec().is_triple());
         int index = *(int *)I->data();
         if (index < 0 || index >= 3) {
             // We are indexing a const triple out of range.  But this
@@ -1031,9 +1031,9 @@ DECLFOLDER(constfold_mxcompassign)
     Symbol *C (rop.inst()->argsymbol(op.firstarg()+3));
     if (! J->is_constant() || ! I->is_constant() || !C->is_constant())
         return 0;  // not much we can do if not assigning constants
-    ASSERT (R->typespec().is_matrix() &&
-            J->typespec().is_int() && I->typespec().is_int() &&
-            (C->typespec().is_float() || C->typespec().is_int()));
+    OSL_DASSERT (R->typespec().is_matrix() &&
+                 J->typespec().is_int() && I->typespec().is_int() &&
+                 (C->typespec().is_float() || C->typespec().is_int()));
 
     // We are obviously not assigning to a constant, but it could be
     // that at this point in our current block, the value of A is known,
@@ -1048,7 +1048,7 @@ DECLFOLDER(constfold_mxcompassign)
     // A[J,I] == C, and thus the assignment doesn't change A's value, we can
     // eliminate the assignment entirely.
     if (AA && AA->is_constant()) {
-        ASSERT (AA->typespec().is_matrix());
+        OSL_DASSERT (AA->typespec().is_matrix());
         int jndex = *(int *)J->data();
         int index = *(int *)I->data();
         if (index < 0 || index >= 3 || jndex < 0 || jndex >= 3) {
@@ -1138,7 +1138,7 @@ DECLFOLDER(constfold_compref)
     Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &Index (*rop.inst()->argsymbol(op.firstarg()+2));
     if (A.is_constant() && Index.is_constant()) {
-        ASSERT (A.typespec().is_triple() && Index.typespec().is_int());
+        OSL_DASSERT (A.typespec().is_triple() && Index.typespec().is_int());
         int index = *(int *)Index.data();
         if (index < 0 || index >= 3) {
             // We are indexing a const triple out of range.  But this
@@ -1163,7 +1163,7 @@ DECLFOLDER(constfold_strlen)
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol &S (*rop.inst()->argsymbol(op.firstarg()+1));
     if (S.is_constant()) {
-        ASSERT (S.typespec().is_string());
+        OSL_DASSERT (S.typespec().is_string());
         int result = (int) (*(ustring *)S.data()).length();
         int cind = rop.add_constant (result);
         rop.turn_into_assign (op, cind, "const fold strlen");
@@ -1212,8 +1212,7 @@ DECLFOLDER(constfold_getchar)
     Symbol &S (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &I (*rop.inst()->argsymbol(op.firstarg()+2));
     if (S.is_constant() && I.is_constant()) {
-        ASSERT (S.typespec().is_string());
-        ASSERT (I.typespec().is_int());
+        OSL_DASSERT (S.typespec().is_string() && I.typespec().is_int());
         int idx = (int) (*(int *)I.data());
         int len = (int) (*(ustring *)S.data()).length();
         int result = idx >= 0 && idx < len ? (*(ustring *)S.data()).c_str()[idx] : 0;
@@ -1233,7 +1232,7 @@ DECLFOLDER(constfold_endswith)
     Symbol &S (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &E (*rop.inst()->argsymbol(op.firstarg()+2));
     if (S.is_constant() && E.is_constant()) {
-        ASSERT (S.typespec().is_string() && E.typespec().is_string());
+        OSL_DASSERT (S.typespec().is_string() && E.typespec().is_string());
         ustring s = *(ustring *)S.data();
         ustring e = *(ustring *)E.data();
         size_t elen = e.length(), slen = s.length();
@@ -1255,7 +1254,7 @@ DECLFOLDER(constfold_stoi)
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol &S (*rop.inst()->argsymbol(op.firstarg()+1));
     if (S.is_constant()) {
-        ASSERT (S.typespec().is_string());
+        OSL_DASSERT (S.typespec().is_string());
         ustring s = *(ustring *)S.data();
         int cind = rop.add_constant (Strutil::from_string<int>(s));
         rop.turn_into_assign (op, cind, "const fold stoi");
@@ -1272,7 +1271,7 @@ DECLFOLDER(constfold_stof)
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol &S (*rop.inst()->argsymbol(op.firstarg()+1));
     if (S.is_constant()) {
-        ASSERT (S.typespec().is_string());
+        OSL_DASSERT (S.typespec().is_string());
         ustring s = *(ustring *)S.data();
         int cind = rop.add_constant (Strutil::from_string<float>(s));
         rop.turn_into_assign (op, cind, "const fold stof");
@@ -1396,7 +1395,7 @@ DECLFOLDER(constfold_format)
                 return 0;
             }
         }
-        ASSERT (pos < prefix.length() && prefix[pos] == '%');
+        OSL_ASSERT (pos < prefix.length() && prefix[pos] == '%');
 
         // cleave off the last format specification into mid
         std::string mid = std::string (prefix, pos);
@@ -1456,8 +1455,8 @@ DECLFOLDER(constfold_substr)
     Symbol &Start (*rop.opargsym (op, 2));
     Symbol &Len (*rop.opargsym (op, 3));
     if (S.is_constant() && Start.is_constant() && Len.is_constant()) {
-        ASSERT (S.typespec().is_string() && Start.typespec().is_int() &&
-                Len.typespec().is_int());
+        OSL_DASSERT (S.typespec().is_string() && Start.typespec().is_int() &&
+                     Len.typespec().is_int());
         ustring s = *(ustring *)S.data();
         int start = *(int *)Start.data();
         int len = *(int *)Len.data();
@@ -1484,7 +1483,7 @@ DECLFOLDER(constfold_regex_search)
     Symbol &Reg (*rop.inst()->argsymbol(op.firstarg()+2));
     if (op.nargs() == 3 // only the 2-arg version without search results
           && Subj.is_constant() && Reg.is_constant()) {
-        DASSERT (Subj.typespec().is_string() && Reg.typespec().is_string());
+        OSL_DASSERT(Subj.typespec().is_string() && Reg.typespec().is_string());
         const ustring &s (*(ustring *)Subj.data());
         const ustring &r (*(ustring *)Reg.data());
         regex reg (r.string());
@@ -1952,7 +1951,7 @@ DECLFOLDER(constfold_normalize)
     // Try to turn R=normalze(x) into R=C
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol &X (*rop.inst()->argsymbol(op.firstarg()+1));
-    DASSERT (X.typespec().is_triple());
+    OSL_DASSERT(X.typespec().is_triple());
     if (X.is_constant()) {
         Vec3 result = *(const Vec3 *)X.data();
         result.normalize();
@@ -1969,7 +1968,7 @@ DECLFOLDER(constfold_triple)
 {
     // Turn R=triple(a,b,c) into R=C if the components are all constants
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 4 || op.nargs() == 5);
+    OSL_DASSERT(op.nargs() == 4 || op.nargs() == 5);
     bool using_space = (op.nargs() == 5);
     Symbol &R (*rop.inst()->argsymbol(op.firstarg()+0));
     Symbol &A (*rop.inst()->argsymbol(op.firstarg()+1+using_space));
@@ -1985,7 +1984,7 @@ DECLFOLDER(constfold_triple)
     }
     if (A.is_constant() && A.typespec().is_float() &&
             B.is_constant() && C.is_constant() && !using_space) {
-        DASSERT (A.typespec().is_float() &&
+        OSL_DASSERT(A.typespec().is_float() &&
                  B.typespec().is_float() && C.typespec().is_float());
         float result[3];
         result[0] = *(const float *)A.data();
@@ -2008,7 +2007,7 @@ DECLFOLDER(constfold_matrix)
     if (using_space && nargs > 2 && rop.opargsym(op,2)->typespec().is_string())
         using_space = 2;
     int nfloats = nargs - 1 - using_space;
-    ASSERT (nfloats == 1 || nfloats == 16 || (nfloats == 0 && using_space == 2));
+    OSL_DASSERT (nfloats == 1 || nfloats == 16 || (nfloats == 0 && using_space == 2));
     if (nargs == 3 && using_space == 2) {
         // Try to simplify R=matrix(from,to) in cases of an identify
         // transform: if From and To are the same variable (even if not a
@@ -2182,7 +2181,7 @@ DECLFOLDER(constfold_transform)
     if (op.nargs() == 4) {
         Symbol &T (*rop.inst()->argsymbol(op.firstarg()+2));
         if (M.is_constant() && T.is_constant()) {
-            DASSERT (M.typespec().is_string() && T.typespec().is_string());
+            OSL_DASSERT(M.typespec().is_string() && T.typespec().is_string());
             ustring from = *(ustring *)M.data();
             ustring to = *(ustring *)T.data();
             ustring syn = rop.shadingsys().commonspace_synonym();
@@ -2242,7 +2241,7 @@ DECLFOLDER(constfold_setmessage)
 
     // Record that the inst set a message
     if (Name.is_constant()) {
-        ASSERT (Name.typespec().is_string());
+        OSL_DASSERT (Name.typespec().is_string());
         rop.register_message (*(ustring *)Name.data());
     } else {
         rop.register_unknown_message ();
@@ -2262,7 +2261,7 @@ DECLFOLDER(constfold_getmessage)
         return 0;    // Don't optimize away sourced getmessage
     Symbol &Name (*rop.inst()->argsymbol(op.firstarg()+1+(int)has_source));
     if (Name.is_constant()) {
-        ASSERT (Name.typespec().is_string());
+        OSL_DASSERT (Name.typespec().is_string());
         if (! rop.message_possibly_set (*(ustring *)Name.data())) {
             // If the messages could not have been sent, get rid of the
             // getmessage op, leave the destination value alone, and
@@ -2293,7 +2292,7 @@ DECLFOLDER(constfold_getattribute)
     //   * getattribute (object, attribute_name, index, value[])
     Opcode &op (rop.inst()->ops()[opnum]);
     int nargs = op.nargs();
-    DASSERT (nargs >= 3 && nargs <= 5);
+    OSL_DASSERT(nargs >= 3 && nargs <= 5);
     bool array_lookup = rop.opargsym(op,nargs-2)->typespec().is_int();
     bool object_lookup = rop.opargsym(op,2)->typespec().is_string() && nargs >= 4;
     int object_slot = (int)object_lookup;
@@ -2398,8 +2397,9 @@ DECLFOLDER(constfold_gettextureinfo)
     Symbol &Filename (*rop.inst()->argsymbol(op.firstarg()+1));
     Symbol &Dataname (*rop.inst()->argsymbol(op.firstarg()+2));
     Symbol &Data (*rop.inst()->argsymbol(op.firstarg()+3));
-    ASSERT (Result.typespec().is_int() && Filename.typespec().is_string() &&
-            Dataname.typespec().is_string());
+    OSL_DASSERT (Result.typespec().is_int() &&
+                 Filename.typespec().is_string() &&
+                 Dataname.typespec().is_string());
 
     if (Filename.is_constant() && Dataname.is_constant()) {
         ustring filename = *(ustring *)Filename.data();
@@ -2480,9 +2480,9 @@ DECLFOLDER(constfold_texture)
     if (op.nargs() > 4 && rop.opargsym(op,4)->typespec().is_float()) {
         //user_derivs = true;
         first_optional_arg = 8;
-        DASSERT (rop.opargsym(op,5)->typespec().is_float());
-        DASSERT (rop.opargsym(op,6)->typespec().is_float());
-        DASSERT (rop.opargsym(op,7)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,5)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,6)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,7)->typespec().is_float());
     }
 
     TextureOpt opt;  // So we can check the defaults
@@ -2494,7 +2494,7 @@ DECLFOLDER(constfold_texture)
     for (int i = first_optional_arg;  i < op.nargs()-1;  i += 2) {
         Symbol &Name = *rop.opargsym (op, i);
         Symbol &Value = *rop.opargsym (op, i+1);
-        DASSERT (Name.typespec().is_string());
+        OSL_DASSERT(Name.typespec().is_string());
         if (Name.is_constant() && Value.is_constant()) {
             ustring name = *(ustring *)Name.data();
             bool elide = false;
@@ -2596,13 +2596,13 @@ DECLFOLDER(constfold_texture)
 DECLFOLDER(constfold_pointcloud_search)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() >= 5);
+    OSL_DASSERT(op.nargs() >= 5);
     int result_sym     = rop.oparg (op, 0);
     Symbol& Filename   = *rop.opargsym (op, 1);
     Symbol& Center     = *rop.opargsym (op, 2);
     Symbol& Radius     = *rop.opargsym (op, 3);
     Symbol& Max_points = *rop.opargsym (op, 4);
-    DASSERT (Filename.typespec().is_string() &&
+    OSL_DASSERT(Filename.typespec().is_string() &&
              Center.typespec().is_triple() && Radius.typespec().is_float() &&
              Max_points.typespec().is_int());
 
@@ -2632,7 +2632,7 @@ DECLFOLDER(constfold_pointcloud_search)
     for (int i = 0, num_queries = 0; i < nattrs; ++i) {
         Symbol& Name  = *rop.opargsym (op, attr_arg_offset + i*2);
         Symbol& Value = *rop.opargsym (op, attr_arg_offset + i*2 + 1);
-        ASSERT (Name.typespec().is_string());
+        OSL_ASSERT (Name.typespec().is_string());
         if (!Name.is_constant())
             return 0;  // unknown optional argument, punt
         if (++num_queries > RuntimeOptimizer::max_new_consts_per_fold)
@@ -2834,7 +2834,7 @@ DECLFOLDER(constfold_noise)
             // on whatever values were previously passed.
             if (rop.opargsym(op,a)->typespec().is_string()) {
                 for ( ; a < op.nargs(); a += 2) {
-                    ASSERT (a+1 < op.nargs());
+                    OSL_ASSERT (a+1 < op.nargs());
                     int cind = rop.add_constant (ustring());
                     rop.inst()->args()[op.firstarg()+a] = cind;
                     rop.inst()->args()[op.firstarg()+a+1] = cind;
@@ -2884,7 +2884,7 @@ DECLFOLDER(constfold_noise)
             rop.turn_into_assign (op, cind, "const fold cellnoise");
             return 1;
         } else {
-            ASSERT (outdim == 3);
+            OSL_DASSERT (outdim == 3);
             Vec3 n;
             if (indim == 1)
                 cell (n, input[0]);
@@ -3042,7 +3042,7 @@ DECLFOLDER(constfold_raytype)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol& Name = *rop.opargsym (op, 1);
-    DASSERT (Name.typespec().is_string());
+    OSL_DASSERT(Name.typespec().is_string());
     if (! Name.is_constant())
         return 0;   // Can't optimize non-constant raytype name
 

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cctype>
 #include <unordered_map>
 
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/strutil.h>
 
 #include <pugixml.hpp>
@@ -192,7 +191,7 @@ Dictionary::get_document_index (ustring dictionaryname)
         dindex = dm->second;
     }
 
-    DASSERT (dindex < (int)m_documents.size());
+    OSL_DASSERT(dindex < (int)m_documents.size());
     return dindex;
 }
 
@@ -204,7 +203,6 @@ Dictionary::dict_find (ustring dictionaryname, ustring query)
     int dindex = get_document_index (dictionaryname);
     if (dindex < 0)
         return dindex;
-    ASSERT (dindex >= 0 && dindex < (int)m_documents.size());
 
     Query q (dindex, 0, query);
     QueryMap::iterator qfound = m_cache.find (q);
@@ -321,7 +319,7 @@ Dictionary::dict_value (int nodeID, ustring attribname,
         int offset = qfound->second.valueoffset;
         int n = type.numelements() * type.aggregate;
         if (type.basetype == TypeDesc::STRING) {
-            ASSERT (n == 1 && "no string arrays in XML");
+            OSL_DASSERT (n == 1 && "no string arrays in XML");
             ((ustring *)data)[0] = m_stringdata[offset];
             return 1;
         }

--- a/src/liboslexec/dual_test.cpp
+++ b/src/liboslexec/dual_test.cpp
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OSL/dual.h>
 #include <OSL/dual_vec.h>
 
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/unittest.h>
 
 using namespace OSL;
@@ -142,5 +141,5 @@ int main(int argc, char *argv[])
 
     // FIXME: Some day, expand to more exhaustive tests of Dual
 
-    return 0;
+    return unit_test_failures;
 }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -227,8 +227,8 @@ LLVMGEN (llvm_gen_nop)
 
 LLVMGEN (llvm_gen_useparam)
 {
-    ASSERT (! rop.inst()->unused() &&
-            "oops, thought this layer was unused, why do we call it?");
+    OSL_DASSERT (! rop.inst()->unused() &&
+                 "oops, thought this layer was unused, why do we call it?");
 
     // If we have multiple params needed on this statement, don't waste
     // time checking the same upstream layer more than once.
@@ -320,7 +320,7 @@ LLVMGEN (llvm_gen_printf)
             std::string ourformat (oldfmt, format);  // straddle the format
             // Doctor it to fix mismatches between format and data
             Symbol& sym (*rop.opargsym (op, arg));
-            ASSERT (! sym.typespec().is_structure_based());
+            OSL_ASSERT (! sym.typespec().is_structure_based());
 
             TypeDesc simpletype (sym.typespec().simpletype());
             int num_elements = simpletype.numelements();
@@ -468,9 +468,9 @@ LLVMGEN (llvm_gen_add)
     Symbol& A = *rop.opargsym (op, 1);
     Symbol& B = *rop.opargsym (op, 2);
 
-    ASSERT (! A.typespec().is_array() && ! B.typespec().is_array());
+    OSL_DASSERT (! A.typespec().is_array() && ! B.typespec().is_array());
     if (Result.typespec().is_closure()) {
-        ASSERT (A.typespec().is_closure() && B.typespec().is_closure());
+        OSL_DASSERT (A.typespec().is_closure() && B.typespec().is_closure());
         llvm::Value *valargs[] = {
             rop.sg_void_ptr(),
             rop.llvm_load_value (A),
@@ -525,7 +525,7 @@ LLVMGEN (llvm_gen_sub)
     TypeDesc type = Result.typespec().simpletype();
     int num_components = type.aggregate;
 
-    ASSERT (! Result.typespec().is_closure_based() &&
+    OSL_DASSERT (! Result.typespec().is_closure_based() &&
             "subtraction of closures not supported");
 
     // The following should handle f-f, v-v, v-f, f-v, i-i
@@ -597,14 +597,14 @@ LLVMGEN (llvm_gen_mul)
                 rop.llvm_call_function ("osl_mul_m_ff", Result, A, B);
             else if (B.typespec().is_matrix())
                 rop.llvm_call_function ("osl_mul_mf", Result, B, A);
-            else ASSERT(0);
+            else OSL_DASSERT(0);
         } else if (A.typespec().is_matrix()) {
             if (B.typespec().is_float())
                 rop.llvm_call_function ("osl_mul_mf", Result, A, B);
             else if (B.typespec().is_matrix())
                 rop.llvm_call_function ("osl_mul_mm", Result, A, B);
-            else ASSERT(0);
-        } else ASSERT (0);
+            else OSL_DASSERT(0);
+        } else OSL_DASSERT (0);
         if (Result.has_derivs())
             rop.llvm_zero_derivs (Result);
         return true;
@@ -622,7 +622,7 @@ LLVMGEN (llvm_gen_mul)
 
         if (Result.has_derivs() && (A.has_derivs() || B.has_derivs())) {
             // Multiplication of duals: (a*b, a*b.dx + a.dx*b, a*b.dy + a.dy*b)
-            ASSERT (is_float);
+            OSL_DASSERT (is_float);
             llvm::Value *ax = rop.llvm_load_value (A, 1, i, type);
             llvm::Value *bx = rop.llvm_load_value (B, 1, i, type);
             llvm::Value *abx = rop.ll.op_mul (a, bx);
@@ -659,7 +659,7 @@ LLVMGEN (llvm_gen_div)
     bool is_float = Result.typespec().is_floatbased();
     int num_components = type.aggregate;
 
-    ASSERT (! Result.typespec().is_closure_based());
+    OSL_DASSERT (! Result.typespec().is_closure_based());
 
     // division involving matrices
     if (Result.typespec().is_matrix()) {
@@ -668,14 +668,14 @@ LLVMGEN (llvm_gen_div)
                 rop.llvm_call_function ("osl_div_m_ff", Result, A, B);
             else if (B.typespec().is_matrix())
                 rop.llvm_call_function ("osl_div_fm", Result, A, B);
-            else ASSERT (0);
+            else OSL_DASSERT (0);
         } else if (A.typespec().is_matrix()) {
             if (B.typespec().is_float())
                 rop.llvm_call_function ("osl_div_mf", Result, A, B);
             else if (B.typespec().is_matrix())
                 rop.llvm_call_function ("osl_div_mm", Result, A, B);
-            else ASSERT (0);
-        } else ASSERT (0);
+            else OSL_DASSERT (0);
+        } else OSL_DASSERT (0);
         if (Result.has_derivs())
             rop.llvm_zero_derivs (Result);
         return true;
@@ -699,7 +699,7 @@ LLVMGEN (llvm_gen_div)
 
         if (deriv) {
             // Division of duals: (a/b, 1/b*(ax-a/b*bx), 1/b*(ay-a/b*by))
-            ASSERT (is_float);
+            OSL_DASSERT (is_float);
             llvm::Value *binv;
             if (B.is_constant() && ! rop.is_zero(B))
                 binv = rop.ll.op_div (rop.ll.constant(1.0f), b);
@@ -769,7 +769,7 @@ LLVMGEN (llvm_gen_modulus)
     }
 
     if (Result.has_derivs()) {
-        ASSERT (is_float);
+        OSL_DASSERT (is_float);
         if (A.has_derivs()) {
             // Modulus of duals: (a mod b, ax, ay)
             for (int d = 1;  d <= 2;  ++d) {
@@ -863,8 +863,8 @@ LLVMGEN (llvm_gen_mix)
     Symbol& B = *rop.opargsym (op, 2);
     Symbol& X = *rop.opargsym (op, 3);
     TypeDesc type = Result.typespec().simpletype();
-    ASSERT (!Result.typespec().is_closure_based() &&
-            Result.typespec().is_floatbased());
+    OSL_DASSERT (!Result.typespec().is_closure_based() &&
+                 Result.typespec().is_floatbased());
     int num_components = type.aggregate;
     int x_components = X.typespec().aggregate();
     bool derivs = (Result.has_derivs() &&
@@ -947,7 +947,7 @@ LLVMGEN (llvm_gen_select)
     Symbol& B = *rop.opargsym (op, 2);
     Symbol& X = *rop.opargsym (op, 3);
     TypeDesc type = Result.typespec().simpletype();
-    ASSERT (!Result.typespec().is_closure_based() &&
+    OSL_DASSERT (!Result.typespec().is_closure_based() &&
             Result.typespec().is_floatbased());
     int num_components = type.aggregate;
     int x_components = X.typespec().aggregate();
@@ -1031,7 +1031,7 @@ LLVMGEN (llvm_gen_bitwise_binary_op)
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& A = *rop.opargsym (op, 1);
     Symbol& B = *rop.opargsym (op, 2);
-    ASSERT (Result.typespec().is_int() && A.typespec().is_int() && 
+    OSL_DASSERT (Result.typespec().is_int() && A.typespec().is_int() && 
             B.typespec().is_int());
 
     llvm::Value *a = rop.loadLLVMValue (A);
@@ -1081,7 +1081,7 @@ LLVMGEN (llvm_gen_unary_op)
         ustring opname = op.opname();
 
         if (opname == op_compl) {
-            ASSERT (dst.typespec().is_int());
+            OSL_DASSERT (dst.typespec().is_int());
             result = rop.ll.op_not (src_val);
         } else {
             // Don't know how to handle this.
@@ -1158,7 +1158,6 @@ LLVMGEN (llvm_gen_compref)
                                     rop.ll.constant(rop.inst()->layername()),
                                     rop.ll.constant(rop.inst()->shadername()) };
             c = rop.ll.call_function ("osl_range_check", args);
-            ASSERT (c);
         }
     }
 
@@ -1316,7 +1315,7 @@ LLVMGEN (llvm_gen_arraylength)
     Opcode &op (rop.inst()->ops()[opnum]);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& A = *rop.opargsym (op, 1);
-    DASSERT (Result.typespec().is_int() && A.typespec().is_array());
+    OSL_DASSERT(Result.typespec().is_int() && A.typespec().is_array());
 
     int len = A.typespec().is_unsized_array() ? A.initializers()
                                               : A.typespec().arraylength();
@@ -1411,8 +1410,8 @@ LLVMGEN (llvm_gen_aassign)
     } else {
         // Try to warn before llvm_fatal_error is called which provides little
         // context as to what went wrong.
-        ASSERT (Result.typespec().simpletype().basetype ==
-                Src.typespec().simpletype().basetype);
+        OSL_ASSERT (Result.typespec().simpletype().basetype ==
+                    Src.typespec().simpletype().basetype);
     }
 
     for (int d = 0;  d <= 2;  ++d) {
@@ -1440,9 +1439,9 @@ LLVMGEN (llvm_gen_construct_color)
     Symbol& X = *rop.opargsym (op, 1+using_space);
     Symbol& Y = *rop.opargsym (op, 2+using_space);
     Symbol& Z = *rop.opargsym (op, 3+using_space);
-    ASSERT (Result.typespec().is_triple() && X.typespec().is_float() &&
-            Y.typespec().is_float() && Z.typespec().is_float() &&
-            (using_space == false || Space.typespec().is_string()));
+    OSL_DASSERT (Result.typespec().is_triple() && X.typespec().is_float() &&
+                 Y.typespec().is_float() && Z.typespec().is_float() &&
+                 (using_space == false || Space.typespec().is_string()));
 
     // First, copy the floats into the vector
     int dmax = Result.has_derivs() ? 3 : 1;
@@ -1485,9 +1484,9 @@ LLVMGEN (llvm_gen_construct_triple)
     Symbol& X = *rop.opargsym (op, 1+using_space);
     Symbol& Y = *rop.opargsym (op, 2+using_space);
     Symbol& Z = *rop.opargsym (op, 3+using_space);
-    ASSERT (Result.typespec().is_triple() && X.typespec().is_float() &&
-            Y.typespec().is_float() && Z.typespec().is_float() &&
-            (using_space == false || Space.typespec().is_string()));
+    OSL_DASSERT (Result.typespec().is_triple() && X.typespec().is_float() &&
+                 Y.typespec().is_float() && Z.typespec().is_float() &&
+                 (using_space == false || Space.typespec().is_string()));
 
     // First, copy the floats into the vector
     int dmax = Result.has_derivs() ? 3 : 1;
@@ -1550,7 +1549,7 @@ LLVMGEN (llvm_gen_matrix)
     bool using_space = (nargs == 3 || nargs == 18);
     bool using_two_spaces = (nargs == 3 && rop.opargsym(op,2)->typespec().is_string());
     int nfloats = nargs - 1 - (int)using_space;
-    ASSERT (nargs == 2 || nargs == 3 || nargs == 17 || nargs == 18);
+    OSL_DASSERT (nargs == 2 || nargs == 3 || nargs == 17 || nargs == 18);
 
     if (using_two_spaces) {
         llvm::Value *args[] = {
@@ -1574,7 +1573,7 @@ LLVMGEN (llvm_gen_matrix)
                 rop.llvm_store_value (src_val, Result, 0, i);
             }
         } else {
-            ASSERT (0);
+            OSL_ASSERT (0);
         }
         if (using_space) {
             llvm::Value *args[] = {
@@ -1597,7 +1596,7 @@ LLVMGEN (llvm_gen_getmatrix)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
     int nargs = op.nargs();
-    ASSERT (nargs == 4);
+    OSL_DASSERT (nargs == 4);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& From = *rop.opargsym (op, 1);
     Symbol& To = *rop.opargsym (op, 2);
@@ -1683,7 +1682,7 @@ LLVMGEN (llvm_gen_transform)
 LLVMGEN (llvm_gen_transformc)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 4);
+    OSL_DASSERT (op.nargs() == 4);
     Symbol *Result = rop.opargsym (op, 0);
     Symbol *From = rop.opargsym (op, 1);
     Symbol *To = rop.opargsym (op, 2);
@@ -1753,7 +1752,7 @@ LLVMGEN (llvm_gen_filterwidth)
     Symbol& Result (*rop.opargsym (op, 0));
     Symbol& Src (*rop.opargsym (op, 1));
 
-    ASSERT (Src.typespec().is_float() || Src.typespec().is_triple());
+    OSL_DASSERT (Src.typespec().is_float() || Src.typespec().is_triple());
     if (Src.has_derivs()) {
         if (Src.typespec().is_float()) {
             llvm::Value *r = rop.ll.call_function ("osl_filterwidth_fdf",
@@ -1783,11 +1782,11 @@ LLVMGEN (llvm_gen_compare_op)
     Symbol &Result (*rop.opargsym (op, 0));
     Symbol &A (*rop.opargsym (op, 1));
     Symbol &B (*rop.opargsym (op, 2));
-    ASSERT (Result.typespec().is_int() && ! Result.has_derivs());
+    OSL_DASSERT (Result.typespec().is_int() && ! Result.has_derivs());
 
     if (A.typespec().is_closure()) {
-        ASSERT (B.typespec().is_int() &&
-                "Only closure==0 and closure!=0 allowed");
+        OSL_ASSERT (B.typespec().is_int() &&
+                    "Only closure==0 and closure!=0 allowed");
         llvm::Value *a = rop.llvm_load_value (A);
         llvm::Value *b = rop.ll.void_ptr_null ();
         llvm::Value *r = (op.opname()==op_eq) ? rop.ll.op_eq(a,b)
@@ -1806,7 +1805,8 @@ LLVMGEN (llvm_gen_compare_op)
     ustring opname = op.opname();
 
     if (rop.use_optix() && A.typespec().is_string()) {
-        ASSERT (B.typespec().is_string() && "Only string-to-string comparison is supported");
+        OSL_DASSERT (B.typespec().is_string()
+                     && "Only string-to-string comparison is supported");
 
         llvm::Value* a = rop.llvm_load_device_string (A, /*follow*/ true);
         llvm::Value* b = rop.llvm_load_device_string (B, /*follow*/ true);
@@ -1817,9 +1817,9 @@ LLVMGEN (llvm_gen_compare_op)
             final_result = rop.ll.op_ne (a, b);
         } else {
             // Don't know how to handle this.
-            ASSERT (0 && "OptiX only supports equality testing for strings");
+            OSL_ASSERT (0 && "OptiX only supports equality testing for strings");
         }
-        ASSERT (final_result);
+        OSL_ASSERT (final_result);
 
         final_result = rop.ll.op_bool_to_int (final_result);
         rop.storeLLVMValue (final_result, Result, 0, 0);
@@ -1859,9 +1859,9 @@ LLVMGEN (llvm_gen_compare_op)
             result = rop.ll.op_ne (a, b);
         } else {
             // Don't know how to handle this.
-            ASSERT (0 && "Comparison error");
+            OSL_ASSERT (0 && "Comparison error");
         }
-        ASSERT (result);
+        OSL_DASSERT (result);
 
         if (final_result) {
             // Combine the component bool based on the op
@@ -1873,7 +1873,7 @@ LLVMGEN (llvm_gen_compare_op)
             final_result = result;
         }
     }
-    ASSERT (final_result);
+    OSL_ASSERT (final_result);
 
     // Convert the single bit bool into an int for now.
     final_result = rop.ll.op_bool_to_int (final_result);
@@ -1891,18 +1891,18 @@ LLVMGEN (llvm_gen_regex)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
     int nargs = op.nargs();
-    ASSERT (nargs == 3 || nargs == 4);
+    OSL_DASSERT (nargs == 3 || nargs == 4);
     Symbol &Result (*rop.opargsym (op, 0));
     Symbol &Subject (*rop.opargsym (op, 1));
     bool do_match_results = (nargs == 4);
     bool fullmatch = (op.opname() == "regex_match");
     Symbol &Match (*rop.opargsym (op, 2));
     Symbol &Pattern (*rop.opargsym (op, 2+do_match_results));
-    ASSERT (Result.typespec().is_int() && Subject.typespec().is_string() &&
-            Pattern.typespec().is_string());
-    ASSERT (!do_match_results || 
-            (Match.typespec().is_array() &&
-             Match.typespec().elementtype().is_int()));
+    OSL_DASSERT (Result.typespec().is_int() && Subject.typespec().is_string() &&
+                 Pattern.typespec().is_string());
+    OSL_DASSERT (!do_match_results || 
+                 (Match.typespec().is_array() &&
+                  Match.typespec().elementtype().is_int()));
 
     llvm::Value* call_args[] = {
         rop.sg_void_ptr(),              // First arg is ShaderGlobals ptr
@@ -1983,7 +1983,7 @@ LLVMGEN (llvm_gen_generic)
             name += "s";
         else if (s->typespec().is_int())
             name += "i";
-        else ASSERT (0);
+        else OSL_ASSERT (0);
     }
 
     if (! Result.has_derivs() || ! any_deriv_args) {
@@ -1997,7 +1997,7 @@ LLVMGEN (llvm_gen_generic)
         rop.llvm_zero_derivs (Result);
     } else {
         // Cases with derivs
-        ASSERT (Result.has_derivs() && any_deriv_args);
+        OSL_ASSERT (Result.has_derivs() && any_deriv_args);
         rop.llvm_call_function (name.c_str(),
                                 cspan<const Symbol*>(args, op.nargs()),
                                 true);
@@ -2025,7 +2025,7 @@ LLVMGEN (llvm_gen_sincos)
             name += "f";
         else if (s->typespec().is_triple())
             name += "v";
-        else ASSERT (0);
+        else OSL_ASSERT (0);
     }
     // push back llvm arguments
     llvm::Value* valargs[] = {
@@ -2162,7 +2162,7 @@ LLVMGEN (llvm_gen_loop_op)
 LLVMGEN (llvm_gen_loopmod_op)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 0);
+    OSL_DASSERT(op.nargs() == 0);
     if (op.opname() == op_break) {
         rop.ll.op_branch (rop.ll.loop_after_block());
     } else {  // continue
@@ -2194,9 +2194,9 @@ llvm_gen_texture_options (BackendLLVM &rop, int opnum,
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));
-        ASSERT (Name.typespec().is_string() &&
-                "optional texture token must be a string");
-        ASSERT (a+1 < op.nargs() && "malformed argument list for texture");
+        OSL_DASSERT (Name.typespec().is_string() &&
+                     "optional texture token must be a string");
+        OSL_DASSERT (a+1 < op.nargs() && "malformed argument list for texture");
         ustring name = *(ustring *)Name.data();
         ++a;  // advance to next argument
 
@@ -2401,9 +2401,9 @@ LLVMGEN (llvm_gen_texture)
     if (op.nargs() > 4 && rop.opargsym(op,4)->typespec().is_float()) {
         user_derivs = true;
         first_optional_arg = 8;
-        DASSERT (rop.opargsym(op,5)->typespec().is_float());
-        DASSERT (rop.opargsym(op,6)->typespec().is_float());
-        DASSERT (rop.opargsym(op,7)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,5)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,6)->typespec().is_float());
+        OSL_DASSERT(rop.opargsym(op,7)->typespec().is_float());
     }
 
     llvm::Value* opt;   // TextureOpt
@@ -2460,8 +2460,8 @@ LLVMGEN (llvm_gen_texture3d)
     if (op.nargs() > 3 && rop.opargsym(op,3)->typespec().is_triple()) {
         user_derivs = true;
         first_optional_arg = 5;
-        DASSERT (rop.opargsym(op,3)->typespec().is_triple());
-        DASSERT (rop.opargsym(op,4)->typespec().is_triple());
+        OSL_DASSERT(rop.opargsym(op,3)->typespec().is_triple());
+        OSL_DASSERT(rop.opargsym(op,4)->typespec().is_triple());
     }
 
     llvm::Value* opt;   // TextureOpt
@@ -2516,7 +2516,7 @@ LLVMGEN (llvm_gen_environment)
     if (op.nargs() > 3 && rop.opargsym(op,3)->typespec().is_triple()) {
         user_derivs = true;
         first_optional_arg = 5;
-        DASSERT (rop.opargsym(op,4)->typespec().is_triple());
+        OSL_DASSERT(rop.opargsym(op,4)->typespec().is_triple());
     }
 
     llvm::Value* opt;   // TextureOpt
@@ -2566,9 +2566,9 @@ llvm_gen_trace_options (BackendLLVM &rop, int opnum,
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));
-        ASSERT (Name.typespec().is_string() &&
-                "optional trace token must be a string");
-        ASSERT (a+1 < op.nargs() && "malformed argument list for trace");
+        OSL_DASSERT (Name.typespec().is_string() &&
+                     "optional trace token must be a string");
+        OSL_DASSERT (a+1 < op.nargs() && "malformed argument list for trace");
         ustring name = *(ustring *)Name.data();
 
         ++a;  // advance to next argument
@@ -2646,7 +2646,7 @@ arg_typecode (Symbol *sym, bool derivs)
         name += "f";
     else if (t.is_triple())
         name += "v";
-    else ASSERT (0);
+    else OSL_ASSERT (0);
     return name;
 }
 
@@ -2662,9 +2662,9 @@ llvm_gen_noise_options (BackendLLVM &rop, int opnum,
     Opcode &op (rop.inst()->ops()[opnum]);
     for (int a = first_optional_arg;  a < op.nargs();  ++a) {
         Symbol &Name (*rop.opargsym(op,a));
-        ASSERT (Name.typespec().is_string() &&
-                "optional noise token must be a string");
-        ASSERT (a+1 < op.nargs() && "malformed argument list for noise");
+        OSL_DASSERT (Name.typespec().is_string() &&
+                     "optional noise token must be a string");
+        OSL_DASSERT (a+1 < op.nargs() && "malformed argument list for noise");
         ustring name = *(ustring *)Name.data();
 
         ++a;  // advance to next argument
@@ -2859,7 +2859,7 @@ LLVMGEN (llvm_gen_noise)
     if (pass_options)
         args[nargs++] = opt;
 
-    DASSERT(nargs < int(sizeof(args) / sizeof(args[0])));
+    OSL_DASSERT(nargs < int(sizeof(args) / sizeof(args[0])));
 
 #if 0
     llvm::outs() << "About to push " << funcname << "\n";
@@ -2907,7 +2907,7 @@ LLVMGEN (llvm_gen_getattribute)
     //   * getattribute (object, attribute_name, index, value[])
     Opcode &op (rop.inst()->ops()[opnum]);
     int nargs = op.nargs();
-    DASSERT (nargs >= 3 && nargs <= 5);
+    OSL_DASSERT(nargs >= 3 && nargs <= 5);
 
     bool array_lookup = rop.opargsym(op,nargs-2)->typespec().is_int();
     bool object_lookup = rop.opargsym(op,2)->typespec().is_string() && nargs >= 4;
@@ -2920,7 +2920,7 @@ LLVMGEN (llvm_gen_getattribute)
     Symbol& Attribute   = *rop.opargsym (op, attrib_slot);
     Symbol& Index       = *rop.opargsym (op, index_slot);  // only valid if array_lookup is true
     Symbol& Destination = *rop.opargsym (op, nargs-1);
-    DASSERT (!Result.typespec().is_closure_based() &&
+    OSL_DASSERT(!Result.typespec().is_closure_based() &&
              !ObjectName.typespec().is_closure_based() && 
              !Attribute.typespec().is_closure_based() &&
              !Index.typespec().is_closure_based() && 
@@ -2953,14 +2953,14 @@ LLVMGEN (llvm_gen_gettextureinfo)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 4);
+    OSL_DASSERT(op.nargs() == 4);
 
     Symbol& Result   = *rop.opargsym (op, 0);
     Symbol& Filename = *rop.opargsym (op, 1);
     Symbol& Dataname = *rop.opargsym (op, 2);
     Symbol& Data     = *rop.opargsym (op, 3);
 
-    DASSERT (!Result.typespec().is_closure_based() &&
+    OSL_DASSERT(!Result.typespec().is_closure_based() &&
              Filename.typespec().is_string() && 
              Dataname.typespec().is_string() &&
              !Data.typespec().is_closure_based() && 
@@ -3006,14 +3006,14 @@ LLVMGEN (llvm_gen_getmessage)
     //   * getmessage (source, attribute_name, value[])
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 3 || op.nargs() == 4);
+    OSL_DASSERT(op.nargs() == 3 || op.nargs() == 4);
     int has_source = (op.nargs() == 4);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& Source = *rop.opargsym (op, 1);
     Symbol& Name   = *rop.opargsym (op, 1+has_source);
     Symbol& Data   = *rop.opargsym (op, 2+has_source);
-    DASSERT (Result.typespec().is_int() && Name.typespec().is_string());
-    DASSERT (has_source == 0 || Source.typespec().is_string());
+    OSL_DASSERT(Result.typespec().is_int() && Name.typespec().is_string());
+    OSL_DASSERT(has_source == 0 || Source.typespec().is_string());
 
     llvm::Value *args[9];
     args[0] = rop.sg_void_ptr();
@@ -3048,10 +3048,10 @@ LLVMGEN (llvm_gen_setmessage)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 2);
+    OSL_DASSERT(op.nargs() == 2);
     Symbol& Name   = *rop.opargsym (op, 0);
     Symbol& Data   = *rop.opargsym (op, 1);
-    DASSERT (Name.typespec().is_string());
+    OSL_DASSERT(Name.typespec().is_string());
 
     llvm::Value *args[7];
     args[0] = rop.sg_void_ptr();
@@ -3081,11 +3081,11 @@ LLVMGEN (llvm_gen_get_simple_SG_field)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 1);
+    OSL_DASSERT(op.nargs() == 1);
 
     Symbol& Result = *rop.opargsym (op, 0);
     int sg_index = rop.ShaderGlobalNameToIndex (op.opname());
-    ASSERT (sg_index >= 0);
+    OSL_DASSERT (sg_index >= 0);
     llvm::Value *sg_field = rop.ll.GEP (rop.sg_ptr(), 0, sg_index);
     llvm::Value* r = rop.ll.op_load(sg_field);
     rop.llvm_store_value (r, Result);
@@ -3099,12 +3099,12 @@ LLVMGEN (llvm_gen_calculatenormal)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 2);
+    OSL_DASSERT(op.nargs() == 2);
 
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& P      = *rop.opargsym (op, 1);
 
-    DASSERT (Result.typespec().is_triple() && P.typespec().is_triple());
+    OSL_DASSERT(Result.typespec().is_triple() && P.typespec().is_triple());
     if (! P.has_derivs()) {
         rop.llvm_assign_zero (Result);
         return true;
@@ -3127,12 +3127,12 @@ LLVMGEN (llvm_gen_area)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() == 2);
+    OSL_DASSERT(op.nargs() == 2);
 
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& P      = *rop.opargsym (op, 1);
 
-    DASSERT (Result.typespec().is_float() && P.typespec().is_triple());
+    OSL_DASSERT(Result.typespec().is_float() && P.typespec().is_triple());
     if (! P.has_derivs()) {
         rop.llvm_assign_zero (Result);
         return true;
@@ -3151,7 +3151,7 @@ LLVMGEN (llvm_gen_spline)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() >= 4 && op.nargs() <= 5);
+    OSL_DASSERT(op.nargs() >= 4 && op.nargs() <= 5);
 
     bool has_knot_count = (op.nargs() == 5);
     Symbol& Result   = *rop.opargsym (op, 0);
@@ -3161,7 +3161,7 @@ LLVMGEN (llvm_gen_spline)
     Symbol& Knots    = has_knot_count ? *rop.opargsym (op, 4) :
                                         *rop.opargsym (op, 3);
 
-    DASSERT (!Result.typespec().is_closure_based() &&
+    OSL_DASSERT(!Result.typespec().is_closure_based() &&
              Spline.typespec().is_string()  && 
              Value.typespec().is_float() &&
              !Knots.typespec().is_closure_based() &&
@@ -3217,7 +3217,7 @@ LLVMGEN (llvm_gen_spline)
 static void
 llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::ClosureEntry *clentry, ustring clname, llvm::Value *mem_void_ptr, int argsoffset)
 {
-    DASSERT(((op.nargs() - argsoffset) % 2) == 0);
+    OSL_DASSERT(((op.nargs() - argsoffset) % 2) == 0);
 
     int Nattrs = (op.nargs() - argsoffset) / 2;
 
@@ -3225,8 +3225,8 @@ llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::Closu
         int argno = attr_i * 2 + argsoffset;
         Symbol &Key     = *rop.opargsym (op, argno);
         Symbol &Value   = *rop.opargsym (op, argno + 1);
-        ASSERT(Key.typespec().is_string());
-        ASSERT(Key.is_constant());
+        OSL_DASSERT(Key.typespec().is_string());
+        OSL_ASSERT(Key.is_constant());
         ustring *key = (ustring *)Key.data();
         TypeDesc ValueType = Value.typespec().simpletype();
 
@@ -3238,7 +3238,7 @@ llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::Closu
             // but in this part of the code is not a big deal
             if (equivalent(p.type,ValueType) && !strcmp(key->c_str(), p.key)) {
             	// store data
-            	DASSERT(p.offset + p.field_size <= clentry->struct_size);
+            	OSL_DASSERT(p.offset + p.field_size <= clentry->struct_size);
                 llvm::Value* dst = rop.ll.offset_ptr (mem_void_ptr, p.offset);
                 llvm::Value* src = rop.llvm_void_ptr (Value);
                 rop.ll.op_memcpy (dst, src, (int)p.type.size(),
@@ -3258,14 +3258,14 @@ llvm_gen_keyword_fill(BackendLLVM &rop, Opcode &op, const ClosureRegistry::Closu
 LLVMGEN (llvm_gen_closure)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() >= 2); // at least the result and the ID
+    OSL_DASSERT (op.nargs() >= 2); // at least the result and the ID
 
     Symbol &Result = *rop.opargsym (op, 0);
     int weighted   = rop.opargsym(op,1)->typespec().is_string() ? 0 : 1;
     Symbol *weight = weighted ? rop.opargsym (op, 1) : NULL;
     Symbol &Id     = *rop.opargsym (op, 1+weighted);
-    DASSERT(Result.typespec().is_closure());
-    DASSERT(Id.typespec().is_string());
+    OSL_DASSERT(Result.typespec().is_closure());
+    OSL_DASSERT(Id.typespec().is_string());
     ustring closure_name = *((ustring *)Id.data());
 
     const ClosureRegistry::ClosureEntry * clentry = rop.shadingsys().find_closure(closure_name);
@@ -3277,7 +3277,7 @@ LLVMGEN (llvm_gen_closure)
         return false;
     }
 
-    ASSERT (op.nargs() >= (2 + weighted + clentry->nformal));
+    OSL_DASSERT (op.nargs() >= (2 + weighted + clentry->nformal));
 
     // Call osl_allocate_closure_component(closure, id, size).  It returns
     // the memory for the closure parameter data.
@@ -3324,7 +3324,7 @@ LLVMGEN (llvm_gen_closure)
     for (int carg = 0; carg < clentry->nformal; ++carg) {
         const ClosureParam &p = clentry->params[carg];
         if (p.key != NULL) break;
-        DASSERT(p.offset + p.field_size <= clentry->struct_size);
+        OSL_DASSERT(p.offset + p.field_size <= clentry->struct_size);
         Symbol &sym = *rop.opargsym (op, carg + 2 + weighted);
         TypeDesc t = sym.typespec().simpletype();
 
@@ -3374,14 +3374,14 @@ LLVMGEN (llvm_gen_pointcloud_search)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() >= 5);
+    OSL_DASSERT(op.nargs() >= 5);
     Symbol& Result     = *rop.opargsym (op, 0);
     Symbol& Filename   = *rop.opargsym (op, 1);
     Symbol& Center     = *rop.opargsym (op, 2);
     Symbol& Radius     = *rop.opargsym (op, 3);
     Symbol& Max_points = *rop.opargsym (op, 4);
 
-    DASSERT (Result.typespec().is_int() && Filename.typespec().is_string() &&
+    OSL_DASSERT(Result.typespec().is_int() && Filename.typespec().is_string() &&
              Center.typespec().is_triple() && Radius.typespec().is_float() &&
              Max_points.typespec().is_int());
 
@@ -3416,7 +3416,7 @@ LLVMGEN (llvm_gen_pointcloud_search)
         Symbol& Name  = *rop.opargsym (op, attr_arg_offset + i*2);
         Symbol& Value = *rop.opargsym (op, attr_arg_offset + i*2 + 1);
 
-        ASSERT (Name.typespec().is_string());
+        OSL_DASSERT (Name.typespec().is_string());
         TypeDesc simpletype = Value.typespec().simpletype();
         if (Name.is_constant() && *((ustring *)Name.data()) == u_index &&
             simpletype.elementtype() == TypeDesc::INT) {
@@ -3488,7 +3488,7 @@ LLVMGEN (llvm_gen_pointcloud_get)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() >= 6);
+    OSL_DASSERT(op.nargs() >= 6);
 
     Symbol& Result     = *rop.opargsym (op, 0);
     Symbol& Filename   = *rop.opargsym (op, 1);
@@ -3548,13 +3548,13 @@ LLVMGEN (llvm_gen_pointcloud_write)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
 
-    DASSERT (op.nargs() >= 3);
+    OSL_DASSERT(op.nargs() >= 3);
     Symbol& Result   = *rop.opargsym (op, 0);
     Symbol& Filename = *rop.opargsym (op, 1);
     Symbol& Pos      = *rop.opargsym (op, 2);
-    DASSERT (Result.typespec().is_int() && Filename.typespec().is_string() &&
+    OSL_DASSERT(Result.typespec().is_int() && Filename.typespec().is_string() &&
              Pos.typespec().is_triple());
-    DASSERT ((op.nargs() & 1) && "must have an even number of attribs");
+    OSL_DASSERT((op.nargs() & 1) && "must have an even number of attribs");
 
     int nattrs = (op.nargs() - 3) / 2;
 
@@ -3604,11 +3604,11 @@ LLVMGEN (llvm_gen_dict_find)
     //     dict_find (string dict, string query)
     //     dict_find (int nodeID, string query)
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 3);
+    OSL_DASSERT(op.nargs() == 3);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& Source = *rop.opargsym (op, 1);
     Symbol& Query  = *rop.opargsym (op, 2);
-    DASSERT (Result.typespec().is_int() && Query.typespec().is_string() &&
+    OSL_DASSERT(Result.typespec().is_int() && Query.typespec().is_string() &&
              (Source.typespec().is_int() || Source.typespec().is_string()));
     bool sourceint = Source.typespec().is_int();  // is it an int?
     llvm::Value *args[] = {
@@ -3628,10 +3628,10 @@ LLVMGEN (llvm_gen_dict_next)
 {
     // dict_net is very straightforward -- just insert sg ptr as first arg
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 2);
+    OSL_DASSERT(op.nargs() == 2);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& NodeID = *rop.opargsym (op, 1);
-    DASSERT (Result.typespec().is_int() && NodeID.typespec().is_int());
+    OSL_DASSERT(Result.typespec().is_int() && NodeID.typespec().is_int());
     llvm::Value *ret = rop.ll.call_function ("osl_dict_next",
                                                rop.sg_void_ptr(),
                                                rop.llvm_load_value(NodeID));
@@ -3645,12 +3645,12 @@ LLVMGEN (llvm_gen_dict_value)
 {
     // int dict_value (int nodeID, string attribname, output TYPE value)
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 4);
+    OSL_DASSERT(op.nargs() == 4);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& NodeID = *rop.opargsym (op, 1);
     Symbol& Name   = *rop.opargsym (op, 2);
     Symbol& Value  = *rop.opargsym (op, 3);
-    DASSERT (Result.typespec().is_int() && NodeID.typespec().is_int() &&
+    OSL_DASSERT(Result.typespec().is_int() && NodeID.typespec().is_int() &&
              Name.typespec().is_string());
     llvm::Value *args[] = {
         rop.sg_void_ptr(),                              // arg 0: shaderglobals ptr
@@ -3670,11 +3670,11 @@ LLVMGEN (llvm_gen_split)
 {
     // int split (string str, output string result[], string sep, int maxsplit)
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() >= 3 && op.nargs() <= 5);
+    OSL_DASSERT(op.nargs() >= 3 && op.nargs() <= 5);
     Symbol& R       = *rop.opargsym (op, 0);
     Symbol& Str     = *rop.opargsym (op, 1);
     Symbol& Results = *rop.opargsym (op, 2);
-    DASSERT (R.typespec().is_int() && Str.typespec().is_string() &&
+    OSL_DASSERT(R.typespec().is_int() && Str.typespec().is_string() &&
              Results.typespec().is_array() &&
              Results.typespec().is_string_based());
 
@@ -3683,14 +3683,14 @@ LLVMGEN (llvm_gen_split)
     args[1] = rop.llvm_void_ptr (Results);
     if (op.nargs() >= 4) {
         Symbol& Sep = *rop.opargsym (op, 3);
-        DASSERT (Sep.typespec().is_string());
+        OSL_DASSERT(Sep.typespec().is_string());
         args[2] = rop.llvm_load_value (Sep);
     } else {
         args[2] = rop.ll.constant ("");
     }
     if (op.nargs() >= 5) {
         Symbol& Maxsplit = *rop.opargsym (op, 4);
-        DASSERT (Maxsplit.typespec().is_int());
+        OSL_DASSERT(Maxsplit.typespec().is_int());
         args[3] = rop.llvm_load_value (Maxsplit);
     } else {
         args[3] = rop.ll.constant (Results.typespec().arraylength());
@@ -3707,7 +3707,7 @@ LLVMGEN (llvm_gen_raytype)
 {
     // int raytype (string name)
     Opcode &op (rop.inst()->ops()[opnum]);
-    DASSERT (op.nargs() == 2);
+    OSL_DASSERT(op.nargs() == 2);
     Symbol& Result = *rop.opargsym (op, 0);
     Symbol& Name = *rop.opargsym (op, 1);
     llvm::Value *args[2] = { rop.sg_void_ptr(), NULL };
@@ -3734,10 +3734,10 @@ LLVMGEN (llvm_gen_raytype)
 LLVMGEN (llvm_gen_blackbody)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 2);
+    OSL_DASSERT (op.nargs() == 2);
     Symbol &Result (*rop.opargsym (op, 0));
     Symbol &Temperature (*rop.opargsym (op, 1));
-    ASSERT (Result.typespec().is_triple() && Temperature.typespec().is_float());
+    OSL_DASSERT (Result.typespec().is_triple() && Temperature.typespec().is_float());
 
     llvm::Value* args[] = { rop.sg_void_ptr(), rop.llvm_void_ptr(Result),
                             rop.llvm_load_value(Temperature) };
@@ -3758,10 +3758,10 @@ LLVMGEN (llvm_gen_blackbody)
 LLVMGEN (llvm_gen_luminance)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 2);
+    OSL_DASSERT (op.nargs() == 2);
     Symbol &Result (*rop.opargsym (op, 0));
     Symbol &C (*rop.opargsym (op, 1));
-    ASSERT (Result.typespec().is_float() && C.typespec().is_triple());
+    OSL_DASSERT (Result.typespec().is_float() && C.typespec().is_triple());
 
     bool deriv = C.has_derivs() && Result.has_derivs();
     llvm::Value* args[] = { rop.sg_void_ptr(), rop.llvm_void_ptr(Result),
@@ -3779,9 +3779,9 @@ LLVMGEN (llvm_gen_luminance)
 LLVMGEN (llvm_gen_isconstant)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 2);
+    OSL_DASSERT (op.nargs() == 2);
     Symbol &Result (*rop.opargsym (op, 0));
-    ASSERT (Result.typespec().is_int());
+    OSL_DASSERT (Result.typespec().is_int());
     Symbol &A (*rop.opargsym (op, 1));
     rop.llvm_store_value (rop.ll.constant(A.is_constant() ? 1 : 0), Result);
     return true;
@@ -3792,7 +3792,7 @@ LLVMGEN (llvm_gen_isconstant)
 LLVMGEN (llvm_gen_functioncall)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 1);
+    OSL_DASSERT (op.nargs() == 1);
 
     llvm::BasicBlock* after_block = rop.ll.push_function ();
 
@@ -3811,7 +3811,7 @@ LLVMGEN (llvm_gen_functioncall)
 LLVMGEN (llvm_gen_return)
 {
     Opcode &op (rop.inst()->ops()[opnum]);
-    ASSERT (op.nargs() == 0);
+    OSL_DASSERT (op.nargs() == 0);
     if (op.opname() == Strings::op_exit) {
         // If it's a real "exit", totally jump out of the shader instance.
         // The exit instance block will be created if it doesn't yet exist.

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -28,11 +28,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/ustring.h>
-#include <OpenImageIO/dassert.h>
 
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/unittest.h>
 #include <OSL/llvm_util.h>
 
 
@@ -115,7 +115,7 @@ test_int_func ()
     // Call it:
     int result = myadd (13, 29);
     std::cout << "The result is " << result << "\n";
-    ASSERT (result == 42);
+    OIIO_CHECK_EQUAL (result, 42);
 }
 
 
@@ -172,7 +172,9 @@ test_triple_func ()
     float r[3], a[3] = { 1.0, 2.0, 3.0 }, b = 42.0;
     f (r, a, b);
     std::cout << "The result is " << r[0] << ' ' << r[1] << ' ' << r[2] << "\n";
-    ASSERT (r[0] == 42.0 && r[1] == 84.0 && r[2] == 126.0);
+    OIIO_CHECK_EQUAL (r[0], 42.0);
+    OIIO_CHECK_EQUAL (r[1], 84.0);
+    OIIO_CHECK_EQUAL (r[2], 126.0);
     }
 }
 
@@ -247,12 +249,12 @@ main (int argc, char *argv[])
         for (int i = 0; i < memtest; ++i) {
             IntFuncOfTwoInts f = test_big_func (i==0);
             int r = f (42, 42);
-            ASSERT (r == 84);
+            OIIO_CHECK_EQUAL (r, 84);
         }
         std::cout << "After " << memtest << " stupid functions compiled:\n";
         std::cout << "   RSS memory = "
                   << OIIO::Strutil::memformat(OIIO::Sysutil::memory_used()) << "\n";
     }
 
-    return 0;
+    return unit_test_failures;
 }

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "osoreader.h"
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/filesystem.h>
@@ -172,7 +171,7 @@ OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name_
             sym.dataoffset ((int) m_master->m_sdefaults.size());
             expand (m_master->m_sdefaults, nvals);
         } else {
-            ASSERT (0 && "unexpected type");
+            OSL_DASSERT (0 && "unexpected type");
         }
     }
     if (sym.symtype() == SymTypeConst) {
@@ -186,7 +185,7 @@ OSOReaderToMaster::symbol (SymType symtype, TypeSpec typespec, const char *name_
             sym.dataoffset ((int) m_master->m_sconsts.size());
             expand (m_master->m_sconsts, nvals);
         } else {
-            ASSERT (0 && "unexpected type");
+            OSL_DASSERT (0 && "unexpected type");
         }
     }
 #if 0
@@ -241,7 +240,7 @@ OSOReaderToMaster::add_param_default (const char *def, size_t offset, const Symb
 void
 OSOReaderToMaster::symdefault (int def)
 {
-    ASSERT (m_master->m_symbols.size() && "symdefault but no sym");
+    OSL_DASSERT (m_master->m_symbols.size() && "symdefault but no sym");
     Symbol &sym (m_master->m_symbols.back());
     size_t offset = sym.dataoffset() + m_sym_default_index;
     ++m_sym_default_index;
@@ -252,7 +251,8 @@ OSOReaderToMaster::symdefault (int def)
         else if (sym.typespec().simpletype().basetype == TypeDesc::INT)
             add_param_default (def, offset, sym);
         else {
-            ASSERT (0 && "unexpected type");
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     } else if (sym.symtype() == SymTypeConst) {
         if (sym.typespec().simpletype().basetype == TypeDesc::FLOAT)
@@ -260,7 +260,8 @@ OSOReaderToMaster::symdefault (int def)
         else if (sym.typespec().simpletype().basetype == TypeDesc::INT)
             m_master->m_iconsts[offset] = def;
         else {
-            ASSERT (0 && "unexpected type");
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     }
 }
@@ -270,7 +271,7 @@ OSOReaderToMaster::symdefault (int def)
 void
 OSOReaderToMaster::symdefault (float def)
 {
-    ASSERT (m_master->m_symbols.size() && "symdefault but no sym");
+    OSL_DASSERT (m_master->m_symbols.size() && "symdefault but no sym");
     Symbol &sym (m_master->m_symbols.back());
     size_t offset = sym.dataoffset() + m_sym_default_index;
     ++m_sym_default_index;
@@ -278,14 +279,15 @@ OSOReaderToMaster::symdefault (float def)
         if (sym.typespec().simpletype().basetype == TypeDesc::FLOAT)
             add_param_default (def, offset, sym);
         else {
-            ASSERT (0 && "unexpected type");
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     } else if (sym.symtype() == SymTypeConst) {
         if (sym.typespec().simpletype().basetype == TypeDesc::FLOAT)
             m_master->m_fconsts[offset] = def;
         else {
-            ASSERTMSG (0, "unexpected type: %s (%s)",
-                       sym.typespec().c_str(), sym.name().c_str());
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     }
 }
@@ -295,7 +297,7 @@ OSOReaderToMaster::symdefault (float def)
 void
 OSOReaderToMaster::symdefault (const char *def)
 {
-    ASSERT (m_master->m_symbols.size() && "symdefault but no sym");
+    OSL_DASSERT (m_master->m_symbols.size() && "symdefault but no sym");
     Symbol &sym (m_master->m_symbols.back());
     size_t offset = sym.dataoffset() + m_sym_default_index;
     ++m_sym_default_index;
@@ -303,15 +305,15 @@ OSOReaderToMaster::symdefault (const char *def)
         if (sym.typespec().simpletype().basetype == TypeDesc::STRING)
             add_param_default (def, offset, sym);
         else {
-            ASSERTMSG (0, "unexpected type: %s (%s)",
-                       sym.typespec().c_str(), sym.name().c_str());
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     } else if (sym.symtype() == SymTypeConst) {
         if (sym.typespec().simpletype().basetype == TypeDesc::STRING)
             m_master->m_sconsts[offset] = ustring(def);
         else {
-            ASSERTMSG (0, "unexpected type: %s (%s)",
-                       sym.typespec().c_str(), sym.name().c_str());
+            OSL_DASSERT_MSG (0, "unexpected type: %s (%s)",
+                             sym.typespec().c_str(), sym.name().c_str());
         }
     }
 }
@@ -321,7 +323,7 @@ OSOReaderToMaster::symdefault (const char *def)
 void
 OSOReaderToMaster::parameter_done ()
 {
-  ASSERT (m_master->m_symbols.size() && "parameter_done but no sym");
+  OSL_DASSERT (m_master->m_symbols.size() && "parameter_done but no sym");
   Symbol &sym (m_master->m_symbols.back());
 
   // set length of unsized array parameters
@@ -586,7 +588,7 @@ ShadingSystemImpl::loadshader (string_view cname)
         ++m_stat_shaders_loaded;
         infof("Loaded \"%s\" (took %s)", filename,
               Strutil::timeintervalformat(loadtime, 2));
-        ASSERT (r);
+        OSL_DASSERT (r);
         r->resolve_syms ();
         // if (debug()) {
         //     std::string s = r->print ();
@@ -639,7 +641,7 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
         ++m_stat_shaders_loaded;
         infof("Loaded \"%s\" (took %s)", shadername,
               Strutil::timeintervalformat(loadtime, 2));
-        ASSERT (r);
+        OSL_DASSERT (r);
         r->resolve_syms ();
         // if (debug()) {
         //     std::string s = r->print ();

--- a/src/liboslexec/lpeparse.cpp
+++ b/src/liboslexec/lpeparse.cpp
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "lpeparse.h"
 #include <OSL/oslclosure.h>
-#include <OpenImageIO/dassert.h>
 
 
 OSL_NAMESPACE_ENTER
@@ -233,7 +232,7 @@ Parser::parseCat()
 LPexp *
 Parser::parseGroup()
 {
-    ASSERT(head() == '<');
+    OSL_DASSERT(head() == '<');
     if (m_ingroup) {
         m_error = "No groups allowed inside of groups";
         return NULL;
@@ -275,7 +274,7 @@ Parser::parseGroup()
 LPexp *
 Parser::parseNegor()
 {
-    ASSERT (head() == '^');
+    OSL_DASSERT (head() == '^');
     SymbolSet symlist;
     symlist.insert(Labels::STOP); // never allowed
     int pos = -1;
@@ -333,7 +332,7 @@ Parser::parseNegor()
 LPexp *
 Parser::parseOrlist()
 {
-    ASSERT(head() == '[');
+    OSL_DASSERT(head() == '[');
     next();
     if (hasInput() && head() == '^')
         return parseNegor();
@@ -362,7 +361,7 @@ Parser::parseOrlist()
 std::pair<int, int>
 Parser::parseRange()
 {
-    ASSERT(head() == '{');
+    OSL_DASSERT(head() == '{');
     next();
     std::string firstnum = "";
     while (hasInput() && '0' <= head() && head() <= '9') {

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 
 #include "oslexec_pvt.h"

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -289,7 +289,7 @@ osl_transform_triple (void *sg_, void *Pin, int Pin_derivs,
                 osl_transformn_vmv(Pout, &M, Pin);
         }
 #ifndef __CUDACC__
-        else ASSERT(0);
+        else OSL_DASSERT(0 && "Unknown transform type");
 #else
         // TBR: Is the ok?
         else ok = false;

--- a/src/liboslexec/oslexec.cpp
+++ b/src/liboslexec/oslexec.cpp
@@ -31,7 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 
 #include "oslexec_pvt.h"
@@ -54,7 +53,8 @@ shadertypename (ShaderType s)
     case ShaderType::Volume :       return ("volume");
     case ShaderType::Light :        return ("light");
     default:
-        ASSERT (0 && "Invalid shader type");
+        OSL_DASSERT (0 && "Invalid shader type");
+        return "unknown";
     }
 }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -364,11 +364,11 @@ public:
     /// Return a pointer to the symbol (specified by integer index),
     /// or NULL (if index was -1, as returned by 'findsymbol').
     Symbol *symbol (int index) {
-        DASSERT (index < (int)m_symbols.size());
+        OSL_DASSERT(index < (int)m_symbols.size());
         return index >= 0 ? &m_symbols[index] : NULL;
     }
     const Symbol *symbol (int index) const {
-        DASSERT (index < (int)m_symbols.size());
+        OSL_DASSERT(index < (int)m_symbols.size());
         return index >= 0 ? &m_symbols[index] : NULL;
     }
 
@@ -442,7 +442,7 @@ public:
 
     const ClosureEntry *get_entry (ustring name) const;
     const ClosureEntry *get_entry (int id) const {
-        DASSERT((size_t)id < m_closure_table.size());
+        OSL_DASSERT((size_t)id < m_closure_table.size());
         return &m_closure_table[id];
     }
 
@@ -1301,10 +1301,10 @@ public:
 
     char * alloc(size_t size, size_t alignment=1) {
         // Alignment must be power of two
-        DASSERT ((alignment & (alignment - 1)) == 0);
+        OSL_DASSERT((alignment & (alignment - 1)) == 0);
 
         // Assume sizes are never larger than the configured BlockSize
-        DASSERT(size + alignment - 1 <= BlockSize);
+        OSL_DASSERT(size + alignment - 1 <= BlockSize);
 
         // Fix up alignment
         m_block_offset += alignment_offset_calc(m_blocks[m_current_block].get() + m_block_offset, alignment);
@@ -1318,7 +1318,7 @@ public:
             m_block_offset = alignment_offset_calc(m_blocks[m_current_block].get(), alignment);
         }
         char* ptr = m_blocks[m_current_block].get() + m_block_offset;
-        DASSERT(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
+        OSL_DASSERT(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
         m_block_offset += size;
         return ptr;
     }
@@ -1332,7 +1332,7 @@ private:
     static inline size_t alignment_offset_calc(void* ptr, size_t alignment) {
         uintptr_t ptrbits = reinterpret_cast<uintptr_t>(ptr);
         uintptr_t offset = ((ptrbits + alignment - 1) & -alignment) - ptrbits;
-        DASSERT((ptrbits + offset) % alignment == 0);
+        OSL_DASSERT((ptrbits + offset) % alignment == 0);
         return offset;
     }
 
@@ -1411,7 +1411,7 @@ public:
     /// Append a new shader instance on to the end of this group
     ///
     void append (ShaderInstanceRef newlayer) {
-        ASSERT (! m_optimized && "should not append to optimized group");
+        OSL_ASSERT (! m_optimized && "should not append to optimized group");
         m_layers.push_back (newlayer);
     }
 

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -55,8 +55,8 @@ public:
     // standard containers.  When C++11 is uniquitous, unique_ptr is the
     // one that should really be used.
 
-    const Partio::ParticlesData* read_access() const { DASSERT(!m_write); return m_partio_cloud; }
-    Partio::ParticlesDataMutable* write_access() const { DASSERT(m_write); return m_partio_cloud; }
+    const Partio::ParticlesData* read_access() const { OSL_DASSERT(!m_write); return m_partio_cloud; }
+    Partio::ParticlesDataMutable* write_access() const { OSL_DASSERT(m_write); return m_partio_cloud; }
 
     ustring m_filename;
 private:
@@ -265,8 +265,8 @@ RendererServices::pointcloud_search (ShaderGlobals *sg,
             return 0;   // No "position" attribute -- fail
     }
 
-    ASSERT (sizeof(size_t) == sizeof(Partio::ParticleIndex) &&
-            "Only will work if Partio ParticleIndex is the size of a size_t");
+    static_assert (sizeof(size_t) == sizeof(Partio::ParticleIndex),
+                   "Partio ParticleIndex should be the size of a size_t");
     // FIXME -- if anybody cares about an architecture in which that is not
     // the case, we can easily allocate local space to retrieve the indices,
     // then copy them back to the caller's indices.
@@ -384,7 +384,7 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
     }
 
     static_assert (sizeof(size_t) == sizeof(Partio::ParticleIndex),
-            "Only will work if Partio ParticleIndex is the size of a size_t");
+                   "Partio ParticleIndex should be the size of a size_t");
     // FIXME -- if anybody cares about an architecture in which that is not
     // the case, we can easily allocate local space to retrieve the indices,
     // then copy them back to the caller's indices.

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -35,7 +35,6 @@ using namespace OSL;
 using namespace OSL::pvt;
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/filesystem.h>
 
 
@@ -52,7 +51,7 @@ RendererServices::RendererServices (TextureSystem *texsys)
         // itself. (Most likely reason: this build of OSL is for a renderer
         // that replaces OIIO's TextureSystem with its own, and therefore
         // wouldn't want to accidentally make an OIIO one here.
-        ASSERT (0 && "RendererServices was not passed a working TextureSystem*");
+        OSL_ASSERT (0 && "RendererServices was not passed a working TextureSystem*");
 #else
         m_texturesys = TextureSystem::create (true /* shared */);
         // Make some good guesses about default options

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -26,7 +26,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 #include <OpenImageIO/strutil.h>
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/thread.h>
 
 #include "oslexec_pvt.h"
@@ -108,12 +107,14 @@ TypeSpec::structure_id (const char *name, bool add)
     std::vector<std::shared_ptr<StructSpec> > & m_structs (struct_list());
     ustring n (name);
     for (int i = (int)m_structs.size()-1;  i > 0;  --i) {
-        ASSERT ((int)m_structs.size() > i);
         if (m_structs[i] && m_structs[i]->name() == n)
             return i;
     }
     if (add) {
-        ASSERT (m_structs.size() < 0x8000 && "more struct id's than fit in a short!");
+        if (m_structs.size() >= 0x8000) {
+            OSL_ASSERT(0 && "more struct id's than fit in a short!");
+            return 0;
+        }
         int id = new_struct (new StructSpec (n, 0));
         return id;
     }
@@ -137,7 +138,7 @@ TypeSpec::new_struct (StructSpec *n)
 bool
 equivalent (const StructSpec *a, const StructSpec *b)
 {
-    ASSERT (a && b);
+    OSL_DASSERT (a && b);
     if (a->numfields() != b->numfields())
         return false;
     for (size_t i = 0;  i < (size_t)a->numfields();  ++i)

--- a/src/liboslnoise/gabornoise.cpp
+++ b/src/liboslnoise/gabornoise.cpp
@@ -502,7 +502,7 @@ gabor (const Dual2<float> &x, const Dual2<float> &y, const NoiseParams *opt)
 OSL_HOSTDEVICE Dual2<float>
 gabor (const Dual2<Vec3> &P, const NoiseParams *opt)
 {
-    DASSERT (opt);
+    OSL_DASSERT(opt);
     GaborParams gp (*opt);
 
     if (gp.do_filter)
@@ -540,7 +540,7 @@ gabor3 (const Dual2<float> &x, const Dual2<float> &y, const NoiseParams *opt)
 OSL_HOSTDEVICE Dual2<Vec3>
 gabor3 (const Dual2<Vec3> &P, const NoiseParams *opt)
 {
-    DASSERT (opt);
+    OSL_DASSERT(opt);
     GaborParams gp (*opt);
 
     if (gp.do_filter)
@@ -582,7 +582,7 @@ pgabor (const Dual2<float> &x, const Dual2<float> &y,
 OSL_HOSTDEVICE Dual2<float>
 pgabor (const Dual2<Vec3> &P, const Vec3 &Pperiod, const NoiseParams *opt)
 {
-    DASSERT (opt);
+    OSL_DASSERT(opt);
     GaborParams gp (*opt);
 
     gp.periodic = true;
@@ -622,7 +622,7 @@ pgabor3 (const Dual2<float> &x, const Dual2<float> &y,
 OSL_HOSTDEVICE Dual2<Vec3>
 pgabor3 (const Dual2<Vec3> &P, const Vec3 &Pperiod, const NoiseParams *opt)
 {
-    DASSERT (opt);
+    OSL_DASSERT(opt);
     GaborParams gp (*opt);
 
     gp.periodic = true;

--- a/src/liboslnoise/simplexnoise.cpp
+++ b/src/liboslnoise/simplexnoise.cpp
@@ -305,7 +305,7 @@ OSL_HOSTDEVICE float simplexnoise2 (float x, float y, int seed,
     // Compute derivative, if requested by supplying non-null pointers
     // for the last two arguments
     if (dnoise_dx) {
-        DASSERT (dnoise_dy);
+        OSL_DASSERT(dnoise_dy);
 	/*  A straight, unoptimised calculation would be like:
      *    *dnoise_dx = -8.0f * t20 * t0 * x0 * ( g0[0] * x0 + g0[1] * y0 ) + t40 * g0[0];
      *    *dnoise_dy = -8.0f * t20 * t0 * y0 * ( g0[0] * x0 + g0[1] * y0 ) + t40 * g0[1];
@@ -474,7 +474,7 @@ simplexnoise3 (float x, float y, float z, int seed,
     // Compute derivative, if requested by supplying non-null pointers
     // for the last three arguments
     if (dnoise_dx) {
-        DASSERT (dnoise_dy && dnoise_dz);
+        OSL_DASSERT(dnoise_dy && dnoise_dz);
 	/*  A straight, unoptimised calculation would be like:
      *     *dnoise_dx = -8.0f * t20 * t0 * x0 * dot(g0[0], g0[1], g0[2], x0, y0, z0) + t40 * g0[0];
      *    *dnoise_dy = -8.0f * t20 * t0 * y0 * dot(g0[0], g0[1], g0[2], x0, y0, z0) + t40 * g0[1];
@@ -671,7 +671,7 @@ simplexnoise4 (float x, float y, float z, float w, int seed,
     // Compute derivative, if requested by supplying non-null pointers
     // for the last four arguments
     if (dnoise_dx) {
-        DASSERT (dnoise_dy && dnoise_dz && dnoise_dw);
+        OSL_DASSERT(dnoise_dy && dnoise_dz && dnoise_dw);
 	/*  A straight, unoptimised calculation would be like:
      *     *dnoise_dx = -8.0f * t20 * t0 * x0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[0];
      *    *dnoise_dy = -8.0f * t20 * t0 * y0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[1];

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <cstdlib>
 
-#include <OpenImageIO/dassert.h>
 #include <OpenImageIO/typedesc.h>
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/strutil.h>
@@ -638,6 +637,10 @@ OSLInput::read_native_scanlines (
     if (! seek_subimage (subimage, miplevel))
         return false;
 #endif
+    if (! m_group.get()) {
+        error("read_native_scanlines called with missing shading group");
+        return false;
+    }
 
     // Create an ImageBuf wrapper of the user's data
     ImageSpec spec = m_spec; // Make a spec that describes just this scanline
@@ -649,7 +652,6 @@ OSLInput::read_native_scanlines (
 
     // Now run the shader on the ImageBuf pixels, which really point to
     // the caller's data buffer.
-    ASSERT (m_group.get());
     ROI roi (spec.x, spec.x+spec.width, spec.y, spec.y+spec.height,
              spec.z, spec.z+spec.depth);
     return shade_image (*shadingsys, *m_group, NULL, ibwrapper, m_outputs,
@@ -687,6 +689,10 @@ OSLInput::read_native_tiles (
     if (! seek_subimage (subimage, miplevel))
         return false;
 #endif
+    if (! m_group.get()) {
+        error("read_native_scanlines called with missing shading group");
+        return false;
+    }
 
     // Create an ImageBuf wrapper of the user's data
     ImageSpec spec = m_spec; // Make a spec that describes just this scanline
@@ -700,7 +706,6 @@ OSLInput::read_native_tiles (
 
     // Now run the shader on the ImageBuf pixels, which really point to
     // the caller's data buffer.
-    ASSERT (m_group.get());
     ROI roi (spec.x, spec.x+spec.width, spec.y, spec.y+spec.height,
              spec.z, spec.z+spec.depth);
     return shade_image (*shadingsys, *m_group, NULL, ibwrapper, m_outputs,

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -132,7 +132,7 @@ public:
         if (!m_renderview)
             return;
 
-        ASSERT( m_image->width() == m_image->height() );
+        OSL_DASSERT( m_image->width() == m_image->height() );
         using namespace OIIO;
 
         int res = m_image->width();
@@ -253,7 +253,7 @@ class OSLToyRenderView : public QLabel {
                 lastParent = parent;
                 parent = parent->parentWidget();
             } while (parent);
-            ASSERT( lastParent != nullptr );
+            OSL_DASSERT( lastParent != nullptr );
             m_magnifier = new Magnifier(lastParent);
         }
 
@@ -971,7 +971,7 @@ OSLToyMainWindow::inventory_params ()
         OSLQuery oslquery (group.get(), i);
         for (size_t p = 0; p < oslquery.nparams(); ++p) {
             auto param = oslquery.getparam (p);
-            ASSERT (param);
+            OSL_DASSERT (param);
             m_shaderparams.push_back (std::make_shared<ParamRec>(*param));
             m_shaderparams.back()->layername = layernames[i];
         }
@@ -1196,7 +1196,7 @@ OSLToyMainWindow::rebuild_param_area ()
 void
 OSLToyMainWindow::set_error_message (int tab, const std::string& msg)
 {
-    ASSERT (tab >= 0 && tab < ntabs());
+    OSL_DASSERT (tab >= 0 && tab < ntabs());
     if (msg.size()) {
         error_displays[tab]->setTextColor (Qt::red);
         error_displays[tab]->setPlainText (msg.c_str());

--- a/src/testrender/background.h
+++ b/src/testrender/background.h
@@ -126,17 +126,17 @@ private:
     }
 
     static float sample_cdf(const float* data, unsigned int n, float x, unsigned int *idx, float* pdf) {
-        DASSERT(x >= 0);
-        DASSERT(x < 1);
+        OSL_DASSERT(x >= 0);
+        OSL_DASSERT(x < 1);
         *idx = std::upper_bound(data, data + n, x) - data;
-        DASSERT(*idx < n);
-        DASSERT(x < data[*idx]);
+        OSL_DASSERT(*idx < n);
+        OSL_DASSERT(x < data[*idx]);
         float scaled_sample;
         if (*idx == 0) {
             *pdf = data[0];
             scaled_sample = x / data[0];
         } else {
-            DASSERT(x >= data[*idx - 1]);
+            OSL_DASSERT(x >= data[*idx - 1]);
             *pdf = data[*idx] - data[*idx - 1];
             scaled_sample = (x - data[*idx - 1]) / (data[*idx] - data[*idx - 1]);
         }

--- a/src/testrender/optix_stringtable.cpp
+++ b/src/testrender/optix_stringtable.cpp
@@ -63,10 +63,10 @@ OptiXStringTable::freetable()
 void OptiXStringTable::init (OSL::optix::Context ctx)
 {
 #ifdef OSL_USE_OPTIX
-    ASSERT (! m_ptr && "StringTable should only be initialized once");
+    OSL_ASSERT (! m_ptr && "StringTable should only be initialized once");
     m_optix_ctx = ctx;
 
-    ASSERT ((m_optix_ctx->getEnabledDeviceCount() == 1) &&
+    OSL_ASSERT ((m_optix_ctx->getEnabledDeviceCount() == 1) &&
             "Only one CUDA device is currently supported");
 
     OSL::cudaMalloc (reinterpret_cast<void**>(&m_ptr), (m_size));
@@ -89,7 +89,7 @@ void OptiXStringTable::init (OSL::optix::Context ctx)
 uint64_t OptiXStringTable::addString (ustring str, ustring var_name)
 {
 #ifdef OSL_USE_OPTIX
-    ASSERT (m_ptr && "StringTable has not been initialized");
+    OSL_ASSERT (m_ptr && "StringTable has not been initialized");
 
     // The strings are laid out in the table as a struct:
     //
@@ -107,7 +107,7 @@ uint64_t OptiXStringTable::addString (ustring str, ustring var_name)
 
     // It should be hard to trigger this assert, unless the table size is
     // very small and the string is very large.
-    ASSERT (m_offset + size <= m_size && "String table allocation error");
+    OSL_ASSERT (m_offset + size <= m_size && "String table allocation error");
 
     int offset = getOffset(str.string());
     if (offset < 0) {
@@ -158,8 +158,8 @@ int OptiXStringTable::getOffset (const std::string& str) const
 void OptiXStringTable::reallocTable()
 {
 #ifdef OSL_USE_OPTIX
-    ASSERT ((m_optix_ctx->getEnabledDeviceCount() == 1) &&
-            "Only one CUDA device is currently supported");
+    OSL_ASSERT ((m_optix_ctx->getEnabledDeviceCount() == 1) &&
+                "Only one CUDA device is currently supported");
 
     m_size *= 2;
     OSL::cudaFree (m_ptr);

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -164,7 +164,7 @@ private:
 struct Sphere : public Primitive {
     Sphere(Vec3 c, float r, int shaderID, bool isLight)
         : Primitive(shaderID, isLight), c(c), r2(r * r) {
-        ASSERT(r > 0);
+        OSL_DASSERT(r > 0);
     }
 
     // returns distance to nearest hit or 0

--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -729,7 +729,7 @@ void process_closure (ShadingResult& result, const ClosureColor* closure, const 
                    case REFRACTION_ID:         ok = result.bsdf.add_bsdf<Refraction , RefractionParams>(cw, *comp->as<RefractionParams>()); break;
                    case TRANSPARENT_ID:        ok = result.bsdf.add_bsdf<Transparent, int             >(cw, 0); break;
                }
-               ASSERT(ok && "Invalid closure invoked in surface shader");
+               OSL_ASSERT(ok && "Invalid closure invoked in surface shader");
            }
            break;
        }
@@ -759,7 +759,7 @@ Vec3 process_background_closure(const ClosureColor* closure) {
            }
     }
     // should never happen
-    ASSERT(false && "Invalid closure invoked in background shader");
+    OSL_ASSERT(false && "Invalid closure invoked in background shader");
     return Vec3(0, 0, 0);
 }
 

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -186,14 +186,14 @@ struct ParamStorage {
     ParamStorage() : fparamindex(0), iparamindex(0), sparamindex(0) {}
 
     void* Int(int i) {
-        ASSERT(iparamindex < N);
+        OSL_DASSERT(iparamindex < N);
         iparamdata[iparamindex] = i;
         iparamindex++;
         return &iparamdata[iparamindex - 1];
     }
 
     void* Float(float f) {
-        ASSERT(fparamindex < N);
+        OSL_DASSERT(fparamindex < N);
         fparamdata[fparamindex] = f;
         fparamindex++;
         return &fparamdata[fparamindex - 1];
@@ -207,7 +207,7 @@ struct ParamStorage {
     }
 
     void* Str(const char* str) {
-        ASSERT(sparamindex < N);
+        OSL_DASSERT(sparamindex < N);
         sparamdata[sparamindex] = ustring(str);
         sparamindex++;
         return &sparamdata[sparamindex - 1];

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -215,7 +215,7 @@ shader_from_buffers (std::string shadername)
 static int
 add_shader (int argc, const char *argv[])
 {
-    ASSERT (argc == 1);
+    OSL_DASSERT(argc == 1);
     string_view shadername (argv[0]);
 
     set_shadingsys_options ();
@@ -258,7 +258,7 @@ action_shaderdecl (int argc, const char *argv[])
 static void
 specify_expr (int argc, const char *argv[])
 {
-    ASSERT (argc == 2);
+    OSL_DASSERT(argc == 2);
     std::string shadername = OIIO::Strutil::sprintf("expr_%d", exprcount++);
     std::string sourcecode =
         "shader " + shadername + " (\n"
@@ -918,7 +918,7 @@ test_group_attributes (ShaderGroup *group)
                                   TypeDesc::PTR, &userdata_offsets);
         shadingsys->getattribute (group, "userdata_derivs",
                                   TypeDesc::PTR, &userdata_derivs);
-        DASSERT (userdata_names && userdata_types && userdata_offsets);
+        OSL_DASSERT(userdata_names && userdata_types && userdata_offsets);
         for (int i = 0; i < nuser; ++i)
             std::cout << "    " << userdata_names[i] << ' '
                       << userdata_types[i] << "  offset="
@@ -934,7 +934,7 @@ test_group_attributes (ShaderGroup *group)
                                   TypeDesc::PTR, &names);
         shadingsys->getattribute (group, "attribute_scopes",
                                   TypeDesc::PTR, &scopes);
-        DASSERT (names && scopes);
+        OSL_DASSERT(names && scopes);
         for (int i = 0; i < nattr; ++i)
             std::cout << "    " << names[i] << ' '
                       << scopes[i] << "\n";


### PR DESCRIPTION
The old macros were from OIIO, namespace polluting, and ASSERT always
aborted the process. The new macros won't conflict with other apps,
and OSL_ASSERT prints error always but only aborts for debug mode,
which discussion concluded was the preferred behavior.

I also policed up the whole set of assertions, and there were many
instances of:

* ASSERT that I deemed downgradable to DASSERT.

* ASSERT/DASSERT that I deemed entirely unnecessary and deleted.

* A few asserts that should always have been OIIO_CHECK_* unit test
  macros.

