### PR TITLE
oslc: add -MT option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,8 +62,8 @@ OSL Language and oslc compiler:
 * New command line argument `oslc --embed-source` embeds the preprocessed
   source code in the `.oso` file itself (helpful for certain debugging
   situations). #1081 (1.11.3)
-* oslc can generate dependency files, honoring the -M, -MM, -MD, -MMD, and
-  -MF flags with similar meanings to gcc and clang. #1085 (1.11.3)
+* oslc can generate dependency files, honoring the -M, -MM, -MD, -MMD, -MF,
+  and -MT flags with similar meanings to gcc and clang. #1085 #1107 (1.11.3)
   Example:
   ```
       $ oslc -MMD test.osl

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -327,8 +327,14 @@ OSLCompilerImpl::read_compile_options (const std::vector<std::string> &options,
             m_preprocess_only = true;
             if (m_deps_filename.empty())
                 m_deps_filename = "stdout";
+        } else if (options[i] == "-MF") {
+            m_deps_filename = options[++i];
         } else if (OIIO::Strutil::starts_with(options[i], "-MF")) {
             m_deps_filename = options[i].substr(3);
+        } else if (options[i] == "-MT") {
+            m_deps_target = options[++i];
+        } else if (OIIO::Strutil::starts_with(options[i], "-MT")) {
+            m_deps_target = options[i].substr(3);
         } else if (options[i].c_str()[0] == '-' && options[i].size() > 2) {
             // options meant for the preprocessor
             if (options[i].c_str()[1] == 'D' || options[i].c_str()[1] == 'U')
@@ -604,10 +610,11 @@ OSLCompilerImpl::write_dependency_file (string_view filename)
 {
     if (m_deps_filename.empty())
         m_deps_filename = OIIO::Filesystem::replace_extension(filename, ".d");
-    std::string target = m_output_filename;
+    std::string target = m_deps_target;
     if (target.empty())
-        target = OIIO::Filesystem::replace_extension(filename, ".oso");
-
+        target = m_output_filename.size()
+               ? m_output_filename
+               : OIIO::Filesystem::replace_extension(filename, ".oso");
     OIIO::debugf("Writing '%s' deps to '%s'\n", target, m_deps_filename);
     FILE* depfile = (m_deps_filename == "stdout" ? stdout
                      : OIIO::Filesystem::fopen (m_deps_filename, "w"));

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -510,6 +510,7 @@ private:
     int m_last_sourceline;
     size_t m_last_sourceline_offset;
     std::string m_deps_filename; ///< Where to write deps? -MF
+    std::string m_deps_target; ///< Custom target: -MF
     std::set<ustring> m_file_dependencies; ///< All include file dependencies
 };
 

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -66,7 +66,8 @@ usage ()
         "\t-buffer        (debugging) Force compile from buffer\n"
         "\t-MD, -MMD      Write a depfile containing headers used, to a file\n"
         "\t-M, -MM        Like -MD, but write depfile to stdout\n"
-        "\t-MF<file>      Specify the name of the depfile to output (for -MD, -MMD)\n"
+        "\t-MF filename   Specify the name of the depfile to output (for -MD, -MMD)\n"
+        "\t-MT target     Specify a custom dependency target name for -M...\n"
         ;
 }
 
@@ -165,9 +166,15 @@ main (int argc, const char *argv[])
                  || ! strcmp(argv[a], "-MD") || !strcmp(argv[a], "--write-dependencies")
                  || ! strcmp(argv[a], "-MMD") || !strcmp(argv[a], "--write-user-dependencies")
                  || OIIO::Strutil::starts_with(argv[a], "-MF")
+                 || OIIO::Strutil::starts_with(argv[a], "-MT")
                  ) {
             // Valid command-line argument
             args.emplace_back(argv[a]);
+            if (a < argc-1 &&
+                (!strcmp(argv[a], "-MF") || !strcmp(argv[a], "-MT"))) {
+                ++a;
+                args.emplace_back(argv[a]);
+            }
         }
         else if (! strcmp (argv[a], "-o") && a < argc-1) {
             // Output filepath

--- a/testsuite/oslc-M/ref/mycustom.d
+++ b/testsuite/oslc-M/ref/mycustom.d
@@ -1,0 +1,2 @@
+customtarget: test.osl \
+  myheader.h

--- a/testsuite/oslc-M/run.py
+++ b/testsuite/oslc-M/run.py
@@ -13,5 +13,8 @@ command += oslc ("-q -MMD -MFmydep.d test.osl")
 # Test deps to stdout
 command += oslc ("-MM test.osl")
 
-outputs = [ "test.d", "mydep.d", "out.txt" ]
+# Test deps with custom target
+command += oslc ("-q -MMD -MF mycustom.d -MT customtarget test.osl")
+
+outputs = [ "test.d", "mydep.d", "mycustom.d", "out.txt" ]
 


### PR DESCRIPTION
Completing the recent dependency generation feature, -MT lets you
customize the name of the dependency target.

Also, to match the C/C++ compilers, we now accept both

    -MF<filename>       # all as one arg
    -MT<target>

    -MF <filename>      # two args
    -MT <target>
