### PR TITLE
Don't merge a layer if it's an entry layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             layers-nonlazycopy layers-repeatedoutputs
             linearstep
             logic loop matrix message
+            mergeinstances-duplicate-entrylayers
             mergeinstances-nouserdata mergeinstances-vararray
             metadata-braces miscmath missing-shader
             named-components

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3102,8 +3102,8 @@ ShadingSystemImpl::merge_instances (ShaderGroup &group, bool post_opt)
 
     // Loop over all layers...
     for (int a = 0;  a < nlayers-1;  ++a) {
-        if (group[a]->unused())    // Don't merge a layer that's not used
-            continue;
+        if (group[a]->unused() || group[a]->entry_layer()) // Don't merge a layer that's not used
+            continue;                                      // or if it's an entry layer
         // Check all later layers...
         for (int b = a+1;  b < nlayers;  ++b) {
             if (group[b]->unused())    // Don't merge a layer that's not used

--- a/testsuite/mergeinstances-duplicate-entrylayers/a.osl
+++ b/testsuite/mergeinstances-duplicate-entrylayers/a.osl
@@ -1,17 +1,12 @@
 shader a
 (
     float frequency = 1,
-
     string noiseType = "perlin",
-
     color amplitude = 1,
-
     int seed = 0,
-
     output color out = 0
 )
 {
     point domain = point(u + seed, v + seed, 0) * frequency;
-
     out = noise(noiseType, domain[0], domain[1]) * amplitude;
 }

--- a/testsuite/mergeinstances-duplicate-entrylayers/a.osl
+++ b/testsuite/mergeinstances-duplicate-entrylayers/a.osl
@@ -1,0 +1,17 @@
+shader a
+(
+    float frequency = 1,
+
+    string noiseType = "perlin",
+
+    color amplitude = 1,
+
+    int seed = 0,
+
+    output color out = 0
+)
+{
+    point domain = point(u + seed, v + seed, 0) * frequency;
+
+    out = noise(noiseType, domain[0], domain[1]) * amplitude;
+}

--- a/testsuite/mergeinstances-duplicate-entrylayers/b.osl
+++ b/testsuite/mergeinstances-duplicate-entrylayers/b.osl
@@ -1,0 +1,9 @@
+shader b
+(
+    color in  = 0,
+
+    output color out = 0
+)
+{
+    out = in;
+}

--- a/testsuite/mergeinstances-duplicate-entrylayers/b.osl
+++ b/testsuite/mergeinstances-duplicate-entrylayers/b.osl
@@ -1,7 +1,6 @@
 shader b
 (
     color in  = 0,
-
     output color out = 0
 )
 {

--- a/testsuite/mergeinstances-duplicate-entrylayers/ref/out.txt
+++ b/testsuite/mergeinstances-duplicate-entrylayers/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Entry layers: b1(1) b2(3) b3(5)
+

--- a/testsuite/mergeinstances-duplicate-entrylayers/run.py
+++ b/testsuite/mergeinstances-duplicate-entrylayers/run.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+command = testshade("--group data/shadergroup -O2 " +
+	                "--entry b1 --entry b2 --entry b3")

--- a/testsuite/mergeinstances-duplicate-entrylayers/shadergroup
+++ b/testsuite/mergeinstances-duplicate-entrylayers/shadergroup
@@ -1,0 +1,11 @@
+shader a a1 ;
+shader b b1 ;
+connect a1.out b1.in ;
+
+shader a a2 ;
+shader b b2 ;
+connect a2.out b2.in ;
+
+shader a a3 ;
+shader b b3 ;
+connect a3.out b3.in ;


### PR DESCRIPTION
## Description
Assertion in merge_instances() with a shader group containing multiple identical entry layers.

This was initially encountered in the 1.9 branch, the issue is still present in the master branch; however only when built with the debug flag, due to the OSL_DASSERT change.

The error in master is:
src/liboslexec/shadingsys.cpp:3159: merge_instances: Assertion 'B->unused()' failed.

To fix this I've added a check into merge_instances() to ensure that a group is not an entry layer.

## Tests
1. Yes I've added a new test case.

2. For the record I am unable to get my test case to fail when running make test.
It seems to only run (for me) using the non-debug build, user error on my part?
The command I was running was 
  make debug test TEST=mergeinstances-duplicate-entrylayers

I did however verify that I receive the assert when running testshade manually with the debug binaries.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ X] I have updated the documentation, if applicable.
- [ X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ X] My code follows the prevailing code style of this project.

