### PR TITLE
Speedup string concat op

### DIFF
--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -53,7 +53,19 @@ namespace pvt {
 OSL_SHADEOP const char *
 osl_concat_sss (const char *s, const char *t)
 {
-    return ustring::sprintf("%s%s", s, t).c_str();
+    size_t sl = USTR(s).length();
+    size_t tl = USTR(t).length();
+    size_t len = sl + tl;
+    std::unique_ptr<char[]> heap_buf;
+    char local_buf[256];
+    char* buf = local_buf;
+    if (len > sizeof(local_buf)) {
+        heap_buf.reset(new char[len]);
+        buf = heap_buf.get();
+    }
+    memcpy(buf     , s, sl);
+    memcpy(buf + sl, t, tl);
+    return ustring(local_buf, len).c_str();
 }
 
 OSL_SHADEOP int


### PR DESCRIPTION
## Description

The string concatenation op was going through `sprintf` which forced at least one
memory allocation to happen, in addition to the expense of going through the parsing logic, etc ... This was roughly doubling the cost of this (already expensive) operation. This commit implements a more direct concatenation via `memcpy`, and uses a small stack buffer in most cases.

## Tests

Production shader which was abusing string concat renders 10% faster (now only `ustring` creation shows up in vtune). Obviously the offending shader will be rewritten, but this seemed like a low hanging fruit.
