### PR TITLE
CI: On Linux, preinstall libsquish & qt5

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -22,7 +22,10 @@ time sudo apt-get -q install -y \
     libgif-dev \
     libpng-dev \
     flex bison libbison-dev \
-    opencolorio-tools
+    opencolorio-tools \
+    libsquish-dev \
+    qt5-default
+
 
 
 # Disable libheif on CI for now... seems to make crashes in CI tests.

--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -79,7 +79,7 @@ OSLToyRenderer::OSLToyRenderer ()
 
     // Set up default shaderglobals
     ShaderGlobals &sg (m_shaderglobals_template);
-    memset (&sg, 0, sizeof(ShaderGlobals));
+    memset ((char *)&sg, 0, sizeof(ShaderGlobals));
     Matrix44 Mshad, Mobj;  // just let these be identity for now
     // Set "shader" space to be Mshad.  In a real renderer, this may be
     // different for each shader group.


### PR DESCRIPTION
libsquish saves a little OIIO build time by not having to build the
embedded version.

qt5 lets the CI build osltoy (doesn't run it, but makes sure there's a
clean build).. and sure enough, there wasn't a clean build on gcc8, so
I have a fix for a picky warning.
