### PR TITLE
Math and aliasing improvements

### DIFF
--- a/src/include/OSL/Imathx.h
+++ b/src/include/OSL/Imathx.h
@@ -151,10 +151,10 @@ makeIdentity(Matrix44 &m)
 //                    handle any non-affine matrices
 static OSL_FORCEINLINE bool test_if_affine(const Matrix44 & m) {
 	using ScalarT = typename Matrix44::BaseType;
-    return m.x[0][3] == ScalarT(0) &
-           m.x[1][3] == ScalarT(0) &
-           m.x[2][3] == ScalarT(0) &
-           m.x[3][3] == ScalarT(1);
+    return (m.x[0][3] == ScalarT(0)) &
+           (m.x[1][3] == ScalarT(0)) &
+           (m.x[2][3] == ScalarT(0)) &
+           (m.x[3][3] == ScalarT(1));
 }
 
 static OSL_FORCEINLINE OSL_HOSTDEVICE Matrix44
@@ -208,15 +208,15 @@ affineInverse(const Matrix44 &m)
         // NOTE: using bitwise OR to avoid C++ semantics that cannot evaluate
         // the right hand side of logical OR unless left hand side is false
         if (
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][0]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][1]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][2]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][0]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][1]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][2]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][0]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][1]) |
-            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][2])
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][0])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][1])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][2])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][0])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][1])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][2])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][0])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][1])) |
+            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][2]))
             ) {
             may_have_divided_by_zero = 1;
         }

--- a/src/include/OSL/Imathx.h
+++ b/src/include/OSL/Imathx.h
@@ -273,7 +273,8 @@ affineInverse(const Matrix44 &m)
 // for this function.  Not ideal, but this is already a slow path
 // for exceptional situations.
 // GCC could use __attribute__((optimize("-fno-fast-math")))
-static OSL_NOINLINE OSL_HOSTDEVICE Matrix44
+// NOTE:  only using "inline" to get ODR (One Definition Rule) behavior
+static inline OSL_HOSTDEVICE Matrix44
 nonAffineInverse(const Matrix44 &source) OSL_CLANG_ATTRIBUTE(optnone)
 {
     OSL_INTEL_PRAGMA(float_control(strict,on,push))

--- a/src/include/OSL/Imathx.h
+++ b/src/include/OSL/Imathx.h
@@ -38,58 +38,70 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-// Might be worth trying to use #pragma clang force_cuda_host_device_[begin/end]
-// and include the real _cuda.h.
-
-#ifndef __CUDACC__
-#include <OpenEXR/ImathVec.h>
-#include <OpenEXR/ImathMatrix.h>
-#include <OpenEXR/ImathColor.h>
-#else
-#define IMATH_HOSTDEVICE __host__ __device__
-#include <OSL/ImathLimits_cuda.h>
-#include <OSL/ImathVec_cuda.h>
-#include <OSL/ImathMatrix_cuda.h>
-#include <OSL/ImathColor_cuda.h>
-#endif
-
-
-// Extensions to Imath
-#include <OSL/matrix22.h>
+#include <OSL/oslconfig.h>
 
 
 OSL_NAMESPACE_ENTER
 
+// Choose to treat helper functions as static
+// so their symbols don't escape and possibly collide
+// with other compilation units who might be compiled with
+// different compiler flags (like target ISA)
 
 /// 3x3 matrix transforming a 3-vector.  This is curiously not supplied
 /// by Imath, so we define it ourselves.
-template <class S, class T>
-inline OSL_HOSTDEVICE void
-multMatrix (const Imath::Matrix33<T> &M, const Imath::Vec3<S> &src,
-            Imath::Vec3<S> &dst)
+static OSL_FORCEINLINE OSL_HOSTDEVICE void
+multMatrix (const Matrix33 &M, const Vec3 &src,
+            Vec3 &dst)
 {
-    S a = src[0] * M[0][0] + src[1] * M[1][0] + src[2] * M[2][0];
-    S b = src[0] * M[0][1] + src[1] * M[1][1] + src[2] * M[2][1];
-    S c = src[0] * M[0][2] + src[1] * M[1][2] + src[2] * M[2][2];
-    dst[0] = a;
-    dst[1] = b;
-    dst[2] = c;
+    // Changed all Vec3 subscripts to access data members versus array casts
+    auto a = src.x * M.x[0][0] + src.y * M.x[1][0] + src.z * M.x[2][0];
+    auto b = src.x * M.x[0][1] + src.y * M.x[1][1] + src.z * M.x[2][1];
+    auto c = src.x * M.x[0][2] + src.y * M.x[1][2] + src.z * M.x[2][2];
+    dst.x = a;
+    dst.y = b;
+    dst.z = c;
+}
+
+// The current Imath::Matrix44<T>::multDirMatrix uses Imath::Vec3<T>::operator[] which
+// causes correctness issues due to aliasing, so we have our own version to avoid it
+static OSL_FORCEINLINE OSL_HOSTDEVICE void
+multDirMatrix(const Matrix44 &M, const Vec3 &src, Vec3 &dst)
+{
+	auto a = src.x * M.x[0][0] + src.y * M.x[1][0] + src.z * M.x[2][0];
+	auto b = src.x * M.x[0][1] + src.y * M.x[1][1] + src.z * M.x[2][1];
+	auto c = src.x * M.x[0][2] + src.y * M.x[1][2] + src.z * M.x[2][2];
+
+    dst.x = a;
+    dst.y = b;
+    dst.z = c;
+}
+
+//
+// Inlinable version to enable vectorization
+// Better results with return by value (versus taking reference parameter)
+static OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
+multiplyDirByMatrix(const Matrix44 &M, const Vec3 &src)
+{
+	auto a = src.x * M.x[0][0] + src.y * M.x[1][0] + src.z * M.x[2][0];
+	auto b = src.x * M.x[0][1] + src.y * M.x[1][1] + src.z * M.x[2][1];
+	auto c = src.x * M.x[0][2] + src.y * M.x[1][2] + src.z * M.x[2][2];
+
+    return Vec3(a,b,c);
 }
 
 
 /// Express dot product as a function rather than a method.
-template<class T>
-inline OSL_HOSTDEVICE T
-dot (const Imath::Vec2<T> &a, const Imath::Vec2<T> &b)
+static OSL_FORCEINLINE OSL_HOSTDEVICE typename Vec2::BaseType
+dot (const Vec2 &a, const Vec2 &b)
 {
     return a.dot (b);
 }
 
 
 /// Express dot product as a function rather than a method.
-template<class T>
-inline OSL_HOSTDEVICE T
-dot (const Imath::Vec3<T> &a, const Imath::Vec3<T> &b)
+static OSL_FORCEINLINE OSL_HOSTDEVICE typename Vec2::BaseType
+dot (const Vec3 &a, const Vec3 &b)
 {
     return a.dot (b);
 }
@@ -97,12 +109,370 @@ dot (const Imath::Vec3<T> &a, const Imath::Vec3<T> &b)
 
 
 /// Return the determinant of a 2x2 matrix.
-template <class T>
-inline OSL_HOSTDEVICE
-T determinant (const Imathx::Matrix22<T> &m)
+static OSL_FORCEINLINE OSL_HOSTDEVICE typename Matrix22::BaseType
+determinant (const Matrix22 &M)
 {
-    return m[0][0]*m[1][1] - m[0][1]*m[1][0];
+    return M.x[0][0]*M.x[1][1] - M.x[0][1]*M.x[1][0];
 }
 
+
+static OSL_FORCEINLINE OSL_HOSTDEVICE void
+makeIdentity(Matrix44 &m)
+{
+	using ScalarT = typename Matrix44::BaseType;
+    // better allow SROA optimizations
+    // by avoiding memset
+    m.x[0][0] = ScalarT(1);
+    m.x[0][1] = ScalarT(0);
+    m.x[0][2] = ScalarT(0);
+    m.x[0][3] = ScalarT(0);
+
+    m.x[1][0] = ScalarT(0);
+    m.x[1][1] = ScalarT(1);
+    m.x[1][2] = ScalarT(0);
+    m.x[1][3] = ScalarT(0);
+
+    m.x[2][0] = ScalarT(0);
+    m.x[2][1] = ScalarT(0);
+    m.x[2][2] = ScalarT(1);
+    m.x[2][3] = ScalarT(0);
+
+    m.x[3][0] = ScalarT(0);
+    m.x[3][1] = ScalarT(0);
+    m.x[3][2] = ScalarT(0);
+    m.x[3][3] = ScalarT(1);
+}
+
+
+// Partition general purpose inverse of Matrix44 into:
+// test_if_affine
+// affineInverse - fast path that is SIMD friendly
+// nonAffineInverse - slow path to be used outside SIMD loop to
+//                    handle any non-affine matrices
+static OSL_FORCEINLINE bool test_if_affine(const Matrix44 & m) {
+	using ScalarT = typename Matrix44::BaseType;
+    return m.x[0][3] == ScalarT(0) &
+           m.x[1][3] == ScalarT(0) &
+           m.x[2][3] == ScalarT(0) &
+           m.x[3][3] == ScalarT(1);
+}
+
+static OSL_FORCEINLINE OSL_HOSTDEVICE Matrix44
+affineInverse(const Matrix44 &m)
+{
+	using ScalarT = typename Matrix44::BaseType;
+    // As we may speculatively call on non-affine matrices and just not use the result
+    // we shouldn't bother verifying m is affine, just assume it and let caller non
+    // use the results
+    Matrix44 s (m.x[1][1] * m.x[2][2] - m.x[2][1] * m.x[1][2],
+                m.x[2][1] * m.x[0][2] - m.x[0][1] * m.x[2][2],
+                m.x[0][1] * m.x[1][2] - m.x[1][1] * m.x[0][2],
+				ScalarT(0),
+
+                m.x[2][0] * m.x[1][2] - m.x[1][0] * m.x[2][2],
+                m.x[0][0] * m.x[2][2] - m.x[2][0] * m.x[0][2],
+                m.x[1][0] * m.x[0][2] - m.x[0][0] * m.x[1][2],
+				ScalarT(0),
+
+                m.x[1][0] * m.x[2][1] - m.x[2][0] * m.x[1][1],
+                m.x[2][0] * m.x[0][1] - m.x[0][0] * m.x[2][1],
+                m.x[0][0] * m.x[1][1] - m.x[1][0] * m.x[0][1],
+				ScalarT(0),
+
+                ScalarT(0),
+                ScalarT(0),
+                ScalarT(0),
+				ScalarT(1));
+
+    auto r = m.x[0][0] * s.x[0][0] + m.x[0][1] * s.x[1][0] + m.x[0][2] * s.x[2][0];
+    auto abs_r = IMATH_INTERNAL_NAMESPACE::abs (r);
+
+    int may_have_divided_by_zero = 0;
+    if (OSL_UNLIKELY(abs_r < ScalarT(1)))
+    {
+    	auto mr = abs_r / Imath::limits<ScalarT>::smallest();
+#if 0
+        OSL_PRAGMA(unroll)
+        for (int i = 0; i < 3; ++i)
+        {
+            OSL_PRAGMA(unroll)
+            for (int j = 0; j < 3; ++j)
+            {
+                if (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[i][j]))
+                {
+                    may_have_divided_by_zero = 1;
+                }
+            }
+        }
+#else
+        // NOTE: using bitwise OR to avoid C++ semantics that cannot evaluate
+        // the right hand side of logical OR unless left hand side is false
+        if (
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][0]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][1]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][2]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][0]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][1]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][2]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][0]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][1]) |
+            mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][2])
+            ) {
+            may_have_divided_by_zero = 1;
+        }
+#endif
+    }
+
+#if 0
+    OSL_PRAGMA(unroll)
+    for (int i = 0; i < 3; ++i)
+    {
+        OSL_PRAGMA(unroll)
+        for (int j = 0; j < 3; ++j)
+        {
+            s.x[i][j] /= r;
+        }
+    }
+#else
+    // Just unroll by hand, about the same size as loop code
+    // NOTE: opportunity to use reciprocal multiply here,
+    // but that would affect the results, although compilers
+    // might do that anyway based on optimization settings
+    s.x[0][0] /= r;
+    s.x[0][1] /= r;
+    s.x[0][2] /= r;
+    s.x[1][0] /= r;
+    s.x[1][1] /= r;
+    s.x[1][2] /= r;
+    s.x[2][0] /= r;
+    s.x[2][1] /= r;
+    s.x[2][2] /= r;
+#endif
+
+    s.x[3][0] = -m.x[3][0] * s.x[0][0] - m.x[3][1] * s.x[1][0] - m.x[3][2] * s.x[2][0];
+    s.x[3][1] = -m.x[3][0] * s.x[0][1] - m.x[3][1] * s.x[1][1] - m.x[3][2] * s.x[2][1];
+    s.x[3][2] = -m.x[3][0] * s.x[0][2] - m.x[3][1] * s.x[1][2] - m.x[3][2] * s.x[2][2];
+
+    if (OSL_UNLIKELY(may_have_divided_by_zero == 1))
+    {
+        makeIdentity(s);
+    }
+    return s;
+}
+
+
+// Avoid potential aliasing issues with OIIO implementation,
+// but main purpose is to turn off FMA which can affect
+// rounding and order of operations which can affect results
+// with near 0 divisor.  Really only an issue when trying to
+// match results between LLVM IR based implementation and
+// compiler optimized versions which may have optimized
+// differently than the LLVM IR version.
+// Clang doesn't currently have a way to control fast-math/fp:strict
+// at a per function level, so we will resort to disabling optimization
+// for this function.  Not ideal, but this is already a slow path
+// for exceptional situations.
+// GCC could use __attribute__((optimize("-fno-fast-math")))
+static OSL_NOINLINE OSL_HOSTDEVICE Matrix44
+nonAffineInverse(const Matrix44 &source) OSL_CLANG_ATTRIBUTE(optnone)
+{
+    OSL_INTEL_PRAGMA(float_control(strict,on,push))
+
+	using ScalarT = typename Matrix44::BaseType;
+    Matrix44 t(source);
+    Matrix44 s;
+
+    // Forward elimination
+
+    for (int i = 0; i < 3 ; i++)
+    {
+        int pivot = i;
+
+        ScalarT pivotsize = t.x[i][i];
+
+        if (pivotsize < 0)
+            pivotsize = -pivotsize;
+
+        for (int j = i + 1; j < 4; j++)
+        {
+            ScalarT tmp = t.x[j][i];
+
+            if (tmp < 0)
+                tmp = -tmp;
+
+            if (tmp > pivotsize)
+            {
+                pivot = j;
+                pivotsize = tmp;
+            }
+        }
+
+        if (pivotsize == 0)
+        {
+            return Matrix44();
+        }
+
+        if (pivot != i)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                ScalarT tmp;
+
+                tmp = t.x[i][j];
+                t.x[i][j] = t.x[pivot][j];
+                t.x[pivot][j] = tmp;
+
+                tmp = s.x[i][j];
+                s.x[i][j] = s.x[pivot][j];
+                s.x[pivot][j] = tmp;
+            }
+        }
+
+        for (int j = i + 1; j < 4; j++)
+        {
+            ScalarT f = t.x[j][i] / t.x[i][i];
+
+            for (int k = 0; k < 4; k++)
+            {
+                t.x[j][k] -= f * t.x[i][k];
+                s.x[j][k] -= f * s.x[i][k];
+            }
+        }
+    }
+
+    // Backward substitution
+
+    for (int i = 3; i >= 0; --i)
+    {
+        ScalarT f;
+
+        if ((f = t.x[i][i]) == 0)
+        {
+            return Matrix44();
+        }
+
+        for (int j = 0; j < 4; j++)
+        {
+            t.x[i][j] /= f;
+            s.x[i][j] /= f;
+        }
+
+        for (int j = 0; j < i; j++)
+        {
+            f = t.x[j][i];
+
+            for (int k = 0; k < 4; k++)
+            {
+                t.x[j][k] -= f * t.x[i][k];
+                s.x[j][k] -= f * s.x[i][k];
+            }
+        }
+    }
+
+    return s;
+}
+
+
+// In order to have inlinable Matrix44*float
+// Override with a more specific version than
+// template <class T>
+// inline Matrix44<T>
+// operator * (T a, const Matrix44<T> &v);
+
+static OSL_FORCEINLINE OSL_HOSTDEVICE Matrix44
+operator * (typename Matrix44::BaseType a, const Matrix44 &v)
+{
+    return Matrix44 (v.x[0][0] * a,
+                     v.x[0][1] * a,
+                     v.x[0][2] * a,
+                     v.x[0][3] * a,
+                     v.x[1][0] * a,
+                     v.x[1][1] * a,
+                     v.x[1][2] * a,
+                     v.x[1][3] * a,
+                     v.x[2][0] * a,
+                     v.x[2][1] * a,
+                     v.x[2][2] * a,
+                     v.x[2][3] * a,
+                     v.x[3][0] * a,
+                     v.x[3][1] * a,
+                     v.x[3][2] * a,
+                     v.x[3][3] * a);
+}
+
+static OSL_FORCEINLINE OSL_HOSTDEVICE Matrix44
+inlinedTransposed (const Matrix44 &m)
+{
+    return Matrix44 (m.x[0][0],
+                     m.x[1][0],
+                     m.x[2][0],
+                     m.x[3][0],
+                     m.x[0][1],
+                     m.x[1][1],
+                     m.x[2][1],
+                     m.x[3][1],
+                     m.x[0][2],
+                     m.x[1][2],
+                     m.x[2][2],
+                     m.x[3][2],
+                     m.x[0][3],
+                     m.x[1][3],
+                     m.x[2][3],
+                     m.x[3][3]);
+}
+
+// Inlinable version to enable vectorization
+// Better results with return by value (versus taking reference parameter)
+static OSL_FORCEINLINE OSL_HOSTDEVICE Matrix44
+multiplyMatrixByMatrix (const Matrix44 &a,
+                       const Matrix44 &b)
+{
+    const auto a00 = a.x[0][0];
+    const auto a01 = a.x[0][1];
+    const auto a02 = a.x[0][2];
+    const auto a03 = a.x[0][3];
+
+    const auto c00  = a00 * b.x[0][0]  + a01 * b.x[1][0]  + a02 * b.x[2][0]  + a03 * b.x[3][0];
+    const auto c01  = a00 * b.x[0][1]  + a01 * b.x[1][1]  + a02 * b.x[2][1]  + a03 * b.x[3][1];
+    const auto c02  = a00 * b.x[0][2]  + a01 * b.x[1][2]  + a02 * b.x[2][2] + a03 * b.x[3][2];
+    const auto c03  = a00 * b.x[0][3]  + a01 * b.x[1][3]  + a02 * b.x[2][3] + a03 * b.x[3][3];
+
+    const auto a10 = a.x[1][0];
+    const auto a11 = a.x[1][1];
+    const auto a12 = a.x[1][2];
+    const auto a13 = a.x[1][3];
+
+    const auto c10  = a10 * b.x[0][0]  + a11 * b.x[1][0]  + a12 * b.x[2][0]  + a13 * b.x[3][0];
+    const auto c11  = a10 * b.x[0][1]  + a11 * b.x[1][1]  + a12 * b.x[2][1]  + a13 * b.x[3][1];
+    const auto c12  = a10 * b.x[0][2]  + a11 * b.x[1][2]  + a12 * b.x[2][2] + a13 * b.x[3][2];
+    const auto c13  = a10 * b.x[0][3]  + a11 * b.x[1][3]  + a12 * b.x[2][3] + a13 * b.x[3][3];
+
+    const auto a20 = a.x[2][0];
+    const auto a21 = a.x[2][1];
+    const auto a22 = a.x[2][2];
+    const auto a23 = a.x[2][3];
+
+    const auto c20  = a20 * b.x[0][0]  + a21 * b.x[1][0]  + a22 * b.x[2][0]  + a23 * b.x[3][0];
+    const auto c21  = a20 * b.x[0][1]  + a21 * b.x[1][1]  + a22 * b.x[2][1]  + a23 * b.x[3][1];
+    const auto c22 = a20 * b.x[0][2]  + a21 * b.x[1][2]  + a22 * b.x[2][2] + a23 * b.x[3][2];
+    const auto c23 = a20 * b.x[0][3]  + a21 * b.x[1][3]  + a22 * b.x[2][3] + a23 * b.x[3][3];
+
+    const auto a30 = a.x[3][0];
+    const auto a31 = a.x[3][1];
+    const auto a32 = a.x[3][2];
+    const auto a33 = a.x[3][3];
+
+    const auto c30 = a30 * b.x[0][0]  + a31 * b.x[1][0]  + a32 * b.x[2][0]  + a33 * b.x[3][0];
+    const auto c31 = a30 * b.x[0][1]  + a31 * b.x[1][1]  + a32 * b.x[2][1]  + a33 * b.x[3][1];
+    const auto c32 = a30 * b.x[0][2]  + a31 * b.x[1][2]  + a32 * b.x[2][2] + a33 * b.x[3][2];
+    const auto c33 = a30 * b.x[0][3]  + a31 * b.x[1][3]  + a32 * b.x[2][3] + a33 * b.x[3][3];
+    return Matrix44(
+            c00, c01, c02, c03,
+            c10, c11, c12, c13,
+            c20, c21, c22, c23,
+            c30, c31, c32, c33
+        );
+
+}
 
 OSL_NAMESPACE_EXIT

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -152,6 +152,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #endif
 #endif // OSL_DEBUG
 
+#if defined(_MSC_VER)
+    #define OSL_PRAGMA(aUnQuotedPragma) __pragma(aUnQuotedPragma)
+#else
+    #define OSL_PRAGMA(aUnQuotedPragma) _Pragma(#aUnQuotedPragma)
+#endif
+
+#if __INTEL_COMPILER >= 1100
+    #define OSL_INTEL_PRAGMA(aUnQuotedPragma) OSL_PRAGMA(aUnQuotedPragma)
+#else
+    #define OSL_INTEL_PRAGMA(aUnQuotedPragma)
+#endif
+
+#ifdef __clang__
+    #define OSL_CLANG_PRAGMA(aUnQuotedPragma) OSL_PRAGMA(aUnQuotedPragma)
+    #define OSL_CLANG_ATTRIBUTE(value) __attribute__((value))
+#else
+    #define OSL_CLANG_PRAGMA(aUnQuotedPragma)
+    #define OSL_CLANG_ATTRIBUTE(value)
+#endif
 
 // OSL_FORCEINLINE is a function attribute that attempts to make the
 // function always inline. On many compilers regular 'inline' is only
@@ -233,7 +252,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // All the things we need from Imath
 // When compiling for CUDA, we need to make sure the modified Imath
 // headers are included before the stock versions.
-#include <OSL/Imathx.h>
+//
+// Might be worth trying to use #pragma clang force_cuda_host_device_[begin/end]
+// and include the real _cuda.h.
+#ifndef __CUDACC__
+#include <OpenEXR/ImathVec.h>
+#include <OpenEXR/ImathMatrix.h>
+#include <OpenEXR/ImathColor.h>
+#else
+#define IMATH_HOSTDEVICE __host__ __device__
+#include <OSL/ImathLimits_cuda.h>
+#include <OSL/ImathVec_cuda.h>
+#include <OSL/ImathMatrix_cuda.h>
+#include <OSL/ImathColor_cuda.h>
+#endif
+
+// Extensions to Imath
+#include "matrix22.h"
 
 // Temporary bug fix: having trouble with cuda complaining about {fmt} lib.
 // Work around by disabling it from oiio headers.

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -105,7 +105,8 @@ osl_div_m_ff (void *r, float a, float b)
 OSL_SHADEOP OSL_HOSTDEVICE void
 osl_transpose_mm (void *r, void *m)
 {
-    MAT(r) = MAT(m).transposed();
+    //MAT(r) = MAT(m).transposed();
+	MAT(r) = inlinedTransposed(MAT(m));
 }
 
 
@@ -129,7 +130,8 @@ OSL_SHADEOP OSL_HOSTDEVICE void osl_transformv_vmv(void *result, void* M_, void*
 {
    const Vec3 &v = VEC(v_);
    const Matrix44 &M = MAT(M_);
-   M.multDirMatrix (v, VEC(result));
+   //M.multDirMatrix (v, VEC(result));
+   multDirMatrix (M, v, VEC(result));
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void osl_transformv_dvmdv(void *result, void* M_, void* v_)
@@ -145,14 +147,16 @@ OSL_SHADEOP OSL_HOSTDEVICE void osl_transformn_vmv(void *result, void* M_, void*
 {
    const Vec3 &v = VEC(v_);
    const Matrix44 &M = MAT(M_);
-   M.inverse().transposed().multDirMatrix (v, VEC(result));
+   //M.inverse().transposed().multDirMatrix (v, VEC(result));
+   multDirMatrix(inlinedTransposed(M.inverse()), v, VEC(result));
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void osl_transformn_dvmdv(void *result, void* M_, void* v_)
 {
    const Dual2<Vec3> &v = DVEC(v_);
    const Matrix44    &M = MAT(M_);
-   multDirMatrix (M.inverse().transposed(), v, DVEC(result));
+   //multDirMatrix (M.inverse().transposed(), v, DVEC(result));
+   multDirMatrix (inlinedTransposed(M.inverse()), v, DVEC(result));
 }
 
 #ifndef __CUDACC__
@@ -370,10 +374,10 @@ template <typename F>
 OSL_HOSTDEVICE inline F det4x4(const Imath::Matrix44<F> &m)
 {
     // assign to individual variable names to aid selecting correct elements
-    F a1 = m[0][0], b1 = m[0][1], c1 = m[0][2], d1 = m[0][3];
-    F a2 = m[1][0], b2 = m[1][1], c2 = m[1][2], d2 = m[1][3];
-    F a3 = m[2][0], b3 = m[2][1], c3 = m[2][2], d3 = m[2][3];
-    F a4 = m[3][0], b4 = m[3][1], c4 = m[3][2], d4 = m[3][3];
+    F a1 = m.x[0][0], b1 = m.x[0][1], c1 = m.x[0][2], d1 = m.x[0][3];
+    F a2 = m.x[1][0], b2 = m.x[1][1], c2 = m.x[1][2], d2 = m.x[1][3];
+    F a3 = m.x[2][0], b3 = m.x[2][1], c3 = m.x[2][2], d3 = m.x[2][3];
+    F a4 = m.x[3][0], b4 = m.x[3][1], c4 = m.x[3][2], d4 = m.x[3][3];
     return a1 * det3x3( b2, b3, b4, c2, c3, c4, d2, d3, d4)
          - b1 * det3x3( a2, a3, a4, c2, c3, c4, d2, d3, d4)
          + c1 * det3x3( a2, a3, a4, b2, b3, b4, d2, d3, d4)


### PR DESCRIPTION
## Description

Move inclusion of Imath*cuda.h from Imathx.h to oslconfig.h
Avoid aliasing in helper math functions by not using Vec3::operator [] and instead accessing .x, .y, .z data members directly.  Likewise for Vec2.
Avoid aliasing in helper math functions by not calling Matrix44::operator [] which returns a float *.  Instead use the x[4][4] datamember directly which keeps it type safe and avoids casting down to a float *.
Made math helper functions static OSL_FORCELINE where possible to avoid any collisions with other translation units who might be compiled with different compiler flags (like target ISA).
To make some of the aliasing avoidance changes, needed to introduce some free functions to be called instead of existing base class methods (which exist in a different open source project).
Partitioned general purpose inverse of Matrix44 into:
  test_if_affine
  affineInverse - fast path that is SIMD friendly
   nonAffineInverse - slow path to be used outside SIMD loop to
                      handle any non-affine matrices
Changed math helpers declared in OSL namespace to work on OSL::Matrix44, OSL::Vec3, etc. instead of Imath::Matrix44<T> as the helpers would not have function should OSL::Matrix44 be defined as anything other than Imath::Matrix44<T>.
Updated Matrix22 to avoid taking addresses with memset and memcpy that could prevent compiler Scalar Replacement of Aggregates optimizations.
Avoid aliasing issues in Matrix22 implementation by removing Matrix22::operator[] and using .x[2][2] directly and avoiding Vec2::operator[].
Removed default parameter to Matrix22::inverse(bool singExc) and added Matrix22::inverse() const noexcept, to allow for improved execution within SIMD loops.
Unrolled small loops in math helpers to avoid introducing control flow and dependencies during execution.
Updated opmatrix.cpp to call free function versions of transpose and multDirMatrix to utilized the versions added to Imathx.h
Added OSL_PRAGMA(unquoted) as a cross platform means of declaring a pragma
Added OSL_INTEL_PRAGMA to emit pragmas that are specific to ICC
Added OSL_CLANG_PRAGMA to emit pragmas that are specific to Clang
Added OSL_CLANG_ATTRIBUTE to emit attributes that are specific to Clang

## Checklist:

- [ X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

