### PR TITLE
Refactor implementation of template<class T, int PARTIALS> Dual

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -90,9 +90,10 @@ OSL_NAMESPACE_ENTER
 #else
     namespace pvt {
         template<typename T>
-        static constexpr T static_min(T a, T b) { return (b < a) ? b : a; }
-    } // namespace pvt
-    // explanation of passing code block as macro argument to handle
+        static OSL_HOSTDEVICE constexpr T static_min(T a, T b) {
+            return (b < a) ? b : a;
+        }
+    }    // explanation of passing code block as macro argument to handle
     // nested comma operators that might break up the code block into
     // multiple macro arguments
     // https://mort.coffee/home/obscure-c-features/
@@ -153,12 +154,12 @@ public:
     // To better enable Scalar Replacement of Aggregates and other
     // transformations, CLANG has easier time if the per element
     // constructors declared.
-    OIIO_CONSTEXPR14 DualStorage() {}
-    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage() {}
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx)
     : m_val(val)
     , m_dx(dx)
     {}
-    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
     : m_val(other.m_val)
     , m_dx(other.m_dx)
     {}
@@ -182,13 +183,13 @@ public:
     // To better enable Scalar Replacement of Aggregates and other
     // transformations, CLANG has easier time if the per element
     // constructors declared.
-    OIIO_CONSTEXPR14 DualStorage() {}
-    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage() {}
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy)
     : m_val(val)
     , m_dx(dx)
     , m_dy(dy)
     {}
-    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
     : m_val(other.m_val)
     , m_dx(other.m_dx)
     , m_dy(other.m_dy)
@@ -215,15 +216,15 @@ public:
     // To better enable Scalar Replacement of Aggregates and other
     // transformations, CLANG has easier time if the per element
     // constructors declared.
-    OIIO_CONSTEXPR14 DualStorage() {}
-    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy, const T & dz)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage() {}
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy, const T & dz)
     : m_val(val)
     , m_dx(dx)
     , m_dy(dy)
     , m_dz(dz)
     {}
 
-    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
     : m_val(other.m_val)
     , m_dx(other.m_dx)
     , m_dy(other.m_dy)

--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -69,7 +69,7 @@ OSL_NAMESPACE_ENTER
 // NOTE:  To improve compile times and reduce compiler memory usage,
 // we may choose not to use the generic lambda based version for
 // certain compilers/versions.
-#if (__cplusplus >= 201402L) && !defined(__INTEL_COMPILER)
+#if (__cplusplus >= 201402L) && !defined(__INTEL_COMPILER) && !defined(__GNUC__)
     // explanation of passing code block as macro argument to handle
     // nested comma operators that might break up the code block into
     // multiple macro arguments
@@ -385,9 +385,8 @@ public:
     ///
     friend std::ostream& operator<< (std::ostream &out, const Dual &x) {
         out << x.val() << "[";
-        constexpr int partial_count = PARTIALS;
         OSL_INDEX_LOOP(i, PARTIALS, {
-            out << (x.partial(i)) << ((i < partial_count) ? ',' : ']');
+            out << (x.partial(i)) << ((i < PARTIALS) ? ',' : ']');
         });
         return out;
     }

--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -29,6 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <initializer_list>
+#include <utility>
 #include <OSL/oslconfig.h>
 #include <OSL/oslversion.h>
 #include <OpenImageIO/fmath.h>
@@ -43,6 +44,70 @@ OSL_NAMESPACE_ENTER
 
 
 
+// To generically access elements or partials of a Dual, use a ConstIndex<#>.
+// NOTE:  Each ConstIndex<#> (ConstIndex<0>, ConstIndex<1>, ConstIndex<2>, ...)
+// is a different type and known at compile time.  A regular loop index will
+// not work to access elements or partials.  For non-generic code, the methods
+// .val(), .dx(), .dy(), .dz() should be used.
+// For generic code, the macro "OSL_INDEX_LOOP(__INDEX_NAME, __COUNT, ...)"
+// is provided to execute a code block (...) with __INDEX_NAME correctly typed
+// for each ConstIndex<#> within the # range [0-__COUNT).
+// In practice, this means changing
+//     for(int i=0; i < elements;++i) {
+//          elem(i) += value;
+//     }
+// to
+//     OSL_INDEX_LOOP(i, elements, {
+//          elem(i) += value;
+//     });
+
+
+// If possible (C++14+) use generic lambda based to loop to repeat code
+// sequences with compile time known ConstIndex.  Otherwise for c++11,
+// a more limited manually unrolled loop to a fixed maximum __COUNT
+// works because dead code elimination prunes extraneous iterations.
+// NOTE:  To improve compile times and reduce compiler memory usage,
+// we may choose not to use the generic lambda based version for
+// certain compilers/versions.
+#if (__cplusplus >= 201402L) && !defined(__INTEL_COMPILER)
+    // explanation of passing code block as macro argument to handle
+    // nested comma operators that might break up the code block into
+    // multiple macro arguments
+    // https://mort.coffee/home/obscure-c-features/
+    //
+    // The macro's variable argument list populates the body of the functor lambda.
+    // NOTE: generic lambda parameter __INDEX_NAME means that the functor itself
+    // is a template that accepts any type.  The static_foreach will call the
+    // templated functor with different types of ConstIndex<#> where # is [0-__COUNT)
+    #define OSL_INDEX_LOOP(__INDEX_NAME, __COUNT, ...) \
+        { \
+            auto functor = [&](auto __INDEX_NAME) { \
+                __VA_ARGS__; \
+            }; \
+            static_foreach<ConstIndex, __COUNT>(functor); \
+        }
+
+#else
+    namespace pvt {
+        template<typename T>
+        static constexpr T static_min(T a, T b) { return (b < a) ? b : a; }
+    } // namespace pvt
+    // explanation of passing code block as macro argument to handle
+    // nested comma operators that might break up the code block into
+    // multiple macro arguments
+    // https://mort.coffee/home/obscure-c-features/
+    //
+    // We rely on dead code elimination to quickly get rid of the code emitted
+    // for out of range indices, but we do take care to not generate any ConstIndex<#>
+    // that would be out of range using the static_min helper
+    #define OSL_INDEX_LOOP(__INDEX_NAME, __COUNT, ...) \
+        static_assert((__COUNT) < 4, "macro based expansion must be repeated to support higher __COUNT values"); \
+        { ConstIndex<0> __INDEX_NAME; __VA_ARGS__ ; } \
+        if ((__COUNT) > 1) { ConstIndex<pvt::static_min(1, (__COUNT)-1)> __INDEX_NAME; __VA_ARGS__ ; } \
+        if ((__COUNT) > 2) { ConstIndex<pvt::static_min(2, (__COUNT)-1)> __INDEX_NAME; __VA_ARGS__ ; } \
+        if ((__COUNT) > 3) { ConstIndex<pvt::static_min(3, (__COUNT)-1)> __INDEX_NAME; __VA_ARGS__ ; }
+#endif
+
 /// Dual numbers are used to represent values and their derivatives.
 ///
 /// The method is summarized in:
@@ -52,144 +117,281 @@ OSL_NAMESPACE_ENTER
 ///
 ///
 
+// Default DualStorage can handle any number of partials by storing elements
+// in an array.  In practice the array subscript operation can require
+// standard data layout so that the base address + index works.  This
+// can inhibit other transformations useful for vectorization such as
+// storing data members in a Structure Of Arrays (SOA) layout
+template<class T, int PARTIALS>
+class DualStorage
+{
+public:
+    T m_elem[PARTIALS+1];
+
+    template<int N>
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<N>) const { return m_elem[N]; }
+    template<int N>
+    OSL_HOSTDEVICE T& elem (ConstIndex<N>)  { return m_elem[N]; }
+};
+
+
+// Specialize DualStorage for specific number of partials and store elements
+// as individual data members.  Because each ConstIndex<#> is its own type and
+// identifies a specific element, we can overload the elem function for each
+// specific ConstIndex<#> and return the corresponding data member.
+// The main benefit is better enabling of SROA (Scalar Replacement of Aggregates)
+// and other transformations that allow each data member to be
+// optimized independently, kept in vector registers vs. scatter back to the
+// stack, and more.
+template<class T>
+class DualStorage<T, 1>
+{
+public:
+    T m_val;
+    T m_dx;
+
+    // To better enable Scalar Replacement of Aggregates and other
+    // transformations, CLANG has easier time if the per element
+    // constructors declared.
+    OIIO_CONSTEXPR14 DualStorage() {}
+    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx)
+    : m_val(val)
+    , m_dx(dx)
+    {}
+    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    : m_val(other.m_val)
+    , m_dx(other.m_dx)
+    {}
+
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<0>) const { return m_val; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<1>) const { return m_dx; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<0>)  { return m_val; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<1>)  { return m_dx; }
+};
+
+
+// Specialize layout to be explicit data members vs. array
+template<class T>
+class DualStorage<T, 2>
+{
+public:
+    T m_val;
+    T m_dx;
+    T m_dy;
+
+    // To better enable Scalar Replacement of Aggregates and other
+    // transformations, CLANG has easier time if the per element
+    // constructors declared.
+    OIIO_CONSTEXPR14 DualStorage() {}
+    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy)
+    : m_val(val)
+    , m_dx(dx)
+    , m_dy(dy)
+    {}
+    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    : m_val(other.m_val)
+    , m_dx(other.m_dx)
+    , m_dy(other.m_dy)
+    {}
+
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<0>) const { return m_val; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<1>) const { return m_dx; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<2>) const { return m_dy; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<0>)  { return m_val; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<1>)  { return m_dx; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<2>)  { return m_dy; }
+};
+
+
+template<class T>
+class DualStorage<T, 3>
+{
+public:
+    T m_val;
+    T m_dx;
+    T m_dy;
+    T m_dz;
+
+    // To better enable Scalar Replacement of Aggregates and other
+    // transformations, CLANG has easier time if the per element
+    // constructors declared.
+    OIIO_CONSTEXPR14 DualStorage() {}
+    OIIO_CONSTEXPR14 DualStorage(const T & val, const T & dx, const T & dy, const T & dz)
+    : m_val(val)
+    , m_dx(dx)
+    , m_dy(dy)
+    , m_dz(dz)
+    {}
+
+    OIIO_CONSTEXPR14 DualStorage(const DualStorage &other)
+    : m_val(other.m_val)
+    , m_dx(other.m_dx)
+    , m_dy(other.m_dy)
+    , m_dz(other.dz)
+    {}
+
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<0>) const { return m_val; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<1>) const { return m_dx; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<2>) const { return m_dy; }
+    OSL_HOSTDEVICE constexpr const T& elem (ConstIndex<3>) const { return m_dz; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<0>)  { return m_val; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<1>)  { return m_dx; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<2>)  { return m_dy; }
+    OSL_HOSTDEVICE T& elem (ConstIndex<3>)  { return m_dz; }
+};
+
+// Single generic implementation of Dual can handle any number of partials
+// delegating access to element storage to the DualStorage base class
 template<
          class T,           // Base data type
          int PARTIALS=1     // Number of dimentions of partial derivs
         >
-class Dual {
+class Dual : public DualStorage<T, PARTIALS> {
     static const int elements = PARTIALS+1;   // main value + partials
     static_assert (PARTIALS>=1, "Can't have a Dual with 0 partials");
 public:
     using value_type = T;
-    static inline OSL_HOSTDEVICE OIIO_CONSTEXPR14 T zero() { return T(0.0); }
+    static OSL_INLINE OSL_HOSTDEVICE OIIO_CONSTEXPR14 T zero() { return T(0.0); }
+
+    using DualStorage<T, PARTIALS>::elem;
+    template<int N>
+    OSL_HOSTDEVICE constexpr const T partial (ConstIndex<N>) const { return elem(ConstIndex<N+1>()); }
+    template<int N>
+    OSL_HOSTDEVICE T& partial (ConstIndex<N>) { return elem(ConstIndex<N+1>()); }
 
     /// Default ctr leaves everything uninitialized
     ///
-    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual () { }
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual ()
+    : DualStorage<T, PARTIALS>()
+    {}
 
     /// Construct a Dual from just a real value (derivs set to 0)
     ///
-    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const T &x) {
-        m_data[0] = x;
-        for (int i = 1; i <= PARTIALS; ++i)
-            m_data[i] = zero();
-    }
-
-    /// Copy constructor from another Dual of same type and dimension.
-    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const Dual &x) {
-        for (int i = 0; i <= PARTIALS; ++i)
-            m_data[i] = T(x.m_data[i]);
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const T &x)
+    : DualStorage<T, PARTIALS>()
+    {
+        val() = x;
+        OSL_INDEX_LOOP(i, PARTIALS, {
+           partial(i) = zero();
+        });
     }
 
     /// Copy constructor from another Dual of same dimension and different,
     /// but castable, data type.
     template<class F>
-    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const Dual<F,PARTIALS> &x) {
-        for (int i = 0; i <= PARTIALS; ++i)
-            m_data[i] = T(x.elem(i));
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const Dual<F,PARTIALS> &x)
+    : DualStorage<T, PARTIALS>()
+    {
+        OSL_INDEX_LOOP(i, elements, {
+            elem(i) = T(x.elem(i));
+        });
     }
+
+    //OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const Dual &x) = default;
+    OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (const Dual &x)
+    : DualStorage<T, PARTIALS>(x)
+    {}
 
     /// Construct a Dual from a real and infinitesimals.
     ///
-    OSL_HOSTDEVICE constexpr Dual (const T &x, const T &dx) : m_data{ x, dx } {
-        static_assert(PARTIALS==1, "Wrong number of initializers");
-    }
-    OSL_HOSTDEVICE constexpr Dual (const T &x, const T &dx, const T &dy)
-        : m_data{ x, dx, dy }
+    template<typename... DerivListT>
+    OSL_HOSTDEVICE constexpr Dual (const T &x, const DerivListT & ...derivs)
+    : DualStorage<T, PARTIALS>{ x, static_cast<T>(derivs)...}
     {
-        static_assert(PARTIALS==2, "Wrong number of initializers");
+        static_assert(sizeof...(DerivListT)==PARTIALS, "Wrong number of initializers");
     }
-    OSL_HOSTDEVICE void set (const T &x, const T &dx) {
-        static_assert(PARTIALS==1, "Wrong number of initializers");
-        m_data[0] = x;
-        m_data[1] = dx;
+
+protected:
+    template<int... IntListT, typename... ValueListT>
+    OSL_HOSTDEVICE OSL_INLINE void set_expander (pvt::int_sequence<IntListT...> indices, const ValueListT & ...values)
+    {
+        __OSL_EXPAND_PARAMETER_PACKS( elem(ConstIndex<IntListT>()) = values );
     }
-    OSL_HOSTDEVICE void set (const T &x, const T &dx, const T &dy) {
-        static_assert(PARTIALS==2, "Wrong number of initializers");
-        m_data[0] = x;
-        m_data[1] = dx;
-        m_data[2] = dy;
+public:
+
+    template<typename... ValueListT>
+    OSL_HOSTDEVICE void set (const ValueListT & ...values)
+    {
+        static_assert(sizeof...(ValueListT)==elements, "Wrong number of initializers");
+
+        set_expander(pvt::make_int_sequence<elements>(), values...);
     }
 
     OSL_HOSTDEVICE OIIO_CONSTEXPR14 Dual (std::initializer_list<T> vals) {
 #if OIIO_CPLUSPLUS_VERSION >= 14
         static_assert (vals.size() == elements, "Wrong number of initializers");
 #endif
-        for (int i = 0; i < elements; ++i)
-            m_data[i] = vals.begin()[i];
+        OSL_INDEX_LOOP(i, elements, {
+            elem(i) = vals.begin()[i];
+        });
     }
 
     /// Return the real value.
-    OSL_HOSTDEVICE constexpr const T& val () const { return m_data[0]; }
-    OSL_HOSTDEVICE T& val () { return m_data[0]; }
+    OSL_HOSTDEVICE constexpr const T& val () const { return elem(ConstIndex<0>()); }
+    OSL_HOSTDEVICE T& val () { return elem(ConstIndex<0>()); }
 
     /// Return the partial derivative with respect to x.
-    OSL_HOSTDEVICE constexpr const T& dx () const { return m_data[1]; }
-    OSL_HOSTDEVICE T& dx () { return m_data[1]; }
+    OSL_HOSTDEVICE constexpr const T& dx () const { return elem(ConstIndex<1>()); }
+    OSL_HOSTDEVICE T& dx () { return elem(ConstIndex<1>()); }
 
     /// Return the partial derivative with respect to y.
-    /// Only valid if there are at least 2 partial dimensions.
-    OSL_HOSTDEVICE constexpr const T& dy () const {
-        static_assert(PARTIALS>=2, "Cannot call dy without at least 2 partials");
-        return m_data[2];
+    template<typename ThisType = Dual, typename std::enable_if<ThisType::elements==3, int>::type = 0>
+    OSL_HOSTDEVICE constexpr const T &
+    dy () const {
+        return elem(ConstIndex<2>());
     }
+    template<typename ThisType = Dual, typename std::enable_if<ThisType::elements==3, int>::type = 0>
     OSL_HOSTDEVICE T& dy () {
-        static_assert(PARTIALS>=2, "Cannot call dy without at least 2 partials");
-        return m_data[2];
+        return elem(ConstIndex<2>());
     }
 
     /// Return the partial derivative with respect to z.
     /// Only valid if there are at least 3 partial dimensions.
+    template<typename ThisType = Dual, typename std::enable_if<ThisType::elements==4, int>::type = 0>
     OSL_HOSTDEVICE constexpr const T& dz () const {
-        static_assert(PARTIALS>=3, "Cannot call dz without at least 3 partials");
-        return m_data[3];
+        return elem(ConstIndex<3>());
     }
+    template<typename ThisType = Dual, typename std::enable_if<ThisType::elements==4, int>::type = 0>
     OSL_HOSTDEVICE T& dz () {
-        static_assert(PARTIALS>=3, "Cannot call dz without at least 3 partials");
-        return m_data[3];
+        return elem(ConstIndex<3>());
     }
 
     /// Clear the derivatives; leave the value alone.
     OSL_HOSTDEVICE void clear_d () {
-        for (int i = 1; i <= PARTIALS; ++i)
-            m_data[i] = zero();
-    }
-
-    /// Return the i-th partial derivative.
-    OSL_HOSTDEVICE constexpr const T& partial (int i) const {
-        return m_data[i+1];
-    }
-
-    /// Return a mutable reference to the i-th partial derivative.
-    /// Use with caution!
-    OSL_HOSTDEVICE T& partial (int i) {
-        return m_data[i+1];
+        OSL_INDEX_LOOP(i, PARTIALS, {
+            partial(i) = zero();
+        });
     }
 
     /// Assignment of a real (the derivs are implicitly 0).
     OSL_HOSTDEVICE const Dual & operator= (const T &x) {
-        m_data[0] = x;
-        for (int i = 1; i <= PARTIALS; ++i)
-            m_data[i] = T(0);
+        val() = x;
+        OSL_INDEX_LOOP(i, PARTIALS, {
+            partial(i) = zero();
+        });
         return *this;
     }
 
-    /// Access like an array -- be careful! Element 0 is the main value,
-    /// elements [1..PARTIALS] are the infinitessimals.
-    OSL_HOSTDEVICE constexpr const T& elem (int i) const { return m_data[i]; }
-    OSL_HOSTDEVICE T& elem (int i) { return m_data[i]; }
+    OSL_HOSTDEVICE const Dual & operator= (const Dual &other) {
+        OSL_INDEX_LOOP(i, elements, {
+            elem(i) = other.elem(i);
+        });
+        return *this;
+    }
+
+
 
     /// Stream output.  Format as: "val[dx,dy,...]"
     ///
     friend std::ostream& operator<< (std::ostream &out, const Dual &x) {
-        out << x.m_data[0] << "[";
-        for (int i = 1; i < PARTIALS; ++i)
-            out << x.m_data[i] << ',';
-        return out << x.m_data[PARTIALS] << "]";
+        out << x.val() << "[";
+        constexpr int partial_count = PARTIALS;
+        OSL_INDEX_LOOP(i, PARTIALS, {
+            out << (x.partial(i)) << ((i < partial_count) ? ',' : ']');
+        });
+        return out;
     }
 
-private:
-    T m_data[elements];  ///< [0] is the value, [1..PARTIALS] are derivs
 };
 
 
@@ -221,17 +423,18 @@ template<class T> using Dual2 = Dual<T,2>;
 /// Addition of duals.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const Dual<T,P> &b)
 {
     Dual<T,P> result = a;
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         result.elem(i) += b.elem(i);
+    });
     return result;
 }
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const T &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, const T &b)
 {
     Dual<T,P> result = a;
     result.val() += b;
@@ -240,7 +443,7 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const Dual<T,P> &a, 
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const T &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator+ (const T &a, const Dual<T,P> &b)
 {
     Dual<T,P> result = b;
     result.val() += a;
@@ -249,16 +452,17 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator+ (const T &a, const Du
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P>& operator+= (Dual<T,P> &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P>& operator+= (Dual<T,P> &a, const Dual<T,P> &b)
 {
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         a.elem(i) += b.elem(i);
+    });
     return a;
 }
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P>& operator+= (Dual<T,P> &a, const T &b)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P>& operator+= (Dual<T,P> &a, const T &b)
 {
     a.val() += b;
     return a;
@@ -268,17 +472,18 @@ OSL_HOSTDEVICE inline Dual<T,P>& operator+= (Dual<T,P> &a, const T &b)
 /// Subtraction of duals.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const Dual<T,P> &b)
 {
     Dual<T,P> result;
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         result.elem(i) = a.elem(i) - b.elem(i);
+    });
     return result;
 }
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const T &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, const T &b)
 {
     Dual<T,P> result = a;
     result.val() -= b;
@@ -287,27 +492,29 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a, 
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const T &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator- (const T &a, const Dual<T,P> &b)
 {
     Dual<T,P> result;
     result.val() = a - b.val();
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = -b.elem(i);
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = -b.partial(i);
+    });
     return result;
 }
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P>& operator-= (Dual<T,P> &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P>& operator-= (Dual<T,P> &a, const Dual<T,P> &b)
 {
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         a.elem(i) -= b.elem(i);
+    });
     return a;
 }
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P>& operator-= (Dual<T,P> &a, const T &b)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P>& operator-= (Dual<T,P> &a, const T &b)
 {
     a.val() -= b.val();
     return a;
@@ -318,11 +525,12 @@ OSL_HOSTDEVICE inline Dual<T,P>& operator-= (Dual<T,P> &a, const T &b)
 /// Negation of duals.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a)
 {
     Dual<T,P> result;
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         result.elem(i) = -a.elem(i);
+    });
     return result;
 }
 
@@ -330,14 +538,15 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator- (const Dual<T,P> &a)
 /// Multiplication of duals. This will work for any Dual<T>*Dual<S>
 /// where T*S is meaningful.
 template<class T, int P, class S>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 auto
-operator* (const Dual<T,P> &a, const Dual<S,P> &b) -> Dual<decltype(a.elem(0)*b.elem(0)),P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 auto
+operator* (const Dual<T,P> &a, const Dual<S,P> &b) -> Dual<decltype(a.val()*b.val()),P>
 {
     // Use the chain rule
-    Dual<decltype(a.elem(0)*b.elem(0)),P> result;
+    Dual<decltype(a.val()*b.val()),P> result;
     result.val() = a.val() * b.val();
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = a.val()*b.elem(i) + a.elem(i)*b.val();
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = a.val()*b.partial(i) + a.partial(i)*b.val();
+    });
     return result;
 }
 
@@ -346,12 +555,13 @@ operator* (const Dual<T,P> &a, const Dual<S,P> &b) -> Dual<decltype(a.elem(0)*b.
 /// Dual<T> * S where T*S is meaningful.
 template<class T, int P, class S,
          DUAL_REQUIRES(is_Dual<S>::value == false)>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 auto
-operator* (const Dual<T,P> &a, const S &b) -> Dual<decltype(a.elem(0)*b),P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 auto
+operator* (const Dual<T,P> &a, const S &b) -> Dual<decltype(a.val()*b),P>
 {
-    Dual<decltype(a.elem(0)*b),P> result;
-    for (int i = 0; i <= P; ++i)
+    Dual<decltype(a.val()*b),P> result;
+    OSL_INDEX_LOOP(i, P+1, {
         result.elem(i) = a.elem(i) * b;
+    });
     return result;
 }
 
@@ -360,10 +570,11 @@ operator* (const Dual<T,P> &a, const S &b) -> Dual<decltype(a.elem(0)*b),P>
 ///
 template<class T, int P, class S,
          DUAL_REQUIRES(is_Dual<S>::value == false)>
-OSL_HOSTDEVICE inline const Dual<T,P>& operator*= (Dual<T,P> &a, const S &b)
+OSL_HOSTDEVICE OSL_INLINE const Dual<T,P>& operator*= (Dual<T,P> &a, const S &b)
 {
-    for (int i = 0; i <= P; ++i)
+    OSL_INDEX_LOOP(i, P+1, {
         a.elem(i) *= b;
+    });
     return a;
 }
 
@@ -373,8 +584,8 @@ OSL_HOSTDEVICE inline const Dual<T,P>& operator*= (Dual<T,P> &a, const S &b)
 /// Dual<T> * S where T*S is meaningful.
 template<class T, int P, class S,
          DUAL_REQUIRES(is_Dual<S>::value == false)>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 auto
-operator* (const S &b, const Dual<T,P> &a) -> Dual<decltype(a.elem(0)*b),P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 auto
+operator* (const S &b, const Dual<T,P> &a) -> Dual<decltype(a.val()*b),P>
 {
     return a*b;
 }
@@ -384,14 +595,15 @@ operator* (const S &b, const Dual<T,P> &a) -> Dual<decltype(a.elem(0)*b),P>
 /// Division of duals.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const Dual<T,P> &b)
 {
     T bvalinv = T(1) / b.val();
     T aval_bval = a.val() / b.val();
     Dual<T,P> result;
     result.val() = aval_bval;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = bvalinv * (a.elem(i) - aval_bval * b.elem(i));
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = bvalinv * (a.partial(i) - aval_bval * b.partial(i));
+    });
     return result;
 }
 
@@ -399,14 +611,15 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, 
 /// Division of dual by scalar.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const T &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, const T &b)
 {
     T bvalinv = T(1) / b;
     T aval_bval = a.val() / b;
     Dual<T,P> result;
     result.val() = aval_bval;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = bvalinv * a.elem(i);
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = bvalinv * a.partial(i);
+    });
     return result;
 }
 
@@ -414,14 +627,15 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const Dual<T,P> &a, 
 /// Division of scalar by dual.
 ///
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const T &aval, const Dual<T,P> &b)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> operator/ (const T &aval, const Dual<T,P> &b)
 {
     T bvalinv = T(1) / b.val();
     T aval_bval = aval / b.val();
     Dual<T,P> result;
     result.val() = aval_bval;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = bvalinv * ( - aval_bval * b.elem(i));
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = bvalinv * ( - aval_bval * b.partial(i));
+    });
     return result;
 }
 
@@ -429,75 +643,75 @@ OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> operator/ (const T &aval, const
 
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator< (const Dual<T,P> &a, const Dual<T,P> &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator< (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() < b.val();
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator< (const Dual<T,P> &a, const T &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator< (const Dual<T,P> &a, const T &b) {
     return a.val() < b;
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator> (const Dual<T,P> &a, const Dual<T,P> &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator> (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() > b.val();
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator> (const Dual<T,P> &a, const T &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator> (const Dual<T,P> &a, const T &b) {
     return a.val() > b;
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator<= (const Dual<T,P> &a, const Dual<T,P> &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator<= (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() <= b.val();
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator<= (const Dual<T,P> &a, const T &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator<= (const Dual<T,P> &a, const T &b) {
     return a.val() <= b;
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator>= (const Dual<T,P> &a, const Dual<T,P> &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator>= (const Dual<T,P> &a, const Dual<T,P> &b) {
     return a.val() >= b.val();
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool operator>= (const Dual<T,P> &a, const T &b) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool operator>= (const Dual<T,P> &a, const T &b) {
     return a.val() >= b;
 }
 
 
 
 // Eliminate the derivatives of a number, works for scalar as well as Dual.
-template<class T> OSL_HOSTDEVICE inline constexpr const T&
+template<class T> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
 removeDerivatives (const T &x) { return x; }
 
-template<class T, int P> OSL_HOSTDEVICE inline constexpr const T&
+template<class T, int P> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
 removeDerivatives (const Dual<T,P> &x) { return x.val(); }
 
 
 // Get the x derivative (or 0 for a non-Dual)
-template<class T> OSL_HOSTDEVICE inline constexpr const T&
+template<class T> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
 getXDerivative (const T &x) { return T(0); }
 
-template<class T, int P> OSL_HOSTDEVICE inline constexpr const T&
-getXDerivative (const Dual<T,P> &x) { return x.partial(0); }
+template<class T, int P> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
+getXDerivative (const Dual<T,P> &x) { return x.dx(); }
 
 
 // Get the y derivative (or 0 for a non-Dual)
-template<class T> OSL_HOSTDEVICE inline constexpr const T&
+template<class T> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
 getYDerivative (const T &x) { return T(0); }
 
-template<class T, int P> OSL_HOSTDEVICE inline constexpr const T&
-getYDerivative (const Dual<T,P> &x) { return x.partial(1); }
+template<class T, int P> OSL_HOSTDEVICE OSL_INLINE constexpr const T&
+getYDerivative (const Dual<T,P> &x) { return x.dy(); }
 
 
 // Simple templated "copy" function
-template<class T> OSL_HOSTDEVICE inline void
+template<class T> OSL_HOSTDEVICE OSL_INLINE void
 assignment (T &a, const T &b) { a = b; }
-template<class T, int P> OSL_HOSTDEVICE inline void
+template<class T, int P> OSL_HOSTDEVICE OSL_INLINE void
 assignment (T &a, const Dual<T,P> &b) { a = b.val(); }
 
 // Templated value equality. For scalars, it's the same as regular ==.
@@ -506,22 +720,22 @@ assignment (T &a, const Dual<T,P> &b) { a = b.val(); }
 // return if just their value is equal or if the whole struct (including
 // derivs) are equal.
 template<class T>
-OSL_HOSTDEVICE inline constexpr bool equalVal (const T &x, const T &y) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool equalVal (const T &x, const T &y) {
     return x == y;
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool equalVal (const Dual<T,P> &x, const Dual<T,P> &y) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool equalVal (const Dual<T,P> &x, const Dual<T,P> &y) {
     return x.val() == y.val();
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool equalVal (const Dual<T,P> &x, const T &y) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool equalVal (const Dual<T,P> &x, const T &y) {
     return x.val() == y;
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr bool equalVal (const T &x, const Dual<T,P> &y) {
+OSL_HOSTDEVICE OSL_INLINE constexpr bool equalVal (const T &x, const Dual<T,P> &y) {
     return x == y.val();
 }
 
@@ -532,15 +746,17 @@ OSL_HOSTDEVICE inline constexpr bool equalVal (const T &x, const Dual<T,P> &y) {
 // function f(scalar), then the dual function F(<u,u'>) is defined as:
 //    F(<u,u'>) = < f(u), f'(u)*u' >
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P>
 dualfunc (const Dual<T,P>& u, const T& f_val, const T& df_val)
 {
     Dual<T,P> result;
     result.val() = f_val;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = df_val * u.elem(i);
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = df_val * u.partial(i);
+    });
     return result;
 }
+
 
 // Helper for constructing the result of a Dual function of two variables,
 // given the scalar version and its derivative. In general, the dual-form of
@@ -548,28 +764,30 @@ dualfunc (const Dual<T,P>& u, const T& f_val, const T& df_val)
 //   F(<u,u'>, <v,v'>) = < f(u,v), dfdu(u,v)u' + dfdv(u,v)v' >
 // (from http://en.wikipedia.org/wiki/Automatic_differentiation)
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P>
 dualfunc (const Dual<T,P>& u, const Dual<T,P>& v,
           const T& f_val, const T& dfdu_val, const T& dfdv_val)
 {
     Dual<T,P> result;
     result.val() = f_val;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = dfdu_val * u.elem(i) + dfdv_val * v.elem(i);
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = dfdu_val * u.partial(i) + dfdv_val * v.partial(i);
+    });
     return result;
 }
 
 
 // Helper for construction the result of a Dual function of three variables.
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P>
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P>
 dualfunc (const Dual<T,P>& u, const Dual<T,P>& v, const Dual<T,P>& w,
           const T& f_val, const T& dfdu_val, const T& dfdv_val, const T& dfdw_val)
 {
     Dual<T,P> result;
     result.val() = f_val;
-    for (int i = 1; i <= P; ++i)
-        result.elem(i) = dfdu_val * u.elem(i) + dfdv_val * v.elem(i) + dfdw_val * w.elem(i);
+    OSL_INDEX_LOOP(i, P, {
+        result.partial(i) = dfdu_val * u.partial(i) + dfdv_val * v.partial(i) + dfdw_val * w.partial(i);
+    });
     return result;
 }
 
@@ -577,7 +795,7 @@ dualfunc (const Dual<T,P>& u, const Dual<T,P>& v, const Dual<T,P>& w,
 
 // f(x) = cos(x), f'(x) = -sin(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> cos (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> cos (const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::sincos(a.val(), &sina, &cosa);
@@ -585,7 +803,7 @@ OSL_HOSTDEVICE inline Dual<T,P> cos (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_cos(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_cos(const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::fast_sincos (a.val(), &sina, &cosa);
@@ -594,7 +812,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_cos(const Dual<T,P> &a)
 
 // f(x) = sin(x),  f'(x) = cos(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> sin (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> sin (const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::sincos(a.val(), &sina, &cosa);
@@ -602,7 +820,7 @@ OSL_HOSTDEVICE inline Dual<T,P> sin (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_sin(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_sin(const Dual<T,P> &a)
 {
     T sina, cosa;
     OIIO::fast_sincos (a.val(), &sina, &cosa);
@@ -610,7 +828,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_sin(const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline void sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
+OSL_HOSTDEVICE OSL_INLINE void sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
 {
 	T sina, cosa;
 	OIIO::sincos(a.val(), &sina, &cosa);
@@ -619,7 +837,7 @@ OSL_HOSTDEVICE inline void sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P>
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline void fast_sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
+OSL_HOSTDEVICE OSL_INLINE void fast_sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual<T,P> *cosine)
 {
 	T sina, cosa;
 	OIIO::fast_sincos(a.val(), &sina, &cosa);
@@ -629,7 +847,7 @@ OSL_HOSTDEVICE inline void fast_sincos(const Dual<T,P> &a, Dual<T,P> *sine, Dual
 
 // f(x) = tan(x), f'(x) = sec^2(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> tan (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> tan (const Dual<T,P> &a)
 {
     T tana  = std::tan (a.val());
     T cosa  = std::cos (a.val());
@@ -638,7 +856,7 @@ OSL_HOSTDEVICE inline Dual<T,P> tan (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_tan(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_tan(const Dual<T,P> &a)
 {
     T tana  = OIIO::fast_tan (a.val());
     T cosa  = OIIO::fast_cos (a.val());
@@ -648,7 +866,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_tan(const Dual<T,P> &a)
 
 // f(x) = cosh(x), f'(x) = sinh(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> cosh (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> cosh (const Dual<T,P> &a)
 {
     T f = std::cosh(a.val());
     T df = std::sinh(a.val());
@@ -656,7 +874,7 @@ OSL_HOSTDEVICE inline Dual<T,P> cosh (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_cosh(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_cosh(const Dual<T,P> &a)
 {
     T f = OIIO::fast_cosh(a.val());
     T df = OIIO::fast_sinh(a.val());
@@ -666,7 +884,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_cosh(const Dual<T,P> &a)
 
 // f(x) = sinh(x), f'(x) = cosh(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> sinh (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> sinh (const Dual<T,P> &a)
 {
     T f = std::sinh(a.val());
     T df = std::cosh(a.val());
@@ -674,7 +892,7 @@ OSL_HOSTDEVICE inline Dual<T,P> sinh (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_sinh(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_sinh(const Dual<T,P> &a)
 {
     T f = OIIO::fast_sinh(a.val());
     T df = OIIO::fast_cosh(a.val());
@@ -683,7 +901,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_sinh(const Dual<T,P> &a)
 
 // f(x) = tanh(x), f'(x) = sech^2(x)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> tanh (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> tanh (const Dual<T,P> &a)
 {
     T tanha = std::tanh(a.val());
     T cosha = std::cosh(a.val());
@@ -692,7 +910,7 @@ OSL_HOSTDEVICE inline Dual<T,P> tanh (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_tanh(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_tanh(const Dual<T,P> &a)
 {
     T tanha = OIIO::fast_tanh(a.val());
     T cosha = OIIO::fast_cosh(a.val());
@@ -702,7 +920,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_tanh(const Dual<T,P> &a)
 
 // f(x) = acos(x), f'(x) = -1/(sqrt(1 - x^2))
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_acos (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_acos (const Dual<T,P> &a)
 {
     if (a.val() >= T(1))
         return Dual<T,P> (T(0));
@@ -714,7 +932,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_acos (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_acos(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_acos(const Dual<T,P> &a)
 {
     T f = OIIO::fast_acos(a.val());
     T df = fabsf(a.val()) < 1.0f ? -1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
@@ -723,7 +941,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_acos(const Dual<T,P> &a)
 
 // f(x) = asin(x), f'(x) = 1/(sqrt(1 - x^2))
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_asin (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_asin (const Dual<T,P> &a)
 {
     if (a.val() >= T(1))
         return Dual<T,P> (T(M_PI/2));
@@ -735,7 +953,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_asin (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_asin(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_asin(const Dual<T,P> &a)
 {
     T f = OIIO::fast_asin(a.val());
     T df = fabsf(a.val()) < 1.0f ? 1.0f / sqrtf(1.0f - a.val() * a.val()) : 0.0f;
@@ -745,7 +963,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_asin(const Dual<T,P> &a)
 
 // f(x) = atan(x), f'(x) = 1/(1 + x^2)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> atan (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> atan (const Dual<T,P> &a)
 {
     T f = std::atan (a.val());
     T df = T(1) / (T(1) + a.val()*a.val());
@@ -753,7 +971,7 @@ OSL_HOSTDEVICE inline Dual<T,P> atan (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_atan(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_atan(const Dual<T,P> &a)
 {
     T f = OIIO::fast_atan(a.val());
     T df = 1.0f / (1.0f + a.val() * a.val());
@@ -765,7 +983,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_atan(const Dual<T,P> &a)
 // reference:  http://en.wikipedia.org/wiki/Atan2
 // (above link has other formulations)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> atan2 (const Dual<T,P> &y, const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> atan2 (const Dual<T,P> &y, const Dual<T,P> &x)
 {
     T atan2xy = std::atan2 (y.val(), x.val());
     T denom = (x.val() == T(0) && y.val() == T(0)) ? T(0) : T(1) / (x.val()*x.val() + y.val()*y.val());
@@ -773,7 +991,7 @@ OSL_HOSTDEVICE inline Dual<T,P> atan2 (const Dual<T,P> &y, const Dual<T,P> &x)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_atan2(const Dual<T,P> &y, const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_atan2(const Dual<T,P> &y, const Dual<T,P> &x)
 {
     T atan2xy = OIIO::fast_atan2(y.val(), x.val());
     T denom = (x.val() == 0 && y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
@@ -783,7 +1001,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_atan2(const Dual<T,P> &y, const Dual<T,P> &
 // f(x) = log(a), f'(x) = 1/x
 // (log base e)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_log (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_log (const Dual<T,P> &a)
 {
     T f = OIIO::safe_log(a.val());
     T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / a.val();
@@ -791,7 +1009,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_log (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_log(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_log(const Dual<T,P> &a)
 {
     T f = OIIO::fast_log(a.val());
     T df = a.val() < std::numeric_limits<float>::min() ? 0.0f : 1.0f / a.val();
@@ -806,7 +1024,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_log(const Dual<T,P> &a)
 //   (from http://en.wikipedia.org/wiki/Automatic_differentiation)
 // so, pow(u,v) = < u^v, vu^(v-1) u' + log(u)u^v v' >
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_pow (const Dual<T,P> &u, const Dual<T,P> &v)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_pow (const Dual<T,P> &u, const Dual<T,P> &v)
 {
     // NOTE: this function won't return exactly the same as pow(x,y) because we
     // use the identity u^v=u * u^(v-1) which does not hold in all cases for our
@@ -820,7 +1038,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_pow (const Dual<T,P> &u, const Dual<T,P> &v
 using OIIO::safe_pow;
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_safe_pow(const Dual<T,P> &u, const Dual<T,P> &v)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_safe_pow(const Dual<T,P> &u, const Dual<T,P> &v)
 {
     // NOTE: same issue as above (fast_safe_pow does even more clamping)
     T powuvm1 = OIIO::fast_safe_pow (u.val(), v.val() - 1.0f);
@@ -832,7 +1050,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_safe_pow(const Dual<T,P> &u, const Dual<T,P
 // f(x) = log2(x), f'(x) = 1/(x*log2)
 // (log base 2)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_log2 (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_log2 (const Dual<T,P> &a)
 {
     T f = safe_log2(a.val());
     T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN2));
@@ -840,7 +1058,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_log2 (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_log2(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_log2(const Dual<T,P> &a)
 {
     T f = OIIO::fast_log2(a.val());
     T aln2 = a.val() * float(M_LN2);
@@ -851,7 +1069,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_log2(const Dual<T,P> &a)
 // f(x) = log10(x), f'(x) = 1/(x*log10)
 // (log base 10)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> safe_log10 (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> safe_log10 (const Dual<T,P> &a)
 {
     T f = safe_log10(a.val());
     T df = a.val() < std::numeric_limits<T>::min() ? T(0) : T(1) / (a.val() * T(M_LN10));
@@ -859,7 +1077,7 @@ OSL_HOSTDEVICE inline Dual<T,P> safe_log10 (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_log10(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_log10(const Dual<T,P> &a)
 {
     T f  = OIIO::fast_log10(a.val());
     T aln10 = a.val() * float(M_LN10);
@@ -869,14 +1087,14 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_log10(const Dual<T,P> &a)
 
 // f(x) = e^x, f'(x) = e^x
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> exp (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> exp (const Dual<T,P> &a)
 {
     T f = std::exp(a.val());
     return dualfunc (a, f, f);
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_exp(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_exp(const Dual<T,P> &a)
 {
     T f = OIIO::fast_exp(a.val());
     return dualfunc (a, f, f);
@@ -884,7 +1102,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_exp(const Dual<T,P> &a)
 
 // f(x) = 2^x, f'(x) = (2^x)*log(2)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> exp2 (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> exp2 (const Dual<T,P> &a)
 {
     using std::exp2;
     T f = exp2(a.val());
@@ -892,7 +1110,7 @@ OSL_HOSTDEVICE inline Dual<T,P> exp2 (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_exp2(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_exp2(const Dual<T,P> &a)
 {
     T f = OIIO::fast_exp2(float(a.val()));
     return dualfunc (a, f, f*T(M_LN2));
@@ -901,7 +1119,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_exp2(const Dual<T,P> &a)
 
 // f(x) = e^x - 1, f'(x) = e^x
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> expm1 (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> expm1 (const Dual<T,P> &a)
 {
     using std::expm1;
     T f  = expm1(a.val());
@@ -910,7 +1128,7 @@ OSL_HOSTDEVICE inline Dual<T,P> expm1 (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_expm1(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_expm1(const Dual<T,P> &a)
 {
     T f  = OIIO::fast_expm1(a.val());
     T df = OIIO::fast_exp  (a.val());
@@ -919,7 +1137,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_expm1(const Dual<T,P> &a)
 
 // f(x) = erf(x), f'(x) = (2e^(-x^2))/sqrt(pi)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> erf (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> erf (const Dual<T,P> &a)
 {
     using std::erf;
     T f = erf (a.val());
@@ -929,7 +1147,7 @@ OSL_HOSTDEVICE inline Dual<T,P> erf (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_erf(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_erf(const Dual<T,P> &a)
 {
     T f = OIIO::fast_erf (float(a.val())); // float version!
     const T two_over_sqrt_pi = 1.128379167095512573896158903f;
@@ -939,7 +1157,7 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_erf(const Dual<T,P> &a)
 
 // f(x) = erfc(x), f'(x) = -(2e^(-x^2))/sqrt(pi)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> erfc (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> erfc (const Dual<T,P> &a)
 {
     using std::erfc;
     T f = erfc (a.val()); // float version!
@@ -949,7 +1167,7 @@ OSL_HOSTDEVICE inline Dual<T,P> erfc (const Dual<T,P> &a)
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fast_erfc(const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fast_erfc(const Dual<T,P> &a)
 {
     T f = OIIO::fast_erfc (float(a.val())); // float version!
     const T two_over_sqrt_pi = -1.128379167095512573896158903f;
@@ -960,44 +1178,52 @@ OSL_HOSTDEVICE inline Dual<T,P> fast_erfc(const Dual<T,P> &a)
 
 // f(x) = sqrt(x), f'(x) = 1/(2*sqrt(x))
 template<class T, int P>
-OSL_HOSTDEVICE inline OIIO_CONSTEXPR14 Dual<T,P> sqrt (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE OIIO_CONSTEXPR14 Dual<T,P> sqrt (const Dual<T,P> &a)
 {
-    if (a.val() <= T(0))
-        return Dual<T,P> (T(0));
-    T f  = std::sqrt(a.val());
-    T df = T(0.5) / f;
-    return dualfunc (a, f, df);
+    Dual<T,P> result;
+    if (OSL_EXPECT_TRUE(a.val() > T(0))) {
+        T f  = std::sqrt(a.val());
+        T df = T(0.5) / f;
+        result = dualfunc (a, f, df);
+    } else {
+        result = Dual<T,P> (T(0));
+    }
+    return result;
 }
 
 // f(x) = 1/sqrt(x), f'(x) = -1/(2*x^(3/2))
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> inversesqrt (const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> inversesqrt (const Dual<T,P> &a)
 {
     // do we want to print an error message?
-    if (a.val() <= T(0))
-        return Dual<T,P> (T(0));
-    T f  = T(1)/std::sqrt(a.val());
-    T df = T(-0.5)*f/a.val();
-    return dualfunc (a, f, df);
+    Dual<T,P> result;
+    if (OSL_EXPECT_TRUE(a.val() > T(0))) {
+        T f  = T(1)/std::sqrt(a.val());
+        T df = T(-0.5)*f/a.val();
+        result = dualfunc (a, f, df);
+    } else {
+        result = Dual<T,P> (T(0));
+    }
+    return result;
 }
 
 // (fx) = x*(1-a) + y*a, f'(x) = (1-a)x' + (y - x)*a' + a*y'
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> mix (const Dual<T,P> &x, const Dual<T,P> &y, const Dual<T,P> &a)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> mix (const Dual<T,P> &x, const Dual<T,P> &y, const Dual<T,P> &a)
 {
     T mixval = x.val()*(T(1)-a.val()) + y.val()*a.val();
     return dualfunc (x, y, a, mixval, T(1)-a.val(), a.val(), y.val() - x.val());
 }
 
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> fabs (const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> fabs (const Dual<T,P> &x)
 {
     return x.val() >= T(0) ? x : -x;
 }
 
 
 
-OSL_HOSTDEVICE inline float smoothstep(float e0, float e1, float x) { 
+OSL_HOSTDEVICE OSL_INLINE float smoothstep(float e0, float e1, float x) {
     if (x < e0) return 0.0f;
     else if (x >= e1) return 1.0f;
     else {
@@ -1008,7 +1234,7 @@ OSL_HOSTDEVICE inline float smoothstep(float e0, float e1, float x) {
 
 // f(t) = (3-2t)t^2,   t = (x-e0)/(e1-e0)
 template<class T, int P>
-OSL_HOSTDEVICE inline Dual<T,P> smoothstep (const Dual<T,P> &e0, const Dual<T,P> &e1, const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE Dual<T,P> smoothstep (const Dual<T,P> &e0, const Dual<T,P> &e1, const Dual<T,P> &x)
 {
    if (x.val() < e0.val()) {
       return Dual<T,P> (T(0));
@@ -1030,7 +1256,7 @@ template<> inline OSL_HOSTDEVICE OIIO_CONSTEXPR14 float3 Dual<float3, 2>::zero()
 
 // ceil(Dual) loses derivatives
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr float ceil (const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE constexpr float ceil (const Dual<T,P> &x)
 {
     return std::ceil(x.val());
 }
@@ -1038,7 +1264,7 @@ OSL_HOSTDEVICE inline constexpr float ceil (const Dual<T,P> &x)
 
 // floor(Dual) loses derivatives
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr float floor (const Dual<T,P> &x)
+OSL_HOSTDEVICE OSL_INLINE constexpr float floor (const Dual<T,P> &x)
 {
     return std::floor(x.val());
 }
@@ -1046,7 +1272,7 @@ OSL_HOSTDEVICE inline constexpr float floor (const Dual<T,P> &x)
 
 // floor, cast to an int.
 template<class T, int P>
-OSL_HOSTDEVICE inline constexpr int
+OSL_HOSTDEVICE OSL_INLINE constexpr int
 ifloor (const Dual<T,P> &x)
 {
     return (int)floor(x);

--- a/src/liboslnoise/gabornoise.cpp
+++ b/src/liboslnoise/gabornoise.cpp
@@ -340,7 +340,7 @@ gabor_cell (GaborParams &gp, const Vec3 &c_i, const Dual2<Vec3> &x_c_i,
                 // Now evaluate the 2D filtered kernel
                 Dual2<Vec3> xkit;
                 multMatrix (gp.local, x_k_i, xkit);
-                Dual2<Vec2> x_k_i_t = make_Vec2 (comp(xkit,0), comp(xkit,1));
+                Dual2<Vec2> x_k_i_t = make_Vec2 (comp_x(xkit), comp_y(xkit));
                 Dual2<float> gk = gabor_kernel (w_i_t_s_f, omega_i_t_s_f, phi_i_t_s_f, a_i_t_s_f, x_k_i_t); // 2D
                 if (! OIIO::isfinite(gk.val())) {
                     // Numeric failure of the filtered version.  Fall


### PR DESCRIPTION

## Description

Change Dual<T,PARTIALS> to not use array based data members and avoid any control flow loops for operations on it.  The change better enables compilers to keep values in registers via SROA (Scalar Replacement of Aggregates) optimizations as well as enable more efficient SIMD vectorization of loops using dual types.

The generic implementation of Dual defers storage of base class DualStorage which can be specialized for 1, 2, or 3 PARTIALS.  Specialized DualStorage have individual data members: m_val, m_dx, m_dy, m_dz instead of an array m_elem[PARTIALS].  To provide index based access to the data members, a ConstIndex<int> is introduced.  The DualStorage provides element access to applicable ConstIndex<#>:
    constexpr const T& elem (ConstIndex<0>) const { return m_val; }
    constexpr const T& elem (ConstIndex<1>) const { return m_dx; }
    constexpr const T& elem (ConstIndex<2>) const { return m_dy; }
    T& elem (ConstIndex<0>)  { return m_val; }
    T& elem (ConstIndex<1>)  { return m_dx; }
    T& elem (ConstIndex<2>)  { return m_dy; }
And support for non-constant index based access is removed.  So generic Dual implementation that loops over indices has been updated to use a mechanism to statically unroll a loop at compile time emitting the loop body with the correctly typed ConstIndex<#>.  To make this simple, a macro:
OSL_INDEX_LOOP(__INDEX_NAME, __COUNT, ...).  In practice, this means changing
     for(int i=0; i < elements;++i) {
          elem(i) += value;
     }
to
     OSL_INDEX_LOOP(i, elements, {
          elem(i) += value;
     });

Replaced index based component helper with explicit named helpers:
comp(xkit,0), comp(xkit,1)
changes to
comp_x(xkit), comp_y(xkit)
As it turned out all accesses where with hard coded 0, 1, 2 so no loss in functionality and improved readability.

Update opcolor implementation to avoid subscript operators [0],[1],[2] and use named data members .x, .y. z to avoid pointer aliasing issues.
Update opcolor implementation to avoid mat[?][?] operators that loose multidimensional C array data type  and access the underlying c array directly mat.x[?][?]


## Tests

Dual2 is used in existing code and existing tests should exercise it.
## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X ] I have updated the documentation, if applicable.
- [X ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X ] My code follows the prevailing code style of this project.

