### PR TITLE
Fix CI problems on GI, need OpenEXR 2.3+

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   linux-2018:
-    name: "Linux VFX 2018-ish: gcc6, C++11, llvm7, OIIO 2.0, sse2, exr2.2"
+    name: "Linux VFX 2018-ish: gcc6, C++11, llvm7, OIIO 2.0, sse2, exr2.3"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -14,7 +14,7 @@ jobs:
           USE_CPP: 11
           CMAKE_CXX_STANDARD: 11
           LLVM_VERSION: 7.0.1
-          OPENEXR_BRANCH: v2.2.0
+          OPENEXR_VERSION: 2.3.0
           OPENIMAGEIO_BRANCH: RB-2.0
           USE_SIMD: sse2
         run: |
@@ -33,7 +33,7 @@ jobs:
           USE_CPP: 14
           CMAKE_CXX_STANDARD: 14
           LLVM_VERSION: 8.0.0
-          OPENEXR_BRANCH: v2.3.0
+          OPENEXR_VERSION: 2.3.0
           OPENIMAGEIO_BRANCH: RB-2.1
           USE_SIMD: sse4.2
         run: |
@@ -67,7 +67,6 @@ jobs:
 #          CXX: g++-8
 #          CMAKE_CXX_STANDARD: 14
 #          USE_SIMD: avx2,f16c
-#          OPENEXR_BRANCH: v2.4.0
 #        run: |
 #            source src/build-scripts/ci-startup.bash
 #            source src/build-scripts/gh-installdeps.bash
@@ -86,7 +85,7 @@ jobs:
           CMAKE_CXX_STANDARD: 14
           LLVM_VERSION: 9.0.0
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.4.0
+          OPENEXR_VERSION: 2.4.0
           OPENIMAGEIO_BRANCH: master
         run: |
             source src/build-scripts/ci-startup.bash
@@ -105,7 +104,7 @@ jobs:
           CMAKE_CXX_STANDARD: 14
           LLVM_VERSION: 9.0.0
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.4.0
+          OPENEXR_VERSION: 2.4.0
           OPENIMAGEIO_BRANCH: master
         run: |
             source src/build-scripts/ci-startup.bash
@@ -124,7 +123,7 @@ jobs:
           CMAKE_CXX_STANDARD: 17
           LLVM_VERSION: 9.0.0
           USE_SIMD: avx2,f16c
-          OPENEXR_BRANCH: v2.4.0
+          OPENEXR_VERSION: 2.4.0
           OPENIMAGEIO_BRANCH: master
         run: |
             source src/build-scripts/ci-startup.bash
@@ -132,7 +131,7 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-oldest:
-    name: "Linux oldest everything: gcc6, C++11, llvm7, oiio 2.0, no simd, exr2.2"
+    name: "Linux oldest everything: gcc6, C++11, llvm7, oiio 2.0, no simd, exr2.3"
     # Unfortunately, this isn't the oldest of everything we support, but
     # rather, the oldest of everything we can easily get on GH CI.
     # Should be gcc 4.8 if we can figure out how to make that work.
@@ -147,7 +146,7 @@ jobs:
           CMAKE_CXX_STANDARD: 11
           LLVM_VERSION: 7.0.1
           USE_SIMD: 0
-          OPENEXR_BRANCH: v2.2.0
+          OPENEXR_VERSION: 2.3.0
           OPENIMAGEIO_BRANCH: RB-2.0
         run: |
             source src/build-scripts/ci-startup.bash
@@ -186,7 +185,7 @@ jobs:
   #       env:
   #         PYTHON_VERSION: 3.6
   #         CMAKE_GENERATOR: "Visual Studio 16 2019"
-  #         OPENEXR_BRANCH: v2.4.0
+  #         OPENEXR_VERSION: 2.4.0
   #       run: |
   #           source src/build-scripts/ci-startup.bash
   #           source src/build-scripts/gh-win-installdeps.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ branches:
 matrix:
     fast_finish: true
     include:
-      - name: "VFX Platform 2018 (gcc6, c++14), llvm 7, OIIO master, avx/f16c"
+      - name: "VFX Platform 2018 (gcc6, c++14), llvm 7, OIIO master, OpenEXR 2.3, avx/f16c"
         os: linux
         compiler: gcc
         addons:
@@ -98,12 +98,12 @@ matrix:
               - *common-packages
               - *common-boost-packages
               - g++-6
-        env: WHICHGCC=6 USE_CPP=14 LLVM_VERSION=7.0.1 OPENIMAGEIO_BRANCH=master USE_SIMD=avx,f16c BUILD_CMAKE=1
+        env: WHICHGCC=6 USE_CPP=14 LLVM_VERSION=7.0.1 OPENIMAGEIO_BRANCH=master OPENEXR_VERSION=2.3.0 USE_SIMD=avx,f16c BUILD_CMAKE=1
       - name: "MacOS (latest Apple clang, llvm 7, OIIO master, latest homebrew libs"
         os: osx
         compiler: clang
         env: PYTHON_VERSION=3.7
-      - name: "VFX Platform 2017 (gcc48, c++11), llvm 6, OIIO release, sse4.2"
+      - name: "VFX Platform 2017 (gcc48, c++11), llvm 6, OIIO release, OpenEXR 2.3, sse4.2"
         os: linux
         dist: trusty
         compiler: gcc
@@ -113,8 +113,8 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.0 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=release BUILD_CMAKE=1
-      - name: "Older things: OIIO 2.0, llvm 6, boost 1.58"
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.0 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=release OPENEXR_VERSION=2.3.0 BUILD_CMAKE=1
+      - name: "Older things: OIIO 2.0, llvm 6, boost 1.58, OpenEXR 2.2"
         os: linux
         dist: trusty
         compiler: gcc
@@ -124,7 +124,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
       - name: "gcc7, llvm7, C++14"
         os: linux
@@ -160,7 +160,7 @@ matrix:
               - *common-boost-packages
               - g++-6
         env: DEBUG=1 WHICHGCC=6 LLVM_VERSION=7.0.0 OPENIMAGEIO_BRANCH=master BUILD_CMAKE=1
-      - name: "Oldest everything: gcc4.8, LLVM 6, OIIO 2.0, no simd"
+      - name: "Oldest everything: gcc4.8, LLVM 6, OIIO 2.0, OpenEXR 2.2, no simd"
         os: linux
         dist: trusty
         compiler: gcc
@@ -170,7 +170,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: USE_SIMD=0 LLVM_VERSION=6.0.1 OPENIMAGEIO_BRANCH=RB-2.0 BUILD_CMAKE=1
+        env: USE_SIMD=0 LLVM_VERSION=6.0.1 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
 
 notifications:


### PR DESCRIPTION
Not sure why, but something changed recently on GitHub CI that is
causing our CI tests to fail... but not on the OSL build itself, only
on the OpenEXR dependency build, and only when using OpenEXR 2.2.

I don't have time for this nonsense, so just adjust all the GH CI
tests to use OpenEXR >= 2.3. Adjust some of the TravisCI tests to use
OpenEXR 2.2 so we still have some proper test coverage of it.

