### PR TITLE
SIMD Friendly Math and Noise refinements to work inside SIMD loops

### DIFF
--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -185,7 +185,7 @@ namespace pvt {
 #endif
 
 #if (OSL_CPLUSPLUS_VERSION >= 17)
-    template<class... Ts>
+    template<class... ListT>
     using conjunction = std::conjunction<ListT...>;
 #else
     template<class... ListT>

--- a/src/include/OSL/oslconfig.h
+++ b/src/include/OSL/oslconfig.h
@@ -148,6 +148,9 @@ namespace pvt {
 
     template<int EndBeforeT>
     using make_int_sequence =  std::make_integer_sequence<int, EndBeforeT>;
+
+    template<bool... BoolListT >
+    using bool_sequence = std::integer_sequence<bool, BoolListT... >;
 #else
     // std::integer_sequence requires c++14 library support,
     // we have our own version here in case the environment is c++14 compiler
@@ -174,7 +177,31 @@ namespace pvt {
 
     template<int EndBeforeT>
     using make_int_sequence = typename int_sequence_generator<0, EndBeforeT, int_sequence<> >::type;
+
+    template<bool... BoolListT >
+    struct bool_sequence
+	{
+	};
 #endif
+
+#if (OSL_CPLUSPLUS_VERSION >= 17)
+    template<class... Ts>
+    using conjunction = std::conjunction<ListT...>;
+#else
+    template<class... ListT>
+    using conjunction = std::is_same<bool_sequence<true,ListT::value...>, bool_sequence<ListT::value..., true>>;
+#endif
+
+    // We need the SFINAE type to be different for
+    // enable_if_type from disable_if_type so that we can apply both to
+    // the same template signature to avoid
+    // "error: invalid redeclaration of member function template"
+    // NOTE: std::enable_if_t is a c++14 library feature, our baseline
+    // and we wish to remain compatible with c++11 header libraries.
+    // Also we are using std::true_type vs. void as the default type
+    template <bool TestT, typename TypeT = std::true_type>
+    using enable_if_type = typename std::enable_if<TestT, TypeT>::type;
+
 } // namespace pvt
 
 // Instead of relying on compiler loop unrolling, we can statically call functor

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -198,8 +198,8 @@ bjfinal (const int4& a_, const int4& b_, const int4& c_)
 /// hash an array of N 32 bit values into a pseudo-random value
 /// based on my favorite hash: http://burtleburtle.net/bob/c/lookup3.c
 /// templated so that the compiler can unroll the loops for us
-template <int N> OSL_HOSTDEVICE
-OSL_FORCEINLINE unsigned int
+template <int N>
+OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 reference_inthash (const unsigned int k[N]) {
     // now hash the data!
     unsigned int a, b, c, len = N;
@@ -232,7 +232,7 @@ using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, H
 // NOTE: only accept unsigned int's so that overloads with unsigned int's will be chosen.
 // Callers with "int" parameters will need to static_cast<unsigned int>(param)
 template<typename ...ListT, typename = RequireAllSame<unsigned int, ListT...> >
-OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 inthash (ListT... uintList)  {
     const int count = sizeof...(uintList);
 	const unsigned int iv[count] = {uintList...};
@@ -251,7 +251,7 @@ inthash (ListT... uintList)  {
 	// The upshot is no need to create a k[N] on the stack and hopefully
 	// simpler time for optimizer as it has no need to deal with while
 	// loop and switch statement.
-	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	inthash (const unsigned int k0) {
 		// now hash the data!
 		unsigned int start_val = 0xdeadbeef + (1 << 2) + 13;
@@ -261,7 +261,7 @@ inthash (ListT... uintList)  {
 		return c;
 	}
 
-	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	inthash (const unsigned int k0, const unsigned int k1) {
 		// now hash the data!
 		unsigned int start_val = 0xdeadbeef + (2 << 2) + 13;
@@ -272,7 +272,7 @@ inthash (ListT... uintList)  {
 		return c;
 	}
 
-	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2) {
 		// now hash the data!
 		unsigned int start_val = 0xdeadbeef + (3 << 2) + 13;
@@ -284,7 +284,7 @@ inthash (ListT... uintList)  {
 		return c;
 	}
 
-	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2, const unsigned int k3) {
 		// now hash the data!
 		unsigned int start_val = 0xdeadbeef + (4 << 2) + 13;
@@ -298,7 +298,7 @@ inthash (ListT... uintList)  {
 		return c;
 	}
 
-	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2, const unsigned int k3, const unsigned int k4) {
 		// now hash the data!
 		unsigned int start_val = 0xdeadbeef + (5 << 2) + 13;
@@ -361,7 +361,7 @@ inthash_simd (const int4& key_x, const int4& key_y, const int4& key_z, const int
 // controlling how the float inputs are transformed
 template<typename DerivedT>
 struct IntHashNoiseBase  {
-	IntHashNoiseBase () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE IntHashNoiseBase () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
     	result = hashFloat(x);
@@ -399,13 +399,13 @@ struct IntHashNoiseBase  {
 
 private:
     template<typename ...ListT>
-    OSL_HOSTDEVICE OSL_FORCEINLINE float
+    OSL_FORCEINLINE OSL_HOSTDEVICE float
     hashFloat (ListT... floatList) const {
         return bits_to_01(inthash(DerivedT::transformToUint(floatList)...));
     }
 
     template<typename ...ListT>
-    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
     hashVec (ListT... floatList) const {
     	return inthashVec(DerivedT::transformToUint(floatList)...);
     }
@@ -418,7 +418,7 @@ private:
     // and extra seed values, but leave door open for overloads of inthashVec
     // for specific parameter combinations
     template<typename ...ListT>
-    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
     inthashVec (ListT... uintList) const {
         constexpr int N = sizeof...(uintList) + 1;
     	unsigned int k[N] = {uintList...};
@@ -434,7 +434,7 @@ private:
     // extra seed values, but leave door open for overloads of inthashVec
     // for specific parameter combinations
     template<typename ...ListT>
-    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
 	inthashVec (ListT... uintList) const  {
         return Vec3(bits_to_01(inthash(uintList..., 0u)),
         			bits_to_01(inthash(uintList..., 1u)),
@@ -485,9 +485,9 @@ private:
 };
 
 struct CellNoise: public IntHashNoiseBase<CellNoise>  {
-    CellNoise () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE CellNoise () { }
 
-    static OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+    static OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	transformToUint(float val)
     {
     	return OIIO::ifloor(val);
@@ -495,9 +495,9 @@ struct CellNoise: public IntHashNoiseBase<CellNoise>  {
 };
 
 struct HashNoise: public IntHashNoiseBase<HashNoise>  {
-	HashNoise () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE HashNoise () { }
 
-    static OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+    static OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 	transformToUint(float val)
     {
     	return sfm::bit_cast<float,unsigned int>(val);
@@ -510,7 +510,7 @@ struct HashNoise: public IntHashNoiseBase<HashNoise>  {
 // its underlying implementation.
 template <typename BaseNoiseT>
 struct PeriodicAdaptionOf {
-	PeriodicAdaptionOf () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE PeriodicAdaptionOf () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
     	m_impl(result, wrap (x, px));
@@ -640,9 +640,9 @@ inthashf (const float *x, float y)
 // combinations be specified using polymorphism.  Main reason is so that
 // different versions can pass parameters by value vs. reference.
 //template <typename B, typename F>
-//OSL_FORCEINLINE F select (B b, const F& t, const F& f) { return b ? t : f; }
+//OSL_FORCEINLINE OSL_HOSTDEVICE F select (B b, const F& t, const F& f) { return b ? t : f; }
 
-OSL_FORCEINLINE float select(const bool b, float t, float f) {
+OSL_FORCEINLINE OSL_HOSTDEVICE float select(const bool b, float t, float f) {
     // NOTE:  parameters must NOT be references, to avoid inlining caller's creation of
     // these values down inside the conditional assignments which can create to complex
     // of a code flow for Clang's vectorizer to handle
@@ -652,7 +652,7 @@ OSL_FORCEINLINE float select(const bool b, float t, float f) {
     return b ? t : f;
 }
 
-OSL_FORCEINLINE Dual2<float> select(const bool b, const Dual2<float> &t, const Dual2<float> &f) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<float> select(const bool b, const Dual2<float> &t, const Dual2<float> &f) {
     // Because t & f are a references, we don't want inlining to expand t.val(), t.dx(), or t.dy()
     // inside the conditional branch creating a more complex flow by forcing the inlined
     // abstract syntax tree to only be evaluated when the condition is true.
@@ -733,11 +733,11 @@ OSL_FORCEINLINE Dual2<float4> select (const int4& b, const Dual2<float4>& t, con
 // different versions can pass parameters by value vs. reference.
 //template <typename B, typename F>
 //template<typename FLOAT, typename BOOL>
-//OSL_FORCEINLINE FLOAT negate_if (const FLOAT& val, const BOOL& b) {
+//OSL_FORCEINLINE OSL_HOSTDEVICE FLOAT negate_if (const FLOAT& val, const BOOL& b) {
 //    return b ? -val : val;
 //}
 
-OSL_FORCEINLINE float negate_if (const float val, const bool cond) {
+OSL_FORCEINLINE OSL_HOSTDEVICE float negate_if (const float val, const bool cond) {
     // NOTE:  parameters must NOT be references, to avoid inlining caller's creation of
     // these values down inside the conditional assignments which can create to complex
     // of a code flow for vectorizer to handle
@@ -746,7 +746,7 @@ OSL_FORCEINLINE float negate_if (const float val, const bool cond) {
 }
 
 
-OSL_FORCEINLINE Dual2<float> negate_if(const Dual2<float> &val, const bool cond) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<float> negate_if(const Dual2<float> &val, const bool cond) {
     // NOTE: negation happens outside of conditional, then is blended based on the condition
     Dual2<float> neg_val(-val);
 
@@ -837,8 +837,8 @@ OSL_FORCEINLINE Dual2<float> extract (const Dual2<float4>& a)
 // Equivalent to OIIO::bilerp (a, b, c, d, u, v), but if abcd are already
 // packed into a float4. We assume T is float and VECTYPE is float4,
 // but it also works if T is Dual2<float> and VECTYPE is Dual2<float4>.
-template<typename T, typename VECTYPE> OSL_HOSTDEVICE
-OSL_FORCEINLINE T bilerp (VECTYPE abcd, T u, T v) {
+template<typename T, typename VECTYPE>
+OSL_FORCEINLINE OSL_HOSTDEVICE T bilerp (VECTYPE abcd, T u, T v) {
     VECTYPE xx = OIIO::lerp (abcd, OIIO::simd::shuffle<1,1,3,3>(abcd), u);
     return OIIO::simd::extract<0>(OIIO::lerp (xx,OIIO::simd::shuffle<2>(xx), v));
 }
@@ -870,7 +870,7 @@ OSL_FORCEINLINE float trilerp (const float4& abcd, const float4& efgh, const flo
 
 
 // always return a value inside [0,b) - even for negative numbers
-inline OSL_HOSTDEVICE int imod(int a, int b) {
+OSL_FORCEINLINE OSL_HOSTDEVICE int imod(int a, int b) {
 #if 0
     a %= b;
     return a < 0 ? a + b : a;
@@ -895,13 +895,13 @@ inline int4 imod(const int4& a, int b) {
 // floorfrac return ifloor as well as the fractional remainder
 // FIXME: already implemented inside OIIO but can't easily override it for duals
 //        inside a different namespace
-inline OSL_HOSTDEVICE float floorfrac(float x, int* i) {
+OSL_FORCEINLINE OSL_HOSTDEVICE float floorfrac(float x, int* i) {
     *i = OIIO::ifloor(x);
     return x - *i;
 }
 
 // floorfrac with derivs
-inline OSL_HOSTDEVICE Dual2<float> floorfrac(const Dual2<float> &x, int* i) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<float> floorfrac(const Dual2<float> &x, int* i) {
     float frac = floorfrac(x.val(), i);
     // slope of x is not affected by this operation
     return Dual2<float>(frac, x.dx(), x.dy());
@@ -932,8 +932,8 @@ inline Dual2<float4> floorfrac(const Dual2<float4> &x, int4* i) {
 
 // Perlin 'fade' function. Can be overloaded for float, Dual2, as well
 // as float4 / Dual2<float4>.
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T fade (const T &t) {
+template <typename T>
+OSL_HOSTDEVICE OSL_FORCEINLINE T fade (const T &t) {
    return t * t * t * (t * (t * T(6.0f) - T(15.0f)) + T(10.0f));
 }
 
@@ -949,16 +949,16 @@ OSL_FORCEINLINE T fade (const T &t) {
 //    3D:   0.936
 //    4D:   0.870
 
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T grad (int hash, const T &x) {
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T grad (int hash, const T &x) {
     int h = hash & 15;
     float g = 1 + (h & 7);  // 1, 2, .., 8
     if (h&8) g = -g;        // random sign
     return g * x;           // dot-product
 }
 
-template <typename I, typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y) {
+template <typename I, typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T grad (const I &hash, const T &x, const T &y) {
     // 8 possible directions (+-1,+-2) and (+-2,+-1)
     I h = hash & 7;
     T u = select (h<4, x, y);
@@ -967,8 +967,8 @@ OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y) {
     return negate_if(u, h&1) + negate_if(v, h&2);
 }
 
-template <typename I, typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y, const T &z) {
+template <typename I, typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T grad (const I &hash, const T &x, const T &y, const T &z) {
     // use vectors pointing to the edges of the cube
     I h = hash & 15;
     T u = select (h<8, x, y);
@@ -976,8 +976,8 @@ OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y, const T &z) {
     return negate_if(u,h&1) + negate_if(v,h&2);
 }
 
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T grad (const int hash, const T &x, const T &y, const T &z) {
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T grad (const int hash, const T &x, const T &y, const T &z) {
     // use vectors pointing to the edges of the cube
     int h = hash & 15;
     T u = select (h<8, x, y);
@@ -992,8 +992,8 @@ OSL_FORCEINLINE T grad (const int hash, const T &x, const T &y, const T &z) {
     return negate_if(u,h&1) + negate_if(v,h&2);
 }
 
-template <typename I, typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y, const T &z, const T &w) {
+template <typename I, typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T grad (const I &hash, const T &x, const T &y, const T &z, const T &w) {
     // use vectors pointing to the edges of the hypercube
     I h = hash & 31;
     T u = select (h<24, x, y);
@@ -1057,14 +1057,14 @@ OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float>
     return make_Vec3 (rx, ry, rz);
 }
 
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T scale1 (const T &result) { return 0.2500f * result; }
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T scale2 (const T &result) { return 0.6616f * result; }
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T scale3 (const T &result) { return 0.9820f * result; }
-template <typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE T scale4 (const T &result) { return 0.8344f * result; }
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T scale1 (const T &result) { return 0.2500f * result; }
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T scale2 (const T &result) { return 0.6616f * result; }
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T scale3 (const T &result) { return 0.9820f * result; }
+template <typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE T scale4 (const T &result) { return 0.8344f * result; }
 
 
 struct HashScalar {
@@ -1129,7 +1129,7 @@ OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i sliceup (unsigned int h) {
 }
 
 struct HashVector {
-    static OSL_FORCEINLINE HashScalar convertToScalar() { return HashScalar(); }
+    static OSL_FORCEINLINE OSL_HOSTDEVICE HashScalar convertToScalar() { return HashScalar(); }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x) const {
         return sliceup(inthash(static_cast<unsigned int>(x)));
@@ -1184,21 +1184,21 @@ struct HashVector {
 struct HashScalarPeriodic {
 private:
     friend struct HashVectorPeriodic;
-    OSL_FORCEINLINE HashScalarPeriodic () {}
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic () {}
 public:
-    OSL_HOSTDEVICE HashScalarPeriodic (float px) {
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic (float px) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
     }
-    OSL_HOSTDEVICE HashScalarPeriodic (float px, float py) {
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic (float px, float py) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
     }
-    OSL_HOSTDEVICE HashScalarPeriodic (float px, float py, float pz) {
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic (float px, float py, float pz) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
         m_pz = OIIO::ifloor(pz); if (m_pz < 1) m_pz = 1;
     }
-    OSL_HOSTDEVICE HashScalarPeriodic (float px, float py, float pz, float pw) {
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic (float px, float py, float pz, float pw) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
         m_pz = OIIO::ifloor(pz); if (m_pz < 1) m_pz = 1;
@@ -1257,19 +1257,19 @@ public:
 };
 
 struct HashVectorPeriodic {
-    OSL_HOSTDEVICE HashVectorPeriodic (float px) {
+	OSL_FORCEINLINE OSL_HOSTDEVICE HashVectorPeriodic (float px) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
     }
-    OSL_HOSTDEVICE HashVectorPeriodic (float px, float py) {
+	OSL_FORCEINLINE OSL_HOSTDEVICE HashVectorPeriodic (float px, float py) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
     }
-    OSL_HOSTDEVICE HashVectorPeriodic (float px, float py, float pz) {
+	OSL_FORCEINLINE OSL_HOSTDEVICE HashVectorPeriodic (float px, float py, float pz) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
         m_pz = OIIO::ifloor(pz); if (m_pz < 1) m_pz = 1;
     }
-    OSL_HOSTDEVICE HashVectorPeriodic (float px, float py, float pz, float pw) {
+	OSL_FORCEINLINE OSL_HOSTDEVICE HashVectorPeriodic (float px, float py, float pz, float pw) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
         m_py = OIIO::ifloor(py); if (m_py < 1) m_py = 1;
         m_pz = OIIO::ifloor(pz); if (m_pz < 1) m_pz = 1;
@@ -1278,7 +1278,7 @@ struct HashVectorPeriodic {
 
     int m_px, m_py, m_pz, m_pw;
 
-    OSL_FORCEINLINE HashScalarPeriodic convertToScalar() const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE HashScalarPeriodic convertToScalar() const {
         HashScalarPeriodic r;
         r.m_px = m_px;
         r.m_py = m_py;
@@ -1350,8 +1350,8 @@ struct CGScalar
     static constexpr bool allowSIMD = false;
 };
 
-template <typename CGPolicyT = CGDefault, typename V, typename H, typename T> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (V& result, H& hash, const T &x) {
+template <typename CGPolicyT = CGDefault, typename V, typename H, typename T>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (V& result, H& hash, const T &x) {
     int X; T fx = floorfrac(x, &X);
     T u = fade(fx);
 
@@ -1360,8 +1360,8 @@ OSL_FORCEINLINE void perlin (V& result, H& hash, const T &x) {
     result = scale1 (lerp_result);
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (float &result, const H &hash, const float &x, const float &y)
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (float &result, const H &hash, const float &x, const float &y)
 {
 #if OIIO_SIMD
     if (CGPolicyT::allowSIMD)
@@ -1402,8 +1402,8 @@ OSL_FORCEINLINE void perlin (float &result, const H &hash, const float &x, const
     }
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (float &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (float &result, const H &hash,
                     const float &x, const float &y, const float &z)
 {
 #if OIIO_SIMD
@@ -1479,8 +1479,8 @@ OSL_FORCEINLINE void perlin (float &result, const H &hash,
 
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (float &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (float &result, const H &hash,
                     const float &x, const float &y, const float &z, const float &w)
 {
 #if OIIO_SIMD
@@ -1563,8 +1563,8 @@ OSL_FORCEINLINE void perlin (float &result, const H &hash,
     }
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y)
 {
 #if OIIO_SIMD
@@ -1608,8 +1608,8 @@ OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
     }
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
 {
 #if OIIO_SIMD
@@ -1673,8 +1673,8 @@ OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
     }
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y,
                     const Dual2<float> &z, const Dual2<float> &w)
 {
@@ -1768,8 +1768,8 @@ OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
 }
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y)
 {
 #if OIIO_SIMD
@@ -1825,8 +1825,8 @@ OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
 
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y, const float &z)
 {
 #if OIIO_SIMD
@@ -1971,8 +1971,8 @@ OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
     }
 }
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y, const float &z, const float &w)
 {
 #if OIIO_SIMD
@@ -2060,8 +2060,8 @@ OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
 }
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y)
 {
 #if OIIO_SIMD
@@ -2121,8 +2121,8 @@ OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
 }
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
 {
 #if OIIO_SIMD
@@ -2197,8 +2197,8 @@ OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
 }
 
 
-template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
-OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H>
+OSL_FORCEINLINE OSL_HOSTDEVICE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y,
                     const Dual2<float> &z, const Dual2<float> &w)
 {
@@ -2307,7 +2307,7 @@ OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
 
 template<typename CGPolicyT = CGDefault>
 struct NoiseImpl {
-    NoiseImpl () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE NoiseImpl () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
         HashScalar h;
@@ -2445,7 +2445,7 @@ struct NoiseScalar : NoiseImpl<CGScalar> {};
 
 template<typename CGPolicyT = CGDefault>
 struct SNoiseImpl {
-    OSL_HOSTDEVICE SNoiseImpl () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE SNoiseImpl () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
         HashScalar h;
@@ -2553,7 +2553,7 @@ struct SNoiseScalar : SNoiseImpl<CGScalar> {};
 
 template<typename CGPolicyT = CGDefault>
 struct PeriodicNoiseImpl {
-    OSL_HOSTDEVICE PeriodicNoiseImpl () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE PeriodicNoiseImpl () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
         HashScalarPeriodic h(px);
@@ -2678,7 +2678,7 @@ struct PeriodicNoiseScalar : PeriodicNoiseImpl<CGScalar> {};
 
 template<typename CGPolicyT = CGDefault>
 struct PeriodicSNoiseImpl {
-    OSL_HOSTDEVICE PeriodicSNoiseImpl () { }
+	OSL_FORCEINLINE OSL_HOSTDEVICE PeriodicSNoiseImpl () { }
 
     OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
         HashScalarPeriodic h(px);
@@ -3144,7 +3144,7 @@ struct USimplexNoise {
 // Scalar version of USimplexNoise that is SIMD friendly suitable to be
 // inlined inside of a SIMD loops
 struct USimplexNoiseScalar {
-    USimplexNoiseScalar () { }
+	OSL_FORCEINLINE USimplexNoiseScalar () { }
 
     OSL_FORCEINLINE void operator() (float &result, float x) const {
         result = 0.5f * (sfm::simplexnoise1<0/* seed */>(x) + 1.0f);

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -29,12 +29,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <limits>
+#include <type_traits>
 
 #include <OSL/dual.h>
 #include <OSL/dual_vec.h>
+#include <OSL/sfm_simplex.h>
+#include <OSL/sfmath.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/simd.h>
+
 
 OSL_NAMESPACE_ENTER
 
@@ -147,7 +151,10 @@ namespace {
 // convert a 32 bit integer into a floating point number in [0,1]
 inline OSL_HOSTDEVICE float bits_to_01 (unsigned int bits) {
     // divide by 2^32-1
-    return bits * (1.0f / std::numeric_limits<unsigned int>::max());
+	// Calculate inverse constant with double precision to avoid
+	//     warning: implicit conversion from 'unsigned int' to 'float' changes value from 4294967295 to 4294967296
+    constexpr float convertFactor = static_cast<float>(static_cast<double>(1.0) / static_cast<double>(std::numeric_limits<unsigned int>::max()));
+    return bits * convertFactor;
 }
 
 
@@ -170,7 +177,7 @@ OSL_FORCEINLINE int4
 bjfinal (const int4& a_, const int4& b_, const int4& c_)
 {
     using OIIO::simd::rotl32;
-	int4 a(a_), b(b_), c(c_);
+    int4 a(a_), b(b_), c(c_);
     c ^= b; c -= rotl32(b,14);
     a ^= c; a -= rotl32(c,11);
     b ^= a; b -= rotl32(a,25);
@@ -182,13 +189,18 @@ bjfinal (const int4& a_, const int4& b_, const int4& c_)
 }
 #endif
 
+#ifndef __OSL_USE_REFERENCE_INT_HASH
+	// Warning the reference hash may cause incorrect results when
+	// used inside a SIMD loop due to its complexity
+	#define __OSL_USE_REFERENCE_INT_HASH 0
+#endif
 
 /// hash an array of N 32 bit values into a pseudo-random value
 /// based on my favorite hash: http://burtleburtle.net/bob/c/lookup3.c
 /// templated so that the compiler can unroll the loops for us
 template <int N> OSL_HOSTDEVICE
-inline unsigned int
-inthash (const unsigned int k[N]) {
+OSL_FORCEINLINE unsigned int
+reference_inthash (const unsigned int k[N]) {
     // now hash the data!
     unsigned int a, b, c, len = N;
     a = b = c = 0xdeadbeef + (len << 2) + 13;
@@ -211,6 +223,96 @@ inthash (const unsigned int k[N]) {
     return c;
 }
 
+
+template<typename HeadT, typename... ListT>
+using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT>...>::value>::type;
+
+// Allow any number of arguments to be adapted to the array based reference_inthash
+// and leave door open for overloads of inthash with specific parameters.
+// NOTE: only accept unsigned int's so that overloads with unsigned int's will be chosen.
+// Callers with "int" parameters will need to static_cast<unsigned int>(param)
+template<typename ...ListT, typename = RequireAllSame<unsigned int, ListT...> >
+OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+inthash (ListT... uintList)  {
+    const int count = sizeof...(uintList);
+	const unsigned int iv[count] = {uintList...};
+	return reference_inthash<count>(iv);
+}
+
+#if (__OSL_USE_REFERENCE_INT_HASH == 0)
+	// Do not rely on compilers to fully optimizing the
+	// reference_inthash<int N> template above.
+	// The fact it takes an array parameter
+	// could cause confusion and extra work for a compiler to convert
+	// from x,y,z,w -> k[4] then index them.  So to simplify things
+	// for compilers and avoid requiring actual stack space for the k[N]
+	// array versus tracking builtin integer types in registers,
+	// here are hand unrolled versions of inthash for 1-5 parameters.
+	// The upshot is no need to create a k[N] on the stack and hopefully
+	// simpler time for optimizer as it has no need to deal with while
+	// loop and switch statement.
+	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	inthash (const unsigned int k0) {
+		// now hash the data!
+		unsigned int start_val = 0xdeadbeef + (1 << 2) + 13;
+
+		unsigned int a = start_val + k0;
+		unsigned int c = OIIO::bjhash::bjfinal(a, start_val, start_val);
+		return c;
+	}
+
+	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	inthash (const unsigned int k0, const unsigned int k1) {
+		// now hash the data!
+		unsigned int start_val = 0xdeadbeef + (2 << 2) + 13;
+
+		unsigned int a = start_val + k0;
+		unsigned int b = start_val + k1;
+		unsigned int c = OIIO::bjhash::bjfinal(a, b, start_val);
+		return c;
+	}
+
+	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2) {
+		// now hash the data!
+		unsigned int start_val = 0xdeadbeef + (3 << 2) + 13;
+
+		unsigned int a = start_val + k0;
+		unsigned int b = start_val + k1;
+		unsigned int c = start_val + k2;
+		c = OIIO::bjhash::bjfinal(a, b, c);
+		return c;
+	}
+
+	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2, const unsigned int k3) {
+		// now hash the data!
+		unsigned int start_val = 0xdeadbeef + (4 << 2) + 13;
+
+		unsigned int a = start_val + k0;
+		unsigned int b = start_val + k1;
+		unsigned int c = start_val + k2;
+		OIIO::bjhash::bjmix(a, b, c);
+		a += k3;
+		c = OIIO::bjhash::bjfinal(a, b, c);
+		return c;
+	}
+
+	OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	inthash (const unsigned int k0, const unsigned int k1, const unsigned int k2, const unsigned int k3, const unsigned int k4) {
+		// now hash the data!
+		unsigned int start_val = 0xdeadbeef + (5 << 2) + 13;
+
+		unsigned int a = start_val + k0;
+		unsigned int b = start_val + k1;
+		unsigned int c = start_val + k2;
+		OIIO::bjhash::bjmix(a, b, c);
+		b += k4;
+		a += k3;
+		c = OIIO::bjhash::bjfinal(a, b, c);
+		return c;
+	}
+#endif
 
 #ifndef __CUDA_ARCH__
 // Do four 2D hashes simultaneously.
@@ -253,437 +355,370 @@ inthash_simd (const int4& key_x, const int4& key_y, const int4& key_z, const int
 #endif
 
 
+// Cell and Hash noise only differ in how they transform their inputs from
+// float to unsigned int for use in the inthash function.
+// IntHashNoiseBase serves as base class with DerivedT::transformToUint
+// controlling how the float inputs are transformed
+template<typename DerivedT>
+struct IntHashNoiseBase  {
+	IntHashNoiseBase () { }
 
-struct CellNoise {
-    OSL_HOSTDEVICE CellNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x) const {
-        unsigned int iv[1];
-        iv[0] = OIIO::ifloor (x);
-        hash1<1> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
+    	result = hashFloat(x);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::ifloor (x);
-        iv[1] = OIIO::ifloor (y);
-        hash1<2> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
+    	result = hashFloat(x, y);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::ifloor (p.x);
-        iv[1] = OIIO::ifloor (p.y);
-        iv[2] = OIIO::ifloor (p.z);
-        hash1<3> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
+    	result = hashFloat(p.x, p.y, p.z);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::ifloor (p.x);
-        iv[1] = OIIO::ifloor (p.y);
-        iv[2] = OIIO::ifloor (p.z);
-        iv[3] = OIIO::ifloor (t);
-        hash1<4> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
+    	result = hashFloat(p.x, p.y, p.z, t);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::ifloor (x);
-        hash3<2> (result, iv);
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
+    	result = hashVec(x);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::ifloor (x);
-        iv[1] = OIIO::ifloor (y);
-        hash3<3> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
+    	result = hashVec(x, y);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::ifloor (p.x);
-        iv[1] = OIIO::ifloor (p.y);
-        iv[2] = OIIO::ifloor (p.z);
-        hash3<4> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
+    	result = hashVec(p.x, p.y, p.z);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
-        unsigned int iv[5];
-        iv[0] = OIIO::ifloor (p.x);
-        iv[1] = OIIO::ifloor (p.y);
-        iv[2] = OIIO::ifloor (p.z);
-        iv[3] = OIIO::ifloor (t);
-        hash3<5> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+    	result = hashVec(p.x, p.y, p.z, t);
     }
+
 
 private:
-    template <int N> OSL_HOSTDEVICE
-    inline void hash1 (float &result, const unsigned int k[N]) const {
-        result = bits_to_01(inthash<N>(k));
+    template<typename ...ListT>
+    OSL_HOSTDEVICE OSL_FORCEINLINE float
+    hashFloat (ListT... floatList) const {
+        return bits_to_01(inthash(DerivedT::transformToUint(floatList)...));
     }
 
-    template <int N> OSL_HOSTDEVICE
-    inline void hash3 (Vec3 &result, unsigned int k[N]) const {
-        k[N-1] = 0; result.x = bits_to_01 (inthash<N> (k));
-        k[N-1] = 1; result.y = bits_to_01 (inthash<N> (k));
-        k[N-1] = 2; result.z = bits_to_01 (inthash<N> (k));
+    template<typename ...ListT>
+    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+    hashVec (ListT... floatList) const {
+    	return inthashVec(DerivedT::transformToUint(floatList)...);
+    }
+
+#if __OSL_USE_REFERENCE_INT_HASH
+    // Allow any number of arguments to be adapted to the array based reference_inthash
+    // and leave door open for overloads of hash3 with specific parameters
+
+    // Produce Vec3 result from any number of arguments with array based reference_inthash
+    // and extra seed values, but leave door open for overloads of inthashVec
+    // for specific parameter combinations
+    template<typename ...ListT>
+    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+    inthashVec (ListT... uintList) const {
+        constexpr int N = sizeof...(uintList) + 1;
+    	unsigned int k[N] = {uintList...};
+
+    	Vec3 result;
+        k[N-1] = 0u; result.x = bits_to_01 (reference_inthash<N> (k));
+        k[N-1] = 1u; result.y = bits_to_01 (reference_inthash<N> (k));
+        k[N-1] = 2u; result.z = bits_to_01 (reference_inthash<N> (k));
+        return result;
+    }
+#else
+    // Produce Vec3 result from any number of arguments with inthash and
+    // extra seed values, but leave door open for overloads of inthashVec
+    // for specific parameter combinations
+    template<typename ...ListT>
+    OSL_HOSTDEVICE OSL_FORCEINLINE Vec3
+	inthashVec (ListT... uintList) const  {
+        return Vec3(bits_to_01(inthash(uintList..., 0u)),
+        			bits_to_01(inthash(uintList..., 1u)),
+					bits_to_01(inthash(uintList..., 2u)));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
+	inthashVec (const unsigned int k0, const unsigned int k1, const unsigned int k2) const {
+        // combine implementations of reference_inthash<3> and reference_inthash<4>
+    	// so that we can only perform the bjmix once because k0,k1,k2 are the
+    	// same values passed to reference_inthash<4>, only k3 differs
+        // and if we unroll the work it can be separated
+
+        // now hash the data!
+        unsigned int start_val = 0xdeadbeef + (4 << 2) + 13;
+
+        unsigned int a = start_val + k0;
+        unsigned int b = start_val + k1;
+        unsigned int c = start_val + k2;
+        OIIO::bjhash::bjmix(a, b, c);
+
+        return Vec3(bits_to_01( OIIO::bjhash::bjfinal(a+0, b, c) ),
+                    bits_to_01( OIIO::bjhash::bjfinal(a+1, b, c) ),
+                    bits_to_01( OIIO::bjhash::bjfinal(a+2, b, c) ));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
+	inthashVec (const unsigned int k0, const unsigned int k1, const unsigned int k2, const unsigned int k3) const {
+        // combine implementations of reference_inthash<3> and reference_inthash<5>
+    	// so that we can only perform the bjmix once because k0,k1,k2,k3 are the
+    	// same values passed to reference_inthash<5>, only k4 differs
+        // and if we unroll the work it can be separated
+
+        // now hash the data!
+        unsigned int start_val = 0xdeadbeef + (5 << 2) + 13;
+
+        unsigned int a = start_val + k0;
+        unsigned int b = start_val + k1;
+        unsigned int c = start_val + k2;
+        OIIO::bjhash::bjmix(a, b, c);
+        unsigned int a2 = a + k3;
+
+        return Vec3(bits_to_01( OIIO::bjhash::bjfinal(a2, b+0, c) ),
+                    bits_to_01( OIIO::bjhash::bjfinal(a2, b+1, c) ),
+                    bits_to_01( OIIO::bjhash::bjfinal(a2, b+2, c) ));
+    }
+#endif
+};
+
+struct CellNoise: public IntHashNoiseBase<CellNoise>  {
+    CellNoise () { }
+
+    static OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	transformToUint(float val)
+    {
+    	return OIIO::ifloor(val);
     }
 };
 
+struct HashNoise: public IntHashNoiseBase<HashNoise>  {
+	HashNoise () { }
 
+    static OSL_HOSTDEVICE OSL_FORCEINLINE unsigned int
+	transformToUint(float val)
+    {
+    	return sfm::bit_cast<float,unsigned int>(val);
+    }
+};
 
-struct PeriodicCellNoise {
-    OSL_HOSTDEVICE PeriodicCellNoise () { }
+// Periodic Cell and Hash Noise simply wraps its inputs before
+// performing the same conversions and hashing as the non-periodic version.
+// We define a wrapper on top of Cell or Hash Noise to reuse
+// its underlying implementation.
+template <typename BaseNoiseT>
+struct PeriodicAdaptionOf {
+	PeriodicAdaptionOf () { }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
-        unsigned int iv[1];
-        iv[0] = OIIO::ifloor (wrap (x, px));
-        hash1<1> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
+    	m_impl(result, wrap (x, px));
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y,
-                                           float px, float py) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::ifloor (wrap (x, px));
-        iv[1] = OIIO::ifloor (wrap (y, py));
-        hash1<2> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y,
+                            float px, float py) const {
+    	m_impl(result, wrap (x, px),
+                       wrap (y, py));
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p,
-                                           const Vec3 &pp) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::ifloor (wrap (p.x, pp.x));
-        iv[1] = OIIO::ifloor (wrap (p.y, pp.y));
-        iv[2] = OIIO::ifloor (wrap (p.z, pp.z));
-        hash1<3> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p,
+                            const Vec3 &pp) const {
+    	m_impl(result, wrap (p, pp));
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t,
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t,
                             const Vec3 &pp, float tt) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::ifloor (wrap (p.x, pp.x));
-        iv[1] = OIIO::ifloor (wrap (p.y, pp.y));
-        iv[2] = OIIO::ifloor (wrap (p.z, pp.z));
-        iv[3] = OIIO::ifloor (wrap (t, tt));
-        hash1<4> (result, iv);
+    	m_impl(result, wrap (p, pp),
+					   wrap (t, tt));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::ifloor (wrap (x, px));
-        hash3<2> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
+    	m_impl(result, wrap (x, px));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y,
-                                           float px, float py) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::ifloor (wrap (x, px));
-        iv[1] = OIIO::ifloor (wrap (y, py));
-        hash3<3> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y,
+                            float px, float py) const {
+    	m_impl(result, wrap (x, px),
+    				   wrap (y, py));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::ifloor (wrap (p.x, pp.x));
-        iv[1] = OIIO::ifloor (wrap (p.y, pp.y));
-        iv[2] = OIIO::ifloor (wrap (p.z, pp.z));
-        hash3<4> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
+    	m_impl(result, wrap (p, pp));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t,
-                                           const Vec3 &pp, float tt) const {
-        unsigned int iv[5];
-        iv[0] = OIIO::ifloor (wrap (p.x, pp.x));
-        iv[1] = OIIO::ifloor (wrap (p.y, pp.y));
-        iv[2] = OIIO::ifloor (wrap (p.z, pp.z));
-        iv[3] = OIIO::ifloor (wrap (t, tt));
-        hash3<5> (result, iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t,
+                            const Vec3 &pp, float tt) const {
+    	m_impl(result, wrap (p, pp),
+					   wrap (t, tt));
     }
 
 private:
-    template <int N> OSL_HOSTDEVICE
-    inline void hash1 (float &result, const unsigned int k[N]) const {
-        result = bits_to_01(inthash<N>(k));
-    }
-
-    template <int N> OSL_HOSTDEVICE
-    inline void hash3 (Vec3 &result, unsigned int k[N]) const {
-        k[N-1] = 0; result.x = bits_to_01 (inthash<N> (k));
-        k[N-1] = 1; result.y = bits_to_01 (inthash<N> (k));
-        k[N-1] = 2; result.z = bits_to_01 (inthash<N> (k));
-    }
-
-    inline OSL_HOSTDEVICE float wrap (float s, float period) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE float wrap (float s, float period) const {
+        // TODO: investigate if quick_floor is legal here
+        // and or beneficial
         period = floorf (period);
         if (period < 1.0f)
             period = 1.0f;
         return s - period * floorf (s / period);
     }
 
-    inline OSL_HOSTDEVICE Vec3 wrap (const Vec3 &s, const Vec3 &period) {
-        return Vec3 (wrap (s[0], period[0]),
-                     wrap (s[1], period[1]),
-                     wrap (s[2], period[2]));
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3 wrap (const Vec3 &s, const Vec3 &period) const {
+    	return Vec3(wrap(s.x, period.x),
+    			    wrap(s.y, period.y),
+					wrap(s.z, period.z));
     }
+
+    BaseNoiseT m_impl;
 };
+
+using PeriodicCellNoise = PeriodicAdaptionOf<CellNoise>;
+using PeriodicHashNoise = PeriodicAdaptionOf<HashNoise>;
+
 
 
 
 inline OSL_HOSTDEVICE int
 inthashi (int x)
 {
-    unsigned int i[1];
-    i[0] = (unsigned int)x;
-    return (int) inthash<1>(i);
+    return static_cast<int>(inthash(
+		static_cast<unsigned int>(x)
+	));
 }
 
 inline OSL_HOSTDEVICE int
 inthashf (float x)
 {
-    unsigned int i[1];
-    i[0] = OIIO::bit_cast<float,unsigned int>(x);
-    return (int) inthash<1>(i);
+    return static_cast<int>(
+		inthash(sfm::bit_cast<float,unsigned int>(x))
+	);
 }
 
 inline OSL_HOSTDEVICE int
 inthashf (float x, float y)
 {
-    unsigned int i[2];
-    i[0] = OIIO::bit_cast<float,unsigned int>(x);
-    i[1] = OIIO::bit_cast<float,unsigned int>(y);
-    return (int) inthash<2>(i);
+    return static_cast<int>(
+		inthash(
+			sfm::bit_cast<float,unsigned int>(x),
+			sfm::bit_cast<float,unsigned int>(y)
+		)
+	);
 }
 
 
 inline OSL_HOSTDEVICE int
 inthashf (const float *x)
 {
-    unsigned int i[3];
-    i[0] = OIIO::bit_cast<float,unsigned int>(x[0]);
-    i[1] = OIIO::bit_cast<float,unsigned int>(x[1]);
-    i[2] = OIIO::bit_cast<float,unsigned int>(x[2]);
-    return (int) inthash<3>(i);
+    return static_cast<int>(
+		inthash(
+			sfm::bit_cast<float,unsigned int>(x[0]),
+			sfm::bit_cast<float,unsigned int>(x[1]),
+			sfm::bit_cast<float,unsigned int>(x[2])
+		)
+	);
 }
 
 
 inline OSL_HOSTDEVICE int
 inthashf (const float *x, float y)
 {
-    unsigned int i[4];
-    i[0] = OIIO::bit_cast<float,unsigned int>(x[0]);
-    i[1] = OIIO::bit_cast<float,unsigned int>(x[1]);
-    i[2] = OIIO::bit_cast<float,unsigned int>(x[2]);
-    i[3] = OIIO::bit_cast<float,unsigned int>(y);
-    return (int) inthash<4>(i);
+    return static_cast<int>(
+		inthash(
+			sfm::bit_cast<float,unsigned int>(x[0]),
+			sfm::bit_cast<float,unsigned int>(x[1]),
+			sfm::bit_cast<float,unsigned int>(x[2]),
+			sfm::bit_cast<float,unsigned int>(y)
+		)
+	);
 }
-
-
-
-struct HashNoise {
-    OSL_HOSTDEVICE HashNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x) const {
-        unsigned int iv[1];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (x);
-        hash1<1> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (y);
-        hash1<2> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (p.x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (p.y);
-        iv[2] = OIIO::bit_cast<float,unsigned int> (p.z);
-        hash1<3> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (p.x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (p.y);
-        iv[2] = OIIO::bit_cast<float,unsigned int> (p.z);
-        iv[3] = OIIO::bit_cast<float,unsigned int> (t);
-        hash1<4> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (x);
-        hash3<2> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (y);
-        hash3<3> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (p.x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (p.y);
-        iv[2] = OIIO::bit_cast<float,unsigned int> (p.z);
-        hash3<4> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
-        unsigned int iv[5];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (p.x);
-        iv[1] = OIIO::bit_cast<float,unsigned int> (p.y);
-        iv[2] = OIIO::bit_cast<float,unsigned int> (p.z);
-        iv[3] = OIIO::bit_cast<float,unsigned int> (t);
-        hash3<5> (result, iv);
-    }
-
-private:
-    template <int N> OSL_HOSTDEVICE
-    inline void hash1 (float &result, const unsigned int k[N]) const {
-        result = bits_to_01(inthash<N>(k));
-    }
-
-    template <int N> OSL_HOSTDEVICE
-    inline void hash3 (Vec3 &result, unsigned int k[N]) const {
-        k[N-1] = 0; result.x = bits_to_01 (inthash<N> (k));
-        k[N-1] = 1; result.y = bits_to_01 (inthash<N> (k));
-        k[N-1] = 2; result.z = bits_to_01 (inthash<N> (k));
-    }
-};
-
-
-
-struct PeriodicHashNoise {
-    OSL_HOSTDEVICE PeriodicHashNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
-        unsigned int iv[1];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (x, px));
-        hash1<1> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y,
-                                           float px, float py) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (x, px));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (y, py));
-        hash1<2> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p,
-                                           const Vec3 &pp) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (p.x, pp.x));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (p.y, pp.y));
-        iv[2] = OIIO::bit_cast<float,unsigned int> (wrap (p.z, pp.z));
-        hash1<3> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t,
-                                           const Vec3 &pp, float tt) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (p.x, pp.x));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (p.y, pp.y));
-        iv[2] = OIIO::bit_cast<float,unsigned int> (wrap (p.z, pp.z));
-        iv[3] = OIIO::bit_cast<float,unsigned int> (wrap (t, tt));
-        hash1<4> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
-        unsigned int iv[2];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (x, px));
-        hash3<2> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y,
-                                           float px, float py) const {
-        unsigned int iv[3];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (x, px));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (y, py));
-        hash3<3> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
-        unsigned int iv[4];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (p.x, pp.x));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (p.y, pp.y));
-        iv[2] = OIIO::bit_cast<float,unsigned int> (wrap (p.z, pp.z));
-        hash3<4> (result, iv);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t,
-                                           const Vec3 &pp, float tt) const {
-        unsigned int iv[5];
-        iv[0] = OIIO::bit_cast<float,unsigned int> (wrap (p.x, pp.x));
-        iv[1] = OIIO::bit_cast<float,unsigned int> (wrap (p.y, pp.y));
-        iv[2] = OIIO::bit_cast<float,unsigned int> (wrap (p.z, pp.z));
-        iv[3] = OIIO::bit_cast<float,unsigned int> (wrap (t, tt));
-        hash3<5> (result, iv);
-    }
-
-private:
-    template <int N> OSL_HOSTDEVICE
-    inline void hash1 (float &result, const unsigned int k[N]) const {
-        result = bits_to_01(inthash<N>(k));
-    }
-
-    template <int N> OSL_HOSTDEVICE
-    inline void hash3 (Vec3 &result, unsigned int k[N]) const {
-        k[N-1] = 0; result.x = bits_to_01 (inthash<N> (k));
-        k[N-1] = 1; result.y = bits_to_01 (inthash<N> (k));
-        k[N-1] = 2; result.z = bits_to_01 (inthash<N> (k));
-    }
-
-    inline OSL_HOSTDEVICE float wrap (float s, float period) const {
-        period = floorf (period);
-        if (period < 1.0f)
-            period = 1.0f;
-        return s - period * floorf (s / period);
-    }
-
-    inline OSL_HOSTDEVICE Vec3 wrap (const Vec3 &s, const Vec3 &period) {
-        return Vec3 (wrap (s[0], period[0]),
-                     wrap (s[1], period[1]),
-                     wrap (s[2], period[2]));
-    }
-};
-
-
 
 
 // Define select(bool,truevalue,falsevalue) template that works for a
 // variety of types that we can use for both scalars and vectors. Because ?:
 // won't work properly in template code with vector ops.
-template <typename B, typename F> OSL_HOSTDEVICE
-OSL_FORCEINLINE F select (const B& b, const F& t, const F& f) { return b ? t : f; }
+// NOTE: Removing template and require explicit functions for different
+// combinations be specified using polymorphism.  Main reason is so that
+// different versions can pass parameters by value vs. reference.
+//template <typename B, typename F>
+//OSL_FORCEINLINE F select (B b, const F& t, const F& f) { return b ? t : f; }
+
+OSL_FORCEINLINE float select(const bool b, float t, float f) {
+    // NOTE:  parameters must NOT be references, to avoid inlining caller's creation of
+    // these values down inside the conditional assignments which can create to complex
+    // of a code flow for Clang's vectorizer to handle
+    static_assert(!std::is_reference<decltype(b)>::value, "parameters to select cannot be references");
+    static_assert(!std::is_reference<decltype(t)>::value, "parameters to select cannot be references");
+    static_assert(!std::is_reference<decltype(f)>::value, "parameters to select cannot be references");
+    return b ? t : f;
+}
+
+OSL_FORCEINLINE Dual2<float> select(const bool b, const Dual2<float> &t, const Dual2<float> &f) {
+    // Because t & f are a references, we don't want inlining to expand t.val(), t.dx(), or t.dy()
+    // inside the conditional branch creating a more complex flow by forcing the inlined
+    // abstract syntax tree to only be evaluated when the condition is true.
+    // To avoid this we assign t.val(), t.dx(), t.dy() to local values outside the
+    // conditional to insulate it.
+    // NOTE:  This technique was also necessary to enable vectorization of nested select calls
+    float val(f.val());
+    float tval(t.val());
+
+    float dx(f.dx());
+    float tdx(t.dx());
+
+    float dy(f.dy());
+    float tdy(t.dy());
+
+    // Blend per builtin component to allow
+    // the compiler to track builtins and privatize the data layout
+    // versus requiring a stack location.
+    // Without this work per component, gathers & scatters were being emitted
+    // when used inside SIMD loops.
+#if OSL_NON_INTEL_CLANG
+    // Clang's vectorizor was really insistent that a select operation could not be replaced
+    // with control flow, so had to re-introduce the ? operator to make it happy
+    return Dual2<float> (
+        b ? tval : val,
+        b ? tdx : dx,
+        b ? tdy : dy);
+#else
+    if (b)
+        val = tval;
+
+    if (b)
+        dx = tdx;
+
+    if (b)
+        dy = tdy;
+
+    return Dual2<float> (
+            val,
+            dx,
+            dy);
+#endif
+}
 
 #ifndef __CUDA_ARCH__
-template <> OSL_FORCEINLINE int4 select (const bool4& b, const int4& t, const int4& f) {
-    return blend (f, t, b);
-}
+// Already provided by oiio/simd.h
+//OSL_FORCEINLINE int4 select (const bool4& b, const int4& t, const int4& f) {
+//    return blend (f, t, b);
+//}
 
-template <> OSL_FORCEINLINE float4 select (const bool4& b, const float4& t, const float4& f) {
-    return blend (f, t, b);
-}
+// Already provided by oiio/simd.h
+//OSL_FORCEINLINE float4 select (const bool4& b, const float4& t, const float4& f) {
+//    return blend (f, t, b);
+//}
 
-template <> OSL_FORCEINLINE float4 select (const int4& b, const float4& t, const float4& f) {
+OSL_FORCEINLINE float4 select (const int4& b, const float4& t, const float4& f) {
     return blend (f, t, bool4(b));
 }
 
-template <> OSL_FORCEINLINE Dual2<float4>
+OSL_FORCEINLINE Dual2<float4>
 select (const bool4& b, const Dual2<float4>& t, const Dual2<float4>& f) {
     return Dual2<float4> (blend (f.val(), t.val(), b),
                           blend (f.dx(),  t.dx(),  b),
                           blend (f.dy(),  t.dy(),  b));
 }
 
-template <>
 OSL_FORCEINLINE Dual2<float4> select (const int4& b, const Dual2<float4>& t, const Dual2<float4>& f) {
     return select (bool4(b), t, f);
 }
@@ -693,20 +728,72 @@ OSL_FORCEINLINE Dual2<float4> select (const int4& b, const Dual2<float4>& t, con
 
 // Define negate_if(value,bool) that will work for both scalars and vectors,
 // as well as Dual2's of both.
-template<typename FLOAT, typename BOOL> OSL_HOSTDEVICE
-OSL_FORCEINLINE FLOAT negate_if (const FLOAT& val, const BOOL& b) {
-    return b ? -val : val;
+// NOTE: Removing template and require explicit functions for different
+// combinations be specified using polymorphism.  Main reason is so that
+// different versions can pass parameters by value vs. reference.
+//template <typename B, typename F>
+//template<typename FLOAT, typename BOOL>
+//OSL_FORCEINLINE FLOAT negate_if (const FLOAT& val, const BOOL& b) {
+//    return b ? -val : val;
+//}
+
+OSL_FORCEINLINE float negate_if (const float val, const bool cond) {
+    // NOTE:  parameters must NOT be references, to avoid inlining caller's creation of
+    // these values down inside the conditional assignments which can create to complex
+    // of a code flow for vectorizer to handle
+    static_assert(!std::is_reference<decltype(val)>::value, "parameters to negate_if cannot be references");
+    return cond ? -val : val;
 }
 
+
+OSL_FORCEINLINE Dual2<float> negate_if(const Dual2<float> &val, const bool cond) {
+    // NOTE: negation happens outside of conditional, then is blended based on the condition
+    Dual2<float> neg_val(-val);
+
+    // Blend per builtin component to allow
+    // the compiler to track builtins and privatize the data layout
+    // versus requiring a stack location.
+    float v = val.val();
+    if (cond) {
+        v = neg_val.val();
+    }
+
+    float dx = val.dx();
+    if (cond) {
+        dx = neg_val.dx();
+    }
+
+    float dy = val.dy();
+    if (cond) {
+        dy = neg_val.dy();
+    }
+
+    return Dual2<float>(v, dx, dy);
+}
+
+#if 0 // Unneeded currently
+template <> OSL_FORCEINLINE Dual2<Vec3> negate_if(const Dual2<Vec3> &val, const bool &b) {
+    Dual2<Vec3> r;
+    // Use a ternary operation per builtin component to allow
+    // the compiler to track builtins and privatize the data layout
+    // versus requiring a stack location.
+    Dual2<Vec3> neg_val(-val);
+    r.val() = b ? neg_val.val() : val.val();
+    r.dx() = b ? neg_val.dx() : val.dx();
+    r.dy() = b ? neg_val.dy() : val.dy();
+    return r;
+}
+#endif
+
 #ifndef __CUDA_ARCH__
-template<> OSL_FORCEINLINE float4 negate_if (const float4& val, const int4& b) {
+OSL_FORCEINLINE float4 negate_if (const float4& val, const int4& b) {
     // Special case negate_if for SIMD -- can do it with bit tricks, no branches
     int4 highbit (0x80000000);
     return bitcast_to_float4 (bitcast_to_int4(val) ^ (blend0 (highbit, bool4(b))));
 }
 
 // Special case negate_if for SIMD -- can do it with bit tricks, no branches
-template<> OSL_FORCEINLINE Dual2<float4> negate_if (const Dual2<float4>& val, const int4& b)
+OSL_FORCEINLINE Dual2<float4> negate_if (const Dual2<float4>& val, const int4& b)
 {
     return Dual2<float4> (negate_if (val.val(), b),
                           negate_if (val.dx(),  b),
@@ -784,8 +871,17 @@ OSL_FORCEINLINE float trilerp (const float4& abcd, const float4& efgh, const flo
 
 // always return a value inside [0,b) - even for negative numbers
 inline OSL_HOSTDEVICE int imod(int a, int b) {
+#if 0
     a %= b;
     return a < 0 ? a + b : a;
+#else
+    // Avoid confusing vectorizor by returning a single value
+    int remainder = a % b;
+    if (remainder < 0) {
+        remainder += b;
+    }
+    return remainder;
+#endif
 }
 
 #ifndef __CUDA_ARCH__
@@ -837,7 +933,7 @@ inline Dual2<float4> floorfrac(const Dual2<float4> &x, int4* i) {
 // Perlin 'fade' function. Can be overloaded for float, Dual2, as well
 // as float4 / Dual2<float4>.
 template <typename T> OSL_HOSTDEVICE
-inline T fade (const T &t) {
+OSL_FORCEINLINE T fade (const T &t) {
    return t * t * t * (t * (t * T(6.0f) - T(15.0f)) + T(10.0f));
 }
 
@@ -845,7 +941,7 @@ inline T fade (const T &t) {
 
 // 1,2,3 and 4 dimensional gradient functions - perform a dot product against a
 // randomly chosen vector. Note that the gradient vector is not normalized, but
-// this only affects the overal "scale" of the result, so we simply account for
+// this only affects the overall "scale" of the result, so we simply account for
 // the scale by multiplying in the corresponding "perlin" function.
 // These factors were experimentally calculated to be:
 //    1D:   0.188
@@ -854,7 +950,7 @@ inline T fade (const T &t) {
 //    4D:   0.870
 
 template <typename T> OSL_HOSTDEVICE
-inline T grad (int hash, const T &x) {
+OSL_FORCEINLINE T grad (int hash, const T &x) {
     int h = hash & 15;
     float g = 1 + (h & 7);  // 1, 2, .., 8
     if (h&8) g = -g;        // random sign
@@ -862,7 +958,7 @@ inline T grad (int hash, const T &x) {
 }
 
 template <typename I, typename T> OSL_HOSTDEVICE
-inline T grad (const I &hash, const T &x, const T &y) {
+OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y) {
     // 8 possible directions (+-1,+-2) and (+-2,+-1)
     I h = hash & 7;
     T u = select (h<4, x, y);
@@ -872,7 +968,7 @@ inline T grad (const I &hash, const T &x, const T &y) {
 }
 
 template <typename I, typename T> OSL_HOSTDEVICE
-inline T grad (const I &hash, const T &x, const T &y, const T &z) {
+OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y, const T &z) {
     // use vectors pointing to the edges of the cube
     I h = hash & 15;
     T u = select (h<8, x, y);
@@ -880,8 +976,24 @@ inline T grad (const I &hash, const T &x, const T &y, const T &z) {
     return negate_if(u,h&1) + negate_if(v,h&2);
 }
 
+template <typename T> OSL_HOSTDEVICE
+OSL_FORCEINLINE T grad (const int hash, const T &x, const T &y, const T &z) {
+    // use vectors pointing to the edges of the cube
+    int h = hash & 15;
+    T u = select (h<8, x, y);
+    // Changed from bitwise | to logical || to avoid conversions
+    // to integer from native boolean that was causing gather + scatters
+    // to be generated when used with the select vs.
+    // simple masking or blending.
+    // TODO: couldn't change the grad version above because OpenImageIO::v1_7::simd::bool4
+    // has no || operator defined.  Would be preferable to implement bool4::operator||
+    // and not have this version of grad separate
+    T v = select (h<4, y, select ((h==int(12))||(h==int(14)), x, z));
+    return negate_if(u,h&1) + negate_if(v,h&2);
+}
+
 template <typename I, typename T> OSL_HOSTDEVICE
-inline T grad (const I &hash, const T &x, const T &y, const T &z, const T &w) {
+OSL_FORCEINLINE T grad (const I &hash, const T &x, const T &y, const T &z, const T &w) {
     // use vectors pointing to the edges of the hypercube
     I h = hash & 31;
     T u = select (h<24, x, y);
@@ -892,13 +1004,13 @@ inline T grad (const I &hash, const T &x, const T &y, const T &z, const T &w) {
 
 typedef Imath::Vec3<int> Vec3i;
 
-inline OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x) {
     return Vec3 (grad (hash.x, x),
                  grad (hash.y, x),
                  grad (hash.z, x));
 }
 
-inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x) {
     Dual2<float> rx = grad (hash.x, x);
     Dual2<float> ry = grad (hash.y, x);
     Dual2<float> rz = grad (hash.z, x);
@@ -906,39 +1018,39 @@ inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x) {
 }
 
 
-inline OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y) {
     return Vec3 (grad (hash.x, x, y),
                  grad (hash.y, x, y),
                  grad (hash.z, x, y));
 }
 
-inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y) {
     Dual2<float> rx = grad (hash.x, x, y);
     Dual2<float> ry = grad (hash.y, x, y);
     Dual2<float> rz = grad (hash.z, x, y);
     return make_Vec3 (rx, ry, rz);
 }
 
-inline OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y, float z) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y, float z) {
     return Vec3 (grad (hash.x, x, y, z),
                  grad (hash.y, x, y, z),
                  grad (hash.z, x, y, z));
 }
 
-inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y, Dual2<float> z) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y, Dual2<float> z) {
     Dual2<float> rx = grad (hash.x, x, y, z);
     Dual2<float> ry = grad (hash.y, x, y, z);
     Dual2<float> rz = grad (hash.z, x, y, z);
     return make_Vec3 (rx, ry, rz);
 }
 
-inline OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y, float z, float w) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Vec3 grad (const Vec3i &hash, float x, float y, float z, float w) {
     return Vec3 (grad (hash.x, x, y, z, w),
                  grad (hash.y, x, y, z, w),
                  grad (hash.z, x, y, z, w));
 }
 
-inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y, Dual2<float> z, Dual2<float> w) {
+OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2<float> y, Dual2<float> z, Dual2<float> w) {
     Dual2<float> rx = grad (hash.x, x, y, z, w);
     Dual2<float> ry = grad (hash.y, x, y, z, w);
     Dual2<float> rz = grad (hash.z, x, y, z, w);
@@ -946,45 +1058,45 @@ inline OSL_HOSTDEVICE Dual2<Vec3> grad (const Vec3i &hash, Dual2<float> x, Dual2
 }
 
 template <typename T> OSL_HOSTDEVICE
-inline T scale1 (const T &result) { return 0.2500f * result; }
+OSL_FORCEINLINE T scale1 (const T &result) { return 0.2500f * result; }
 template <typename T> OSL_HOSTDEVICE
-inline T scale2 (const T &result) { return 0.6616f * result; }
+OSL_FORCEINLINE T scale2 (const T &result) { return 0.6616f * result; }
 template <typename T> OSL_HOSTDEVICE
-inline T scale3 (const T &result) { return 0.9820f * result; }
+OSL_FORCEINLINE T scale3 (const T &result) { return 0.9820f * result; }
 template <typename T> OSL_HOSTDEVICE
-inline T scale4 (const T &result) { return 0.8344f * result; }
-
+OSL_FORCEINLINE T scale4 (const T &result) { return 0.8344f * result; }
 
 
 struct HashScalar {
-    OSL_HOSTDEVICE int operator() (int x) const {
-        unsigned int iv[1];
-        iv[0] = x;
-        return inthash<1> (iv);
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x) const {
+        return static_cast<int>(
+			inthash(static_cast<unsigned int>(x))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y) const {
-        unsigned int iv[2];
-        iv[0] = x;
-        iv[1] = y;
-        return inthash<2> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y) const {
+    	return static_cast<int>(
+			inthash(static_cast<unsigned int>(x),
+        	        static_cast<unsigned int>(y))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y, int z) const {
-        unsigned int iv[3];
-        iv[0] = x;
-        iv[1] = y;
-        iv[2] = z;
-        return inthash<3> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y, int z) const {
+    	return static_cast<int>(
+			inthash(static_cast<unsigned int>(x),
+        	        static_cast<unsigned int>(y),
+			 	    static_cast<unsigned int>(z))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y, int z, int w) const {
-        unsigned int iv[4];
-        iv[0] = x;
-        iv[1] = y;
-        iv[2] = z;
-        iv[3] = w;
-        return inthash<4> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y, int z, int w) const {
+    	return static_cast<int>(
+			inthash(static_cast<unsigned int>(x),
+        	        static_cast<unsigned int>(y),
+			  	    static_cast<unsigned int>(z),
+					static_cast<unsigned int>(w))
+		);
     }
 
 #ifndef __CUDA_ARCH__
@@ -1006,47 +1118,38 @@ struct HashScalar {
 
 };
 
+
+OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i sliceup (unsigned int h) {
+    // we only need the low-order bits to be random, so split out
+    // the 32 bit result into 3 parts for each channel
+    return Vec3i(
+		(h      ) & 0xFF,
+		(h >> 8 ) & 0xFF,
+		(h >> 16) & 0xFF);
+}
+
 struct HashVector {
-    OSL_HOSTDEVICE Vec3i operator() (int x) const {
-        unsigned int iv[1];
-        iv[0] = x;
-        return hash3<1> (iv);
+    static OSL_FORCEINLINE HashScalar convertToScalar() { return HashScalar(); }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x) const {
+        return sliceup(inthash(static_cast<unsigned int>(x)));
     }
 
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y) const {
-        unsigned int iv[2];
-        iv[0] = x;
-        iv[1] = y;
-        return hash3<2> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y) const {
+        return sliceup(inthash(static_cast<unsigned int>(x),
+        		               static_cast<unsigned int>(y)));
     }
 
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z) const {
-        unsigned int iv[3];
-        iv[0] = x;
-        iv[1] = y;
-        iv[2] = z;
-        return hash3<3> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z) const {
+        return sliceup(inthash(static_cast<unsigned int>(x),
+        		               static_cast<unsigned int>(y),
+							   static_cast<unsigned int>(z)));
     }
-
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z, int w) const {
-        unsigned int iv[4];
-        iv[0] = x;
-        iv[1] = y;
-        iv[2] = z;
-        iv[3] = w;
-        return hash3<4> (iv);
-    }
-
-    template <int N> OSL_HOSTDEVICE
-    Vec3i hash3 (unsigned int k[N]) const {
-        Vec3i result;
-        unsigned int h = inthash<N> (k);
-        // we only need the low-order bits to be random, so split out
-        // the 32 bit result into 3 parts for each channel
-        result.x = (h      ) & 0xFF;
-        result.y = (h >> 8 ) & 0xFF;
-        result.z = (h >> 16) & 0xFF;
-        return result;
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z, int w) const {
+        return sliceup(inthash(static_cast<unsigned int>(x),
+        		               static_cast<unsigned int>(y),
+							   static_cast<unsigned int>(z),
+							   static_cast<unsigned int>(w)));
     }
 
 #ifndef __CUDA_ARCH__
@@ -1077,7 +1180,12 @@ struct HashVector {
 
 };
 
+
 struct HashScalarPeriodic {
+private:
+    friend struct HashVectorPeriodic;
+    OSL_FORCEINLINE HashScalarPeriodic () {}
+public:
     OSL_HOSTDEVICE HashScalarPeriodic (float px) {
         m_px = OIIO::ifloor(px); if (m_px < 1) m_px = 1;
     }
@@ -1099,34 +1207,34 @@ struct HashScalarPeriodic {
 
     int m_px, m_py, m_pz, m_pw;
 
-    OSL_HOSTDEVICE int operator() (int x) const {
-        unsigned int iv[1];
-        iv[0] = imod (x, m_px);
-        return inthash<1> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x) const {
+        return static_cast<int>(
+			inthash (static_cast<unsigned int>(imod (x, m_px)))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y) const {
-        unsigned int iv[2];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        return inthash<2> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y) const {
+        return static_cast<int>(
+			inthash(static_cast<unsigned int>(imod (x, m_px)),
+        	        static_cast<unsigned int>(imod (y, m_py)))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y, int z) const {
-        unsigned int iv[3];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        iv[2] = imod (z, m_pz);
-        return inthash<3> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y, int z) const {
+        return static_cast<int>(
+			inthash(static_cast<unsigned int>(imod (x, m_px)),
+        	        static_cast<unsigned int>(imod (y, m_py)),
+			 	    static_cast<unsigned int>(imod (z, m_pz)))
+		);
     }
 
-    OSL_HOSTDEVICE int operator() (int x, int y, int z, int w) const {
-        unsigned int iv[4];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        iv[2] = imod (z, m_pz);
-        iv[3] = imod (w, m_pw);
-        return inthash<4> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE int operator() (int x, int y, int z, int w) const {
+        return static_cast<int>(
+			inthash(static_cast<unsigned int>(imod (x, m_px)),
+        	        static_cast<unsigned int>(imod (y, m_py)),
+			  	    static_cast<unsigned int>(imod (z, m_pz)),
+					static_cast<unsigned int>(imod (w, m_pw)))
+		);
     }
 
 #ifndef __CUDA_ARCH__
@@ -1170,47 +1278,35 @@ struct HashVectorPeriodic {
 
     int m_px, m_py, m_pz, m_pw;
 
-    OSL_HOSTDEVICE Vec3i operator() (int x) const {
-        unsigned int iv[1];
-        iv[0] = imod (x, m_px);
-        return hash3<1> (iv);
+    OSL_FORCEINLINE HashScalarPeriodic convertToScalar() const {
+        HashScalarPeriodic r;
+        r.m_px = m_px;
+        r.m_py = m_py;
+        r.m_pz = m_pz;
+        r.m_pw = m_pw;
+        return r;
     }
 
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y) const {
-        unsigned int iv[2];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        return hash3<2> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x) const {
+        return sliceup(inthash(static_cast<unsigned int>(imod (x, m_px))));
     }
 
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z) const {
-        unsigned int iv[3];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        iv[2] = imod (z, m_pz);
-        return hash3<3> (iv);
-
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y) const {
+        return sliceup(inthash(static_cast<unsigned int>(imod (x, m_px)),
+        		               static_cast<unsigned int>(imod (y, m_py))));
     }
 
-    OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z, int w) const {
-        unsigned int iv[4];
-        iv[0] = imod (x, m_px);
-        iv[1] = imod (y, m_py);
-        iv[2] = imod (z, m_pz);
-        iv[3] = imod (w, m_pw);
-        return hash3<4> (iv);
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z) const {
+        return sliceup(inthash(static_cast<unsigned int>(imod (x, m_px)),
+        		               static_cast<unsigned int>(imod (y, m_py)),
+							   static_cast<unsigned int>(imod (z, m_pz))));
     }
 
-    template <int N> OSL_HOSTDEVICE
-    Vec3i hash3 (unsigned int k[N]) const {
-        Vec3i result;
-        unsigned int h = inthash<N> (k);
-        // we only need the low-order bits to be random, so split out
-        // the 32 bit result into 3 parts for each channel
-        result.x = (h      ) & 0xFF;
-        result.y = (h >> 8 ) & 0xFF;
-        result.z = (h >> 16) & 0xFF;
-        return result;
+    OSL_FORCEINLINE OSL_HOSTDEVICE Vec3i operator() (int x, int y, int z, int w) const {
+        return sliceup(inthash(static_cast<unsigned int>(imod (x, m_px)),
+        		               static_cast<unsigned int>(imod (y, m_py)),
+							   static_cast<unsigned int>(imod (z, m_pz)),
+							   static_cast<unsigned int>(imod (w, m_pw))));
     }
 
 #ifndef __CUDA_ARCH__
@@ -1240,24 +1336,36 @@ struct HashVectorPeriodic {
 #endif
 };
 
+// Code Generation Policies
+// main intent is to allow top level classes to share implementation and carry
+// the policy down into helper functions who might diverge in implementation
+// or conditionally emit different code paths
+struct CGDefault
+{
+    static constexpr bool allowSIMD = true;
+};
 
+struct CGScalar
+{
+    static constexpr bool allowSIMD = false;
+};
 
-template <typename V, typename H, typename T> OSL_HOSTDEVICE
-inline void perlin (V& result, H& hash, const T &x) {
+template <typename CGPolicyT = CGDefault, typename V, typename H, typename T> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (V& result, H& hash, const T &x) {
     int X; T fx = floorfrac(x, &X);
     T u = fade(fx);
 
-    result = OIIO::lerp(grad (hash (X  ), fx     ),
+    auto lerp_result = sfm::lerp(grad (hash (X  ), fx     ),
                         grad (hash (X+1), fx-1.0f), u);
-    result = scale1 (result);
+    result = scale1 (lerp_result);
 }
 
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (float &result, const H &hash, const float &x, const float &y)
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (float &result, const H &hash, const float &x, const float &y)
 {
-    // result = 0.0f; return;
 #if OIIO_SIMD
+    if (CGPolicyT::allowSIMD)
+    {
     int4 XY;
     float4 fxy = floorfrac (float4(x,y,0.0f), &XY);
     float4 uv = fade(fxy);  // Note: will be (fade(fx), fade(fy), 0, 0)
@@ -1276,7 +1384,9 @@ inline void perlin (float &result, const H &hash, const float &x, const float &y
     float4 corner_grad = grad (corner_hash, remainderx, remaindery);
     result = scale2 (bilerp (corner_grad, uv[0], uv[1]));
 
-#else
+    } else
+#endif
+    {
     // ORIGINAL, non-SIMD
     int X; float fx = floorfrac(x, &X);
     int Y; float fy = floorfrac(y, &Y);
@@ -1284,21 +1394,21 @@ inline void perlin (float &result, const H &hash, const float &x, const float &y
     float u = fade(fx);
     float v = fade(fy);
 
-    result = OIIO::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
+    float bilerp_result = sfm::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
                            grad (hash (X+1, Y  ), fx-1.0f, fy     ),
                            grad (hash (X  , Y+1), fx     , fy-1.0f),
                            grad (hash (X+1, Y+1), fx-1.0f, fy-1.0f), u, v);
-    result = scale2 (result);
-#endif
+    result = scale2 (bilerp_result);
+    }
 }
 
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (float &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (float &result, const H &hash,
                     const float &x, const float &y, const float &z)
 {
 #if OIIO_SIMD
-    // result = 0; return;
+    if (CGPolicyT::allowSIMD)
+    {
 #if 0
     // You'd think it would be faster to do the floorfrac in parallel, but
     // according to my timings, it is not. I don't understand exactly why.
@@ -1344,8 +1454,9 @@ inline void perlin (float &result, const H &hash,
     float4 corner_grad_z1 = grad (corner_hash_z1, remainderx, remaindery, remainderz-float4::One());
 
     result = scale3 (trilerp (corner_grad_z0, corner_grad_z1, uvw));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; float fx = floorfrac(x, &X);
     int Y; float fy = floorfrac(y, &Y);
@@ -1353,7 +1464,7 @@ inline void perlin (float &result, const H &hash,
     float u = fade(fx);
     float v = fade(fy);
     float w = fade(fz);
-    result = OIIO::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz     ),
+    float trilerp_result = sfm::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz     ),
                             grad (hash (X+1, Y  , Z  ), fx-1.0f, fy     , fz     ),
                             grad (hash (X  , Y+1, Z  ), fx     , fy-1.0f, fz     ),
                             grad (hash (X+1, Y+1, Z  ), fx-1.0f, fy-1.0f, fz     ),
@@ -1362,18 +1473,19 @@ inline void perlin (float &result, const H &hash,
                             grad (hash (X  , Y+1, Z+1), fx     , fy-1.0f, fz-1.0f),
                             grad (hash (X+1, Y+1, Z+1), fx-1.0f, fy-1.0f, fz-1.0f),
                             u, v, w);
-    result = scale3 (result);
-#endif
+    result = scale3 (trilerp_result);
+    }
 }
 
 
 
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (float &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (float &result, const H &hash,
                     const float &x, const float &y, const float &z, const float &w)
 {
 #if OIIO_SIMD
-    // result = 0; return;
+    if (CGPolicyT::allowSIMD)
+    {
 
     int4 XYZW;
     float4 fxyzw = floorfrac (float4(x,y,z,w), &XYZW);
@@ -1413,8 +1525,9 @@ inline void perlin (float &result, const H &hash,
     result = scale4 (OIIO::lerp (trilerp (corner_grad_z0, corner_grad_z1, uvts),
                                  trilerp (corner_grad_z2, corner_grad_z3, uvts),
                                  OIIO::simd::extract<3>(uvts)));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; float fx = floorfrac(x, &X);
     int Y; float fy = floorfrac(y, &Y);
@@ -1426,8 +1539,8 @@ inline void perlin (float &result, const H &hash,
     float t = fade(fz);
     float s = fade(fw);
 
-    result = OIIO::lerp (
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
+    float lerp_result = sfm::lerp (
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
                               grad (hash (X+1, Y  , Z  , W  ), fx-1.0f, fy     , fz     , fw     ),
                               grad (hash (X  , Y+1, Z  , W  ), fx     , fy-1.0f, fz     , fw     ),
                               grad (hash (X+1, Y+1, Z  , W  ), fx-1.0f, fy-1.0f, fz     , fw     ),
@@ -1436,7 +1549,7 @@ inline void perlin (float &result, const H &hash,
                               grad (hash (X  , Y+1, Z+1, W  ), fx     , fy-1.0f, fz-1.0f, fw     ),
                               grad (hash (X+1, Y+1, Z+1, W  ), fx-1.0f, fy-1.0f, fz-1.0f, fw     ),
                               u, v, t),
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
                               grad (hash (X+1, Y  , Z  , W+1), fx-1.0f, fy     , fz     , fw-1.0f),
                               grad (hash (X  , Y+1, Z  , W+1), fx     , fy-1.0f, fz     , fw-1.0f),
                               grad (hash (X+1, Y+1, Z  , W+1), fx-1.0f, fy-1.0f, fz     , fw-1.0f),
@@ -1446,18 +1559,17 @@ inline void perlin (float &result, const H &hash,
                               grad (hash (X+1, Y+1, Z+1, W+1), fx-1.0f, fy-1.0f, fz-1.0f, fw-1.0f),
                               u, v, t),
                s);
-    result = scale4 (result);
-#endif
+    result = scale4 (lerp_result);
+    }
 }
 
-
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y)
 {
 #if OIIO_SIMD
-    // result = 0; return;
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     Dual2<float4> fxy (float4(fx.val(), fy.val(), 0.0f),
@@ -1480,30 +1592,29 @@ inline void perlin (Dual2<float> &result, const H &hash,
     Dual2<float4> corner_grad = grad (corner_hash, remainderx, remaindery);
 
     result = scale2 (bilerp (corner_grad, uv));
-#else
+    } else
+#endif
+    {
     // Non-SIMD case
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     Dual2<float> u = fade(fx);
     Dual2<float> v = fade(fy);
-    result = OIIO::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
+    auto bilerp_result = sfm::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
                            grad (hash (X+1, Y  ), fx-1.0f, fy     ),
                            grad (hash (X  , Y+1), fx     , fy-1.0f),
                            grad (hash (X+1, Y+1), fx-1.0f, fy-1.0f), u, v);
-    result = scale2 (result);
-#endif
+    result = scale2 (bilerp_result);
+    }
 }
 
-
-
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
 {
 #if OIIO_SIMD
-    // result = 0; return;
-
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     int Z; Dual2<float> fz = floorfrac(z, &Z);
@@ -1539,8 +1650,9 @@ inline void perlin (Dual2<float> &result, const H &hash,
     Dual2<float4> xx = OIIO::lerp (xy, shuffle<1,1,3,3>(xy), shuffle<0>(uvw));
     // interpolate along y axis
     result = scale3 (extract<0>(OIIO::lerp (xx,shuffle<2>(xx), shuffle<1>(uvw))));
-
-#else
+    } else
+#endif
+    {
     // Non-SIMD case
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
@@ -1548,7 +1660,7 @@ inline void perlin (Dual2<float> &result, const H &hash,
     Dual2<float> u = fade(fx);
     Dual2<float> v = fade(fy);
     Dual2<float> w = fade(fz);
-    result = OIIO::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz     ),
+    auto tril_result = sfm::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz     ),
                             grad (hash (X+1, Y  , Z  ), fx-1.0f, fy     , fz     ),
                             grad (hash (X  , Y+1, Z  ), fx     , fy-1.0f, fz     ),
                             grad (hash (X+1, Y+1, Z  ), fx-1.0f, fy-1.0f, fz     ),
@@ -1557,21 +1669,18 @@ inline void perlin (Dual2<float> &result, const H &hash,
                             grad (hash (X  , Y+1, Z+1), fx     , fy-1.0f, fz-1.0f),
                             grad (hash (X+1, Y+1, Z+1), fx-1.0f, fy-1.0f, fz-1.0f),
                             u, v, w);
-    result = scale3 (result);
-#endif
+    result = scale3 (tril_result);
+    }
 }
 
-
-
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<float> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<float> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y,
                     const Dual2<float> &z, const Dual2<float> &w)
 {
 #if OIIO_SIMD
-    // result = 0; return;
-
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     int Z; Dual2<float> fz = floorfrac(z, &Z);
@@ -1620,8 +1729,9 @@ inline void perlin (Dual2<float> &result, const H &hash,
     Dual2<float4> xx = OIIO::lerp (xy, shuffle<1,1,3,3>(xy), shuffle<0>(uvts));
     // interpolate along y axis
     result = scale4 (extract<0>(OIIO::lerp (xx,shuffle<2>(xx), shuffle<1>(uvts))));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
@@ -1633,8 +1743,8 @@ inline void perlin (Dual2<float> &result, const H &hash,
     Dual2<float> t = fade(fz);
     Dual2<float> s = fade(fw);
 
-    result = OIIO::lerp (
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
+    auto lerp_result = sfm::lerp (
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
                               grad (hash (X+1, Y  , Z  , W  ), fx-1.0f, fy     , fz     , fw     ),
                               grad (hash (X  , Y+1, Z  , W  ), fx     , fy-1.0f, fz     , fw     ),
                               grad (hash (X+1, Y+1, Z  , W  ), fx-1.0f, fy-1.0f, fz     , fw     ),
@@ -1643,7 +1753,7 @@ inline void perlin (Dual2<float> &result, const H &hash,
                               grad (hash (X  , Y+1, Z+1, W  ), fx     , fy-1.0f, fz-1.0f, fw     ),
                               grad (hash (X+1, Y+1, Z+1, W  ), fx-1.0f, fy-1.0f, fz-1.0f, fw     ),
                               u, v, t),
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
                               grad (hash (X+1, Y  , Z  , W+1), fx-1.0f, fy     , fz     , fw-1.0f),
                               grad (hash (X  , Y+1, Z  , W+1), fx     , fy-1.0f, fz     , fw-1.0f),
                               grad (hash (X+1, Y+1, Z  , W+1), fx-1.0f, fy-1.0f, fz     , fw-1.0f),
@@ -1653,19 +1763,18 @@ inline void perlin (Dual2<float> &result, const H &hash,
                               grad (hash (X+1, Y+1, Z+1, W+1), fx-1.0f, fy-1.0f, fz-1.0f, fw-1.0f),
                               u, v, t),
                s);
-    result = scale4 (result);
-#endif
+    result = scale4 (lerp_result);
+    }
 }
 
 
-
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y)
 {
 #if OIIO_SIMD
-    // result.setValue(0,0,0); return;
+    if (CGPolicyT::allowSIMD)
+    {
     int4 XYZ;
     float4 fxyz = floorfrac (float4(x,y,0), &XYZ);
     float4 uv = fade (fxyz);
@@ -1688,36 +1797,41 @@ inline void perlin (Vec3 &result, const H &hash,
     static const OIIO_SIMD4_ALIGN float f0011[4] = {0,0,1,1};
     float4 remainderx = OIIO::simd::shuffle<0>(fxyz) - (*(float4*)f0101);
     float4 remaindery = OIIO::simd::shuffle<1>(fxyz) - (*(float4*)f0011);
+    float result_comp[3];
     for (int i = 0; i < 3; ++i) {
         float4 corner_grad = grad (corner_hash[i], remainderx, remaindery);
         // Do the bilinear interpolation with SIMD. Here's the fastest way
         // I've found to do it.
         float4 xx = OIIO::lerp (corner_grad, OIIO::simd::shuffle<1,1,3,3>(corner_grad), uv[0]);
-        result[i] = scale2 (OIIO::simd::extract<0>(OIIO::lerp (xx,OIIO::simd::shuffle<2>(xx), uv[1])));
+        result_comp[i] = scale2 (OIIO::simd::extract<0>(OIIO::lerp (xx,OIIO::simd::shuffle<2>(xx), uv[1])));
     }
-#else
+    result = Vec3(result_comp[0], result_comp[1], result_comp[2]);
+    } else
+#endif
+    {
     // Non-SIMD case
     typedef float T;
     int X; T fx = floorfrac(x, &X);
     int Y; T fy = floorfrac(y, &Y);
     T u = fade(fx);
     T v = fade(fy);
-    result = OIIO::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
+    auto bil_result = sfm::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
                            grad (hash (X+1, Y  ), fx-1.0f, fy     ),
                            grad (hash (X  , Y+1), fx     , fy-1.0f),
                            grad (hash (X+1, Y+1), fx-1.0f, fy-1.0f), u, v);
-    result = scale2 (result);
-#endif
+    result = scale2 (bil_result);
+    }
 }
 
 
 
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y, const float &z)
 {
 #if OIIO_SIMD
-    // result.setValue(0,0,0); return;
+    if (CGPolicyT::allowSIMD)
+    {
 #if 0
     // You'd think it would be faster to do the floorfrac in parallel, but
     // according to my timings, it is not. Come back and understand why.
@@ -1762,6 +1876,7 @@ inline void perlin (Vec3 &result, const H &hash,
     float4 remaindery = OIIO::simd::shuffle<1>(fxyz) - (*(float4*)f0011);
     float4 remainderz0 = OIIO::simd::shuffle<2>(fxyz);
     float4 remainderz1 = OIIO::simd::shuffle<2>(fxyz) - float4::One();
+    float result_comp[3];
     for (int i = 0; i < 3; ++i) {
         float4 corner_grad_z0 = grad (corner_hash_z0[i], remainderx, remaindery, remainderz0);
         float4 corner_grad_z1 = grad (corner_hash_z1[i], remainderx, remaindery, remainderz1);
@@ -1771,9 +1886,12 @@ inline void perlin (Vec3 &result, const H &hash,
         // Interpolate along x axis
         float4 xx = OIIO::lerp (xy, OIIO::simd::shuffle<1,1,3,3>(xy), OIIO::simd::shuffle<0>(uvw));
         // interpolate along y axis
-        result[i] = scale3 (OIIO::simd::extract<0>(OIIO::lerp (xx,OIIO::simd::shuffle<2>(xx), OIIO::simd::shuffle<1>(uvw))));
+        result_comp[i] = scale3 (OIIO::simd::extract<0>(OIIO::lerp (xx,OIIO::simd::shuffle<2>(xx), OIIO::simd::shuffle<1>(uvw))));
     }
-#else
+    result = Vec3(result_comp[0],result_comp[1],result_comp[2]);
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; float fx = floorfrac(x, &X);
     int Y; float fy = floorfrac(y, &Y);
@@ -1781,7 +1899,11 @@ inline void perlin (Vec3 &result, const H &hash,
     float u = fade(fx);
     float v = fade(fy);
     float w = fade(fz);
-    result = OIIO::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz      ),
+
+    // A.W. the OIIO_SIMD above differs from the original results
+    // so we are re-implementing the non-SIMD version to match below
+#if 0
+    result = sfm::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz      ),
                             grad (hash (X+1, Y  , Z  ), fx-1.0f, fy     , fz      ),
                             grad (hash (X  , Y+1, Z  ), fx     , fy-1.0f, fz      ),
                             grad (hash (X+1, Y+1, Z  ), fx-1.0f, fy-1.0f, fz      ),
@@ -1791,18 +1913,71 @@ inline void perlin (Vec3 &result, const H &hash,
                             grad (hash (X+1, Y+1, Z+1), fx-1.0f, fy-1.0f, fz-1.0f ),
                             u, v, w);
     result = scale3 (result);
+#else
+    static_assert(std::is_same<Vec3i, decltype(hash(X, Y, Z))>::value, "This re-implementation was developed for Hashs returning a vector type only");
+    // Want to avoid repeating the same hash work 3 times in a row
+    // so rather than executing the vector version, we will use HashScalar
+    // and directly mask its results on a per component basis
+    auto hash_scalar = hash.convertToScalar();
+    int h000 = hash_scalar (X  , Y  , Z  );
+    int h100 = hash_scalar (X+1, Y  , Z  );
+    int h010 = hash_scalar (X  , Y+1, Z  );
+    int h110 = hash_scalar (X+1, Y+1, Z  );
+    int h001 = hash_scalar (X  , Y  , Z+1);
+    int h101 = hash_scalar (X+1, Y  , Z+1);
+    int h011 = hash_scalar (X  , Y+1, Z+1);
+    int h111 = hash_scalar (X+1, Y+1, Z+1);
+
+    // We are mimicking the OIIO_SSE behavior
+    //      result[0] = (h        ) & 0xFF;
+    //      result[1] = (srl(h,8 )) & 0xFF;
+    //      result[2] = (srl(h,16)) & 0xFF;
+    // skipping masking the 0th version, perhaps that is a mistake
+
+    float result0 = sfm::trilerp (grad (h000, fx     , fy     , fz      ),
+                            grad (h100, fx-1.0f, fy     , fz      ),
+                            grad (h010, fx     , fy-1.0f, fz      ),
+                            grad (h110, fx-1.0f, fy-1.0f, fz      ),
+                            grad (h001, fx     , fy     , fz-1.0f ),
+                            grad (h101, fx-1.0f, fy     , fz-1.0f ),
+                            grad (h011, fx     , fy-1.0f, fz-1.0f ),
+                            grad (h111, fx-1.0f, fy-1.0f, fz-1.0f ),
+                            u, v, w);
+
+    float result1 = sfm::trilerp (
+        grad ((h000>>8) & 0xFF, fx     , fy     , fz      ),
+        grad ((h100>>8) & 0xFF, fx-1.0f, fy     , fz      ),
+        grad ((h010>>8) & 0xFF, fx     , fy-1.0f, fz      ),
+        grad ((h110>>8) & 0xFF, fx-1.0f, fy-1.0f, fz      ),
+        grad ((h001>>8) & 0xFF, fx     , fy     , fz-1.0f ),
+        grad ((h101>>8) & 0xFF, fx-1.0f, fy     , fz-1.0f ),
+        grad ((h011>>8) & 0xFF, fx     , fy-1.0f, fz-1.0f ),
+        grad ((h111>>8) & 0xFF, fx-1.0f, fy-1.0f, fz-1.0f ),
+        u, v, w);
+
+    float result2 = sfm::trilerp (
+        grad ((h000>>16) & 0xFF, fx     , fy     , fz      ),
+        grad ((h100>>16) & 0xFF, fx-1.0f, fy     , fz      ),
+        grad ((h010>>16) & 0xFF, fx     , fy-1.0f, fz      ),
+        grad ((h110>>16) & 0xFF, fx-1.0f, fy-1.0f, fz      ),
+        grad ((h001>>16) & 0xFF, fx     , fy     , fz-1.0f ),
+        grad ((h101>>16) & 0xFF, fx-1.0f, fy     , fz-1.0f ),
+        grad ((h011>>16) & 0xFF, fx     , fy-1.0f, fz-1.0f ),
+        grad ((h111>>16) & 0xFF, fx-1.0f, fy-1.0f, fz-1.0f ),
+        u, v, w);
+
+    result = Vec3(scale3 (result0), scale3 (result1), scale3 (result2));
 #endif
+    }
 }
 
-
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Vec3 &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Vec3 &result, const H &hash,
                     const float &x, const float &y, const float &z, const float &w)
 {
 #if OIIO_SIMD
-    // result.setValue(0,0,0); return;
-
+    if (CGPolicyT::allowSIMD)
+    {
     int4 XYZW;
     float4 fxyzw = floorfrac (float4(x,y,z,w), &XYZW);
     float4 uvts = fade (fxyzw);
@@ -1835,16 +2010,20 @@ inline void perlin (Vec3 &result, const H &hash,
     float4 remainderw = OIIO::simd::shuffle<3>(fxyzw);
 //    float4 remainderz0 = shuffle<2>(fxyz);
 //    float4 remainderz1 = shuffle<2>(fxyz) - 1.0f;
+    float result_comp[3];
     for (int i = 0; i < 3; ++i) {
         float4 corner_grad_z0 = grad (corner_hash_z0[i], remainderx, remaindery, remainderz, remainderw);
         float4 corner_grad_z1 = grad (corner_hash_z1[i], remainderx, remaindery, remainderz-float4::One(), remainderw);
         float4 corner_grad_z2 = grad (corner_hash_z2[i], remainderx, remaindery, remainderz, remainderw-float4::One());
         float4 corner_grad_z3 = grad (corner_hash_z3[i], remainderx, remaindery, remainderz-float4::One(), remainderw-float4::One());
-        result[i] = scale4 (OIIO::lerp (trilerp (corner_grad_z0, corner_grad_z1, uvts),
+        result_comp[i] = scale4 (OIIO::lerp (trilerp (corner_grad_z0, corner_grad_z1, uvts),
                                         trilerp (corner_grad_z2, corner_grad_z3, uvts),
                                         OIIO::simd::extract<3>(uvts)));
     }
-#else
+    result = Vec3(result_comp[0],result_comp[1],result_comp[2]);
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; float fx = floorfrac(x, &X);
     int Y; float fy = floorfrac(y, &Y);
@@ -1856,8 +2035,8 @@ inline void perlin (Vec3 &result, const H &hash,
     float t = fade(fz);
     float s = fade(fw);
 
-    result = OIIO::lerp (
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
+    auto l_result = sfm::lerp (
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
                               grad (hash (X+1, Y  , Z  , W  ), fx-1.0f, fy     , fz     , fw     ),
                               grad (hash (X  , Y+1, Z  , W  ), fx     , fy-1.0f, fz     , fw     ),
                               grad (hash (X+1, Y+1, Z  , W  ), fx-1.0f, fy-1.0f, fz     , fw     ),
@@ -1866,7 +2045,7 @@ inline void perlin (Vec3 &result, const H &hash,
                               grad (hash (X  , Y+1, Z+1, W  ), fx     , fy-1.0f, fz-1.0f, fw     ),
                               grad (hash (X+1, Y+1, Z+1, W  ), fx-1.0f, fy-1.0f, fz-1.0f, fw     ),
                               u, v, t),
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
                               grad (hash (X+1, Y  , Z  , W+1), fx-1.0f, fy     , fz     , fw-1.0f),
                               grad (hash (X  , Y+1, Z  , W+1), fx     , fy-1.0f, fz     , fw-1.0f),
                               grad (hash (X+1, Y+1, Z  , W+1), fx-1.0f, fy-1.0f, fz     , fw-1.0f),
@@ -1876,18 +2055,18 @@ inline void perlin (Vec3 &result, const H &hash,
                               grad (hash (X+1, Y+1, Z+1, W+1), fx-1.0f, fy-1.0f, fz-1.0f, fw-1.0f),
                               u, v, t),
                s);
-    result = scale4 (result);
-#endif
+    result = scale4 (l_result);
+    }
 }
 
 
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y)
 {
-    // result = Vec3(0,0,0); return;
 #if OIIO_SIMD
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     Dual2<float4> fxyz (float4(fx.val(), fy.val(), 0.0f),
@@ -1924,30 +2103,31 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
     result.set (Vec3 (r[0].val(), r[1].val(), r[2].val()),
                 Vec3 (r[0].dx(),  r[1].dx(),  r[2].dx()),
                 Vec3 (r[0].dy(),  r[1].dy(),  r[2].dy()));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     Dual2<float> u = fade(fx);
     Dual2<float> v = fade(fy);
-    result = OIIO::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
+    auto bil_result = sfm::bilerp (grad (hash (X  , Y  ), fx     , fy     ),
                            grad (hash (X+1, Y  ), fx-1.0f, fy     ),
                            grad (hash (X  , Y+1), fx     , fy-1.0f),
                            grad (hash (X+1, Y+1), fx-1.0f, fy-1.0f),
                            u, v);
-    result = scale2 (result);
-#endif
+    result = scale2 (bil_result);
+    }
 }
 
 
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y, const Dual2<float> &z)
 {
-    // result = Vec3(0,0,0); return;
 #if OIIO_SIMD
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     int Z; Dual2<float> fz = floorfrac(z, &Z);
@@ -1993,8 +2173,9 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
     result.set (Vec3 (r[0].val(), r[1].val(), r[2].val()),
                 Vec3 (r[0].dx(),  r[1].dx(),  r[2].dx()),
                 Vec3 (r[0].dy(),  r[1].dy(),  r[2].dy()));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
@@ -2002,7 +2183,7 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
     Dual2<float> u = fade(fx);
     Dual2<float> v = fade(fy);
     Dual2<float> w = fade(fz);
-    result = OIIO::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz      ),
+    auto til_result = sfm::trilerp (grad (hash (X  , Y  , Z  ), fx     , fy     , fz      ),
                             grad (hash (X+1, Y  , Z  ), fx-1.0f, fy     , fz      ),
                             grad (hash (X  , Y+1, Z  ), fx     , fy-1.0f, fz      ),
                             grad (hash (X+1, Y+1, Z  ), fx-1.0f, fy-1.0f, fz      ),
@@ -2011,20 +2192,19 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
                             grad (hash (X  , Y+1, Z+1), fx     , fy-1.0f, fz-1.0f ),
                             grad (hash (X+1, Y+1, Z+1), fx-1.0f, fy-1.0f, fz-1.0f ),
                             u, v, w);
-    result = scale3 (result);
-#endif
+    result = scale3 (til_result);
+    }
 }
 
 
-
-template <typename H> OSL_HOSTDEVICE
-inline void perlin (Dual2<Vec3> &result, const H &hash,
+template <typename CGPolicyT = CGDefault, typename H> OSL_HOSTDEVICE
+OSL_FORCEINLINE void perlin (Dual2<Vec3> &result, const H &hash,
                     const Dual2<float> &x, const Dual2<float> &y,
                     const Dual2<float> &z, const Dual2<float> &w)
 {
-    // result = Vec3(0,0,0); return;
 #if OIIO_SIMD
-
+    if (CGPolicyT::allowSIMD)
+    {
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
     int Z; Dual2<float> fz = floorfrac(z, &Z);
@@ -2084,8 +2264,9 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
     result.set (Vec3 (r[0].val(), r[1].val(), r[2].val()),
                 Vec3 (r[0].dx(),  r[1].dx(),  r[2].dx()),
                 Vec3 (r[0].dy(),  r[1].dy(),  r[2].dy()));
-
-#else
+    } else
+#endif
+    {
     // ORIGINAL -- non-SIMD
     int X; Dual2<float> fx = floorfrac(x, &X);
     int Y; Dual2<float> fy = floorfrac(y, &Y);
@@ -2097,8 +2278,8 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
     Dual2<float> t = fade(fz);
     Dual2<float> s = fade(fw);
 
-    result = OIIO::lerp (
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
+    auto l_result = sfm::lerp (
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W  ), fx     , fy     , fz     , fw     ),
                               grad (hash (X+1, Y  , Z  , W  ), fx-1.0f, fy     , fz     , fw     ),
                               grad (hash (X  , Y+1, Z  , W  ), fx     , fy-1.0f, fz     , fw     ),
                               grad (hash (X+1, Y+1, Z  , W  ), fx-1.0f, fy-1.0f, fz     , fw     ),
@@ -2107,7 +2288,7 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
                               grad (hash (X  , Y+1, Z+1, W  ), fx     , fy-1.0f, fz-1.0f, fw     ),
                               grad (hash (X+1, Y+1, Z+1, W  ), fx-1.0f, fy-1.0f, fz-1.0f, fw     ),
                               u, v, t),
-               OIIO::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
+               sfm::trilerp (grad (hash (X  , Y  , Z  , W+1), fx     , fy     , fz     , fw-1.0f),
                               grad (hash (X+1, Y  , Z  , W+1), fx-1.0f, fy     , fz     , fw-1.0f),
                               grad (hash (X  , Y+1, Z  , W+1), fx     , fy-1.0f, fz     , fw-1.0f),
                               grad (hash (X+1, Y+1, Z  , W+1), fx-1.0f, fy-1.0f, fz     , fw-1.0f),
@@ -2117,447 +2298,492 @@ inline void perlin (Dual2<Vec3> &result, const H &hash,
                               grad (hash (X+1, Y+1, Z+1, W+1), fx-1.0f, fy-1.0f, fz-1.0f, fw-1.0f),
                               u, v, t),
                s);
-    result = scale4 (result);
-#endif
+
+    result = scale4 (l_result);
+    }
 }
 
 
 
-struct Noise {
-    OSL_HOSTDEVICE Noise () { }
+template<typename CGPolicyT = CGDefault>
+struct NoiseImpl {
+    NoiseImpl () { }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
         HashScalar h;
-        perlin(result, h, x);
-        result = 0.5f * (result + 1);
+        float perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x);
+        result = 0.5f * (perlin_result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
         HashScalar h;
-        perlin(result, h, x, y);
-        result = 0.5f * (result + 1);
+        float perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x, y);
+        result = 0.5f * (perlin_result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
         HashScalar h;
-        perlin(result, h, p.x, p.y, p.z);
-        result = 0.5f * (result + 1);
+        float perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, p.x, p.y, p.z);
+        result = 0.5f * (perlin_result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
         HashScalar h;
-        perlin(result, h, p.x, p.y, p.z, t);
-        result = 0.5f * (result + 1);
+        float perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, p.x, p.y, p.z, t);
+        result = 0.5f * (perlin_result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
         HashVector h;
-        perlin(result, h, x);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Vec3 perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x);
+        result = 0.5f * (perlin_result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
         HashVector h;
-        perlin(result, h, x, y);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Vec3 perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x, y);
+        result = 0.5f * (perlin_result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
         HashVector h;
-        perlin(result, h, p.x, p.y, p.z);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Vec3 perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, p.x, p.y, p.z);
+        result = 0.5f * (perlin_result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
         HashVector h;
-        perlin(result, h, p.x, p.y, p.z, t);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Vec3 perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, p.x, p.y, p.z, t);
+        result = 0.5f * (perlin_result + Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+    
+    // dual versions
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
+        HashScalar h;
+        Dual2<float> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x);
+        result = 0.5f * (perlin_result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        HashScalar h;
+        Dual2<float> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x, y);
+        result = 0.5f * (perlin_result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
+        HashScalar h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        Dual2<float> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, px, py, pz);
+        result = 0.5f * (perlin_result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        HashScalar h;        
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        Dual2<float> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, px, py, pz, t);
+        result = 0.5f * (perlin_result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
+        HashVector h;
+        Dual2<Vec3> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (perlin_result + Vec3(1, 1, 1));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        HashVector h;
+        Dual2<Vec3> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, x, y);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (perlin_result + Vec3(1, 1, 1));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
+        HashVector h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        Dual2<Vec3> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, px, py, pz);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (perlin_result + Vec3(1, 1, 1));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        HashVector h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        Dual2<Vec3> perlin_result;
+        perlin<CGPolicyT>(perlin_result, h, px, py, pz, t);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (perlin_result + Vec3(1, 1, 1));
+    }
+};
+
+struct Noise : NoiseImpl<CGDefault> {};
+// Scalar version of Noise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct NoiseScalar : NoiseImpl<CGScalar> {};
+
+
+template<typename CGPolicyT = CGDefault>
+struct SNoiseImpl {
+    OSL_HOSTDEVICE SNoiseImpl () { }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+    }
+    
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
+    }
+
+
+    // dual versions
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        HashScalar h;
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
+        HashScalar h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        HashScalar h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        HashVector h;
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
+        HashVector h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        HashVector h;
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
+    }
+};
+
+struct SNoise : SNoiseImpl<CGDefault> {};
+// Scalar version of SNoise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct SNoiseScalar : SNoiseImpl<CGScalar> {};
+
+
+
+template<typename CGPolicyT = CGDefault>
+struct PeriodicNoiseImpl {
+    OSL_HOSTDEVICE PeriodicNoiseImpl () { }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
+        HashScalarPeriodic h(px);
+        perlin<CGPolicyT>(result, h, x);
+        result = 0.5f * (result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y, float px, float py) const {
+        HashScalarPeriodic h(px, py);
+        perlin<CGPolicyT>(result, h, x, y);
+        result = 0.5f * (result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, const Vec3 &pp) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+        result = 0.5f * (result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
+        result = 0.5f * (result + 1.0f);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
+        HashVectorPeriodic h(px);
+        perlin<CGPolicyT>(result, h, x);
+        result = 0.5f * (result + Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y, float px, float py) const {
+        HashVectorPeriodic h(px, py);
+        perlin<CGPolicyT>(result, h, x, y);
+        result = 0.5f * (result + Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
+        HashVectorPeriodic h(pp.x, pp.y, pp.z);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+        result = 0.5f * (result + Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
+        HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
+        result = 0.5f * (result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
     // dual versions
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
-        HashScalar h;
-        perlin(result, h, x);
-        result = 0.5f * (result + 1.0f);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y) const {
-        HashScalar h;
-        perlin(result, h, x, y);
-        result = 0.5f * (result + 1.0f);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
-        HashScalar h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-        result = 0.5f * (result + 1.0f);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
-        HashScalar h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-        result = 0.5f * (result + 1.0f);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
-        HashVector h;
-        perlin(result, h, x);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
-        HashVector h;
-        perlin(result, h, x, y);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
-        HashVector h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
-        HashVector h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
-    }
-};
-
-struct SNoise {
-    OSL_HOSTDEVICE SNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x) const {
-        HashScalar h;
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y) const {
-        HashScalar h;
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p) const {
-        HashScalar h;
-        perlin(result, h, p.x, p.y, p.z);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t) const {
-        HashScalar h;
-        perlin(result, h, p.x, p.y, p.z, t);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
-        HashVector h;
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
-        HashVector h;
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
-        HashVector h;
-        perlin(result, h, p.x, p.y, p.z);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
-        HashVector h;
-        perlin(result, h, p.x, p.y, p.z, t);
-    }
-
-
-    // dual versions
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
-        HashScalar h;
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y) const {
-        HashScalar h;
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
-        HashScalar h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
-        HashScalar h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
-        HashVector h;
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
-        HashVector h;
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
-        HashVector h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
-        HashVector h;
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-    }
-};
-
-
-
-struct PeriodicNoise {
-    OSL_HOSTDEVICE PeriodicNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, float px) const {
         HashScalarPeriodic h(px);
-        perlin(result, h, x);
-        result = 0.5f * (result + 1);
+        perlin<CGPolicyT>(result, h, x);
+        result = 0.5f * (result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y, float px, float py) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y,
+            float px, float py) const {
         HashScalarPeriodic h(px, py);
-        perlin(result, h, x, y);
-        result = 0.5f * (result + 1);
+        perlin<CGPolicyT>(result, h, x, y);
+        result = 0.5f * (result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, const Vec3 &pp) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
         HashScalarPeriodic h(pp.x, pp.y, pp.z);
-        perlin(result, h, p.x, p.y, p.z);
-        result = 0.5f * (result + 1);
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz);
+        result = 0.5f * (result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
-        perlin(result, h, p.x, p.y, p.z, t);
-        result = 0.5f * (result + 1);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
+            const Vec3 &pp, float pt) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);        
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
+        result = 0.5f * (result + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, float px) const {
         HashVectorPeriodic h(px);
-        perlin(result, h, x);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, x);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y, float px, float py) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y,
+            float px, float py) const {
         HashVectorPeriodic h(px, py);
-        perlin(result, h, x, y);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, x, y);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
         HashVectorPeriodic h(pp.x, pp.y, pp.z);
-        perlin(result, h, p.x, p.y, p.z);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1.0f, 1.0f, 1.0f));
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
+            const Vec3 &pp, float pt) const {
         HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
-        perlin(result, h, p.x, p.y, p.z, t);
-        result = 0.5f * (result + Vec3(1, 1, 1));
+        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
+        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
+        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
+        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1.0f, 1.0f, 1.0f));
+    }
+
+};
+
+struct PeriodicNoise : PeriodicNoiseImpl<CGDefault> {};
+// Scalar version of PeriodicNoise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct PeriodicNoiseScalar : PeriodicNoiseImpl<CGScalar> {};
+
+template<typename CGPolicyT = CGDefault>
+struct PeriodicSNoiseImpl {
+    OSL_HOSTDEVICE PeriodicSNoiseImpl () { }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
+        HashScalarPeriodic h(px);
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, float x, float y, float px, float py) const {
+        HashScalarPeriodic h(px, py);
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, const Vec3 &pp) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
+        HashVectorPeriodic h(px);
+        perlin<CGPolicyT>(result, h, x);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y, float px, float py) const {
+        HashVectorPeriodic h(px, py);
+        perlin<CGPolicyT>(result, h, x, y);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
+        HashVectorPeriodic h(pp.x, pp.y, pp.z);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z);
+    }
+
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
+        HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
+        perlin<CGPolicyT>(result, h, p.x, p.y, p.z, t);
     }
 
     // dual versions
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, float px) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, float px) const {
         HashScalarPeriodic h(px);
-        perlin(result, h, x);
-        result = 0.5f * (result + 1.0f);
+        perlin<CGPolicyT>(result, h, x);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y,
-                                           float px, float py) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y,
+            float px, float py) const {
         HashScalarPeriodic h(px, py);
-        perlin(result, h, x, y);
-        result = 0.5f * (result + 1.0f);
+        perlin<CGPolicyT>(result, h, x, y);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
         HashScalarPeriodic h(pp.x, pp.y, pp.z);
         Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
         Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
         Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-        result = 0.5f * (result + 1.0f);
+        perlin<CGPolicyT>(result, h, px, py, pz);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
-                                           const Vec3 &pp, float pt) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
+            const Vec3 &pp, float pt) const {
+        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);        
         Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
         Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
         Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-        result = 0.5f * (result + 1.0f);
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, float px) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, float px) const {
         HashVectorPeriodic h(px);
-        perlin(result, h, x);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, x);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y,
-                                           float px, float py) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y,
+            float px, float py) const {
         HashVectorPeriodic h(px, py);
-        perlin(result, h, x, y);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, x, y);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
         HashVectorPeriodic h(pp.x, pp.y, pp.z);
         Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
         Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
         Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, px, py, pz);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
-                                           const Vec3 &pp, float pt) const {
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
+            const Vec3 &pp, float pt) const {
         HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
         Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
         Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
         Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-        result = Vec3(0.5f, 0.5f, 0.5f) * (result + Vec3(1, 1, 1));
+        perlin<CGPolicyT>(result, h, px, py, pz, t);
     }
+
 };
 
-struct PeriodicSNoise {
-    OSL_HOSTDEVICE PeriodicSNoise () { }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float px) const {
-        HashScalarPeriodic h(px);
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, float x, float y, float px, float py) const {
-        HashScalarPeriodic h(px, py);
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, const Vec3 &pp) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z);
-        perlin(result, h, p.x, p.y, p.z);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (float &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
-        perlin(result, h, p.x, p.y, p.z, t);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float px) const {
-        HashVectorPeriodic h(px);
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y, float px, float py) const {
-        HashVectorPeriodic h(px, py);
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, const Vec3 &pp) const {
-        HashVectorPeriodic h(pp.x, pp.y, pp.z);
-        perlin(result, h, p.x, p.y, p.z);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t, const Vec3 &pp, float pt) const {
-        HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
-        perlin(result, h, p.x, p.y, p.z, t);
-    }
-
-    // dual versions
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, float px) const {
-        HashScalarPeriodic h(px);
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y,
-                                           float px, float py) const {
-        HashScalarPeriodic h(px, py);
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z);
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
-                                           const Vec3 &pp, float pt) const {
-        HashScalarPeriodic h(pp.x, pp.y, pp.z, pt);
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, float px) const {
-        HashVectorPeriodic h(px);
-        perlin(result, h, x);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y,
-                                           float px, float py) const {
-        HashVectorPeriodic h(px, py);
-        perlin(result, h, x, y);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Vec3 &pp) const {
-        HashVectorPeriodic h(pp.x, pp.y, pp.z);
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz);
-    }
-
-    inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t,
-                                           const Vec3 &pp, float pt) const {
-        HashVectorPeriodic h(pp.x, pp.y, pp.z, pt);
-        Dual2<float> px(p.val().x, p.dx().x, p.dy().x);
-        Dual2<float> py(p.val().y, p.dx().y, p.dy().y);
-        Dual2<float> pz(p.val().z, p.dx().z, p.dy().z);
-        perlin(result, h, px, py, pz, t);
-    }
-};
-
+struct PeriodicSNoise : PeriodicSNoiseImpl<CGDefault> {};
+// Scalar version of PeriodicSNoise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct PeriodicSNoiseScalar : PeriodicSNoiseImpl<CGScalar> {};
 
 
 struct SimplexNoise {
@@ -2579,28 +2805,28 @@ struct SimplexNoise {
         result = simplexnoise4 (p.x, p.y, p.z, t);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
-        result[0] = simplexnoise1 (x, 0);
-        result[1] = simplexnoise1 (x, 1);
-        result[2] = simplexnoise1 (x, 2);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
+        result.x = simplexnoise1 (x, 0);
+        result.y = simplexnoise1 (x, 1);
+        result.z = simplexnoise1 (x, 2);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
-        result[0] = simplexnoise2 (x, y, 0);
-        result[1] = simplexnoise2 (x, y, 1);
-        result[2] = simplexnoise2 (x, y, 2);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
+        result.x = simplexnoise2 (x, y, 0);
+        result.y = simplexnoise2 (x, y, 1);
+        result.z = simplexnoise2 (x, y, 2);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
-        result[0] = simplexnoise3 (p.x, p.y, p.z, 0);
-        result[1] = simplexnoise3 (p.x, p.y, p.z, 1);
-        result[2] = simplexnoise3 (p.x, p.y, p.z, 2);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
+        result.x = simplexnoise3 (p.x, p.y, p.z, 0);
+        result.y = simplexnoise3 (p.x, p.y, p.z, 1);
+        result.z = simplexnoise3 (p.x, p.y, p.z, 2);
     }
-
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
-        result[0] = simplexnoise4 (p.x, p.y, p.z, t, 0);
-        result[1] = simplexnoise4 (p.x, p.y, p.z, t, 1);
-        result[2] = simplexnoise4 (p.x, p.y, p.z, t, 2);
+    
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+        result.x = simplexnoise4 (p.x, p.y, p.z, t, 0);
+        result.y = simplexnoise4 (p.x, p.y, p.z, t, 1);
+        result.z = simplexnoise4 (p.x, p.y, p.z, t, 2);
     }
 
 
@@ -2624,19 +2850,19 @@ struct SimplexNoise {
     inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p,
                                            int seed=0) const {
         float r, dndx, dndy, dndz;
-        r = simplexnoise3 (p.val()[0], p.val()[1], p.val()[2],
+        r = simplexnoise3 (p.val().x, p.val().y, p.val().z,
                            seed, &dndx, &dndy, &dndz);
-        result.set (r, dndx * p.dx()[0] + dndy * p.dx()[1] + dndz * p.dx()[2],
-                       dndx * p.dy()[0] + dndy * p.dy()[1] + dndz * p.dy()[2]);
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z,
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z);
     }
 
     inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p,
                                            const Dual2<float> &t, int seed=0) const {
         float r, dndx, dndy, dndz, dndt;
-        r = simplexnoise4 (p.val()[0], p.val()[1], p.val()[2], t.val(),
+        r = simplexnoise4 (p.val().x, p.val().y, p.val().z, t.val(),
                            seed, &dndx, &dndy, &dndz, &dndt);
-        result.set (r, dndx * p.dx()[0] + dndy * p.dx()[1] + dndz * p.dx()[2] + dndt * t.dx(),
-                       dndx * p.dy()[0] + dndy * p.dy()[1] + dndz * p.dy()[2] + dndt * t.dy());
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z + dndt * t.dx(),
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z + dndt * t.dy());
     }
 
     inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
@@ -2673,6 +2899,119 @@ struct SimplexNoise {
 };
 
 
+// Scalar version of SimplexNoise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct SimplexNoiseScalar {
+    SimplexNoiseScalar () { }
+
+    OSL_FORCEINLINE void operator() (float &result, float x) const {
+        result = sfm::simplexnoise1<0/* seed */>(x);
+    }
+
+    OSL_FORCEINLINE void operator() (float &result, float x, float y) const {
+        result = sfm::simplexnoise2<0/* seed */>(x, y);
+    }
+
+    OSL_FORCEINLINE void operator()(float &result, const Vec3 &p) const {
+        result = sfm::simplexnoise3<0/* seed */>(p.x, p.y, p.z);
+    }
+
+    OSL_FORCEINLINE void operator()(float &result, const Vec3 &p, float t) const {
+        result = sfm::simplexnoise4<0/* seed */>(p.x, p.y, p.z, t);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, float x) const {
+        result.x = sfm::simplexnoise1<0/* seed */>(x);
+        result.y = sfm::simplexnoise1<1/* seed */>(x);
+        result.z = sfm::simplexnoise1<2/* seed */>(x);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, float x, float y) const {
+        result.x = sfm::simplexnoise2<0/* seed */>(x, y);
+        result.y = sfm::simplexnoise2<1/* seed */>(x, y);
+        result.z = sfm::simplexnoise2<2/* seed */>(x, y);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, const Vec3 &p) const {
+        result.x = sfm::simplexnoise3<0/* seed */>(p.x, p.y, p.z);
+        result.y = sfm::simplexnoise3<1/* seed */>(p.x, p.y, p.z);
+        result.z = sfm::simplexnoise3<2/* seed */>(p.x, p.y, p.z);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+        result.x = sfm::simplexnoise4<0/* seed */>(p.x, p.y, p.z, t);
+        result.y = sfm::simplexnoise4<1/* seed */>(p.x, p.y, p.z, t);
+        result.z = sfm::simplexnoise4<2/* seed */>(p.x, p.y, p.z, t);
+    }
+
+
+    // dual versions
+    template<int seed=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
+        float r, dndx;
+        r = sfm::simplexnoise1<seed>(x.val(), sfm::DxRef(dndx));
+        result.set (r, dndx * x.dx(), dndx * x.dy());
+    }
+
+    template<int seedT=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        float r, dndx, dndy;
+        r = sfm::simplexnoise2<seedT> (x.val(), y.val(), sfm::DxDyRef(dndx, dndy));
+        result.set (r, dndx * x.dx() + dndy * y.dx(),
+                       dndx * x.dy() + dndy * y.dy());
+    }
+
+    template<int seed=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
+        float dndx, dndy, dndz;
+        const Vec3 &p_val = p.val();
+        float r = sfm::simplexnoise3<seed>(p_val.x, p_val.y, p_val.z, sfm::DxDyDzRef(dndx, dndy, dndz));
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z,
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z);
+    }
+
+    template<int seed=0>
+    OSL_FORCEINLINE void operator()(Dual2<float> &result, const Dual2<Vec3> &p,
+                            const Dual2<float> &t) const {
+        float dndx, dndy, dndz, dndt;
+        float r = sfm::simplexnoise4<seed> (p.val().x, p.val().y, p.val().z, t.val(),
+                           sfm::DxDyDzDwRef(dndx, dndy, dndz, dndt));
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z + dndt * t.dx(),
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z + dndt * t.dy());
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, x);
+        operator()<1>(r1, x);
+        operator()<2>(r2, x);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, x, y);
+        operator()<1>(r1, x, y);
+        operator()<2>(r2, x, y);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, p);
+        operator()<1>(r1, p);
+        operator()<2>(r2, p);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, p, t);
+        operator()<1>(r1, p, t);
+        operator()<2>(r2, p, t);
+        result = make_Vec3 (r0, r1, r2);
+    }
+};
 
 // Unsigned simplex noise
 struct USimplexNoise {
@@ -2694,29 +3033,30 @@ struct USimplexNoise {
         result = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t) + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
-        result[0] = 0.5f * (simplexnoise1 (x, 0) + 1.0f);
-        result[1] = 0.5f * (simplexnoise1 (x, 1) + 1.0f);
-        result[2] = 0.5f * (simplexnoise1 (x, 2) + 1.0f);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x) const {
+        result.x = 0.5f * (simplexnoise1 (x, 0) + 1.0f);
+        result.y = 0.5f * (simplexnoise1 (x, 1) + 1.0f);
+        result.z = 0.5f * (simplexnoise1 (x, 2) + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
-        result[0] = 0.5f * (simplexnoise2 (x, y, 0) + 1.0f);
-        result[1] = 0.5f * (simplexnoise2 (x, y, 1) + 1.0f);
-        result[2] = 0.5f * (simplexnoise2 (x, y, 2) + 1.0f);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, float x, float y) const {
+        result.x = 0.5f * (simplexnoise2 (x, y, 0) + 1.0f);
+        result.y = 0.5f * (simplexnoise2 (x, y, 1) + 1.0f);
+        result.z = 0.5f * (simplexnoise2 (x, y, 2) + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
-        result[0] = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 0) + 1.0f);
-        result[1] = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 1) + 1.0f);
-        result[2] = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 2) + 1.0f);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p) const {
+        result.x = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 0) + 1.0f);
+        result.y = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 1) + 1.0f);
+        result.z = 0.5f * (simplexnoise3 (p.x, p.y, p.z, 2) + 1.0f);
     }
 
-    inline OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
-        result[0] = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 0) + 1.0f);
-        result[1] = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 1) + 1.0f);
-        result[2] = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 2) + 1.0f);
+    OSL_FORCEINLINE OSL_HOSTDEVICE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+        result.x = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 0) + 1.0f);
+        result.y = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 1) + 1.0f);
+        result.z = 0.5f * (simplexnoise4 (p.x, p.y, p.z, t, 2) + 1.0f);
     }
+
 
     // dual versions
 
@@ -2743,28 +3083,28 @@ struct USimplexNoise {
     inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p,
                                            int seed=0) const {
         float r, dndx, dndy, dndz;
-        r = simplexnoise3 (p.val()[0], p.val()[1], p.val()[2],
+        r = simplexnoise3 (p.val().x, p.val().y, p.val().z,
                            seed, &dndx, &dndy, &dndz);
         r = 0.5f * (r + 1.0f);
         dndx *= 0.5f;
         dndy *= 0.5f;
         dndz *= 0.5f;
-        result.set (r, dndx * p.dx()[0] + dndy * p.dx()[1] + dndz * p.dx()[2],
-                       dndx * p.dy()[0] + dndy * p.dy()[1] + dndz * p.dy()[2]);
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z,
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z);
     }
 
     inline OSL_HOSTDEVICE void operator() (Dual2<float> &result, const Dual2<Vec3> &p,
                                            const Dual2<float> &t, int seed=0) const {
         float r, dndx, dndy, dndz, dndt;
-        r = simplexnoise4 (p.val()[0], p.val()[1], p.val()[2], t.val(),
+        r = simplexnoise4 (p.val().x, p.val().y, p.val().z, t.val(),
                            seed, &dndx, &dndy, &dndz, &dndt);
         r = 0.5f * (r + 1.0f);
         dndx *= 0.5f;
         dndy *= 0.5f;
         dndz *= 0.5f;
         dndt *= 0.5f;
-        result.set (r, dndx * p.dx()[0] + dndy * p.dx()[1] + dndz * p.dx()[2] + dndt * t.dx(),
-                       dndx * p.dy()[0] + dndy * p.dy()[1] + dndz * p.dy()[2] + dndt * t.dy());
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z + dndt * t.dx(),
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z + dndt * t.dy());
     }
 
     inline OSL_HOSTDEVICE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
@@ -2798,14 +3138,145 @@ struct USimplexNoise {
         (*this)(r2, p, t, 2);
         result = make_Vec3 (r0, r1, r2);
     }
+
 };
 
+// Scalar version of USimplexNoise that is SIMD friendly suitable to be
+// inlined inside of a SIMD loops
+struct USimplexNoiseScalar {
+    USimplexNoiseScalar () { }
+
+    OSL_FORCEINLINE void operator() (float &result, float x) const {
+        result = 0.5f * (sfm::simplexnoise1<0/* seed */>(x) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (float &result, float x, float y) const {
+        result = 0.5f * (sfm::simplexnoise2<0/* seed */>(x, y) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (float &result, const Vec3 &p) const {
+        result = 0.5f * (sfm::simplexnoise3<0/* seed */>(p.x, p.y, p.z) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (float &result, const Vec3 &p, float t) const {
+        result = 0.5f * (sfm::simplexnoise4<0/* seed */> (p.x, p.y, p.z, t) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, float x) const {
+        result.x = 0.5f * (sfm::simplexnoise1<0/* seed */>(x) + 1.0f);
+        result.y = 0.5f * (sfm::simplexnoise1<1/* seed */>(x) + 1.0f);
+        result.z = 0.5f * (sfm::simplexnoise1<2/* seed */>(x) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, float x, float y) const {
+        result.x = 0.5f * (sfm::simplexnoise2<0>(x, y) + 1.0f);
+        result.y = 0.5f * (sfm::simplexnoise2<1>(x, y) + 1.0f);
+        result.z = 0.5f * (sfm::simplexnoise2<2>(x, y) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, const Vec3 &p) const {
+        result.x = 0.5f * (sfm::simplexnoise3<0/* seed */>(p.x, p.y, p.z) + 1.0f);
+        result.y = 0.5f * (sfm::simplexnoise3<1/* seed */>(p.x, p.y, p.z) + 1.0f);
+        result.z = 0.5f * (sfm::simplexnoise3<2/* seed */>(p.x, p.y, p.z) + 1.0f);
+    }
+
+    OSL_FORCEINLINE void operator() (Vec3 &result, const Vec3 &p, float t) const {
+        result.x = 0.5f * (sfm::simplexnoise4<0/* seed */>(p.x, p.y, p.z, t) + 1.0f);
+        result.y = 0.5f * (sfm::simplexnoise4<1/* seed */>(p.x, p.y, p.z, t) + 1.0f);
+        result.z = 0.5f * (sfm::simplexnoise4<2/* seed */>(p.x, p.y, p.z, t) + 1.0f);
+    }
+
+    // dual versions
+    template<int seed=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<float> &x) const {
+        float r, dndx;
+        r = sfm::simplexnoise1<seed>(x.val(), sfm::DxRef(dndx));
+        r = 0.5f * (r + 1.0f);
+        dndx *= 0.5f;
+        result.set (r, dndx * x.dx(), dndx * x.dy());
+    }
+
+    template<int seedT=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<float> &x,
+                             const Dual2<float> &y) const {
+        float r, dndx, dndy;
+        r = sfm::simplexnoise2<seedT> (x.val(), y.val(), sfm::DxDyRef(dndx, dndy));
+        r = 0.5f * (r + 1.0f);
+        dndx *= 0.5f;
+        dndy *= 0.5f;
+        result.set (r, dndx * x.dx() + dndy * y.dx(),
+                       dndx * x.dy() + dndy * y.dy());
+    }
+
+    template<int seed=0>
+    OSL_FORCEINLINE void operator() (Dual2<float> &result, const Dual2<Vec3> &p) const {
+        float r, dndx, dndy, dndz;
+        const Vec3 &p_val = p.val();
+        r = sfm::simplexnoise3<seed>(p_val.x, p_val.y, p_val.z, sfm::DxDyDzRef(dndx, dndy, dndz));
+        r = 0.5f * (r + 1.0f);
+        dndx *= 0.5f;
+        dndy *= 0.5f;
+        dndz *= 0.5f;
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z,
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z);
+    }
+
+    template<int seed=0>
+    OSL_FORCEINLINE void operator()(Dual2<float> &result, const Dual2<Vec3> &p,
+                            const Dual2<float> &t) const {
+        float dndx, dndy, dndz, dndt;
+        float r = sfm::simplexnoise4<seed> (p.val().x, p.val().y, p.val().z, t.val(),
+                           sfm::DxDyDzDwRef(dndx, dndy, dndz, dndt));
+        r = 0.5f * (r + 1.0f);
+        dndx *= 0.5f;
+        dndy *= 0.5f;
+        dndz *= 0.5f;
+        dndt *= 0.5f;
+        result.set (r, dndx * p.dx().x + dndy * p.dx().y + dndz * p.dx().z + dndt * t.dx(),
+                       dndx * p.dy().x + dndy * p.dy().y + dndz * p.dy().z + dndt * t.dy());
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<float> &x) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, x);
+        operator()<1>(r1, x);
+        operator()<2>(r2, x);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<float> &x, const Dual2<float> &y) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, x, y);
+        operator()<1>(r1, x, y);
+        operator()<2>(r2, x, y);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, p);
+        operator()<1>(r1, p);
+        operator()<2>(r2, p);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+    OSL_FORCEINLINE void operator() (Dual2<Vec3> &result, const Dual2<Vec3> &p, const Dual2<float> &t) const {
+        Dual2<float> r0, r1, r2;
+        operator()<0>(r0, p, t);
+        operator()<1>(r1, p, t);
+        operator()<2>(r2, p, t);
+        result = make_Vec3 (r0, r1, r2);
+    }
+
+};
 } // anonymous namespace
 
 
 
 OSLNOISEPUBLIC OSL_HOSTDEVICE
 Dual2<float> gabor (const Dual2<Vec3> &P, const NoiseParams *opt);
+
+
 
 OSLNOISEPUBLIC OSL_HOSTDEVICE
 Dual2<float> gabor (const Dual2<float> &x, const Dual2<float> &y,
@@ -2894,7 +3365,6 @@ DECLNOISE (cellnoise, CellNoise)
 DECLNOISE (hashnoise, HashNoise)
 
 #undef DECLNOISE
-
 }   // namespace oslnoise
 
 

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -81,6 +81,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  define OSL_INTEL_COMPILER 0
 #endif
 
+// Intel's compiler on OSX may still define __clang__
+// and we have need to know when using a true clang compiler
+#if !defined(__INTEL_COMPILER) && defined(__clang__)
+    #define OSL_NON_INTEL_CLANG  __clang__
+#else
+	#define OSL_NON_INTEL_CLANG  0
+#endif
+
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
 #  if _MSC_VER < 1900
@@ -118,21 +126,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #    define OSL_CONSTEXPR14 constexpr
 #    define OSL_CONSTEXPR17 constexpr
 #    define OSL_CONSTEXPR20 constexpr
+#    define OSL_NODISCARD [[nodiscard]]
 #elif (__cplusplus >= 201703L)
 #    define OSL_CPLUSPLUS_VERSION 17
 #    define OSL_CONSTEXPR14 constexpr
 #    define OSL_CONSTEXPR17 constexpr
 #    define OSL_CONSTEXPR20 /* not constexpr before C++20 */
+#    define OSL_NODISCARD [[nodiscard]]
 #elif (__cplusplus >= 201402L) || (defined(_MSC_VER) && _MSC_VER >= 1914)
 #    define OSL_CPLUSPLUS_VERSION 14
 #    define OSL_CONSTEXPR14 constexpr
 #    define OSL_CONSTEXPR17 /* not constexpr before C++17 */
 #    define OSL_CONSTEXPR20 /* not constexpr before C++20 */
+#    define OSL_NODISCARD /* not nodiscard attribute before C++17 */
 #elif (__cplusplus >= 201103L) || _MSC_VER >= 1900
 #    define OSL_CPLUSPLUS_VERSION 11
 #    define OSL_CONSTEXPR14 /* not constexpr before C++14 */
 #    define OSL_CONSTEXPR17 /* not constexpr before C++17 */
 #    define OSL_CONSTEXPR20 /* not constexpr before C++20 */
+#    define OSL_NODISCARD /* not nodiscard attribute before C++17 */
 #else
 #    error "This version of OSL requires C++11"
 #endif
@@ -229,6 +241,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif // OSL_DEBUG
 
 
+#if OSL_DEBUG
+	// Disable OPENMP_SIMD when debugging
+	#undef OSL_OPENMP_SIMD
+#endif
+
+#ifdef OSL_OPENMP_SIMD
+    #define OSL_OMP_PRAGMA(aUnQuotedPragma) OSL_PRAGMA(aUnQuotedPragma)
+#else
+    #define OSL_OMP_PRAGMA(aUnQuotedPragma)
+#endif
+
 // OSL_FORCEINLINE is a function attribute that attempts to make the
 // function always inline. On many compilers regular 'inline' is only
 // advisory. Put this attribute before the function return type, just like
@@ -257,6 +280,51 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #    define OSL_NOINLINE
 #endif
 
+// OSL_FORCEINLINE_BLOCK tells the compiler that any calls in the next
+// statement (or compound statement/code block)should be inlined whenever
+// the compiler is capable of doing so.  Furthermore, any calls made by those
+// calls should be inlined, and so on recursively.  Has no affect on function calls to
+// whose definition exists in different translation units or calls that are not
+// legal to inline (possibly by OSL_NOINLINE).  Intent is to ensure that entire
+// contents of a SIMD loop body is are fully inlined avoiding compiler hueristcs.
+// However if any debugging code exists inside the code block, then the amount
+// of code inlined could explode.  So great care should be used when placing
+// code inside one of these forced inline blocks.  Note that if OSL_DEBUG is true,
+// it does nothing to avoid over-inlining.
+// NOTE:  only supported by Intel C++ compiler.
+// Unsupported compilers may instead use command line flags to increase their inlining
+// limits/thresholds
+#if OSL_DEBUG
+	#define OSL_FORCEINLINE_BLOCK
+#else
+	#define OSL_FORCEINLINE_BLOCK OSL_INTEL_PRAGMA(forceinline recursive)
+#endif
+
+// Until we have c++20, we can provide our own version of std::assume_aligned
+// http://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p1007r0.pdf
+template<int AlignmentT, class DataT >
+OSL_NODISCARD
+#ifndef __INTEL_COMPILER // constexpr not compatible with ICC's __assume_aligned
+    constexpr
+#endif
+DataT* osl_assume_aligned(DataT* ptr)
+{
+    #ifdef __INTEL_COMPILER
+        __assume_aligned(ptr, AlignmentT);
+        return ptr;
+    #elif defined(__clang__) || defined(__GNUC__)
+        return reinterpret_cast<DataT*>(__builtin_assume_aligned(ptr, AlignmentT));
+    #elif defined(_MSC_VER)
+        constexpr std::uintptr_t unaligned_bit_mask = ((1 << N) - 1);
+        if ((reinterpret_cast<std::uintptr_t>(ptr) & unaligned_bit_mask) == 0)
+            return ptr;
+        else
+            __assume(0); // let compiler know we should never reach this branch
+    #else
+        #error unknown compiler, update osl_assume_aligned to handle (or explicitly ignore) emitting a pointer alignment hint
+        return ptr;
+    #endif
+}
 
 // OSL_MAYBE_UNUSED is a function or variable attribute that assures the
 // compiler that it's fine for the item to appear to be unused.

--- a/src/include/OSL/sfm_simplex.h
+++ b/src/include/OSL/sfm_simplex.h
@@ -1,0 +1,1231 @@
+/*
+Copyright (c) 2009-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <limits>
+
+#include <OSL/dual.h>
+#include <OSL/dual_vec.h>
+#include <OSL/sfmath.h>
+#include <OSL/wide.h>
+#include <OpenImageIO/hash.h>
+#include <OpenImageIO/simd.h>
+
+OSL_NAMESPACE_ENTER
+
+
+///////////////////////////////////////////////////////////////////////
+// Implementation follows...
+//
+// Users don't need to worry about this part
+///////////////////////////////////////////////////////////////////////
+
+#ifdef __OSL_WIDE_PVT
+    namespace __OSL_WIDE_PVT {
+#else
+    namespace pvt {
+#endif
+
+//} // pvt
+
+
+// non SIMD version, should be scalar code meant to be used
+// inside SIMD loops
+// SIMD FRIENDLY MATH
+namespace sfm
+{
+
+// Code to convert lookup tables to masks for 1.0f and -1.0f (default 0.0f) and spit
+// the resulting masks out to std::cout to be cut n pasted back as constants.
+// to be able to
+//#define __OSL_EMIT_GRAD_MASKS 1
+#ifdef __OSL_EMIT_GRAD_MASKS
+
+template<int N>
+static void emit_grad_mask(const char * name, const float (&vals)[N], float target) {
+
+    static_assert(N <= 64, "N too large");
+    typedef typename std::conditional<N <= 16,
+                                      uint16_t,
+                                      uint32_t>::type Mask16or32;
+    typedef typename std::conditional<N <= 8,
+                                      uint8_t,
+                                      Mask16or32>::type MaskType;
+    const char * name_of_mask_type = "uint32_t";
+    // Assume RTTI is disabled, so compile time tests to choose the correct type name
+    if (std::is_same<MaskType, uint16_t>::value)
+        name_of_mask_type = "uint16_t";
+    if (std::is_same<MaskType, uint8_t>::value)
+        name_of_mask_type = "uint8_t";
+    std::cout << "//static constexpr " << name_of_mask_type << " " << name << " = 0b";
+    MaskType mask = static_cast<MaskType>(0u);
+    for(int index=N-1; index >=0; --index) {
+        float val = vals[index];
+        const char * result = "0";
+        if (val == target) {
+            result = "1";
+            mask |= MaskType(1u)<<index;
+        }
+        std::cout << result;
+    }
+    std::cout << ";" << std::endl;
+    // NOTE: use of unary + operator to upconvert uint8_t to not be output as a char
+    std::cout << "static constexpr " << name_of_mask_type << " " << name << " = 0x"
+              << std::hex << std::setw(2*sizeof(MaskType)) << std::uppercase  << std::setfill('0') << +mask << std::nouppercase << std::dec << ";" << std::endl;
+}
+#endif
+
+// Gradient table for 2D. These could be programmed the Ken Perlin way with
+// some clever bit-twiddling, but this is more clear, and not really slower.
+namespace fast_grad2 {
+    alignas(64) static const OSL::Block<Vec2,8> lut_wide(
+        Vec2( -1.0f, -1.0f ), Vec2( 1.0f,  0.0f ), Vec2( -1.0f, 0.0f ), Vec2( 1.0f,  1.0f ),
+        Vec2( -1.0f,  1.0f ), Vec2( 0.0f, -1.0f ), Vec2(  0.0f, 1.0f ), Vec2(  1.0f, -1.0f ));
+
+    //static constexpr uint8_t x_one_mask = 0b10001010;
+    static constexpr uint8_t x_one_mask = 0x8A;
+    //static constexpr uint8_t x_neg_one_mask = 0b00010101;
+    static constexpr uint8_t x_neg_one_mask = 0x15;
+    //static constexpr uint8_t y_one_mask = 0b01011000;
+    static constexpr uint8_t y_one_mask = 0x58;
+    //static constexpr uint8_t y_neg_one_mask = 0b10100001;
+    static constexpr uint8_t y_neg_one_mask = 0xA1;
+
+#ifdef __OSL_EMIT_GRAD_MASKS
+    class OSLEXECPUBLIC mask_emitter {
+    public:
+        mask_emitter() {
+            static bool has_emitted = false;
+            if (!has_emitted) {
+                has_emitted = true;
+                emit_masks();
+            }
+        }
+    private:
+        void emit_masks()
+        {
+            emit_grad_mask("x_one_mask", lut_wide.x, 1.0f);
+            emit_grad_mask("x_neg_one_mask", lut_wide.x, -1.0f);
+
+            emit_grad_mask("y_one_mask", lut_wide.y, 1.0f);
+            emit_grad_mask("y_neg_one_mask", lut_wide.y, -1.0f);
+        }
+    };
+#endif
+}
+
+
+// Gradient directions for 3D.
+// These vectors are based on the midpoints of the 12 edges of a cube.
+// A larger array of random unit length vectors would also do the job,
+// but these 12 (including 4 repeats to make the array length a power
+// of two) work better. They are not random, they are carefully chosen
+// to represent a small, isotropic set of directions.
+
+namespace fast_grad3 {
+    // Store in SOA data layout using our Block helper
+    alignas(64) static const OSL::Block<Vec3,16> lut_wide(
+        Vec3(  1.0f,  0.0f,  1.0f ), Vec3(  0.0f,  1.0f,  1.0f ), // 12 cube edges
+        Vec3( -1.0f,  0.0f,  1.0f ), Vec3( 0.0f, -1.0f,  1.0f ),
+        Vec3(  1.0f,  0.0f, -1.0f ), Vec3( 0.0f,  1.0f, -1.0f ),
+        Vec3( -1.0f,  0.0f, -1.0f ), Vec3(  0.0f, -1.0f, -1.0f ),
+        Vec3(  1.0f, -1.0f,  0.0f ), Vec3( 1.0f,  1.0f,  0.0f ),
+        Vec3( -1.0f,  1.0f,  0.0f ), Vec3( -1.0f, -1.0f,  0.0f ),
+        Vec3(  1.0f,  0.0f,  1.0f ), Vec3( -1.0f,  0.0f,  1.0f ), // 4 repeats to make 16
+        Vec3(  0.0f,  1.0f, -1.0f ), Vec3( 0.0f, -1.0f, -1.0f ));
+
+    //static constexpr uint16_t x_one_mask = 0b0001001100010001;
+    static constexpr uint16_t x_one_mask = 0x1311;
+    //static constexpr uint16_t x_neg_one_mask = 0b0010110001000100;
+    static constexpr uint16_t x_neg_one_mask = 0x2C44;
+
+    //static constexpr uint16_t y_one_mask = 0b0100011000100010;
+    static constexpr uint16_t y_one_mask = 0x4622;
+    //static constexpr uint16_t y_neg_one_mask = 0b1000100110001000;
+    static constexpr uint16_t y_neg_one_mask = 0x8988;
+
+    //static constexpr uint16_t z_one_mask = 0b0011000000001111;
+    static constexpr uint16_t z_one_mask = 0x300F;
+    //static constexpr uint16_t z_neg_one_mask = 0b1100000011110000;
+    static constexpr uint16_t z_neg_one_mask = 0xC0F0;
+
+#ifdef __OSL_EMIT_GRAD_MASKS
+    class OSLEXECPUBLIC mask_emitter {
+    public:
+        mask_emitter() {
+            static bool has_emitted = false;
+            if (!has_emitted) {
+                has_emitted = true;
+                emit_masks();
+            }
+        }
+    private:
+        void emit_masks()
+        {
+            emit_grad_mask("x_one_mask", lut_wide.x, 1.0f);
+            emit_grad_mask("x_neg_one_mask", lut_wide.x, -1.0f);
+
+            emit_grad_mask("y_one_mask", lut_wide.y, 1.0f);
+            emit_grad_mask("y_neg_one_mask", lut_wide.y, -1.0f);
+
+            emit_grad_mask("z_one_mask", lut_wide.z, 1.0f);
+            emit_grad_mask("z_neg_one_mask", lut_wide.z, -1.0f);
+        }
+    };
+#endif
+}
+
+//static fast_grad3::mask_validator the_fast_grad3_mask_validator;
+
+namespace fast_grad4 {
+    alignas(64) static const OSL::Block<Vec4,32> lut_wide(
+      Vec4( 0.0f, 1.0f, 1.0f, 1.0f ),  Vec4( 0.0f, 1.0f, 1.0f, -1.0f ),  Vec4( 0.0f, 1.0f, -1.0f, 1.0f ),  Vec4( 0.0f, 1.0f, -1.0f, -1.0f ), // 32 tesseract edges
+      Vec4( 0.0f, -1.0f, 1.0f, 1.0f ), Vec4( 0.0f, -1.0f, 1.0f, -1.0f ), Vec4( 0.0f, -1.0f, -1.0f, 1.0f ), Vec4( 0.0f, -1.0f, -1.0f, -1.0f ),
+      Vec4( 1.0f, 0.0f, 1.0f, 1.0f ),  Vec4( 1.0f, 0.0f, 1.0f, -1.0f ),  Vec4( 1.0f, 0.0f, -1.0f, 1.0f ),  Vec4( 1.0f, 0.0f, -1.0f, -1.0f ),
+      Vec4( -1.0f, 0.0f, 1.0f, 1.0f ), Vec4( -1.0f, 0.0f, 1.0f, -1.0f ), Vec4( -1.0f, 0.0f, -1.0f, 1.0f ), Vec4( -1.0f, 0.0f, -1.0f, -1.0f ),
+      Vec4( 1.0f, 1.0f, 0.0f, 1.0f ),  Vec4( 1.0f, 1.0f, 0.0f, -1.0f ),  Vec4( 1.0f, -1.0f, 0.0f, 1.0f ),  Vec4( 1.0f, -1.0f, 0.0f, -1.0f ),
+      Vec4( -1.0f, 1.0f, 0.0f, 1.0f ), Vec4( -1.0f, 1.0f, 0.0f, -1.0f ), Vec4( -1.0f, -1.0f, 0.0f, 1.0f ), Vec4( -1.0f, -1.0f, 0.0f, -1.0f ),
+      Vec4( 1.0f, 1.0f, 1.0f, 0.0f ),  Vec4( 1.0f, 1.0f, -1.0f, 0.0f ),  Vec4( 1.0f, -1.0f, 1.0f, 0.0f ),  Vec4( 1.0f, -1.0f, -1.0f, 0.0f ),
+      Vec4( -1.0f, 1.0f, 1.0f, 0.0f ), Vec4( -1.0f, 1.0f, -1.0f, 0.0f ), Vec4( -1.0f, -1.0f, 1.0f, 0.0f ), Vec4( -1.0f, -1.0f, -1.0f, 0.0f ));
+
+
+    //static constexpr uint32_t x_one_mask = 0b00001111000011110000111100000000;
+    static constexpr uint32_t x_one_mask = 0x0F0F0F00;
+    //static constexpr uint32_t x_neg_one_mask = 0b11110000111100001111000000000000;
+    static constexpr uint32_t x_neg_one_mask = 0xF0F0F000;
+    //static constexpr uint32_t y_one_mask = 0b00110011001100110000000000001111;
+    static constexpr uint32_t y_one_mask = 0x3333000F;
+    //static constexpr uint32_t y_neg_one_mask = 0b11001100110011000000000011110000;
+    static constexpr uint32_t y_neg_one_mask = 0xCCCC00F0;
+    //static constexpr uint32_t z_one_mask = 0b01010101000000000011001100110011;
+    static constexpr uint32_t z_one_mask = 0x55003333;
+    //static constexpr uint32_t z_neg_one_mask = 0b10101010000000001100110011001100;
+    static constexpr uint32_t z_neg_one_mask = 0xAA00CCCC;
+    //static constexpr uint32_t w_one_mask = 0b00000000010101010101010101010101;
+    static constexpr uint32_t w_one_mask = 0x00555555;
+    //static constexpr uint32_t w_neg_one_mask = 0b00000000101010101010101010101010;
+    static constexpr uint32_t w_neg_one_mask = 0x00AAAAAA;
+
+#ifdef __OSL_EMIT_GRAD_MASKS
+    class OSLEXECPUBLIC mask_emitter {
+    public:
+        mask_emitter() {
+            static bool has_emitted = false;
+            if (!has_emitted) {
+                has_emitted = true;
+                emit_masks();
+            }
+        }
+    private:
+        void emit_masks()
+        {
+            emit_grad_mask("x_one_mask", lut_wide.x, 1.0f);
+            emit_grad_mask("x_neg_one_mask", lut_wide.x, -1.0f);
+
+            emit_grad_mask("y_one_mask", lut_wide.y, 1.0f);
+            emit_grad_mask("y_neg_one_mask", lut_wide.y, -1.0f);
+
+            emit_grad_mask("z_one_mask", lut_wide.z, 1.0f);
+            emit_grad_mask("z_neg_one_mask", lut_wide.z, -1.0f);
+
+            emit_grad_mask("w_one_mask", lut_wide.w, 1.0f);
+            emit_grad_mask("w_neg_one_mask", lut_wide.w, -1.0f);
+        }
+    };
+#endif
+
+}
+
+
+namespace fast_simplex {
+    static const unsigned char lut[64][4] = {
+      {0,1,2,3},{0,1,3,2},{0,0,0,0},{0,2,3,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,2,3,0},
+      {0,2,1,3},{0,0,0,0},{0,3,1,2},{0,3,2,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,3,2,0},
+      {0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},
+      {1,2,0,3},{0,0,0,0},{1,3,0,2},{0,0,0,0},{0,0,0,0},{0,0,0,0},{2,3,0,1},{2,3,1,0},
+      {1,0,2,3},{1,0,3,2},{0,0,0,0},{0,0,0,0},{0,0,0,0},{2,0,3,1},{0,0,0,0},{2,1,3,0},
+      {0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},
+      {2,0,1,3},{0,0,0,0},{0,0,0,0},{0,0,0,0},{3,0,1,2},{3,0,2,1},{0,0,0,0},{3,1,2,0},
+      {2,1,0,3},{0,0,0,0},{0,0,0,0},{0,0,0,0},{3,1,0,2},{0,0,0,0},{3,2,0,1},{3,2,1,0}};
+
+
+    //static constexpr uint64_t corner2_i_offset_mask = 0b1101000010110000000000000000000000000000000000000000000000000000;
+    static constexpr uint64_t corner2_i_offset_mask = 0xD0B0000000000000;
+    //static constexpr uint64_t corner2_j_offset_mask = 0b0000000000000000000000000000000011000100000000001000110000000000;
+    static constexpr uint64_t corner2_j_offset_mask = 0x00000000C4008C00;
+    //static constexpr uint64_t corner2_k_offset_mask = 0b0000000000000000000000001010001000000000000000000000000010001010;
+    static constexpr uint64_t corner2_k_offset_mask = 0x000000A20000008A;
+    //static constexpr uint64_t corner2_l_offset_mask = 0b0000000100000001000000000000000100000001000000000000000100000001;
+    static constexpr uint64_t corner2_l_offset_mask = 0x0101000101000101;
+    //static constexpr uint64_t corner3_i_offset_mask = 0b1101000110110001000000001010000011000000000000000000000000000000;
+    static constexpr uint64_t corner3_i_offset_mask = 0xD1B100A0C0000000;
+    //static constexpr uint64_t corner3_j_offset_mask = 0b1100000000000000000000000000000011000101000000001000110110001000;
+    static constexpr uint64_t corner3_j_offset_mask = 0xC0000000C5008D88;
+    //static constexpr uint64_t corner3_k_offset_mask = 0b0000000010100000000000001010001100000000000000001000100010001011;
+    static constexpr uint64_t corner3_k_offset_mask = 0x00A000A30000888B;
+    //static constexpr uint64_t corner3_l_offset_mask = 0b0001000100010001000000000000001100000101000000000000010100000011;
+    static constexpr uint64_t corner3_l_offset_mask = 0x1111000305000503;
+    //static constexpr uint64_t corner4_i_offset_mask = 0b1101000110110001000000001010001111000101000000001000000010000000;
+    static constexpr uint64_t corner4_i_offset_mask = 0xD1B100A3C5008080;
+    //static constexpr uint64_t corner4_j_offset_mask = 0b1101000110000000000000001000000011000101000000001000110110001011;
+    static constexpr uint64_t corner4_j_offset_mask = 0xD1800080C5008D8B;
+    //static constexpr uint64_t corner4_k_offset_mask = 0b1000000010110001000000001010001110000000000000001000110110001011;
+    static constexpr uint64_t corner4_k_offset_mask = 0x80B100A380008D8B;
+    //static constexpr uint64_t corner4_l_offset_mask = 0b0101000100110001000000000010001101000101000000000000110100001011;
+    static constexpr uint64_t corner4_l_offset_mask = 0x5131002345000D0B;
+
+
+#ifdef __OSL_EMIT_GRAD_MASKS
+    class OSLEXECPUBLIC mask_emitter {
+    public:
+        mask_emitter() {
+            static bool has_emitted = false;
+            if (!has_emitted) {
+                has_emitted = true;
+                emit_masks();
+            }
+        }
+    private:
+
+        static void emit_mask(const char * name, int vec_index, unsigned char threshold) {
+            std::cout << "//static constexpr uint64_t " << name << " = 0b";
+            uint64_t mask = 0u;
+            for(int index=64-1; index >=0; --index) {
+                unsigned char val = lut[index][vec_index];
+                const char * result = "0";
+                if (val >= threshold) {
+                    result = "1";
+                    mask |= uint64_t(1u)<<index;
+                }
+                std::cout << result;
+            }
+            std::cout << ";" << std::endl;
+            std::cout << "static constexpr uint64_t " << name << " = 0x"
+                      << std::hex << std::setw(2*sizeof(uint64_t)) << std::uppercase  << std::setfill('0') << mask << std::nouppercase << std::dec << ";" << std::endl;
+        }
+
+        void emit_masks()
+        {
+            emit_mask("corner2_i_offset_mask", 0, 3);
+            emit_mask("corner2_j_offset_mask", 1, 3);
+            emit_mask("corner2_k_offset_mask", 2, 3);
+            emit_mask("corner2_l_offset_mask", 3, 3);
+
+            emit_mask("corner3_i_offset_mask", 0, 2);
+            emit_mask("corner3_j_offset_mask", 1, 2);
+            emit_mask("corner3_k_offset_mask", 2, 2);
+            emit_mask("corner3_l_offset_mask", 3, 2);
+
+            emit_mask("corner4_i_offset_mask", 0, 1);
+            emit_mask("corner4_j_offset_mask", 1, 1);
+            emit_mask("corner4_k_offset_mask", 2, 1);
+            emit_mask("corner4_l_offset_mask", 3, 1);
+        }
+    };
+#endif
+}
+
+#ifdef __OSL_EMIT_GRAD_MASKS
+#ifndef __OSL_WIDE_PVT
+// Only emit grad masks for non-wide namespace as the wide would end up generating multiple sets of classes
+// each with its own local static variables and emit the masks multiple times
+static fast_grad2::mask_emitter the_fast_grad2_mask_emitter;
+static fast_grad3::mask_emitter the_fast_grad3_mask_emitter;
+static fast_grad4::mask_emitter the_fast_grad4_mask_emitter;
+static fast_simplex::mask_emitter the_fast_simplex_mask_emitter;
+#endif
+#endif
+
+//#define OSL_VERIFY_SIMPLEX3 1
+#ifdef OSL_VERIFY_SIMPLEX3
+        static void osl_verify_fail(int lineNumber, const char *expression)
+        {
+            std::cout << "Line " << __LINE__ << " failed OSL_VERIFY(" << expression << ")" << std::endl;
+            exit(1);
+        }
+    #define OSL_VERIFY(EXPR) if((EXPR)== false) osl_verify_fail(__LINE__, #EXPR);
+#endif
+
+
+    static OSL_FORCEINLINE uint32_t
+    scramble (uint32_t v0, uint32_t v1=0, uint32_t v2=0)
+    {
+        return OIIO::bjhash::bjfinal (v0, v1, v2^0xdeadbeef);
+    }
+
+
+    template<int seedT>
+    static OSL_FORCEINLINE float
+    grad1 (int i)
+    {
+        int h = scramble (i, seedT);
+        float g = 1.0f + (h & 7);   // Gradient value is one of 1.0, 2.0, ..., 8.0
+        if (h & 8)
+            g = -g;   // Make half of the gradients negative
+        return g;
+    }
+
+    OSL_FORCEINLINE float select(const bool b, float t, float f) { return b ? t : f; }
+    OSL_FORCEINLINE float negate_if (const float val, const bool b) {
+        return b ? -val : val;
+    }
+
+    // To use the old (slower) lookup table based grad, just build with -D__OSL_LUT_GRAD=1
+#ifndef __OSL_LUT_GRAD
+    #define __OSL_LUT_GRAD 0
+#endif
+
+    template<int seedT>
+    static OSL_FORCEINLINE Vec2
+    grad2 (int i, int j)
+    {
+        int h = scramble (i, j, seedT);
+    #if __OSL_LUT_GRAD
+        //return grad2lut[h & 7];
+        return fast_grad2::lut_wide.get(h & 7);
+    #else
+        int clamped_index = h&7;
+        uint8_t bit_index = 0x01 << clamped_index;
+        float x = 0.0f;
+        if (bit_index & fast_grad2::x_one_mask)
+            x = 1.0f;
+        if (bit_index & fast_grad2::x_neg_one_mask)
+            x = -1.0f;
+
+        float y = 0.0f;
+        if (bit_index & fast_grad2::y_one_mask)
+            y = 1.0f;
+        if (bit_index & fast_grad2::y_neg_one_mask)
+            y = -1.0f;
+        return Vec2(x,y);
+    #endif
+    }
+
+    template<int seedT>
+    static OSL_FORCEINLINE Vec3
+    grad3 (int i, int j, int k)
+    {
+        int h = scramble (i, j, scramble (k, seedT));
+#if __OSL_LUT_GRAD
+        //return fast_grad3lut[h & 15];
+        return fast_grad3::lut_wide.get(h & 15);
+#else
+        // Clang was unhappy trying to SIMD a
+        // table lookup, so turn index into a linear bit index
+        // and use a mask to blend 1.0f and -1.0f on the appropriate indices
+        //return fast_grad3::lut_wide.get(h & 15);
+        int clamped_index = h&15;
+        uint16_t bit_index = 0x0001 << clamped_index;
+        float x = 0.0f;
+        if (bit_index & fast_grad3::x_one_mask)
+            x = 1.0f;
+        if (bit_index & fast_grad3::x_neg_one_mask)
+            x = -1.0f;
+
+        float y = 0.0f;
+        if (bit_index & fast_grad3::y_one_mask)
+            y = 1.0f;
+        if (bit_index & fast_grad3::y_neg_one_mask)
+            y = -1.0f;
+
+        float z = 0.0f;
+        if (bit_index & fast_grad3::z_one_mask)
+            z = 1.0f;
+        if (bit_index & fast_grad3::z_neg_one_mask)
+            z = -1.0f;
+
+        return Vec3(x,y,z);
+    }
+#endif
+
+    template<int seedT>
+    static OSL_FORCEINLINE const Vec4
+    grad4 (int i, int j, int k, int l)
+    {
+        int h = scramble (i, j, scramble (k, l, seedT));
+#if __OSL_LUT_GRAD
+        // return fast_grad4lut[h & 31];
+        return fast_grad4::lut_wide.get(h & 31);
+#else
+        // Clang was unhappy trying to SIMD a
+        // table lookup, so turn index into a linear bit index
+        // and use a mask to blend 1.0f and -1.0f on the appropriate indices
+        int clamped_index = h&31;
+        uint32_t bit_index = 0x00000001 << clamped_index;
+        float x = 0.0f;
+        if (bit_index & fast_grad4::x_one_mask)
+            x = 1.0f;
+        if (bit_index & fast_grad4::x_neg_one_mask)
+            x = -1.0f;
+
+        float y = 0.0f;
+        if (bit_index & fast_grad4::y_one_mask)
+            y = 1.0f;
+        if (bit_index & fast_grad4::y_neg_one_mask)
+            y = -1.0f;
+
+        float z = 0.0f;
+        if (bit_index & fast_grad4::z_one_mask)
+            z = 1.0f;
+        if (bit_index & fast_grad4::z_neg_one_mask)
+            z = -1.0f;
+
+        float w = 0.0f;
+        if (bit_index & fast_grad4::w_one_mask)
+            w = 1.0f;
+        if (bit_index & fast_grad4::w_neg_one_mask)
+            w = -1.0f;
+
+        return Vec4(x,y,z,w);
+#endif
+    }
+
+    struct NoDerivs {
+        static OSL_FORCEINLINE constexpr bool has_derivs() { return false; }
+        static OSL_FORCEINLINE void set_dx(float) {}
+        static OSL_FORCEINLINE void set_dy(float) {}
+        static OSL_FORCEINLINE void set_dz(float) {}
+        static OSL_FORCEINLINE void set_dw(float) {}
+    };
+
+    struct DxRef {
+    private:
+        float & m_dx;
+    public:
+
+        explicit OSL_FORCEINLINE DxRef(float &dx)
+        : m_dx(dx)
+        {}
+
+        static OSL_FORCEINLINE constexpr bool has_derivs() { return true; }
+        OSL_FORCEINLINE void set_dx(float val) { m_dx = val; }
+    };
+
+    struct DxDyRef {
+    private:
+        float & m_dx;
+        float & m_dy;
+    public:
+
+        explicit OSL_FORCEINLINE DxDyRef(float &dx, float &dy)
+        : m_dx(dx)
+        , m_dy(dy)
+        {}
+
+        static OSL_FORCEINLINE constexpr bool has_derivs() { return true; }
+        OSL_FORCEINLINE void set_dx(float val) { m_dx = val; }
+        OSL_FORCEINLINE void set_dy(float val) { m_dy = val; }
+    };
+
+    struct DxDyDzRef {
+    private:
+        float & m_dx;
+        float & m_dy;
+        float & m_dz;
+    public:
+
+        explicit OSL_FORCEINLINE DxDyDzRef(float &dx, float &dy, float &dz)
+        : m_dx(dx)
+        , m_dy(dy)
+        , m_dz(dz)
+        {}
+
+        static OSL_FORCEINLINE constexpr bool has_derivs() { return true; }
+        OSL_FORCEINLINE void set_dx(float val) { m_dx = val; }
+        OSL_FORCEINLINE void set_dy(float val) { m_dy = val; }
+        OSL_FORCEINLINE void set_dz(float val) { m_dz = val; }
+    };
+
+    struct DxDyDzDwRef {
+    private:
+        float & m_dx;
+        float & m_dy;
+        float & m_dz;
+        float & m_dw;
+    public:
+
+        explicit OSL_FORCEINLINE DxDyDzDwRef(float &dx, float &dy, float &dz, float &dw)
+        : m_dx(dx)
+        , m_dy(dy)
+        , m_dz(dz)
+        , m_dw(dw)
+        {}
+
+        static OSL_FORCEINLINE constexpr bool has_derivs() { return true; }
+        OSL_FORCEINLINE void set_dx(float val) { m_dx = val; }
+        OSL_FORCEINLINE void set_dy(float val) { m_dy = val; }
+        OSL_FORCEINLINE void set_dz(float val) { m_dz = val; }
+        OSL_FORCEINLINE void set_dw(float val) { m_dw = val; }
+    };
+
+    // 1D simplex noise with derivative.
+    // If the last argument is not null, the analytic derivative
+    // is also calculated.
+    template<int seedT, typename OptionalDerivsT = NoDerivs>
+    static OSL_FORCEINLINE float
+    simplexnoise1 (float x, OptionalDerivsT derivPolicy = OptionalDerivsT())
+    {
+        int i0 = sfm::ifloor(x);
+        int i1 = i0 + 1;
+        float x0 = x - i0;
+        float x1 = x0 - 1.0f;
+
+        float x20 = x0*x0;
+        float t0 = 1.0f - x20;
+        //  if(t0 < 0.0f) t0 = 0.0f; // Never happens for 1D: x0<=1 always
+        float t20 = t0 * t0;
+        float t40 = t20 * t20;
+        float gx0 = grad1<seedT> (i0);
+        float n0 = t40 * gx0 * x0;
+
+        float x21 = x1*x1;
+        float t1 = 1.0f - x21;
+        //  if(t1 < 0.0f) t1 = 0.0f; // Never happens for 1D: |x1|<=1 always
+        float t21 = t1 * t1;
+        float t41 = t21 * t21;
+        float gx1 = grad1<seedT> (i1);
+        float n1 = t41 * gx1 * x1;
+
+        // Sum up and scale the result.  The scale is empirical, to make it
+        // cover [-1,1], and to make it approximately match the range of our
+        // Perlin noise implementation.
+        const float scale = 0.36f;
+
+        if (derivPolicy.has_derivs()) {
+            // Compute derivative according to:
+            // *dnoise_dx = -8.0f * t20 * t0 * x0 * (gx0 * x0) + t40 * gx0;
+            // *dnoise_dx += -8.0f * t21 * t1 * x1 * (gx1 * x1) + t41 * gx1;
+            float dnoise_dx = t20 * t0 * gx0 * x20;
+            dnoise_dx += t21 * t1 * gx1 * x21;
+            dnoise_dx *= -8.0f;
+            dnoise_dx += t40 * gx0 + t41 * gx1;
+            dnoise_dx *= scale;
+            derivPolicy.set_dx(dnoise_dx);
+        }
+
+        return scale * (n0 + n1);
+    }
+
+    // 2D simplex noise with derivatives.
+    // If the last two arguments are not null, the analytic derivative
+    // (the 2D gradient of the scalar noise field) is also calculated.
+    template<int seedT, typename OptionalDerivsT = NoDerivs>
+    static OSL_FORCEINLINE float
+    simplexnoise2 (float x, float y, OptionalDerivsT derivPolicy = OptionalDerivsT())
+    {
+        // Skewing factors for 2D simplex grid:
+        const float F2 = 0.366025403f;   // = 0.5*(sqrt(3.0)-1.0)
+        const float G2 = 0.211324865f;  // = (3.0-Math.sqrt(3.0))/6.0
+
+        /* Skew the input space to determine which simplex cell we're in */
+        float s = ( x + y ) * F2; /* Hairy factor for 2D */
+        float xs = x + s;
+        float ys = y + s;
+        int i = sfm::ifloor(xs);
+        int j = sfm::ifloor(ys);
+
+        float t = (float) (i + j) * G2;
+        float X0 = i - t; /* Unskew the cell origin back to (x,y) space */
+        float Y0 = j - t;
+        float x0 = x - X0; /* The x,y distances from the cell origin */
+        float y0 = y - Y0;
+
+        /* For the 2D case, the simplex shape is an equilateral triangle.
+         * Determine which simplex we are in. */
+        //int i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
+        //if (x0 > y0) {
+        //    i1 = 1; j1 = 0;   // lower triangle, XY order: (0,0)->(1,0)->(1,1)
+        //} else {
+        //    i1 = 0; j1 = 1;   // upper triangle, YX order: (0,0)->(0,1)->(1,1)
+        //}
+        int i1 = (x0 > y0);
+        int j1 = !i1;
+
+        // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
+        // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
+        // c = (3-sqrt(3))/6
+        float x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords
+        float y1 = y0 - j1 + G2;
+        float x2 = x0 - 1.0f + 2.0f * G2; // Offsets for last corner in (x,y) unskewed coords
+        float y2 = y0 - 1.0f + 2.0f * G2;
+
+
+        // Noise contributions from the simplex corners
+        // Calculate the contribution from the three corners
+        Vec2 g0 = grad2<seedT> (i, j);
+        Vec2 g1 = grad2<seedT> (i+i1, j+j1);
+        Vec2 g2 = grad2<seedT> (i+1, j+1);
+
+        float t0 = 0.5f - x0 * x0 - y0 * y0;
+        float t20 = t0 * t0;
+        float t40 = t20 * t20;
+        float tn0 = t40 * (g0.x * x0 + g0.y * y0);
+        float n0 = (t0 >= 0.0f) ? tn0 : 0.0f;
+
+        float t1 = 0.5f - x1 * x1 - y1 * y1;
+        float t21 = t1 * t1;
+        float t41 = t21 * t21;
+        float tn1 = t41 * (g1.x * x1 + g1.y * y1);
+        float n1 = (t1 >= 0.0f) ? tn1 : 0.0f;
+
+        float t2 = 0.5f - x2 * x2 - y2 * y2;
+        float t22 = t2 * t2;
+        float t42 = t22 * t22;
+        float tn2 = t42 * (g2.x * x2 + g2.y * y2);
+        float n2 = (t2 >= 0.0f) ? tn2 : 0.0f;
+
+        // Sum up and scale the result.  The scale is empirical, to make it
+        // cover [-1,1], and to make it approximately match the range of our
+        // Perlin noise implementation.
+        const float scale = 64.0f;
+        float noise = scale * (n0 + n1 + n2);
+
+        // Compute derivative, if requested by supplying non-null pointers
+        // for the last two arguments
+        if (derivPolicy.has_derivs()) {
+            // As we always calculated g# above,
+            // we need to zero out those who were invalid
+            // before they are used in more calculations
+            g0 = (t0 >= 0.0f) ? g0 : Vec2(0.0f);
+            g1 = (t1 >= 0.0f) ? g1 : Vec2(0.0f);
+            g2 = (t2 >= 0.0f) ? g2 : Vec2(0.0f);
+        /*  A straight, unoptimised calculation would be like:
+         *    *dnoise_dx = -8.0f * t20 * t0 * x0 * ( g0[0] * x0 + g0[1] * y0 ) + t40 * g0[0];
+         *    *dnoise_dy = -8.0f * t20 * t0 * y0 * ( g0[0] * x0 + g0[1] * y0 ) + t40 * g0[1];
+         *    *dnoise_dx += -8.0f * t21 * t1 * x1 * ( g1[0] * x1 + g1[1] * y1 ) + t41 * g1[0];
+         *    *dnoise_dy += -8.0f * t21 * t1 * y1 * ( g1[0] * x1 + g1[1] * y1 ) + t41 * g1[1];
+         *    *dnoise_dx += -8.0f * t22 * t2 * x2 * ( g2[0] * x2 + g2[1] * y2 ) + t42 * g2[0];
+         *    *dnoise_dy += -8.0f * t22 * t2 * y2 * ( g2[0] * x2 + g2[1] * y2 ) + t42 * g2[1];
+         */
+            float temp0 = t20 * t0 * (g0.x * x0 + g0.y * y0);
+            float dnoise_dx = temp0 * x0;
+            float dnoise_dy = temp0 * y0;
+            float temp1 = t21 * t1 * (g1.x * x1 + g1.y * y1);
+            dnoise_dx += temp1 * x1;
+            dnoise_dy += temp1 * y1;
+            float temp2 = t22 * t2 * (g2.x* x2 + g2.y * y2);
+            dnoise_dx += temp2 * x2;
+            dnoise_dy += temp2 * y2;
+            dnoise_dx *= -8.0f;
+            dnoise_dy *= -8.0f;
+            dnoise_dx += t40 * g0.x + t41 * g1.x + t42 * g2.x;
+            dnoise_dy += t40 * g0.y + t41 * g1.y + t42 * g2.y;
+            dnoise_dx *= scale; /* Scale derivative to match the noise scaling */
+            dnoise_dy *= scale;
+            derivPolicy.set_dx(dnoise_dx);
+            derivPolicy.set_dy(dnoise_dy);
+        }
+        return noise;
+    }
+
+    // 3D simplex noise with derivatives.
+    // If the last tthree arguments are not null, the analytic derivative
+    // (the 3D gradient of the scalar noise field) is also calculated.
+    template<int seedT, typename OptionalDerivsT = NoDerivs>
+    static OSL_FORCEINLINE float
+    simplexnoise3 (float x, float y, float z, OptionalDerivsT derivPolicy = OptionalDerivsT())
+    {
+        // Skewing factors for 3D simplex grid:
+        const float F3 = 0.333333333f;   // = 1/3
+        const float G3 = 0.166666667f;   // = 1/6
+
+        // Skew the input space to determine which simplex cell we're in
+        float s = (x+y+z)*F3; // Very nice and simple skew factor for 3D
+        float xs = x+s;
+        float ys = y+s;
+        float zs = z+s;
+
+        int i = sfm::ifloor(xs);
+        int j = sfm::ifloor(ys);
+        int k = sfm::ifloor(zs);
+
+        float t = (float)(i+j+k)*G3;
+        float X0 = i-t; // Unskew the cell origin back to (x,y,z) space
+        float Y0 = j-t;
+        float Z0 = k-t;
+
+        float x0 = x-X0; // The x,y,z distances from the cell origin
+        float y0 = y-Y0;
+        float z0 = z-Z0;
+
+        // For the 3D case, the simplex shape is a slightly irregular tetrahedron.
+        // Determine which simplex we are in.
+        int i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords
+        int i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
+        // NOTE:  The GLSL version of the flags produced different results
+        // These flags are derived directly from the conditional logic
+        // which is repeated in the verification code block following
+        int bg0 = (x0 >= y0);
+        int bg1 = (y0 >= z0);
+        int bg2 = (x0 >= z0);
+        int nbg0 = !bg0;
+        int nbg1 = !bg1;
+        int nbg2 = !bg2;
+        i1 = bg0 & (bg1 | bg2);
+        j1 = nbg0 & bg1;
+        k1 =  nbg1 & ((bg0 & nbg2) | nbg0) ;
+        i2 = bg0 | (bg1 & bg2);
+        j2 = bg1 | nbg0;
+        k2 = (bg0 & nbg1) | (nbg0 &(nbg1 | nbg2));
+
+#ifdef OSL_VERIFY_SIMPLEX3  // Keep around to validate the bit logic above
+        {
+               if (x0>=y0) {
+                        if (y0>=z0) {
+                            OSL_VERIFY(i1==1);
+                            OSL_VERIFY(j1==0);
+                            OSL_VERIFY(k1==0);
+                            OSL_VERIFY(i2==1);
+                            OSL_VERIFY(j2==1);
+                            OSL_VERIFY(k2==0);  /* X Y Z order */
+                        } else if (x0>=z0) {
+                            OSL_VERIFY(i1==1);
+                            OSL_VERIFY(j1==0);
+                            OSL_VERIFY(k1==0);
+                            OSL_VERIFY(i2==1);
+                            OSL_VERIFY(j2==0);
+                            OSL_VERIFY(k2==1);  /* X Z Y order */
+                        } else {
+                            OSL_VERIFY(i1==0);
+                            OSL_VERIFY(j1==0);
+                            OSL_VERIFY(k1==1);
+                            OSL_VERIFY(i2==1);
+                            OSL_VERIFY(j2==0);
+                            OSL_VERIFY(k2==1);  /* Z X Y order */
+                        }
+                    } else { // x0<y0
+                        if (y0<z0) {
+                            OSL_VERIFY(i1==0);
+                            OSL_VERIFY(j1==0);
+                            OSL_VERIFY(k1==1);
+                            OSL_VERIFY(i2==0);
+                            OSL_VERIFY(j2==1);
+                            OSL_VERIFY(k2==1);  /* Z Y X order */
+                        } else if (x0<z0) {
+                            OSL_VERIFY(i1==0);
+                            OSL_VERIFY(j1==1);
+                            OSL_VERIFY(k1==0);
+                            OSL_VERIFY(i2==0);
+                            OSL_VERIFY(j2==1);
+                            OSL_VERIFY(k2==1);  /* Y Z X order */
+                        } else {
+                            OSL_VERIFY(i1==0);
+                            OSL_VERIFY(j1==1);
+                            OSL_VERIFY(k1==0);
+                            OSL_VERIFY(i2==1);
+                            OSL_VERIFY(j2==1);
+                            OSL_VERIFY(k2==0);  /* Y X Z order */
+                        }
+                    }
+        }
+    #endif
+
+        // A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
+        // a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and
+        // a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z),
+        // where c = 1/6.
+        float x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords
+        float y1 = y0 - j1 + G3;
+        float z1 = z0 - k1 + G3;
+        float x2 = x0 - i2 + 2.0f * G3; // Offsets for third corner in (x,y,z) coords
+        float y2 = y0 - j2 + 2.0f * G3;
+        float z2 = z0 - k2 + 2.0f * G3;
+        float x3 = x0 - 1.0f + 3.0f * G3; // Offsets for last corner in (x,y,z) coords
+        float y3 = y0 - 1.0f + 3.0f * G3;
+        float z3 = z0 - 1.0f + 3.0f * G3;
+
+        // As we do not expect any coherency between data lanes
+        // Hoisted work out of conditionals to encourage masking blending
+        // versus a check for coherency
+        // In other words we will do all the work, all the time versus
+        // trying to manage it on a per lane basis.
+        // NOTE: this may be slower if used for serial vs. simd
+        Vec3 g0 = grad3<seedT>(i, j, k);
+        Vec3 g1 = grad3<seedT>(i+i1, j+j1, k+k1);
+        Vec3 g2 = grad3<seedT>(i+i2, j+j2, k+k2);
+        Vec3 g3 = grad3<seedT>(i+1, j+1, k+1);
+
+        // Calculate the contribution from the four corners
+        float t0 = 0.5f - x0*x0 - y0*y0 - z0*z0;
+        float t20 = t0 * t0;
+        float t40 = t20 * t20;
+        // NOTE: avoid array access of points, always use
+        // the real data members to avoid aliasing issues
+        //n0 = t40 * (g0[0] * x0 + g0[1] * y0 + g0[2] * z0);
+        float tn0 = t40 * (g0.x * x0 + g0.y * y0 + g0.z * z0);
+        float n0 = (t0 >= 0.0f) ? tn0 : 0.0f;
+
+        float t1 = 0.5f - x1*x1 - y1*y1 - z1*z1;
+        float t21 = t1 * t1;
+        float t41 = t21 * t21;
+        float tn1 = t41 * (g1.x * x1 + g1.y * y1 + g1.z * z1);
+        float n1 = (t1 >= 0.0f) ? tn1 : 0.0f;
+
+        float t2 = 0.5f - x2*x2 - y2*y2 - z2*z2;
+        float t22 = t2 * t2;
+        float t42 = t22 * t22;
+        float tn2 = t42 * (g2.x * x2 + g2.y * y2 + g2.z * z2);
+        float n2 = (t2 >= 0.0f) ? tn2 : 0.0f;
+
+        float t3 = 0.5f - x3*x3 - y3*y3 - z3*z3;
+        float t23 = t3 * t3;
+        float t43 = t23 * t23;
+        float tn3 = t43 * (g3.x * x3 + g3.y * y3 + g3.z * z3);
+        float n3 = (t3 >= 0.0f) ? tn3 : 0.0f;
+
+        // Sum up and scale the result.  The scale is empirical, to make it
+        // cover [-1,1], and to make it approximately match the range of our
+        // Perlin noise implementation.
+        constexpr float scale = 68.0f;
+        float noise = scale * (n0 + n1 + n2 + n3);
+
+
+        if (derivPolicy.has_derivs()) {
+            // As we always calculated g# above,
+            // we need to zero out those who were invalid
+            // before they are used in more calculations
+            g0 = (t0 >= 0.0f) ? g0 : Vec3(0.0f);
+            g1 = (t1 >= 0.0f) ? g1 : Vec3(0.0f);
+            g2 = (t2 >= 0.0f) ? g2 : Vec3(0.0f);
+            g3 = (t3 >= 0.0f) ? g3 : Vec3(0.0f);
+
+            /*  A straight, unoptimized calculation would be like:
+            *     *dnoise_dx = -8.0f * t20 * t0 * x0 * dot(g0[0], g0[1], g0[2], x0, y0, z0) + t40 * g0[0];
+            *    *dnoise_dy = -8.0f * t20 * t0 * y0 * dot(g0[0], g0[1], g0[2], x0, y0, z0) + t40 * g0[1];
+            *    *dnoise_dz = -8.0f * t20 * t0 * z0 * dot(g0[0], g0[1], g0[2], x0, y0, z0) + t40 * g0[2];
+            *    *dnoise_dx += -8.0f * t21 * t1 * x1 * dot(g1[0], g1[1], g1[2], x1, y1, z1) + t41 * g1[0];
+            *    *dnoise_dy += -8.0f * t21 * t1 * y1 * dot(g1[0], g1[1], g1[2], x1, y1, z1) + t41 * g1[1];
+            *    *dnoise_dz += -8.0f * t21 * t1 * z1 * dot(g1[0], g1[1], g1[2], x1, y1, z1) + t41 * g1[2];
+            *    *dnoise_dx += -8.0f * t22 * t2 * x2 * dot(g2[0], g2[1], g2[2], x2, y2, z2) + t42 * g2[0];
+            *    *dnoise_dy += -8.0f * t22 * t2 * y2 * dot(g2[0], g2[1], g2[2], x2, y2, z2) + t42 * g2[1];
+            *    *dnoise_dz += -8.0f * t22 * t2 * z2 * dot(g2[0], g2[1], g2[2], x2, y2, z2) + t42 * g2[2];
+            *    *dnoise_dx += -8.0f * t23 * t3 * x3 * dot(g3[0], g3[1], g3[2], x3, y3, z3) + t43 * g3[0];
+            *    *dnoise_dy += -8.0f * t23 * t3 * y3 * dot(g3[0], g3[1], g3[2], x3, y3, z3) + t43 * g3[1];
+            *    *dnoise_dz += -8.0f * t23 * t3 * z3 * dot(g3[0], g3[1], g3[2], x3, y3, z3) + t43 * g3[2];
+            */
+            float temp0 = t20 * t0 * (g0.x * x0 + g0.y * y0 + g0.z * z0);
+            float dnoise_dx = temp0 * x0;
+            float dnoise_dy = temp0 * y0;
+            float dnoise_dz = temp0 * z0;
+            float temp1 = t21 * t1 * (g1.x * x1 + g1.y * y1 + g1.z * z1);
+            dnoise_dx += temp1 * x1;
+            dnoise_dy += temp1 * y1;
+            dnoise_dz += temp1 * z1;
+            float temp2 = t22 * t2 * (g2.x * x2 + g2.y * y2 + g2.z * z2);
+            dnoise_dx += temp2 * x2;
+            dnoise_dy += temp2 * y2;
+            dnoise_dz += temp2 * z2;
+            float temp3 = t23 * t3 * (g3.x * x3 + g3.y * y3 + g3.z * z3);
+            dnoise_dx += temp3 * x3;
+            dnoise_dy += temp3 * y3;
+            dnoise_dz += temp3 * z3;
+            dnoise_dx *= -8.0f;
+            dnoise_dy *= -8.0f;
+            dnoise_dz *= -8.0f;
+            dnoise_dx += t40 * g0.x + t41 * g1.x + t42 * g2.x + t43 * g3.x;
+            dnoise_dy += t40 * g0.y + t41 * g1.y + t42 * g2.y + t43 * g3.y;
+            dnoise_dz += t40 * g0.z + t41 * g1.z + t42 * g2.z + t43 * g3.z;
+            dnoise_dx *= scale; // Scale derivative to match the noise scaling
+            dnoise_dy *= scale;
+            dnoise_dz *= scale;
+
+            derivPolicy.set_dx(dnoise_dx);
+            derivPolicy.set_dy(dnoise_dy);
+            derivPolicy.set_dz(dnoise_dz);
+        }
+
+        return noise;
+    }
+
+
+    // 4D simplex noise with derivatives.
+    // If the last four arguments are not null, the analytic derivative
+    // (the 4D gradient of the scalar noise field) is also calculated.
+    template<int seedT, typename OptionalDerivsT = NoDerivs>
+    static OSL_FORCEINLINE float
+    simplexnoise4 (float x, float y, float z, float w, OptionalDerivsT derivPolicy = OptionalDerivsT())
+    {
+        // The skewing and unskewing factors are hairy again for the 4D case
+        const float F4 = 0.309016994; // F4 = (Math.sqrt(5.0)-1.0)/4.0
+        const float G4 = 0.138196601; // G4 = (5.0-Math.sqrt(5.0))/20.0
+
+        // Gradients at simplex corners
+        //const float *g0 = zero, *g1 = zero, *g2 = zero, *g3 = zero, *g4 = zero;
+
+        // Noise contributions from the four simplex corners
+        //float n0=0.0f, n1=0.0f, n2=0.0f, n3=0.0f, n4=0.0f;
+        //float t20 = 0.0f, t21 = 0.0f, t22 = 0.0f, t23 = 0.0f, t24 = 0.0f;
+        //float t40 = 0.0f, t41 = 0.0f, t42 = 0.0f, t43 = 0.0f, t44 = 0.0f;
+
+        // Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in
+        float s = (x + y + z + w) * F4; // Factor for 4D skewing
+        float xs = x + s;
+        float ys = y + s;
+        float zs = z + s;
+        float ws = w + s;
+        int i = sfm::ifloor(xs);
+        int j = sfm::ifloor(ys);
+        int k = sfm::ifloor(zs);
+        int l = sfm::ifloor(ws);
+
+        float t = (i + j + k + l) * G4; // Factor for 4D unskewing
+        float X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
+        float Y0 = j - t;
+        float Z0 = k - t;
+        float W0 = l - t;
+
+        float x0 = x - X0;  // The x,y,z,w distances from the cell origin
+        float y0 = y - Y0;
+        float z0 = z - Z0;
+        float w0 = w - W0;
+
+        // For the 4D case, the simplex is a 4D shape I won't even try to describe.
+        // To find out which of the 24 possible simplices we're in, we need to
+        // determine the magnitude ordering of x0, y0, z0 and w0.
+        // The method below is a reasonable way of finding the ordering of x,y,z,w
+        // and then find the correct traversal order for the simplex we’re in.
+        // First, six pair-wise comparisons are performed between each possible pair
+        // of the four coordinates, and then the results are used to add up binary
+        // bits for an integer index into a precomputed lookup table, simplex[].
+        int c1 = (x0 > y0) ? 32 : 0;
+        int c2 = (x0 > z0) ? 16 : 0;
+        int c3 = (y0 > z0) ? 8 : 0;
+        int c4 = (x0 > w0) ? 4 : 0;
+        int c5 = (y0 > w0) ? 2 : 0;
+        int c6 = (z0 > w0) ? 1 : 0;
+        int c = c1 | c2 | c3 | c4 | c5 | c6; // '|' is mostly faster than '+'
+
+        int i1, j1, k1, l1; // The integer offsets for the second simplex corner
+        int i2, j2, k2, l2; // The integer offsets for the third simplex corner
+        int i3, j3, k3, l3; // The integer offsets for the fourth simplex corner
+
+        // simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some order.
+        // Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w and x<w
+        // impossible. Only the 24 indices which have non-zero entries make any sense.
+        // We use a thresholding to set the coordinates in turn from the largest magnitude.
+        // The number 3 in the "simplex" array is at the position of the largest coordinate.
+
+#ifndef __OSL_LUT_SIMPLEX
+    #define __OSL_LUT_SIMPLEX 0
+#endif
+#if __OSL_LUT_SIMPLEX
+        // TODO: get rid of this lookup, try it with pure conditionals,
+        // TODO: This should not be required, backport it from Bill's GLSL code!
+        i1 = fast_simplex::lut[c][0]>=3 ? 1 : 0;
+        j1 = fast_simplex::lut[c][1]>=3 ? 1 : 0;
+        k1 = fast_simplex::lut[c][2]>=3 ? 1 : 0;
+        l1 = fast_simplex::lut[c][3]>=3 ? 1 : 0;
+        // The number 2 in the "simplex" array is at the second largest coordinate.
+        i2 = fast_simplex::lut[c][0]>=2 ? 1 : 0;
+        j2 = fast_simplex::lut[c][1]>=2 ? 1 : 0;
+        k2 = fast_simplex::lut[c][2]>=2 ? 1 : 0;
+        l2 = fast_simplex::lut[c][3]>=2 ? 1 : 0;
+        // The number 1 in the "simplex" array is at the second smallest coordinate.
+        i3 = fast_simplex::lut[c][0]>=1 ? 1 : 0;
+        j3 = fast_simplex::lut[c][1]>=1 ? 1 : 0;
+        k3 = fast_simplex::lut[c][2]>=1 ? 1 : 0;
+        l3 = fast_simplex::lut[c][3]>=1 ? 1 : 0;
+        // The fifth corner has all coordinate offsets = 1, so no need to look that up.
+#else
+        uint64_t bit_index = uint64_t(1u) << c;
+
+        i1 = (bit_index & fast_simplex::corner2_i_offset_mask) >> c;
+        j1 = (bit_index & fast_simplex::corner2_j_offset_mask) >> c;
+        k1 = (bit_index & fast_simplex::corner2_k_offset_mask) >> c;
+        l1 = (bit_index & fast_simplex::corner2_l_offset_mask) >> c;
+        // The number 2 in the "simplex" array is at the second largest coordinate.
+        i2 = (bit_index & fast_simplex::corner3_i_offset_mask) >> c;
+        j2 = (bit_index & fast_simplex::corner3_j_offset_mask) >> c;
+        k2 = (bit_index & fast_simplex::corner3_k_offset_mask) >> c;
+        l2 = (bit_index & fast_simplex::corner3_l_offset_mask) >> c;
+        // The number 1 in the "simplex" array is at the second smallest coordinate.
+        i3 = (bit_index & fast_simplex::corner4_i_offset_mask) >> c;
+        j3 = (bit_index & fast_simplex::corner4_j_offset_mask) >> c;
+        k3 = (bit_index & fast_simplex::corner4_k_offset_mask) >> c;
+        l3 = (bit_index & fast_simplex::corner4_l_offset_mask) >> c;
+        // The fifth corner has all coordinate offsets = 1, so no need to look that up.
+#endif
+
+
+        float x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coords
+        float y1 = y0 - j1 + G4;
+        float z1 = z0 - k1 + G4;
+        float w1 = w0 - l1 + G4;
+        float x2 = x0 - i2 + 2.0f * G4; // Offsets for third corner in (x,y,z,w) coords
+        float y2 = y0 - j2 + 2.0f * G4;
+        float z2 = z0 - k2 + 2.0f * G4;
+        float w2 = w0 - l2 + 2.0f * G4;
+        float x3 = x0 - i3 + 3.0f * G4; // Offsets for fourth corner in (x,y,z,w) coords
+        float y3 = y0 - j3 + 3.0f * G4;
+        float z3 = z0 - k3 + 3.0f * G4;
+        float w3 = w0 - l3 + 3.0f * G4;
+        float x4 = x0 - 1.0f + 4.0f * G4; // Offsets for last corner in (x,y,z,w) coords
+        float y4 = y0 - 1.0f + 4.0f * G4;
+        float z4 = z0 - 1.0f + 4.0f * G4;
+        float w4 = w0 - 1.0f + 4.0f * G4;
+
+        // As we do not expect any coherency between data lanes
+        // Hoisted work out of conditionals to encourage masking blending
+        // versus a check for coherency
+        // In other words we will do all the work, all the time versus
+        // trying to manage it on a per lane basis.
+        // NOTE: this may be slower if used for serial vs. simd
+        Vec4 g0 = grad4<seedT>(i, j, k, l);
+        Vec4 g1 = grad4<seedT>(i+i1, j+j1, k+k1, l+l1);
+        Vec4 g2 = grad4<seedT>(i+i2, j+j2, k+k2, l+l2);
+        Vec4 g3 = grad4<seedT>(i+i3, j+j3, k+k3, l+l3);
+        Vec4 g4 = grad4<seedT>(i+1, j+1, k+1, l+1);
+
+        // Calculate the contribution from the five corners
+        float t0 = 0.5f - x0*x0 - y0*y0 - z0*z0 - w0*w0;
+        // NOTE: avoid array access of points, always use
+        // the real data members to avoid aliasing issues
+
+        float t20 = t0 * t0;
+        float t40 = t20 * t20;
+        float tn0 = t40 * (g0.x * x0 + g0.y * y0 + g0.z * z0 + g0.w * w0);
+        float n0 = (t0 >= 0.0f) ? tn0 : 0.0f;
+
+        float t1 = 0.5f - x1*x1 - y1*y1 - z1*z1 - w1*w1;
+        float t21 = t1 * t1;
+        float t41 = t21 * t21;
+        float tn1 = t41 * (g1.x * x1 + g1.y * y1 + g1.z * z1 + g1.w * w1);
+        float n1 = (t1 >= 0.0f) ? tn1 : 0.0f;
+
+        float t2 = 0.5f - x2*x2 - y2*y2 - z2*z2 - w2*w2;
+        float t22 = t2 * t2;
+        float t42 = t22 * t22;
+        float tn2 = t42 * (g2.x * x2 + g2.y * y2 + g2.z * z2 + g2.w * w2);
+        float n2 = (t2 >= 0.0f) ? tn2 : 0.0f;
+
+        float t3 = 0.5f - x3*x3 - y3*y3 - z3*z3 - w3*w3;
+        float t23 = t3 * t3;
+        float t43 = t23 * t23;
+        float tn3 = t43 * (g3.x * x3 + g3.y * y3 + g3.z * z3 + g3.w * w3);
+        float n3 = (t3 >= 0.0f) ? tn3 : 0.0f;
+
+        float t4 = 0.5f - x4*x4 - y4*y4 - z4*z4 - w4*w4;
+        float t24 = t4 * t4;
+        float t44 = t24 * t24;
+        float tn4 = t44 * (g4.x * x4 + g4.y * y4 + g4.z * z4 + g4.w * w4);
+        float n4 = (t4 >= 0.0f) ? tn4 : 0.0f;
+
+        // Sum up and scale the result.  The scale is empirical, to make it
+        // cover [-1,1], and to make it approximately match the range of our
+        // Perlin noise implementation.
+        const float scale = 54.0f;
+        float noise = scale * (n0 + n1 + n2 + n3 + n4);
+
+        if (derivPolicy.has_derivs()) {
+            // As we always calculated g# above,
+            // we need to zero out those who were invalid
+            // before they are used in more calculations
+            g0 = (t0 >= 0.0f) ? g0 : Vec4(0.0f);
+            g1 = (t1 >= 0.0f) ? g1 : Vec4(0.0f);
+            g2 = (t2 >= 0.0f) ? g2 : Vec4(0.0f);
+            g3 = (t3 >= 0.0f) ? g3 : Vec4(0.0f);
+            g4 = (t4 >= 0.0f) ? g4 : Vec4(0.0f);
+
+            /*  A straight, unoptimised calculation would be like:
+            *     *dnoise_dx = -8.0f * t20 * t0 * x0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[0];
+            *    *dnoise_dy = -8.0f * t20 * t0 * y0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[1];
+            *    *dnoise_dz = -8.0f * t20 * t0 * z0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[2];
+            *    *dnoise_dw = -8.0f * t20 * t0 * w0 * dot(g0[0], g0[1], g0[2], g0[3], x0, y0, z0, w0) + t40 * g0[3];
+            *    *dnoise_dx += -8.0f * t21 * t1 * x1 * dot(g1[0], g1[1], g1[2], g1[3], x1, y1, z1, w1) + t41 * g1[0];
+            *    *dnoise_dy += -8.0f * t21 * t1 * y1 * dot(g1[0], g1[1], g1[2], g1[3], x1, y1, z1, w1) + t41 * g1[1];
+            *    *dnoise_dz += -8.0f * t21 * t1 * z1 * dot(g1[0], g1[1], g1[2], g1[3], x1, y1, z1, w1) + t41 * g1[2];
+            *    *dnoise_dw = -8.0f * t21 * t1 * w1 * dot(g1[0], g1[1], g1[2], g1[3], x1, y1, z1, w1) + t41 * g1[3];
+            *    *dnoise_dx += -8.0f * t22 * t2 * x2 * dot(g2[0], g2[1], g2[2], g2[3], x2, y2, z2, w2) + t42 * g2[0];
+            *    *dnoise_dy += -8.0f * t22 * t2 * y2 * dot(g2[0], g2[1], g2[2], g2[3], x2, y2, z2, w2) + t42 * g2[1];
+            *    *dnoise_dz += -8.0f * t22 * t2 * z2 * dot(g2[0], g2[1], g2[2], g2[3], x2, y2, z2, w2) + t42 * g2[2];
+            *    *dnoise_dw += -8.0f * t22 * t2 * w2 * dot(g2[0], g2[1], g2[2], g2[3], x2, y2, z2, w2) + t42 * g2[3];
+            *    *dnoise_dx += -8.0f * t23 * t3 * x3 * dot(g3[0], g3[1], g3[2], g3[3], x3, y3, z3, w3) + t43 * g3[0];
+            *    *dnoise_dy += -8.0f * t23 * t3 * y3 * dot(g3[0], g3[1], g3[2], g3[3], x3, y3, z3, w3) + t43 * g3[1];
+            *    *dnoise_dz += -8.0f * t23 * t3 * z3 * dot(g3[0], g3[1], g3[2], g3[3], x3, y3, z3, w3) + t43 * g3[2];
+            *    *dnoise_dw += -8.0f * t23 * t3 * w3 * dot(g3[0], g3[1], g3[2], g3[3], x3, y3, z3, w3) + t43 * g3[3];
+            *    *dnoise_dx += -8.0f * t24 * t4 * x4 * dot(g4[0], g4[1], g4[2], g4[3], x4, y4, z4, w4) + t44 * g4[0];
+            *    *dnoise_dy += -8.0f * t24 * t4 * y4 * dot(g4[0], g4[1], g4[2], g4[3], x4, y4, z4, w4) + t44 * g4[1];
+            *    *dnoise_dz += -8.0f * t24 * t4 * z4 * dot(g4[0], g4[1], g4[2], g4[3], x4, y4, z4, w4) + t44 * g4[2];
+            *    *dnoise_dw += -8.0f * t24 * t4 * w4 * dot(g4[0], g4[1], g4[2], g4[3], x4, y4, z4, w4) + t44 * g4[3];
+            */
+            float temp0 = t20 * t0 * (g0.x * x0 + g0.y * y0 + g0.z * z0 + g0.w * w0);
+            float dnoise_dx = temp0 * x0;
+            float dnoise_dy = temp0 * y0;
+            float dnoise_dz = temp0 * z0;
+            float dnoise_dw = temp0 * w0;
+            float temp1 = t21 * t1 * (g1.x * x1 + g1.y * y1 + g1.z * z1 + g1.w * w1);
+            dnoise_dx += temp1 * x1;
+            dnoise_dy += temp1 * y1;
+            dnoise_dz += temp1 * z1;
+            dnoise_dw += temp1 * w1;
+            float temp2 = t22 * t2 * (g2.x * x2 + g2.y * y2 + g2.z * z2 + g2.w * w2);
+            dnoise_dx += temp2 * x2;
+            dnoise_dy += temp2 * y2;
+            dnoise_dz += temp2 * z2;
+            dnoise_dw += temp2 * w2;
+            float temp3 = t23 * t3 * (g3.x * x3 + g3.y * y3 + g3.z * z3 + g3.w * w3);
+            dnoise_dx += temp3 * x3;
+            dnoise_dy += temp3 * y3;
+            dnoise_dz += temp3 * z3;
+            dnoise_dw += temp3 * w3;
+            float temp4 = t24 * t4 * (g4.x * x4 + g4.y * y4 + g4.z * z4 + g4.w * w4);
+            dnoise_dx += temp4 * x4;
+            dnoise_dy += temp4 * y4;
+            dnoise_dz += temp4 * z4;
+            dnoise_dw += temp4 * w4;
+            dnoise_dx *= -8.0f;
+            dnoise_dy *= -8.0f;
+            dnoise_dz *= -8.0f;
+            dnoise_dw *= -8.0f;
+            dnoise_dx += t40 * g0.x + t41 * g1.x + t42 * g2.x + t43 * g3.x + t44 * g4.x;
+            dnoise_dy += t40 * g0.y + t41 * g1.y + t42 * g2.y + t43 * g3.y + t44 * g4.y;
+            dnoise_dz += t40 * g0.z + t41 * g1.z + t42 * g2.z + t43 * g3.z + t44 * g4.z;
+            dnoise_dw += t40 * g0.w + t41 * g1.w + t42 * g2.w + t43 * g3.w + t44 * g4.w;
+            // Scale derivative to match the noise scaling
+            dnoise_dx *= scale;
+            dnoise_dy *= scale;
+            dnoise_dz *= scale;
+            dnoise_dw *= scale;
+
+
+            derivPolicy.set_dx(dnoise_dx);
+            derivPolicy.set_dy(dnoise_dy);
+            derivPolicy.set_dz(dnoise_dz);
+            derivPolicy.set_dw(dnoise_dw);
+        }
+        return noise;
+    }
+
+} // namespace sfm
+
+
+} // namespace __OSL_WIDE_PVT or pvt
+
+
+OSL_NAMESPACE_EXIT

--- a/src/include/OSL/sfmath.h
+++ b/src/include/OSL/sfmath.h
@@ -1,0 +1,1121 @@
+/*
+Copyright (c) 2017 Intel Inc., et al.
+All Rights Reserved.
+  
+Copyright (c) 2009-2015 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+
+#include <cmath>
+
+#include "dual.h"
+#include "dual_vec.h"
+#include "Imathx.h"
+
+#include <OpenEXR/ImathFun.h>
+#include <OpenEXR/ImathMatrix.h>
+#include <OpenImageIO/fmath.h>
+
+
+OSL_NAMESPACE_ENTER
+
+#ifdef __OSL_WIDE_PVT
+    namespace __OSL_WIDE_PVT {
+#else
+    namespace pvt {
+#endif
+
+
+
+// SIMD FRIENDLY MATH
+// Scalar code meant to be used from inside
+// compiler vectorized SIMD loops.
+// No intrinsics or assembly, just vanilla C++
+namespace sfm
+{
+    // Math code derived from OpenImageIO/fmath.h
+    // including it's copyrights in the namespace
+    /*
+      Copyright 2008-2014 Larry Gritz and the other authors and contributors.
+      All Rights Reserved.
+
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are
+      met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the software's owners nor the names of its
+        contributors may be used to endorse or promote products derived from
+        this software without specific prior written permission.
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+      (This is the Modified BSD License)
+
+      A few bits here are based upon code from NVIDIA that was also released
+      under the same modified BSD license, and marked as:
+         Copyright 2004 NVIDIA Corporation. All Rights Reserved.
+
+      Some parts of this file were first open-sourced in Open Shading Language,
+      then later moved here. The original copyright notice was:
+         Copyright (c) 2009-2014 Sony Pictures Imageworks Inc., et al.
+
+      Many of the math functions were copied from or inspired by other
+      public domain sources or open source packages with compatible licenses.
+      The individual functions give references were applicable.
+    */
+
+    // Math code derived from OpenEXR/ImathMatrix.h
+    // including it's copyrights in the namespace
+    /*
+       Copyright (c) 2002-2012, Industrial Light & Magic, a division of Lucas
+       Digital Ltd. LLC
+
+       All rights reserved.
+
+       Redistribution and use in source and binary forms, with or without
+       modification, are permitted provided that the following conditions are
+       met:
+       *       Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+       *       Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following disclaimer
+       in the documentation and/or other materials provided with the
+       distribution.
+       *       Neither the name of Industrial Light & Magic nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+       THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+       "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+       LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+       A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+       OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+       SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+       LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+       DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+       THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    */
+
+	/// return the greatest integer <= x
+	OSL_FORCEINLINE int ifloor (float x) {
+		//    return (int) x - ((x < 0) ? 1 : 0);
+
+		// std::floor is another option, however that appears to be
+		// a function call right now, and this sequence appears cheaper
+		//return static_cast<int>(x - ((x < 0.0f) ? 1.0f : 0.0f));
+
+		// This factoring should allow the expensive float to integer
+		// conversion to happen at the same time the comparison is
+		// in an out of order CPU
+		return (static_cast<int>(x)) - ((x < 0.0f) ? 1 : 0);
+	}
+
+    /// Fused multiply and add: (a*b + c)
+    OSL_FORCEINLINE float madd (float a, float b, float c) {
+        // Avoid simulating FMA on non-FMA hardware
+        // This can result in differences between FMA and non-FMA hardware
+        // but a simulated result is really slow
+        return a * b + c;
+    }
+
+    /// Identical to OIIO::lerp(a,b,u), but always inlined
+    /// to not inhibit CLANG vectorization
+    template <class T, class Q>
+    OSL_FORCEINLINE T
+    lerp (const T& v0, const T& v1, const Q& x)
+    {
+        // NOTE: a*(1-x) + b*x is much more numerically stable than a+x*(b-a)
+        return v0*(Q(1)-x) + v1*x;
+    }
+
+    /// Identical to OIIO::bilerp(a,b,c,d,u,v), but always inlined
+    /// to not inhibit CLANG vectorization
+    template <class T, class Q>
+    OSL_FORCEINLINE T
+    bilerp(const T& v0, const T& v1, const T& v2, const T& v3, const Q& s, const Q& t)
+    {
+        // NOTE: a*(t-1) + b*t is much more numerically stable than a+t*(b-a)
+        Q s1 = Q(1) - s;
+        return T ((Q(1)-t)*(v0*s1 + v1*s) + t*(v2*s1 + v3*s));
+    }
+
+    /// Identical to OIIO::trilerp(a,b,c,d,e,f,g,h,u,v,w), but always inlined
+    /// to not inhibit CLANG vectorization
+    template <class T, class Q>
+    OSL_FORCEINLINE T
+    trilerp (const T & v0, const T & v1, const T & v2, const T & v3, const T & v4, const T & v5, const T & v6, const T & v7, const Q &s, const Q &t, const Q & r)
+    {
+        // NOTE: a*(t-1) + b*t is much more numerically stable than a+t*(b-a)
+        Q s1 = Q(1) - s;
+        Q t1 = Q(1) - t;
+        Q r1 = Q(1) - r;
+
+        return T (r1*(t1*(v0*s1 + v1*s) + t*(v2*s1 + v3*s)) +
+                   r*(t1*(v4*s1 + v5*s) + t*(v6*s1 + v7*s)));
+    }
+
+    // Native OIIO::isinf wasn't vectorizing and was branchy
+    // this slightly perturbed version fairs better and is branch free
+    // when vectorized
+    OSL_FORCEINLINE int isinf (float x) {
+
+        // Based on algorithm in OIIO missing_math.h for _MSC_VER < 1800
+        int r = 0;
+        // NOTE: using bitwise | to avoid branches
+        if (!(OIIO::isfinite(x)|OIIO::isnan(x))) {
+            r = static_cast<int>(copysignf(1.0f,x));
+        }
+        return r;
+    }
+
+    // Exists mainly to allow the same function name to work
+    // with Dual2 and float
+    OSL_FORCEINLINE float absf (float x)
+    {
+#if 0
+        //return x >= 0.0f ? x : -x;
+#elif 0
+        // Move negation operation out of conditional
+        // so result should be masked blend or ternary
+        float neg_x = -x;
+        return (x >= 0.0f) ? x : neg_x;
+#else
+        // gcc header use builtin abs that does bit twiddling 2 instructions
+        return std::abs(x);
+#endif
+    }
+
+    template<typename T> OSL_FORCEINLINE T negate(const T &x) {
+        #if OSL_FAST_MATH
+            // Compiler using a constant bit mask to perform negation,
+            // and reading a constant involves accessing its memory location.
+            // Alternatively the compiler can create a 0 value in register
+            // in a constant time not involving the memory subsystem.
+            // So we can subtract from 0 to effectively negate a value.
+            // Handling of +0.0f and -0.0f might differ from IEE here.
+            // But in graphics practice we don't see a problem with codes
+            // using this approach and a measurable 10%(+|-5%) performance gain
+            return T(0) - x;
+        #else
+            return -x;
+        #endif
+    }
+
+    OSL_FORCEINLINE Dual2<float> absf (const Dual2<float> &x)
+    {
+        // Avoid ternary ops whose operands have side effects
+        // in favor of code that executes both sides masked
+        // return x.val() >= 0.0f ? x : -x;
+
+        // NOTE: negation happens outside of conditional, then is blended based on the condition
+        Dual2<float> neg_x = negate(x);
+
+        bool cond = x.val() < 0.0f;
+        // Blend per builtin component to allow
+        // the compiler to track builtins and privatize the data layout
+        // versus requiring a stack location.
+        float val = x.val();
+        if (cond) {
+            val = neg_x.val();
+        }
+
+        float dx = x.dx();
+        if (cond) {
+            dx = neg_x.dx();
+        }
+
+        float dy = x.dy();
+        if (cond) {
+            dy = neg_x.dy();
+        }
+
+        return Dual2<float>(val, dx, dy);
+    }
+
+    OSL_FORCEINLINE int absi (int x)
+    {
+        //return x >= 0 ? x : -x;
+        return std::abs(x);
+    }
+#if 0
+    template <typename IN_TYPE, typename OUT_TYPE>
+    OSL_FORCEINLINE OUT_TYPE bit_cast (const IN_TYPE val) {
+        static_assert(sizeof(IN_TYPE) == sizeof(OUT_TYPE), "when casting between types they must be the same size");
+        union {
+            IN_TYPE inVal;
+            OUT_TYPE outVal;
+        } in_or_out;
+        in_or_out.inVal = val;
+        return in_or_out.outVal;
+    }
+#else
+    // C++20 has std::bit_cast, although explicit SIMD may still
+    // be unhappy
+    template <typename IN_TYPE, typename OUT_TYPE>
+    OSL_FORCEINLINE OUT_TYPE bit_cast (const IN_TYPE val) {
+        static_assert(sizeof(IN_TYPE) == sizeof(OUT_TYPE), "when casting between types they must be the same size");
+        OUT_TYPE r;
+        memcpy(&r, &val, sizeof(OUT_TYPE));
+        return r;
+    }
+#endif
+
+#ifdef __INTEL_COMPILER
+    // Although the union based type punning in the bit_cast template
+    // is legal and supported by strict type analysis, a vectorizing compiler
+    // may take it too literally and create a temporary and attempt to share
+    // memory location, as a union is supposed to do.
+    // Within a SIMD loop, this however can result in a AOS of unions, with
+    // a gather to pull the data back out in the new type.
+    // Theoretically a compiler could try and use a SOA of its union when
+    // certain conditions are met.  Until support to that level is reached,
+    // we can instead use compiler specific intrinsics to perform the cast
+    // Specialize the template for casts which compiler intrinsics exist
+    template <>
+    OSL_FORCEINLINE uint32_t bit_cast<float, uint32_t> (const float val) {
+          static_assert(sizeof(float) == sizeof(uint32_t), "when casting between types they must be the same size");
+          return static_cast<uint32_t>(_castf32_u32(val));
+    }
+    template <>
+    OSL_FORCEINLINE int32_t bit_cast<float, int32_t> (const float val) {
+          static_assert(sizeof(float) == sizeof(int32_t), "when casting between types they must be the same size");
+          return static_cast<int32_t>(_castf32_u32(val));
+    }
+    template <>
+    OSL_FORCEINLINE float bit_cast<uint32_t, float> (const uint32_t val) {
+          static_assert(sizeof(uint32_t) == sizeof(float), "when casting between types they must be the same size");
+          return _castu32_f32(val);
+    }
+    template <>
+    OSL_FORCEINLINE float bit_cast<int32_t, float> (const int32_t val) {
+          static_assert(sizeof(int32_t) == sizeof(float), "when casting between types they must be the same size");
+          return _castu32_f32(val);
+    }
+
+    template <>
+    OSL_FORCEINLINE uint64_t bit_cast<double, uint64_t> (const double val) {
+          static_assert(sizeof(double) == sizeof(uint64_t), "when casting between types they must be the same size");
+          return static_cast<uint64_t>(_castf64_u64(val));
+    }
+    template <>
+    OSL_FORCEINLINE int64_t bit_cast<double, int64_t> (const double val) {
+          static_assert(sizeof(double) == sizeof(int64_t), "when casting between types they must be the same size");
+          return static_cast<int64_t>(_castf64_u64(val));
+    }
+    template <>
+    OSL_FORCEINLINE double bit_cast<uint64_t, double> (const uint64_t val) {
+          static_assert(sizeof(uint64_t) == sizeof(double), "when casting between types they must be the same size");
+          return _castu64_f64(val);
+    }
+    template <>
+    OSL_FORCEINLINE double bit_cast<int64_t, double> (const int64_t val) {
+          static_assert(sizeof(int64_t) == sizeof(double), "when casting between types they must be the same size");
+          return _castu64_f64(val);
+    }
+#endif
+
+    OSL_FORCEINLINE int bitcast_to_int (float x) { return bit_cast<float,int>(x); }
+    OSL_FORCEINLINE float bitcast_to_float (int x) { return bit_cast<int,float>(x); }
+
+    /// clamp a to bounds [low,high].
+    template <class T>
+    OSL_FORCEINLINE T
+    clamp (T a, T low, T high)
+    {
+        // OIIO clamp only does the 2nd comparison in the else
+        // block, which will generate extra code in a SIMD masking scenario
+        //return (a < low) ? low : ((a > high) ? high : a);
+
+        // The following should result in a max and min instruction, thats it
+        if (a < low) {
+            a = low;
+        }
+        if (a > high) {
+            a = high;
+        }
+        return a;
+    }
+
+    template<typename T>
+    T log2 (const T& xval); // undefined
+
+    template<>
+    OSL_FORCEINLINE float log2<float> (const float& xval) {
+        // NOTE: clamp to avoid special cases and make result "safe" from large negative values/nans
+        float x = clamp (xval, std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
+        // based on https://github.com/LiraNuna/glsl-sse2/blob/master/source/vec4.h
+        unsigned bits = bit_cast<float, unsigned>(x);
+        int exponent = int(bits >> 23) - 127;
+        float f = bit_cast<unsigned, float>((bits & 0x007FFFFF) | 0x3f800000) - 1.0f;
+        // Examined 2130706432 values of log2 on [1.17549435e-38,3.40282347e+38]: 0.0797524457 avg ulp diff, 3713596 max ulp, 7.62939e-06 max error
+        // ulp histogram:
+        //  0  = 97.46%
+        //  1  =  2.29%
+        //  2  =  0.11%
+        float f2 = f * f;
+        float f4 = f2 * f2;
+        float hi = madd(f, -0.00931049621349f,  0.05206469089414f);
+        float lo = madd(f,  0.47868480909345f, -0.72116591947498f);
+        hi = madd(f, hi, -0.13753123777116f);
+        hi = madd(f, hi,  0.24187369696082f);
+        hi = madd(f, hi, -0.34730547155299f);
+        lo = madd(f, lo,  1.442689881667200f);
+        return ((f4 * hi) + (f * lo)) + exponent;
+    }
+
+    template<>
+    OSL_FORCEINLINE Dual2<float> log2<Dual2<float>>(const Dual2<float> &a)
+    {
+        float loga = log2(a.val());
+        float aln2 = a.val() * float(M_LN2);
+        float inva = aln2 < std::numeric_limits<float>::min() ? 0.0f : 1.0f / aln2;
+        return Dual2<float> (loga, inva * a.dx(), inva * a.dy());
+    }
+
+    template<typename T>
+    OSL_FORCEINLINE T log (const T& x) {
+        // Examined 2130706432 values of logf on [1.17549435e-38,3.40282347e+38]: 0.313865375 avg ulp diff, 5148137 max ulp, 7.62939e-06 max error
+        return log2(x) * T(M_LN2);
+    }
+
+    template<typename T>
+    OSL_FORCEINLINE T log10 (const T& x) {
+        // Examined 2130706432 values of log10f on [1.17549435e-38,3.40282347e+38]: 0.631237033 avg ulp diff, 4471615 max ulp, 3.8147e-06 max error
+        return log2(x) * T(M_LN2 / M_LN10);
+    }
+
+    OSL_FORCEINLINE float logb (float x) {
+        // don't bother with denormals
+        x = absf(x);
+        if (x < std::numeric_limits<float>::min()) x = std::numeric_limits<float>::min();
+        if (x > std::numeric_limits<float>::max()) x = std::numeric_limits<float>::max();
+        unsigned bits = bit_cast<float, unsigned>(x);
+        return float (int(bits >> 23) - 127);
+    }
+
+    template<typename T>
+    OSL_FORCEINLINE T exp2 (const T & xval); // undefined
+
+    template<>
+    OSL_FORCEINLINE float exp2<float> (const float & xval) {
+#if OSL_NON_INTEL_CLANG
+        // Not ideal, but CLANG was unhappy using the bitcast/memcpy/reinter_cast/union
+        // inside an explicit SIMD loop, so revert to calling the standard version
+        return std::exp2(xval);
+#else
+        // clamp to safe range for final addition
+        float x = clamp (xval, -126.0f, 126.0f);
+        // range reduction
+        int m = static_cast<int>(x); x -= m;
+        x = 1.0f - (1.0f - x); // crush denormals (does not affect max ulps!)
+        // 5th degree polynomial generated with sollya
+        // Examined 2247622658 values of exp2 on [-126,126]: 2.75764912 avg ulp diff, 232 max ulp
+        // ulp histogram:
+        //  0  = 87.81%
+        //  1  =  4.18%
+        float r = 1.33336498402e-3f;
+        r = madd(x, r, 9.810352697968e-3f);
+        r = madd(x, r, 5.551834031939e-2f);
+        r = madd(x, r, 0.2401793301105f);
+        r = madd(x, r, 0.693144857883f);
+        r = madd(x, r, 1.0f);
+        // multiply by 2 ^ m by adding in the exponent
+        // NOTE: left-shift of negative number is undefined behavior
+
+        // Clang: loop not vectorized: unsafe dependent memory operations in loop
+        return bit_cast<unsigned, float>(bit_cast<float, unsigned>(r) + (static_cast<unsigned>(m) << 23));
+
+        // Clang: loop not vectorized: unsafe dependent memory operations in loop
+//        union {
+//            float float_val;
+//            unsigned int uint_val;
+//        } float_or_uint;
+//        float_or_uint.float_val = r;
+//        float_or_uint.uint_val += (static_cast<unsigned>(m) << 23);
+//        return float_or_uint.float_val;
+#endif
+    }
+
+    template<>
+    OSL_FORCEINLINE Dual2<float> exp2<Dual2<float>>(const Dual2<float> &a)
+    {
+        float exp2a = sfm::template exp2(a.val());
+        return Dual2<float> (exp2a, exp2a*float(M_LN2)*a.dx(), exp2a*float(M_LN2)*a.dy());
+    }
+
+    template <typename T>
+    OSL_FORCEINLINE T exp (const T& x) {
+        // Examined 2237485550 values of exp on [-87.3300018,87.3300018]: 2.6666452 avg ulp diff, 230 max ulp
+        return sfm::exp2(x * T(1 / M_LN2));
+    }
+
+    OSL_FORCEINLINE float expm1 (float x) {
+        if (absf(x) < 0.03f) {
+            float y = 1.0f - (1.0f - x); // crush denormals
+            return copysignf(madd(0.5f, y * y, y), x);
+        } else
+            return exp(x) - 1.0f;
+    }
+
+    OSL_FORCEINLINE Dual2<float> expm1(const Dual2<float> &a)
+    {
+        float expm1a = expm1(a.val());
+        float expa   = exp  (a.val());
+        return Dual2<float> (expm1a, expa * a.dx(), expa * a.dy());
+    }
+
+    OSL_FORCEINLINE float erf(const float x)
+    {
+        // Examined 1082130433 values of erff on [0,4]: 1.93715e-06 max error
+        // Abramowitz and Stegun, 7.1.28
+        const float a1 = 0.0705230784f;
+        const float a2 = 0.0422820123f;
+        const float a3 = 0.0092705272f;
+        const float a4 = 0.0001520143f;
+        const float a5 = 0.0002765672f;
+        const float a6 = 0.0000430638f;
+        const float a = absf(x);
+        const float b = 1.0f - (1.0f - a); // crush denormals
+        const float r = madd(madd(madd(madd(madd(madd(a6, b, a5), b, a4), b, a3), b, a2), b, a1), b, 1.0f);
+        const float s = r * r; // ^2
+        const float t = s * s; // ^4
+        const float u = t * t; // ^8
+        const float v = u * u; // ^16
+        return copysign(1.0f - 1.0f / v, x);
+    }
+
+    OSL_FORCEINLINE Dual2<float> erf(const Dual2<float> &a)
+    {
+        float erfa = erf (a.val());
+        float two_over_sqrt_pi = 1.128379167095512573896158903f;
+        float derfadx = exp(-a.val() * a.val()) * two_over_sqrt_pi;
+        return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
+    }
+
+    OSL_FORCEINLINE float erfc (float x)
+    {
+        // Examined 2164260866 values of erfcf on [-4,4]: 1.90735e-06 max error
+        // ulp histogram:
+        //   0  = 80.30%
+        return 1.0f - erf(x);
+    }
+
+    OSL_FORCEINLINE Dual2<float> erfc(const Dual2<float> &a)
+    {
+        float erfa = erfc (a.val());
+        float two_over_sqrt_pi = -1.128379167095512573896158903f;
+        float derfadx = exp(-a.val() * a.val()) * two_over_sqrt_pi;
+        //float derfadx = std::exp(-a.val() * a.val()) * two_over_sqrt_pi;
+        return Dual2<float> (erfa, derfadx * a.dx(), derfadx * a.dy());
+    }
+
+
+
+    OSL_FORCEINLINE float safe_pow (float x, float y) {
+        if (y == 0) return 1.0f; // x^0=1
+        if (x == 0) return 0.0f; // 0^y=0
+        // be cheap & exact for special case of squaring and identity
+        if (y == 1.0f)
+            return x;
+        if (y == 2.0f)
+            return std::min (x*x, std::numeric_limits<float>::max());
+        float sign = 1.0f;
+        if (OSL_UNLIKELY(x < 0)) {
+            // if x is negative, only deal with integer powers
+            // powf returns NaN for non-integers, we will return 0 instead
+            int ybits = bitcast_to_int(y) & 0x7fffffff;
+            if (ybits >= 0x4b800000) {
+                // always even int, keep positive
+            } else if (ybits >= 0x3f800000) {
+                // bigger than 1, check
+                int k = (ybits >> 23) - 127;  // get exponent
+                int j =  ybits >> (23 - k);   // shift out possible fractional bits
+                if ((j << (23 - k)) == ybits) // rebuild number and check for a match
+                    sign = bit_cast<int, float>(0x3f800000 | (j << 31)); // +1 for even, -1 for odd
+                else
+                    return 0.0f; // not integer
+            } else {
+                return 0.0f; // not integer
+            }
+        }
+        return sign * exp2(y * log2(std::abs(x)));
+
+    }
+
+    OSL_FORCEINLINE Dual2<float> safe_pow(const Dual2<float> &u, const Dual2<float> &v)
+    {
+        // NOTE: same issue as above (fast_safe_pow does even more clamping)
+        float powuvm1 = sfm::safe_pow (u.val(), v.val() - 1.0f);
+        float powuv   = powuvm1 * u.val();
+        float logu    = u.val() > 0 ? log(u.val()) : 0.0f;
+        return Dual2<float> ( powuv, v.val()*powuvm1 * u.dx() + logu*powuv * v.dx(),
+                                     v.val()*powuvm1 * u.dy() + logu*powuv * v.dy() );
+    }
+
+    OSL_FORCEINLINE float safe_fmod (float a, float b) {
+        //return (b != 0.0f) ? std::fmod (a,b) : 0.0f;
+        if (OSL_LIKELY(b != 0.0f)) {
+            // return std::fmod (a,b);
+            // std::fmod was getting called serially instead
+            // of vectorizing, so we will just do the
+            // calculation ourselves
+            //
+            // The floating-point remainder of the division operation
+            // a/b is a - N*b, where N = a/b with its fractional part truncated.
+            int N = static_cast<int>(a/b);
+            return a - N*b;
+        }
+        return 0.0f;
+    }
+
+    OSL_FORCEINLINE Dual2<float> safe_fmod (const Dual2<float> &a, const Dual2<float> &b) {
+        return Dual2<float> (safe_fmod (a.val(), b.val()), a.dx(), a.dy());
+    }
+
+#if 0 // emitted directly by llvm_gen_wide.cpp
+    OSL_FORCEINLINE float safe_div(float a, float b) {
+        return (b != 0.0f) ? (a / b) : 0.0f;
+    }
+
+    OSL_FORCEINLINE int safe_div(int a, int b) {
+        return (b != 0) ? (a / b) : 0;
+    }
+#endif
+
+
+    /// Round to nearest integer, returning as an int.
+    OSL_FORCEINLINE int fast_rint (float x) {
+        // used by sin/cos/tan range reduction
+    #if 0
+        // single roundps instruction on SSE4.1+ (for gcc/clang at least)
+        //return static_cast<int>(rintf(x));
+        return rintf(x);
+    #else
+        // emulate rounding by adding/substracting 0.5
+        return static_cast<int>(x + copysignf(0.5f, x));
+
+        // Other possible factorings
+        //return (x >= 0.0f) ? static_cast<int>(x + 0.5f) : static_cast<int>(x - 0.5f);
+        //return static_cast<int>(x +  (x >= 0.0f) ? 0.5f : - 0.5f);
+        //float pad = (x >= 0.0f) ? 0.5f : - 0.5f;
+        //return static_cast<int>(x + pad);
+        //return nearbyint(x);
+#endif
+    }
+
+
+    OSL_FORCEINLINE float sin (float x) {
+        // very accurate argument reduction from SLEEF
+        // starts failing around x=262000
+        // Results on: [-2pi,2pi]
+        // Examined 2173837240 values of sin: 0.00662760244 avg ulp diff, 2 max ulp, 1.19209e-07 max error
+        int q = fast_rint (x * float(M_1_PI));
+        float qf = q;
+        x = madd(qf, -0.78515625f*4, x);
+        x = madd(qf, -0.00024187564849853515625f*4, x);
+        x = madd(qf, -3.7747668102383613586e-08f*4, x);
+        x = madd(qf, -1.2816720341285448015e-12f*4, x);
+        x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+        float s = x * x;
+        if ((q & 1) != 0) x = -x;
+        // this polynomial approximation has very low error on [-pi/2,+pi/2]
+        // 1.19209e-07 max error in total over [-2pi,+2pi]
+        float u = 2.6083159809786593541503e-06f;
+        u = madd(u, s, -0.0001981069071916863322258f);
+        u = madd(u, s, +0.00833307858556509017944336f);
+        u = madd(u, s, -0.166666597127914428710938f);
+        u = madd(s, u * x, x);
+
+        /* ORIGINAL OIIO 1.7 did the following, which would create a discontinuity
+         * should u be just 1ulp past 1.0.  This was happening with FMA hardware
+         * do to reduced amount of rounding for intermediate results.
+         * It makes more sense to just perform a true clamping operation.
+         *   // For large x, the argument reduction can fail and the polynomial can be
+         *   // evaluated with arguments outside the valid internal. Just clamp the bad
+         *   // values away (setting to 0.0f means no branches need to be generated).
+         *   if (fabsf(u) > 1.0f) u = 0.0f;
+         */
+        return clamp(u,-1.0f, 1.0f);
+    }
+    OSL_FORCEINLINE float cos (float x) {
+        // same argument reduction as fast_sin
+        int q = fast_rint (x * float(M_1_PI));
+        float qf = q;
+        x = madd(qf, -0.78515625f*4, x);
+        x = madd(qf, -0.00024187564849853515625f*4, x);
+        x = madd(qf, -3.7747668102383613586e-08f*4, x);
+        x = madd(qf, -1.2816720341285448015e-12f*4, x);
+        x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+        float s = x * x;
+        // polynomial from SLEEF's sincosf, max error is
+        // 4.33127e-07 over [-2pi,2pi] (98% of values are "exact")
+        float u = -2.71811842367242206819355e-07f;
+        u = madd(u, s, +2.47990446951007470488548e-05f);
+        u = madd(u, s, -0.00138888787478208541870117f);
+        u = madd(u, s, +0.0416666641831398010253906f);
+        u = madd(u, s, -0.5f);
+        u = madd(u, s, +1.0f);
+        if ((q & 1) != 0) u = -u;
+        /* ORIGINAL OIIO 1.7 did the following, which would create a discontinuity
+         * should u be just 1ulp past 1.0.  This was happening with FMA hardware
+         * do to reduced amount of rounding for intermediate results.
+         * It makes more sense to just perform a true clamping operation.
+         *   if (fabsf(u) > 1.0f) u = 0.0f;
+         */
+        return clamp(u,-1.0f, 1.0f);
+    }
+    OSL_FORCEINLINE void sincos (float x, float & sine, float& cosine) {
+        // same argument reduction as fast_sin
+        int q = fast_rint (x * float(M_1_PI));
+        float qf = q;
+        x = madd(qf, -0.78515625f*4, x);
+        x = madd(qf, -0.00024187564849853515625f*4, x);
+        x = madd(qf, -3.7747668102383613586e-08f*4, x);
+        x = madd(qf, -1.2816720341285448015e-12f*4, x);
+        x = float(M_PI_2) - (float(M_PI_2) - x); // crush denormals
+        float s = x * x;
+        // NOTE: same exact polynomials as fast_sin and fast_cos above
+        if ((q & 1) != 0) x = -x;
+        float su = 2.6083159809786593541503e-06f;
+        su = madd(su, s, -0.0001981069071916863322258f);
+        su = madd(su, s, +0.00833307858556509017944336f);
+        su = madd(su, s, -0.166666597127914428710938f);
+        su = madd(s, su * x, x);
+        float cu = -2.71811842367242206819355e-07f;
+        cu = madd(cu, s, +2.47990446951007470488548e-05f);
+        cu = madd(cu, s, -0.00138888787478208541870117f);
+        cu = madd(cu, s, +0.0416666641831398010253906f);
+        cu = madd(cu, s, -0.5f);
+        cu = madd(cu, s, +1.0f);
+        if ((q & 1) != 0) cu = -cu;
+        /* ORIGINAL OIIO 1.7 did the following, which would create a discontinuity
+         * should su or cu be just 1ulp past 1.0.  This was happening with FMA hardware
+         * do to reduced amount of rounding for intermediate results.
+         * It makes more sense to just perform a true clamping operation.
+         *   if (fabsf(su) > 1.0f) su = 0.0f;
+         *   if (fabsf(cu) > 1.0f) cu = 0.0f;
+         */
+        sine   = clamp(su,-1.0f, 1.0f);;
+        cosine = clamp(cu,-1.0f, 1.0f);;
+    }
+
+    // NOTE: this approximation is only valid on [-8192.0,+8192.0], it starts becoming
+    // really poor outside of this range because the reciprocal amplifies errors
+    OSL_FORCEINLINE float tan (float x) {
+        // derived from SLEEF implementation
+        // note that we cannot apply the "denormal crush" trick everywhere because
+        // we sometimes need to take the reciprocal of the polynomial
+        int q = fast_rint (x * float(2 * M_1_PI));
+        float qf = q;
+        x = madd(qf, -0.78515625f*2, x);
+        x = madd(qf, -0.00024187564849853515625f*2, x);
+        x = madd(qf, -3.7747668102383613586e-08f*2, x);
+        x = madd(qf, -1.2816720341285448015e-12f*2, x);
+        if ((q & 1) == 0)
+        x = float(M_PI_4) - (float(M_PI_4) - x); // crush denormals (only if we aren't inverting the result later)
+        float s = x * x;
+        float u = 0.00927245803177356719970703f;
+        u = madd(u, s, 0.00331984995864331722259521f);
+        u = madd(u, s, 0.0242998078465461730957031f);
+        u = madd(u, s, 0.0534495301544666290283203f);
+        u = madd(u, s, 0.133383005857467651367188f);
+        u = madd(u, s, 0.333331853151321411132812f);
+        u = madd(s, u * x, x);
+        if ((q & 1) != 0) u = -1.0f / u;
+        return u;
+    }
+
+    OSL_FORCEINLINE Dual2<float> tan(const Dual2<float> &a)
+    {
+        float tana  = sfm::tan (a.val());
+        float cosa  = sfm::cos (a.val());
+        float sec2a = 1 / (cosa * cosa);
+        return Dual2<float> (tana, sec2a * a.dx(), sec2a * a.dy());
+    }
+
+    OSL_FORCEINLINE float atan (float x) {
+        const float a = absf(x);
+        const float k = a > 1.0f ? 1 / a : a;
+        const float s = 1.0f - (1.0f - k); // crush denormals
+        const float t = s * s;
+        // http://mathforum.org/library/drmath/view/62672.html
+        // Examined 4278190080 values of atan: 2.36864877 avg ulp diff, 302 max ulp, 6.55651e-06 max error      // (with  denormals)
+        // Examined 4278190080 values of atan: 171160502 avg ulp diff, 855638016 max ulp, 6.55651e-06 max error // (crush denormals)
+        float r = s * madd(0.43157974f, t, 1.0f) / madd(madd(0.05831938f, t, 0.76443945f), t, 1.0f);
+        if (a > 1.0f) r = 1.570796326794896557998982f - r;
+        return copysignf(r, x);
+    }
+
+    OSL_FORCEINLINE Dual2<float> atan(const Dual2<float> &a)
+    {
+        float arctana = sfm::atan(a.val());
+        float denom   = 1.0f / (1.0f + a.val() * a.val());
+        return Dual2<float> (arctana, denom * a.dx(), denom * a.dy());
+
+    }
+
+    OSL_FORCEINLINE float atan2 (float y, float x) {
+        // based on atan approximation above
+        // the special cases around 0 and infinity were tested explicitly
+        // the only case not handled correctly is x=NaN,y=0 which returns 0 instead of nan
+        const float a = absf(x);
+        const float b = absf(y);
+
+        //const float k = (b == 0) ? 0.0f : ((a == b) ? 1.0f : (b > a ? a / b : b / a));
+        // When applying to all lanes in SIMD, we end up doing extra masking and 2 divides.
+        // So lets just do 1 divide and swap the parameters instead.
+        // And if we are going to do a doing a divide anyway, when a == b it should be 1.0f anyway
+        // so lets not bother special casing it.
+        bool b_is_greater_than_a = b > a;
+        float sa = b_is_greater_than_a ? b : a;
+        float sb = b_is_greater_than_a ? a : b;
+        const float k = (b == 0) ? 0.0f : sb/sa;
+
+        const float s = 1.0f - (1.0f - k); // crush denormals
+        const float t = s * s;
+
+        float r = s * madd(0.43157974f, t, 1.0f) / madd(madd(0.05831938f, t, 0.76443945f), t, 1.0f);
+
+        if (b_is_greater_than_a) r = 1.570796326794896557998982f - r; // account for arg reduction
+        // TODO:  investigate if testing x < 0.0f is more efficient or even the same
+        if (bit_cast<float, unsigned>(x) & 0x80000000u) // test sign bit of x
+            r = float(M_PI) - r;
+        return copysignf(r, y);
+    }
+
+    OSL_FORCEINLINE Dual2<float> atan2(const Dual2<float> &y, const Dual2<float> &x)
+    {
+        float atan2xy = sfm::atan2(y.val(), x.val());
+        // NOTE: using bitwise & to avoid branches
+        float denom = (x.val() == 0 & y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
+        return Dual2<float> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
+                                       (y.val()*x.dy() - x.val()*y.dy())*denom );
+    }
+
+    OSL_FORCEINLINE float cosh (float x) {
+        // Examined 2237485550 values of cosh on [-87.3300018,87.3300018]: 1.78256726 avg ulp diff, 178 max ulp
+        float e = sfm::exp(absf(x));
+        return 0.5f * e + 0.5f / e;
+    }
+
+    OSL_FORCEINLINE float sinh (float x) {
+        float a = absf(x);
+        if (OSL_UNLIKELY(a > 1.0f)) {
+            // Examined 53389559 values of sinh on [1,87.3300018]: 33.6886442 avg ulp diff, 178 max ulp
+            float e = sfm::exp(a);
+            return copysignf(0.5f * e - 0.5f / e, x);
+        } else {
+            a = 1.0f - (1.0f - a); // crush denorms
+            float a2 = a * a;
+            // degree 7 polynomial generated with sollya
+            // Examined 2130706434 values of sinh on [-1,1]: 1.19209e-07 max error
+            float r = 2.03945513931e-4f;
+            r = madd(r, a2, 8.32990277558e-3f);
+            r = madd(r, a2, 0.1666673421859f);
+            r = madd(r * a, a2, a);
+            return copysignf(r, x);
+        }
+    }
+
+    inline float tanh (float x) {
+        // Examined 4278190080 values of tanh on [-3.40282347e+38,3.40282347e+38]: 3.12924e-06 max error
+        // NOTE: ulp error is high because of sub-optimal handling around the origin
+        float e = sfm::exp(2.0f * absf(x));
+        return copysignf(1 - 2 / (1 + e), x);
+    }
+
+    OSL_FORCEINLINE Dual2<float> cosh(const Dual2<float> &a)
+    {
+        float cosha = sfm::cosh(a.val());
+        float sinha = sfm::sinh(a.val());
+        return Dual2<float> (cosha, sinha * a.dx(), sinha * a.dy());
+    }
+
+    OSL_FORCEINLINE Dual2<float> sinh(const Dual2<float> &a)
+    {
+        float cosha = sfm::cosh(a.val());
+        float sinha = sfm::sinh(a.val());
+        return Dual2<float> (sinha, cosha * a.dx(), cosha * a.dy());
+    }
+
+    OSL_FORCEINLINE Dual2<float> tanh(const Dual2<float> &a)
+    {
+        float tanha = sfm::tanh(a.val());
+        float cosha = sfm::cosh(a.val());
+        float sech2a = 1 / (cosha * cosha);
+        return Dual2<float> (tanha, sech2a * a.dx(), sech2a * a.dy());
+    }
+
+    OSL_FORCEINLINE Dual2<float> sin(const Dual2<float> &a)
+    {
+        float sina, cosa;
+        sfm::sincos (a.val(), sina, cosa);
+        return Dual2<float> (sina, cosa * a.dx(), cosa * a.dy());
+    }
+
+    OSL_FORCEINLINE Dual2<float> cos(const Dual2<float> &a)
+    {
+        float sina, cosa;
+        sfm::sincos (a.val(), sina, cosa);
+        return Dual2<float> (cosa, -sina * a.dx(), -sina * a.dy());
+    }
+
+
+    // because lengthTiny does alot of work including another
+    // sqrt, we really want to skip that if possible because
+    // with SIMD execution, we end up doing the sqrt twice
+    // and blending the results.  Although code could be
+    // refactored to do a single sqrt, think its better
+    // to skip the code block as we don't expect near 0 lengths
+    // TODO: get OpenEXR ImathVec to update to similar, don't think
+    // it can cause harm
+
+    // Imath::Vec3::lengthTiny is private
+    // local copy here no changes
+    OSL_FORCEINLINE float accessibleTinyLength(const Vec3 &N)
+    {
+//        float absX = (N.x >= float (0))? N.x: -N.x;
+//        float absY = (N.y >= float (0))? N.y: -N.y;
+//        float absZ = (N.z >= float (0))? N.z: -N.z;
+        // gcc builtin for abs is 2 instructions using bit twiddling vs. compares
+        float absX = absf(N.x);
+        float absY = absf(N.y);
+        float absZ = absf(N.z);
+
+        float max = absX;
+
+        if (max < absY)
+            max = absY;
+
+        if (max < absZ)
+            max = absZ;
+
+        if (OSL_UNLIKELY(max == 0.0f))
+            return 0.0f;
+
+        //
+        // Do not replace the divisions by max with multiplications by 1/max.
+        // Computing 1/max can overflow but the divisions below will always
+        // produce results less than or equal to 1.
+        //
+
+        absX /= max;
+        absY /= max;
+        absZ /= max;
+
+        return max * Imath::Math<float>::sqrt (absX * absX + absY * absY + absZ * absZ);
+    }
+
+    OSL_FORCEINLINE
+    float length(const Vec3 &N)
+    {
+        float length2 = N.dot (N);
+
+        if (OSL_UNLIKELY(length2 < float (2) * Imath::limits<float>::smallest()))
+            return accessibleTinyLength(N);
+
+        return Imath::Math<float>::sqrt (length2);
+    }
+
+    OSL_FORCEINLINE Vec3
+    normalize(const Vec3 &N)
+    {
+        float l = length(N);
+
+        if (OSL_UNLIKELY(l == float (0)))
+            return Vec3 (float (0));
+
+        return Vec3 (N.x / l, N.y / l, N.z / l);
+    }
+
+
+    OSL_FORCEINLINE Dual2<Vec3>
+    normalize (const Dual2<Vec3> &a)
+    {
+        // NOTE: using bitwise & to avoid branches
+        if (OSL_UNLIKELY(a.val().x == 0.0f & a.val().y == 0.0f & a.val().z == 0.0f)) {
+            return Dual2<Vec3> (Vec3(0.0f, 0.0f, 0.0f),
+                                Vec3(0.0f, 0.0f, 0.0f),
+                                Vec3(0.0f, 0.0f, 0.0f));
+        } else {
+            Dual2<float> ax (a.val().x, a.dx().x, a.dy().x);
+            Dual2<float> ay (a.val().y, a.dx().y, a.dy().y);
+            Dual2<float> az (a.val().z, a.dx().z, a.dy().z);
+            Dual2<float> inv_length = 1.0f / sqrt(ax*ax + ay*ay + az*az);
+            ax = ax*inv_length;
+            ay = ay*inv_length;
+            az = az*inv_length;
+            return Dual2<Vec3> (Vec3(ax.val(), ay.val(), az.val()),
+                                Vec3(ax.dx(),  ay.dx(),  az.dx() ),
+                                Vec3(ax.dy(),  ay.dy(),  az.dy() ));
+        }
+    }
+
+
+    template<typename T>
+    OSL_FORCEINLINE
+    T max_val(T left, T right)
+    {
+        return (right > left)? right: left;
+    }
+
+    class Matrix33 : public Imath::Matrix33<float>
+    {
+    public:
+        typedef Imath::Matrix33<float> parent;
+
+        OSL_FORCEINLINE Matrix33 (Imath::Uninitialized uninit)
+        : parent(uninit)
+        {}
+
+        // Avoid the memset that is part of the Imath::Matrix33
+        // default constructor
+        OSL_FORCEINLINE Matrix33 ()
+        : parent(1.0f, 0.0f, 0.0f,
+                                 0.0f, 1.0f, 0.0f,
+                                 0.0f, 0.0f, 1.0f)
+        {}
+
+        OSL_FORCEINLINE Matrix33 (float a, float b, float c, float d, float e, float f, float g, float h, float i)
+        : parent(a,b,c,d,e,f,g,h,i)
+        {}
+
+        OSL_FORCEINLINE Matrix33 (const Imath::Matrix33<float> &a)
+        : parent(a)
+        {}
+
+        // Avoid the memcpy that is part of the Imath::Matrix33
+        OSL_FORCEINLINE
+        Matrix33 (const float a[3][3])
+        : Imath::Matrix33<float>(
+            a[0][0], a[0][1], a[0][2],
+            a[1][0], a[1][1], a[1][2],
+            a[2][0], a[2][1], a[2][2])
+        {}
+
+
+        // Avoid the memcpy that is part of Imath::Matrix33::operator=
+        OSL_FORCEINLINE Matrix33 &
+        operator = (const Matrix33 &v)
+        {
+            parent::x[0][0] = v.x[0][0];
+            parent::x[0][1] = v.x[0][1];
+            parent::x[0][2] = v.x[0][2];
+
+            parent::x[1][0] = v.x[1][0];
+            parent::x[1][1] = v.x[1][1];
+            parent::x[1][2] = v.x[1][2];
+
+            parent::x[2][0] = v.x[2][0];
+            parent::x[2][1] = v.x[2][1];
+            parent::x[2][2] = v.x[2][2];
+
+            return *this;
+        }
+
+
+        // Avoid Imath::Matrix33::operator * that
+        // initializing values to 0 before overwriting them
+        // Also manually unroll its nested loops
+        OSL_FORCEINLINE Matrix33
+        operator * (const Matrix33 &v) const
+        {
+            Matrix33 tmp(Imath::UNINITIALIZED);
+
+            tmp.x[0][0] = parent::x[0][0] * v.x[0][0] +
+                          parent::x[0][1] * v.x[1][0] +
+                          parent::x[0][2] * v.x[2][0];
+            tmp.x[0][1] = parent::x[0][0] * v.x[0][1] +
+                    parent::x[0][1] * v.x[1][1] +
+                    parent::x[0][2] * v.x[2][1];
+            tmp.x[0][2] = parent::x[0][0] * v.x[0][2] +
+                    parent::x[0][1] * v.x[1][2] +
+                    parent::x[0][2] * v.x[2][2];
+
+            tmp.x[1][0] = parent::x[1][0] * v.x[0][0] +
+                    parent::x[1][1] * v.x[1][0] +
+                    parent::x[1][2] * v.x[2][0];
+            tmp.x[1][1] = parent::x[1][0] * v.x[0][1] +
+                    parent::x[1][1] * v.x[1][1] +
+                    parent::x[1][2] * v.x[2][1];
+            tmp.x[1][2] = parent::x[1][0] * v.x[0][2] +
+                    parent::x[1][1] * v.x[1][2] +
+                    parent::x[1][2] * v.x[2][2];
+
+            tmp.x[2][0] = parent::x[2][0] * v.x[0][0] +
+                    parent::x[2][1] * v.x[1][0] +
+                    parent::x[2][2] * v.x[2][0];
+            tmp.x[2][1] = parent::x[2][0] * v.x[0][1] +
+                    parent::x[2][1] * v.x[1][1] +
+                    parent::x[2][2] * v.x[2][1];
+            tmp.x[2][2] = parent::x[2][0] * v.x[0][2] +
+                    parent::x[2][1] * v.x[1][2] +
+                    parent::x[2][2] * v.x[2][2];
+
+            return tmp;
+        }
+    };
+
+
+    OSL_FORCEINLINE sfm::Matrix33
+    make_matrix33_cols (const Vec3 &a, const Vec3 &b, const Vec3 &c)
+    {
+        return sfm::Matrix33 (a.x, b.x, c.x,
+                         a.y, b.y, c.y,
+                         a.z, b.z, c.z);
+    }
+
+
+
+    // Considering having functionally equivalent versions of Vec3, Color3, Matrix44
+    // with slight modifications to inlining and implementation to avoid aliasing and
+    // improve likelyhood of proper privation of local variables within a SIMD loop
+
+} // namespace sfm
+
+} // namespace __OSL_WIDE_PVT or pvt
+
+
+
+
+OSL_NAMESPACE_EXIT

--- a/src/include/OSL/sfmath.h
+++ b/src/include/OSL/sfmath.h
@@ -827,7 +827,7 @@ namespace sfm
     {
         float atan2xy = sfm::atan2(y.val(), x.val());
         // NOTE: using bitwise & to avoid branches
-        float denom = (x.val() == 0 & y.val() == 0) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
+        float denom = ((x.val() == 0) & (y.val() == 0)) ? 0.0f : 1.0f / (x.val() * x.val() + y.val() * y.val());
         return Dual2<float> ( atan2xy, (y.val()*x.dx() - x.val()*y.dx())*denom,
                                        (y.val()*x.dy() - x.val()*y.dy())*denom );
     }
@@ -973,7 +973,7 @@ namespace sfm
     normalize (const Dual2<Vec3> &a)
     {
         // NOTE: using bitwise & to avoid branches
-        if (OSL_UNLIKELY(a.val().x == 0.0f & a.val().y == 0.0f & a.val().z == 0.0f)) {
+        if (OSL_UNLIKELY((a.val().x == 0.0f) & (a.val().y == 0.0f) & (a.val().z == 0.0f))) {
             return Dual2<Vec3> (Vec3(0.0f, 0.0f, 0.0f),
                                 Vec3(0.0f, 0.0f, 0.0f),
                                 Vec3(0.0f, 0.0f, 0.0f));

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -1,0 +1,1352 @@
+/*
+Copyright (c) 2017 Intel Inc., et al.
+All Rights Reserved.
+ 
+Copyright (c) 2009-2013 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <type_traits>
+
+#include <OSL/oslconfig.h>
+//#include "mask.h"
+#include "dual_vec.h"
+#include "Imathx.h"
+
+OSL_NAMESPACE_ENTER
+
+// template<DataT>
+// struct ImplDefinedProxy
+//{
+//    typedef DataT ValueType;
+//    operator DataT () const;
+//    const DataT & operator = (const DataT & value) const;
+//};
+//
+// A Proxy object abstracts the location and layout of some DataT.
+// DataT can be imported, with an assignment
+// operator, or exported, with a conversion operator.
+// Direct pointer access is not provided as the
+// data layout inside may not adhere to C ABI.
+// This approach enables user code to use DataT
+// and let Proxy objects handle moving the data
+// in-between layouts (AOS<->SOA).
+// "unproxy(impl_proxy)" will extract the correctly type value.
+// NOTE: assignment operator is const, making Proxy objects
+// suitable to be passed by value through lambda closures
+
+// Exporting data out of a proxy requires a conversion operator,
+// which requires the left hand side of an expression to be correctly
+// typed (because its a parameter or static_cast).
+// Correctly typed usage may not be present in the users code,
+//
+// IE:  std::cout << proxy_obj;
+//
+// and cause a compilation failure.
+// To work around this, a helper free function is provided to export the
+// correctly typed value of a proxy object
+//
+// typename ImplDefinedProxy::ValueType const unproxy(const ImplDefinedProxy &proxy);
+//
+// IE:  std::cout << unproxy(proxy_obj);
+
+
+template <typename DataT, int WidthT>
+struct Block;
+// A Block provides physical storage for WidthT entries of DataT,
+// WidthT is typically set to the # of physical SIMD data lanes
+// on a system.
+// The data itself is stored in a SOA (Structure of Arrays) layout.
+// DataT may be Dual2<T>.
+// DataT must NOT be an array, arrays are supported by having
+// and array of Block[].
+// Implementations should support the following interface:
+//{
+//    Block() = default;
+//    // We want to avoid accidentally copying these when the intent was to just pass a reference,
+//    // especially with lambda closures
+//    Block(const Block &other) = delete;
+//    // Use default constructor + assignment operator to effectively copy construct
+//
+//    template<typename... DataListT, typename = pvt::enable_if_type<(sizeof...(DataListT) == WidthT)> >
+//    explicit OSL_FORCEINLINE
+//    Block(const DataListT &...values);
+//
+//    void set(int lane, const DataT & value);  // when DataT is not const
+//    DataT get(int lane) const;
+//
+//    impl-defined-proxy operator[](int lane);  // when DataT is not const
+//    impl-defined-const-proxy operator[](int lane) const
+//
+//    void dump(const char *name) const;
+//};
+
+// More wrappers will be added here to wrap a reference to Block data along with a mask...
+
+// Utilities to assign all data lanes to the same value
+template <typename DataT, int WidthT>
+OSL_FORCEINLINE void assign_all(Block<DataT, WidthT> &, const DataT &);
+
+
+
+
+
+
+
+
+
+// IMPLEMENTATION BELOW
+// NOTE: not all combinations of DataT, const DataT, DataT[], DataT[3] are implemented
+// only specialization actually used by the current code base are here.
+// NOTE: additional constructors & helpers functions exist in the implementation
+// that were not specified in the descriptions above for brevity.
+
+static constexpr int MaxSupportedSimdLaneCount = 16;
+
+/// Type for an opaque pointer to whatever the renderer uses to represent a
+/// coordinate transformation.
+typedef const void * TransformationPtr;
+
+namespace pvt {
+    // Forward declarations
+    template <typename DataT, int WidthT>
+    struct LaneProxy;
+    template <typename ConstDataT, int WidthT>
+    struct ConstLaneProxy;
+};
+
+// Type to establish proper alignment for a vector register of a given width.
+// Can be used with alignas(VecReg<WidthT>) attribute
+// or be a base class to force derived class to adhere to
+// its own alignment restrictions
+template <int WidthT>
+struct alignas(WidthT*sizeof(float)) VecReg {
+    // NOTE: regardless of the actual type, our goal is to
+    // establish the # of bytes a vector registor holds
+    // for that purpose we just use float.
+    // Should OSL::Float change to double this would need
+    // to as well.
+    static constexpr int alignment = WidthT*sizeof(float);
+};
+
+static_assert(std::alignment_of<VecReg<16>>::value == 64, "Unexepected alignment");
+static_assert(std::alignment_of<VecReg<8>>::value == 32, "Unexepected alignment");
+static_assert(std::alignment_of<VecReg<4>>::value == 16, "Unexepected alignment");
+static_assert(std::alignment_of<VecReg<16>>::value == VecReg<16>::alignment, "Unexepected alignment");
+static_assert(std::alignment_of<VecReg<8>>::value == VecReg<8>::alignment, "Unexepected alignment");
+static_assert(std::alignment_of<VecReg<4>>::value == VecReg<4>::alignment, "Unexepected alignment");
+
+
+template <typename BuiltinT, int WidthT>
+struct alignas(VecReg<WidthT>) BlockOfBuiltin
+{
+    typedef BuiltinT ValueType;
+    static constexpr int width = WidthT;
+
+    ValueType data[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, ValueType value)
+    {
+        data[lane] = value;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, ValueType value, bool laneMask)
+    {
+        if (laneMask) {
+            data[lane] = value;
+        }
+    }
+
+    OSL_FORCEINLINE void
+    set_all(ValueType value)
+    {
+        OSL_FORCEINLINE_BLOCK
+        {
+            OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
+            for(int i = 0; i < WidthT; ++i)
+            {
+                data[i] = value;
+            }
+        }
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const ValueType & value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... BuiltinListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, ValueType headValue, BuiltinListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE BlockOfBuiltin() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    BlockOfBuiltin(const BlockOfBuiltin &other) = delete;
+
+    template<typename... BuiltinListT, typename = pvt::enable_if_type<(sizeof...(BuiltinListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    BlockOfBuiltin(const BuiltinListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(BuiltinListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+    OSL_FORCEINLINE BuiltinT
+    get(int lane) const
+    {
+        return data[lane];
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(static_cast<Block<ValueType, WidthT> &>(*this), lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(static_cast<const Block<ValueType, WidthT> &>(*this), lane);
+    }
+
+    void dump(const char *name) const
+    {
+        if (name != nullptr) {
+            std::cout << name << " = ";
+        }
+        std::cout << "{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << data[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+    }
+};
+
+
+
+
+
+// Specializations
+template <int WidthT>
+struct Block<float, WidthT> : public BlockOfBuiltin<float, WidthT> {};
+
+template <int WidthT>
+struct Block<int, WidthT> : public BlockOfBuiltin<int, WidthT> {};
+
+template <int WidthT>
+struct Block<TransformationPtr, WidthT> : public BlockOfBuiltin<TransformationPtr, WidthT> {};
+
+
+// Vec4 isn't used by external interfaces, but some internal
+// noise functions utilize a wide version of it.
+typedef Imath::Vec4<Float>     Vec4;
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Vec4, WidthT>
+{
+    typedef Vec4 ValueType;
+    static constexpr int width = WidthT;
+    float x[WidthT];
+    float y[WidthT];
+    float z[WidthT];
+    float w[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec4 & value)
+    {
+        x[lane] = value.x;
+        y[lane] = value.y;
+        z[lane] = value.z;
+        w[lane] = value.w;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec4 & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x[lane] = value.x;
+        if (laneMask)
+            y[lane] = value.y;
+        if (laneMask)
+            z[lane] = value.z;
+        if (laneMask)
+            w[lane] = value.w;
+    }
+
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const Vec4 & value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... Vec4ListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, Vec4 headValue, Vec4ListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... Vec4ListT, typename = pvt::enable_if_type<(sizeof...(Vec4ListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const Vec4ListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(Vec4ListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE Vec4
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lx = x[lane];
+        float ly = y[lane];
+        float lz = z[lane];
+        float lw = w[lane];
+
+        return Vec4(lx, ly, lz, lw);
+
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+
+    void dump(const char *name) const
+    {
+        if (name != nullptr) {
+            std::cout << name << " = ";
+        }
+        std::cout << "x{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << x[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "y{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << y[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "z{"    ;
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << z[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "w{"    ;
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << w[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+    }
+
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Vec3, WidthT>
+{
+    typedef Vec3 ValueType;
+    static constexpr int width = WidthT;
+    float x[WidthT];
+    float y[WidthT];
+    float z[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec3 & value)
+    {
+        x[lane] = value.x;
+        y[lane] = value.y;
+        z[lane] = value.z;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec3 & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x[lane] = value.x;
+        if (laneMask)
+            y[lane] = value.y;
+        if (laneMask)
+            z[lane] = value.z;
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const Vec3 & value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... Vec3ListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, Vec3 headValue, Vec3ListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... Vec3ListT, typename = pvt::enable_if_type<(sizeof...(Vec3ListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const Vec3ListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(Vec3ListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE Vec3
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lx = x[lane];
+        float ly = y[lane];
+        float lz = z[lane];
+
+        return Vec3(lx, ly, lz);
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+
+    void dump(const char *name) const
+    {
+        if (name != nullptr) {
+            std::cout << name << " = ";
+        }
+        std::cout << "x{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << x[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "y{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << y[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "z{"    ;
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << z[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+    }
+
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Vec2, WidthT>
+{
+    typedef Vec2 ValueType;
+    static constexpr int width = WidthT;
+    float x[WidthT];
+    float y[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec2 & value)
+    {
+        x[lane] = value.x;
+        y[lane] = value.y;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const Vec2 & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x[lane] = value.x;
+        if (laneMask)
+            y[lane] = value.y;
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const Vec2 & value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... Vec2ListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, Vec2 headValue, Vec2ListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... Vec2ListT, typename = pvt::enable_if_type<(sizeof...(Vec2ListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const Vec2ListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(Vec2ListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE Vec2
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lx = x[lane];
+        float ly = y[lane];
+
+        return Vec2(lx, ly);
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+
+    void dump(const char *name) const
+    {
+        if (name != nullptr) {
+            std::cout << name << " = ";
+        }
+        std::cout << "x{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << x[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "y{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << y[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+    }
+
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Color3, WidthT>
+{
+    typedef Color3 ValueType;
+    static constexpr int width = WidthT;
+    float x[WidthT];
+    float y[WidthT];
+    float z[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const Color3 & value)
+    {
+        x[lane] = value.x;
+        y[lane] = value.y;
+        z[lane] = value.z;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const Color3 & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x[lane] = value.x;
+        if (laneMask)
+            y[lane] = value.y;
+        if (laneMask)
+            z[lane] = value.z;
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const Color3 & value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... Color3ListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, Color3 headValue, Color3ListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... Color3ListT, typename = pvt::enable_if_type<(sizeof...(Color3ListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const Color3ListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(Color3ListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE Color3
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lx = x[lane];
+        float ly = y[lane];
+        float lz = z[lane];
+
+        return Color3(lx, ly, lz);
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+
+    void dump(const char *name) const
+    {
+        if (name != nullptr) {
+            std::cout << name << " = ";
+        }
+        std::cout << "x{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << x[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "y{";
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << y[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+        std::cout << "z{"    ;
+        for(int i=0; i < WidthT; ++i)
+        {
+            std::cout << z[i];
+            if (i < (WidthT-1))
+                std::cout << ",";
+
+        }
+        std::cout << "}" << std::endl;
+    }
+
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Matrix44, WidthT>
+{
+    typedef Matrix44 ValueType;
+    static constexpr int width = WidthT;
+
+    float x00[WidthT];
+    float x01[WidthT];
+    float x02[WidthT];
+    float x03[WidthT];
+
+    float x10[WidthT];
+    float x11[WidthT];
+    float x12[WidthT];
+    float x13[WidthT];
+
+    float x20[WidthT];
+    float x21[WidthT];
+    float x22[WidthT];
+    float x23[WidthT];
+
+    float x30[WidthT];
+    float x31[WidthT];
+    float x32[WidthT];
+    float x33[WidthT];
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    OSL_FORCEINLINE void
+    set(int lane, const Matrix44 & value)
+    {
+        x00[lane] = value.x[0][0];
+        x01[lane] = value.x[0][1];
+        x02[lane] = value.x[0][2];
+        x03[lane] = value.x[0][3];
+
+        x10[lane] = value.x[1][0];
+        x11[lane] = value.x[1][1];
+        x12[lane] = value.x[1][2];
+        x13[lane] = value.x[1][3];
+
+        x20[lane] = value.x[2][0];
+        x21[lane] = value.x[2][1];
+        x22[lane] = value.x[2][2];
+        x23[lane] = value.x[2][3];
+
+        x30[lane] = value.x[3][0];
+        x31[lane] = value.x[3][1];
+        x32[lane] = value.x[3][2];
+        x33[lane] = value.x[3][3];
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const Matrix44 & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x00[lane] = value.x[0][0];
+        if (laneMask)
+            x01[lane] = value.x[0][1];
+        if (laneMask)
+            x02[lane] = value.x[0][2];
+        if (laneMask)
+            x03[lane] = value.x[0][3];
+
+        if (laneMask)
+            x10[lane] = value.x[1][0];
+        if (laneMask)
+            x11[lane] = value.x[1][1];
+        if (laneMask)
+            x12[lane] = value.x[1][2];
+        if (laneMask)
+            x13[lane] = value.x[1][3];
+
+        if (laneMask)
+            x20[lane] = value.x[2][0];
+        if (laneMask)
+            x21[lane] = value.x[2][1];
+        if (laneMask)
+            x22[lane] = value.x[2][2];
+        if (laneMask)
+            x23[lane] = value.x[2][3];
+
+        if (laneMask)
+            x30[lane] = value.x[3][0];
+        if (laneMask)
+            x31[lane] = value.x[3][1];
+        if (laneMask)
+            x32[lane] = value.x[3][2];
+        if (laneMask)
+            x33[lane] = value.x[3][3];
+    }
+
+    OSL_FORCEINLINE Matrix44
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float v00 = x00[lane];
+        float v01 = x01[lane];
+        float v02 = x02[lane];
+        float v03 = x03[lane];
+
+        float v10 = x10[lane];
+        float v11 = x11[lane];
+        float v12 = x12[lane];
+        float v13 = x13[lane];
+
+        float v20 = x20[lane];
+        float v21 = x21[lane];
+        float v22 = x22[lane];
+        float v23 = x23[lane];
+
+        float v30 = x30[lane];
+        float v31 = x31[lane];
+        float v32 = x32[lane];
+        float v33 = x33[lane];
+
+        return Matrix44(
+            v00, v01, v02, v03,
+            v10, v11, v12, v13,
+            v20, v21, v22, v23,
+            v30, v31, v32, v33
+            );
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<ustring, WidthT>
+{
+    static constexpr int width = WidthT;
+    typedef ustring ValueType;
+
+    // To enable vectorization, use uintptr_t to store the ustring (const char *)
+    uintptr_t str[WidthT];
+    static_assert(sizeof(ustring) == sizeof(const char*), "ustring must be pointer size");
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    OSL_FORCEINLINE void
+    set(int lane, const ustring& value)
+    {
+        str[lane] = reinterpret_cast<uintptr_t>(value.c_str());
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const ustring& value, bool laneMask)
+    {
+        if (laneMask)
+            str[lane] = reinterpret_cast<uintptr_t>(value.c_str());
+    }
+
+    OSL_FORCEINLINE ustring
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        auto unique_cstr = reinterpret_cast<const char *>(str[lane]);
+        return ustring::from_unique(unique_cstr);
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Dual2<float>, WidthT>
+{
+    typedef Dual2<float> ValueType;
+    static constexpr int width = WidthT;
+    float x[WidthT];
+    float dx[WidthT];
+    float dy[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value)
+    {
+        x[lane] = value.val();
+        dx[lane] = value.dx();
+        dy[lane] = value.dy();
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            x[lane] = value.val();
+        if (laneMask)
+            dx[lane] = value.dx();
+        if (laneMask)
+            dy[lane] = value.dy();
+    }
+
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const ValueType &value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... ValueListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, ValueType headValue, ValueListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... ValueListT, typename = pvt::enable_if_type<(sizeof...(ValueListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const ValueListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(ValueListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE ValueType
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lx = x[lane];
+        float ldx = dx[lane];
+        float ldy = dy[lane];
+        return ValueType(lx, ldx, ldy);
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+};
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Dual2<Vec3>, WidthT>
+{
+    typedef Dual2<Vec3> ValueType;
+    static constexpr int width = WidthT;
+
+    float val_x[WidthT];
+    float val_y[WidthT];
+    float val_z[WidthT];
+
+    float dx_x[WidthT];
+    float dx_y[WidthT];
+    float dx_z[WidthT];
+
+    float dy_x[WidthT];
+    float dy_y[WidthT];
+    float dy_z[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value)
+    {
+        val_x[lane] = value.val().x;
+        val_y[lane] = value.val().y;
+        val_z[lane] = value.val().z;
+
+        dx_x[lane] = value.dx().x;
+        dx_y[lane] = value.dx().y;
+        dx_z[lane] = value.dx().z;
+
+        dy_x[lane] = value.dy().x;
+        dy_y[lane] = value.dy().y;
+        dy_z[lane] = value.dy().z;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            val_x[lane] = value.val().x;
+        if (laneMask)
+            val_y[lane] = value.val().y;
+        if (laneMask)
+            val_z[lane] = value.val().z;
+
+        if (laneMask)
+            dx_x[lane] = value.dx().x;
+        if (laneMask)
+            dx_y[lane] = value.dx().y;
+        if (laneMask)
+            dx_z[lane] = value.dx().z;
+
+        if (laneMask)
+            dy_x[lane] = value.dy().x;
+        if (laneMask)
+            dy_y[lane] = value.dy().y;
+        if (laneMask)
+            dy_z[lane] = value.dy().z;
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const ValueType &value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... ValueListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, ValueType headValue, ValueListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... ValueListT, typename = pvt::enable_if_type<(sizeof...(ValueListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const ValueListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(ValueListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+
+    OSL_FORCEINLINE ValueType
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lval_x = val_x[lane];
+        float lval_y = val_y[lane];
+        float lval_z = val_z[lane];
+
+        float ldx_x = dx_x[lane];
+        float ldx_y = dx_y[lane];
+        float ldx_z = dx_z[lane];
+
+        float ldy_x = dy_x[lane];
+        float ldy_y = dy_y[lane];
+        float ldy_z = dy_z[lane];
+
+
+        return ValueType(Vec3(lval_x, lval_y, lval_z),
+                Vec3(ldx_x, ldx_y, ldx_z),
+                Vec3(ldy_x, ldy_y, ldy_z));
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+};
+
+
+
+template <int WidthT>
+struct alignas(VecReg<WidthT>) Block<Dual2<Color3>, WidthT>
+{
+    typedef Dual2<Color3> ValueType;
+    static constexpr int width = WidthT;
+    float val_x[WidthT];
+    float val_y[WidthT];
+    float val_z[WidthT];
+
+    float dx_x[WidthT];
+    float dx_y[WidthT];
+    float dx_z[WidthT];
+
+    float dy_x[WidthT];
+    float dy_y[WidthT];
+    float dy_z[WidthT];
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value)
+    {
+        val_x[lane] = value.val().x;
+        val_y[lane] = value.val().y;
+        val_z[lane] = value.val().z;
+
+        dx_x[lane] = value.dx().x;
+        dx_y[lane] = value.dx().y;
+        dx_z[lane] = value.dx().z;
+
+        dy_x[lane] = value.dy().x;
+        dy_y[lane] = value.dy().y;
+        dy_z[lane] = value.dy().z;
+    }
+
+    OSL_FORCEINLINE void
+    set(int lane, const ValueType & value, bool laneMask)
+    {
+        // Encourage blend operation with per
+        // component test of mask
+        if (laneMask)
+            val_x[lane] = value.val().x;
+        if (laneMask)
+            val_y[lane] = value.val().y;
+        if (laneMask)
+            val_z[lane] = value.val().z;
+
+        if (laneMask)
+            dx_x[lane] = value.dx().x;
+        if (laneMask)
+            dx_y[lane] = value.dx().y;
+        if (laneMask)
+            dx_z[lane] = value.dx().z;
+
+        if (laneMask)
+            dy_x[lane] = value.dy().x;
+        if (laneMask)
+            dy_y[lane] = value.dy().y;
+        if (laneMask)
+            dy_z[lane] = value.dy().z;
+    }
+
+protected:
+    template<int HeadIndexT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT>, const ValueType &value)
+    {
+        set(HeadIndexT, value);
+    }
+
+    template<int HeadIndexT, int... TailIndexListT, typename... ValueListT>
+    OSL_FORCEINLINE void
+    set(pvt::int_sequence<HeadIndexT, TailIndexListT...>, ValueType headValue, ValueListT... tailValues)
+    {
+        set(HeadIndexT, headValue);
+        set(pvt::int_sequence<TailIndexListT...>(), tailValues...);
+        return;
+    }
+public:
+
+    OSL_FORCEINLINE Block() = default;
+    // We want to avoid accidentally copying these when the intent was to just pass a reference
+    Block(const Block &other) = delete;
+
+    template<typename... ValueListT, typename = pvt::enable_if_type<(sizeof...(ValueListT) == WidthT)> >
+    explicit OSL_FORCEINLINE
+    Block(const ValueListT &...values)
+    {
+        typedef pvt::make_int_sequence<sizeof...(ValueListT)> int_seq_type;
+        set(int_seq_type(), values...);
+        return;
+    }
+
+    OSL_FORCEINLINE ValueType
+    get(int lane) const
+    {
+        // Intentionally have local variables as an intermediate between the
+        // array accesses and the constructor of the return type.
+        // As most constructors accept a const reference this can cause the
+        // array access itself to be forwarded through inlining inside the
+        // constructor and possibly further.
+        float lval_x = val_x[lane];
+        float lval_y = val_y[lane];
+        float lval_z = val_z[lane];
+
+        float ldx_x = dx_x[lane];
+        float ldx_y = dx_y[lane];
+        float ldx_z = dx_z[lane];
+
+        float ldy_x = dy_x[lane];
+        float ldy_y = dy_y[lane];
+        float ldy_z = dy_z[lane];
+
+
+        return ValueType(Vec3(lval_x, lval_y, lval_z),
+                Vec3(ldx_x, ldx_y, ldx_z),
+                Vec3(ldy_x, ldy_y, ldy_z));
+    }
+
+    OSL_FORCEINLINE pvt::LaneProxy<ValueType, WidthT>
+    operator[](int lane)
+    {
+        return pvt::LaneProxy<ValueType, WidthT>(*this, lane);
+    }
+
+    OSL_FORCEINLINE pvt::ConstLaneProxy<const ValueType, WidthT>
+    operator[](int lane) const
+    {
+        return pvt::ConstLaneProxy<const ValueType, WidthT>(*this, lane);
+    }
+};
+
+template <typename DataT, int WidthT>
+OSL_FORCEINLINE void
+assign_all(Block<DataT, WidthT> &wide_data, const DataT &value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
+        for(int i = 0; i < WidthT; ++i) {
+            wide_data.set(i, value);
+        }
+    }
+}
+
+
+OSL_NAMESPACE_EXIT

--- a/src/liboslnoise/gabornoise.h
+++ b/src/liboslnoise/gabornoise.h
@@ -213,8 +213,8 @@ make_orthonormals (Vec3 &v, Vec3 &a, Vec3 &b)
 
 
 // Helper function: per-component 'floor' of a Dual2<Vec3>.
-inline Vec3
-floor OSL_HOSTDEVICE (const Dual2<Vec3> &vd)
+inline OSL_HOSTDEVICE Vec3
+floor (const Dual2<Vec3> &vd)
 {
     // avoid aliasing issues by not using the [] operator
     const Vec3 &v (vd.val());

--- a/src/liboslnoise/gabornoise.h
+++ b/src/liboslnoise/gabornoise.h
@@ -1,0 +1,226 @@
+/*
+Copyright (c) 2012 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <limits>
+
+
+#include "oslexec_pvt.h"
+#include <OSL/oslnoise.h>
+#include <OSL/dual_vec.h>
+#include <OSL/Imathx.h>
+
+#include <OpenImageIO/fmath.h>
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {
+
+// TODO: It would be preferable to use the Imath versions of these functions in
+//       all cases, but these templates should suffice until a more complete
+//       device-friendly version of Imath is available.
+namespace hostdevice {
+template <typename T> inline OSL_HOSTDEVICE T clamp (T x, T lo, T hi);
+#ifndef __CUDA_ARCH__
+template <> inline OSL_HOSTDEVICE double clamp<double> (double x, double lo, double hi) { return Imath::clamp (x, lo, hi); }
+template <> inline OSL_HOSTDEVICE float  clamp<float>  (float x, float lo, float hi)    { return Imath::clamp (x, lo, hi); }
+#else
+template <> inline OSL_HOSTDEVICE double clamp<double> (double x, double lo, double hi) { return (x < lo) ? lo : ((x > hi) ? hi : x); }
+template <> inline OSL_HOSTDEVICE float  clamp<float>  (float x, float lo, float hi)    { return (x < lo) ? lo : ((x > hi) ? hi : x); }
+#endif
+}
+
+static OSL_DEVICE constexpr float Gabor_Frequency = 2.0;
+static OSL_DEVICE constexpr float Gabor_Impulse_Weight = 1.0f;
+
+// The Gabor kernel in theory has infinite support (its envelope is
+// a Gaussian).  To restrict the distance at which we must sum the
+// kernels, we only consider those whose Gaussian envelopes are
+// above the truncation threshold, as a portion of the Gaussian's
+// peak value.
+static OSL_DEVICE const float Gabor_Truncate = 0.02f;
+
+
+
+// Very fast random number generator based on [Borosh & Niederreiter 1983]
+// linear congruential generator.
+class fast_rng {
+public:
+    // seed based on the cell containing P
+    OSL_DEVICE
+    fast_rng (const Vec3 &p, int seed=0) {
+        // Use guts of cellnoise
+        m_seed = inthash(unsigned(OIIO::ifloor(p.x)),
+                         unsigned(OIIO::ifloor(p.y)),
+                         unsigned(OIIO::ifloor(p.z)),
+                         unsigned(seed));
+        if (! m_seed)
+            m_seed = 1;
+    }
+    // Return uniform on [0,1)
+    OSL_HOSTDEVICE
+    float operator() () {
+        return (m_seed *= 3039177861u) / float(UINT_MAX);
+    }
+    // Return poisson distribution with the given mean
+    OSL_HOSTDEVICE
+    int poisson (float mean) {
+        float g = expf (-mean);
+        unsigned int em = 0;
+        float t = (*this)();
+        while (t > g) {
+            ++em;
+            t *= (*this)();
+        }
+        return em;
+    }
+private:
+    unsigned int m_seed;
+};
+
+// The Gabor kernel is a harmonic (cosine) modulated by a Gaussian
+// envelope.  This version is augmented with a phase, per [Lagae2011].
+//   \param  weight      magnitude of the pulse
+//   \param  omega       orientation of the harmonic
+//   \param  phi         phase of the harmonic.
+//   \param  bandwidth   width of the gaussian envelope (called 'a'
+//                          in [Lagae09].
+//   \param  x           the position being sampled
+template <class VEC>   // VEC should be Vec3 or Vec2
+inline OSL_HOSTDEVICE Dual2<float>
+gabor_kernel (const Dual2<float> &weight, const VEC &omega,
+              const Dual2<float> &phi, float bandwidth, const Dual2<VEC> &x)
+{
+    // see Equation 1
+    Dual2<float> g = exp (float(-M_PI) * (bandwidth * bandwidth) * dot(x,x));
+    Dual2<float> h = cos (float(M_TWO_PI) * dot(omega,x) + phi);
+    return weight * g * h;
+}
+
+
+
+inline OSL_HOSTDEVICE void
+slice_gabor_kernel_3d (const Dual2<float> &d, float w, float a,
+                       const Vec3 &omega, float phi,
+                       Dual2<float> &w_s, Vec2 &omega_s, Dual2<float> &phi_s)
+{
+    // Equation 6
+    w_s = w * exp(float(-M_PI) * (a*a)*(d*d));
+    //omega_s[0] = omega[0];
+    //omega_s[1] = omega[1];
+    //phi_s = phi - float(M_TWO_PI) * d * omega[2];
+    omega_s.x = omega.x;
+    omega_s.y = omega.y;
+    // A.W. think this was a bug, supposed to be omega.z not omega.x;
+    //phi_s = phi - float(M_TWO_PI) * d * omega.x;
+    phi_s = phi - float(M_TWO_PI) * d * omega.z;
+}
+
+
+static  OSL_HOSTDEVICE void
+filter_gabor_kernel_2d (const Matrix22 &filter, const Dual2<float> &w, float a,
+                        const Vec2 &omega, const Dual2<float> &phi,
+                        Dual2<float> &w_f, float &a_f,
+                        Vec2 &omega_f, Dual2<float> &phi_f)
+{
+    //  Equation 10
+    Matrix22 Sigma_f = filter;
+    Dual2<float> c_G = w;
+    Vec2 mu_G = omega;
+    Matrix22 Sigma_G = (a * a / float(M_TWO_PI)) * Matrix22();
+    float c_F = 1.0f / (float(M_TWO_PI) * sqrtf(determinant(Sigma_f)));
+    Matrix22 Sigma_F = float(1.0 / (4.0 * M_PI * M_PI)) * Sigma_f.inverse();
+    Matrix22 Sigma_G_Sigma_F = Sigma_G + Sigma_F;
+    Dual2<float> c_GF = c_F * c_G
+        * (1.0f / (float(M_TWO_PI) * sqrtf(determinant(Sigma_G_Sigma_F))))
+        * expf(-0.5f * dot(Sigma_G_Sigma_F.inverse()*mu_G, mu_G));
+    Matrix22 Sigma_G_i = Sigma_G.inverse();
+    Matrix22 Sigma_GF = (Sigma_F.inverse() + Sigma_G_i).inverse();
+    Vec2 mu_GF;
+    Matrix22 Sigma_GF_Gi = Sigma_GF * Sigma_G_i;
+    Sigma_GF_Gi.multMatrix (mu_G, mu_GF);
+    w_f = c_GF;
+    a_f = sqrtf(M_TWO_PI * sqrtf(determinant(Sigma_GF)));
+    omega_f = mu_GF;
+    phi_f = phi;
+}
+
+
+OSL_FORCEINLINE OSL_HOSTDEVICE float
+wrap (float s, float period)
+{
+    period = floorf (period);
+    if (period < 1.0f)
+        period = 1.0f;
+    return s - period * floorf (s / period);
+}
+
+
+// avoid aliasing issues
+static OSL_FORCEINLINE OSL_HOSTDEVICE Vec3
+wrap (const Vec3 &s, const Vec3 &period)
+{
+    return Vec3 (wrap (s.x, period.x),
+                 wrap (s.y, period.y),
+                 wrap (s.z, period.z));
+}
+
+
+// Normalize v and set a and b to be unit vectors (any two unit vectors)
+// that are orthogonal to v and each other.  We get the first
+// orthonormal by taking the cross product of v and (1,0,0), unless v
+// points roughly toward (1,0,0), in which case we cross with (0,1,0).
+// Either way, we get something orthogonal.  Then cross(v,a) is mutually
+// orthogonal to the other two.
+inline OSL_HOSTDEVICE void
+make_orthonormals (Vec3 &v, Vec3 &a, Vec3 &b)
+{
+    // avoid aliasing issues by not using the [] operator
+    v.normalize();
+    if (fabsf(v.x) < 0.9f)
+        a.setValue (0.0f, v.z, -v.y);   // v X (1,0,0)
+    else
+        a.setValue (-v.z, 0.0f, v.x);   // v X (0,1,0)
+    a.normalize ();
+    b = v.cross (a);
+//    b.normalize ();  // note: not necessary since v is unit length
+}
+
+
+
+// Helper function: per-component 'floor' of a Dual2<Vec3>.
+inline Vec3
+floor OSL_HOSTDEVICE (const Dual2<Vec3> &vd)
+{
+    // avoid aliasing issues by not using the [] operator
+    const Vec3 &v (vd.val());
+    return Vec3 (floorf(v.x), floorf(v.y), floorf(v.z));
+}
+
+} // namespace pvt
+
+OSL_NAMESPACE_EXIT

--- a/src/liboslnoise/sfm_gabornoise.h
+++ b/src/liboslnoise/sfm_gabornoise.h
@@ -1,0 +1,631 @@
+/*
+Copyright (c) 2012 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <OSL/sfmath.h>
+
+#include "gabornoise.h"
+
+
+OSL_NAMESPACE_ENTER
+
+namespace __OSL_WIDE_PVT {
+
+// non SIMD version, should be scalar code meant to be used
+// inside SIMD loops
+// SIMD FRIENDLY MATH
+namespace sfm
+{
+
+// Very fast random number generator based on [Borosh & Niederreiter 1983]
+// linear congruential generator.
+class fast_rng {
+public:
+    // seed based on the cell containing P
+    OSL_FORCEINLINE fast_rng (const Vec3 &p, int seed=0) {
+        // Use guts of cellnoise
+        m_seed = inthash(unsigned(OIIO::ifloor(p.x)),
+                         unsigned(OIIO::ifloor(p.y)),
+                         unsigned(OIIO::ifloor(p.z)),
+                         unsigned(seed));
+        if (! m_seed)
+            m_seed = 1;
+    }
+
+    OSL_FORCEINLINE fast_rng(const fast_rng &other)
+    : m_seed(other.m_seed)
+    {}
+
+    // Return uniform on [0,1)
+    OSL_FORCEINLINE float operator() () {
+        //return (m_seed *= 3039177861u) / float(UINT_MAX);
+        return (m_seed *= 3039177861u)*(1.0f/float(UINT_MAX));
+    }
+
+    // Return poisson distribution with the given mean
+    OSL_FORCEINLINE int poisson (float mean) {
+        float g = expf (-mean);
+        unsigned int em = 0;
+        float t = (*this)();
+        while (t > g) {
+            ++em;
+            t *= (*this)();
+        }
+        return em;
+    }
+private:
+    unsigned int m_seed;
+};
+
+
+// The Gabor kernel is a harmonic (cosine) modulated by a Gaussian
+// envelope.  This version is augmented with a phase, per [Lagae2011].
+//   \param  weight      magnitude of the pulse
+//   \param  omega       orientation of the harmonic
+//   \param  phi         phase of the harmonic.
+//   \param  bandwidth   width of the gaussian envelope (called 'a'
+//                          in [Lagae09].
+//   \param  x           the position being sampled
+// Looks identical to OSL::pvt::gabor_kernel, but will call sfm::exp & sfm::cos
+template <class VEC>   // VEC should be Vec3 or Vec2
+static OSL_FORCEINLINE Dual2<float>
+gabor_kernel (const Dual2<float> &weight, const VEC &omega,
+              const Dual2<float> &phi, float bandwidth, const Dual2<VEC> &x)
+{
+    // see Equation 1
+
+    Dual2<float> g = exp (float(-M_PI) * (bandwidth * bandwidth) * dot(x,x));
+    Dual2<float> h = cos (float(M_TWO_PI) * dot(omega,x) + phi);
+    return weight * g * h;
+}
+
+// Looks identical to OSL::pvt::slice_gabor_kernel_3d, but will call sfm::exp
+static OSL_FORCEINLINE void
+slice_gabor_kernel_3d (const Dual2<float> &d, float w, float a,
+                       const Vec3 &omega, float phi,
+                       Dual2<float> &w_s, Vec2 &omega_s, Dual2<float> &phi_s)
+{
+    // Equation 6
+    w_s = w * exp(float(-M_PI) * (a*a)*(d*d));
+    //omega_s[0] = omega[0];
+    //omega_s[1] = omega[1];
+    //phi_s = phi - float(M_TWO_PI) * d * omega[2];
+    omega_s.x = omega.x;
+    omega_s.y = omega.y;
+    // A.W. think this was a bug, supposed to be omega.z not omega.x;
+    //phi_s = phi - float(M_TWO_PI) * d * omega.x;
+    phi_s = phi - float(M_TWO_PI) * d * omega.z;
+}
+
+    struct GaborUniformParams {
+        float a;
+        float lambda;
+        float sqrt_lambda_inv;
+        float radius, radius2, radius3, radius_inv;
+
+        OSL_FORCEINLINE GaborUniformParams (const NoiseParams &opt)
+        {
+            float bandwidth = Imath::clamp(opt.bandwidth,0.01f,100.0f);
+            // NOTE: this could be a source of numerical differences
+            // between the single point vs. batched
+    //#if OSL_FAST_MATH
+    //        float TWO_to_bandwidth = OIIO::fast_exp2(bandwidth);
+    //#else
+            float TWO_to_bandwidth = exp2f(bandwidth);
+    //#endif
+            //static const float SQRT_PI_OVER_LN2 = sqrtf (M_PI / M_LN2);
+            // To match GCC result of sqrtf (M_PI / M_LN2)
+            static constexpr float SQRT_PI_OVER_LN2 = 2.128934e+00f;
+
+            a = Gabor_Frequency * ((TWO_to_bandwidth - 1.0f) / (TWO_to_bandwidth + 1.0f)) * SQRT_PI_OVER_LN2;
+            // Calculate the maximum radius from which we consider the kernel
+            // impulse centers -- derived from the threshold and bandwidth.
+            radius = sqrtf(-logf(Gabor_Truncate) / float(M_PI)) / a;
+            radius2 = radius * radius;
+            radius3 = radius2 * radius;
+            radius_inv = 1.0f / radius;
+            // Lambda is the impulse density.
+            float impulses = Imath::clamp (opt.impulses, 1.0f, 32.0f);
+            lambda = impulses / (float(1.33333 * M_PI) * radius3);
+            sqrt_lambda_inv = 1.0f / sqrtf(lambda);
+        }
+    };
+
+
+
+    struct GaborParams {
+        Matrix22 filter;
+        sfm::Matrix33 local;
+        Vec3 N;
+        Vec3 period;
+        Vec3 omega; // anisotropy orientation
+        float det_filter;
+        int do_filter;
+
+        OSL_FORCEINLINE GaborParams(const Vec3 &direction)
+        : filter(Imath::UNINITIALIZED)
+        , local(Imath::UNINITIALIZED)
+        , omega(direction)
+        {}
+
+
+        OSL_FORCEINLINE GaborParams(const GaborParams &other)
+        : filter(other.filter)
+        , local(other.local)
+        , N(other.N)
+        , period(other.period)
+        , omega(other.omega)
+        , det_filter(other.det_filter)
+        , do_filter (other.do_filter)
+        {}
+
+    };
+
+
+    // set up the filter matrix
+    static OSL_FORCEINLINE void
+    gabor_setup_filter (const Dual2<Vec3> &P, sfm::GaborParams &gp)
+    {
+        // Make texture-space normal, tangent, bitangent
+        Vec3 n, t, b;
+        n = P.dx().cross (P.dy());  // normal to P
+        int do_filter = 1;
+        if (n.dot(n) < 1.0e-6f) {  /* length of deriv < 1/1000 */
+            // No way to do filter if we have no derivs, and no reason to
+            // do it if it's too small to have any effect.
+            do_filter = 0;
+        } else {
+            make_orthonormals (n, t, b);
+
+            // Rotations from tangent<->texture space
+            sfm::Matrix33 Mtex_to_tan = sfm::make_matrix33_cols (t, b, n);  // M3_local
+            sfm::Matrix33 Mscreen_to_tex = sfm::make_matrix33_cols (P.dx(), P.dy(), Vec3(0.0f,0.0f,0.0f));
+            sfm::Matrix33 Mscreen_to_tan = Mscreen_to_tex * Mtex_to_tan;  // M3_scr_tan
+            Matrix22 M_scr_tan (Mscreen_to_tan.x[0][0], Mscreen_to_tan.x[0][1],
+                                Mscreen_to_tan.x[1][0], Mscreen_to_tan.x[1][1]);
+            float sigma_f_scr = 0.5f;
+            Matrix22 Sigma_f_scr (sigma_f_scr * sigma_f_scr, 0.0f,
+                                  0.0f, sigma_f_scr * sigma_f_scr);
+            Matrix22 M_scr_tan_t = M_scr_tan.transposed();
+            Matrix22 Sigma_f_tan = M_scr_tan_t * Sigma_f_scr * M_scr_tan;
+
+            gp.N = n;
+            gp.filter = Sigma_f_tan;
+            gp.local  = Mtex_to_tan;
+            float det_filter = determinant(Sigma_f_tan);
+            gp.det_filter = det_filter;
+            if (det_filter < 1.0e-18f) {
+                do_filter = 0;
+                // Turn off filtering when tiny values will lead to numerical
+                // errors later if we filter.  Yes, it's kind of arbitrary.
+            }
+        }
+        gp.do_filter = do_filter;
+    }
+
+// Choose an omega and phi value for a particular gabor impulse,
+// based on the user-selected noise mode.
+    template<int AnisotropicT>
+    static OSL_FORCEINLINE void
+    gabor_sample (const sfm::GaborParams &gp, const Vec3 &x_c, sfm::fast_rng &rng,
+                  Vec3 &omega, float &phi)
+    {
+        // section 3.3, solid random-phase gabor noise
+        if (AnisotropicT == 1 /* anisotropic */) {
+            omega = gp.omega;
+        } else if (AnisotropicT == 0 /* isotropic */) {
+            float omega_t = float (M_TWO_PI) * rng();
+            // float omega_p = acosf(lerp(-1.0f, 1.0f, rng()));
+            float cos_omega_p = OIIO::lerp(-1.0f, 1.0f, rng());
+            float sin_omega_p = sqrtf (sfm::max_val (0.0f, 1.0f - cos_omega_p*cos_omega_p));
+#if 0
+            float sin_omega_t, cos_omega_t;
+    #if OSL_FAST_MATH
+            OIIO::fast_sincos (omega_t, &sin_omega_t, &cos_omega_t);
+    #else
+            OIIO::sincos (omega_t, &sin_omega_t, &cos_omega_t);
+    #endif
+#else
+    #if OSL_FAST_MATH
+            float sin_omega_t, cos_omega_t;
+            sfm::sincos (omega_t, sin_omega_t, cos_omega_t);
+    #else
+            // NOTE: optimizing compilers will see sin & cos
+            // on the same value and call a single sincos function
+            float sin_omega_t = sinf(omega_t);
+            float cos_omega_t = cosf(omega_t);
+    #endif
+#endif
+            //omega = Vec3 (cos_omega_t*sin_omega_p, sin_omega_t*sin_omega_p, cos_omega_p).normalized();
+            omega = sfm::normalize(Vec3 (cos_omega_t*sin_omega_p, sin_omega_t*sin_omega_p, cos_omega_p));
+        } else {
+            // otherwise hybrid
+            float omega_r = gp.omega.length();
+            float omega_t =  float(M_TWO_PI) * rng();
+#if 0
+            float sin_omega_t, cos_omega_t;
+    #if OSL_FAST_MATH
+            OIIO::fast_sincos (omega_t, &sin_omega_t, &cos_omega_t);
+    #else
+            OIIO::sincos (omega_t, &sin_omega_t, &cos_omega_t);
+    #endif
+#else
+    #if OSL_FAST_MATH
+            float sin_omega_t, cos_omega_t;
+            sfm::sincos (omega_t, sin_omega_t, cos_omega_t);
+    #else
+            // NOTE: optimizing compilers will see sin & cos
+            // on the same value and call a single sincos function
+            float sin_omega_t = sinf(omega_t);
+            float cos_omega_t = cosf(omega_t);
+    #endif
+#endif
+            omega = omega_r * Vec3(cos_omega_t, sin_omega_t, 0.0f);
+        }
+        phi = float(M_TWO_PI) * rng();
+    }
+
+    // gabor_cell was unnecesarily calling down to sample even when outside the radius
+    // however to match existing results, we need to bump the random number generator
+    // an equivalent # of times.  Here the sample function stripped down to just
+    // the rng() calls
+    template<int AnisotropicT>
+    static OSL_FORCEINLINE void
+    gabor_no_sample (sfm::fast_rng &rng)
+    {
+        // section 3.3, solid random-phase gabor noise
+        if (AnisotropicT == 1 /* anisotropic */) {
+        } else if (AnisotropicT == 0 /* isotropic */) {
+            rng();
+            rng();
+        } else {
+            rng();
+        }
+        rng();
+    }
+
+    static OSL_FORCEINLINE void
+    filter_gabor_kernel_2d (const Matrix22 &filter, const Dual2<float> &w, float a,
+                            const Vec2 &omega, const Dual2<float> &phi,
+                            Dual2<float> &w_f, float &a_f,
+                            Vec2 &omega_f, Dual2<float> &phi_f)
+    {
+        //  Equation 10
+        Matrix22 Sigma_f = filter;
+        Dual2<float> c_G = w;
+        Vec2 mu_G = omega;
+        Matrix22 Sigma_G = (a * a / float(M_TWO_PI)) * Matrix22();
+        float c_F = 1.0f / (float(M_TWO_PI) * sqrtf(determinant(Sigma_f)));
+#if 0
+        Matrix22 Sigma_F = float(1.0 / (4.0 * M_PI * M_PI)) * Sigma_f.inverse();
+#else
+        Matrix22 Sigma_f_inverse = Sigma_f.inverse();
+        Matrix22 Sigma_F = float(1.0 / (4.0 * M_PI * M_PI)) * Sigma_f_inverse;
+#endif
+        Matrix22 Sigma_G_Sigma_F = Sigma_G + Sigma_F;
+        Dual2<float> c_GF = c_F * c_G
+            * (1.0f / (float(M_TWO_PI) * sqrtf(determinant(Sigma_G_Sigma_F))))
+            * expf(-0.5f * dot(Sigma_G_Sigma_F.inverse()*mu_G, mu_G));
+        Matrix22 Sigma_G_i = Sigma_G.inverse();
+        Matrix22 Sigma_GF = (Sigma_F.inverse() + Sigma_G_i).inverse();
+        Vec2 mu_GF;
+        Matrix22 Sigma_GF_Gi = Sigma_GF * Sigma_G_i;
+        Sigma_GF_Gi.multMatrix (mu_G, mu_GF);
+        w_f = c_GF;
+        a_f = sqrtf(M_TWO_PI * sqrtf(determinant(Sigma_GF)));
+        omega_f = mu_GF;
+        phi_f = phi;
+    }
+
+
+    // Evaluate the summed contribution of all gabor impulses within the
+    // cell whose corner is c_i.  x_c_i is vector from x (the point
+    // we are trying to evaluate noise at) and c_i.
+    template<int AnisotropicT, typename FilterPolicyT, bool PeriodicT>
+    static OSL_FORCEINLINE Dual2<float>
+    gabor_cell (const sfm::GaborUniformParams &gup, const sfm::GaborParams &gp, const Vec3 &c_i, const Dual2<Vec3> &x_c_i,
+                int seed = 0)
+    {
+        sfm::fast_rng rng (PeriodicT ? Vec3(wrap(c_i,gp.period)) : c_i, seed);
+        int n_impulses = rng.poisson (gup.lambda * gup.radius3);
+        Dual2<float> sum = 0.0f;
+
+        for (int i = 0; i < n_impulses; i++) {
+            // OLD code: Vec3 x_i_c (rng(), rng(), rng());
+            // Turned out that C++ spec says order of args are unspecified.
+            // gcc appeared to do right-to-left, so to make sure our noise
+            // function is locked down (and works identically for clang,
+            // which evaluates left-to-right), we ask for the rng() calls
+            // one at a time and match the way it looked before.
+            float z_rng = rng(), y_rng = rng(), x_rng = rng();
+            Vec3 x_i_c (x_rng, y_rng, z_rng);
+            Dual2<Vec3> x_k_i = gup.radius * (x_c_i - x_i_c);
+            if (OSL_UNLIKELY(x_k_i.val().length2() < gup.radius2)) {
+                float phi_i;
+                Vec3 omega_i;
+                // moved inside of conditional, notice workaround in the else
+                // case to match random number generator of the original version
+                sfm::gabor_sample<AnisotropicT>(gp, c_i, rng, omega_i, phi_i);
+
+                if (OSL_LIKELY(FilterPolicyT::active && (gp.do_filter == 1))) {
+                    // Transform the impulse's anisotropy into tangent space
+                    Vec3 omega_i_t;
+                    multMatrix (gp.local, omega_i, omega_i_t);
+
+                    // Slice to get a 2D kernel
+                    Dual2<float> d_i = -dot(gp.N, x_k_i);
+                    Dual2<float> w_i_t_s;
+                    Vec2 omega_i_t_s;
+                    Dual2<float> phi_i_t_s;
+                    slice_gabor_kernel_3d (d_i, Gabor_Impulse_Weight, gup.a,
+                                           omega_i_t, phi_i,
+                                           w_i_t_s, omega_i_t_s, phi_i_t_s);
+
+                    // Filter the 2D kernel
+                    Dual2<float> w_i_t_s_f;
+                    float a_i_t_s_f;
+                    Vec2 omega_i_t_s_f;
+                    Dual2<float> phi_i_t_s_f;
+                    sfm::filter_gabor_kernel_2d (gp.filter, w_i_t_s, gup.a, omega_i_t_s, phi_i_t_s, w_i_t_s_f, a_i_t_s_f, omega_i_t_s_f, phi_i_t_s_f);
+
+                    // Now evaluate the 2D filtered kernel
+                    Dual2<Vec3> xkit;
+                    multMatrix (gp.local, x_k_i, xkit);
+                    Dual2<Vec2> x_k_i_t = make_Vec2 (comp_x(xkit), comp_y(xkit));
+                    Dual2<float> gk = gabor_kernel (w_i_t_s_f, omega_i_t_s_f, phi_i_t_s_f, a_i_t_s_f, x_k_i_t); // 2D
+#if defined(__AVX512F__) && defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800)
+                    // icc17 with AVX512 had some incorrect results
+                    // due to the not_finite code path executing even
+                    // when the value was finite.  Workaround: using isnan | isinf
+                    // instead of isfinite avoided the issue.
+                    // icc18u3 doesn't exhibit the problem
+                    // NOTE: tried using bitwise | to avoid branches and got internal compiler error
+                    //bool not_finite = std::isnan(gk.val()) | std::isinf(gk.val());
+                    bool not_finite = std::isnan(gk.val()) || std::isinf(gk.val());
+#else
+                    bool not_finite = !OIIO::isfinite(gk.val());
+#endif
+                    if (OSL_UNLIKELY(not_finite))
+                    {
+                        // Numeric failure of the filtered version.  Fall
+                        // back on the unfiltered.
+                        gk = gabor_kernel (Gabor_Impulse_Weight, omega_i, phi_i, gup.a, x_k_i);  // 3D
+                    }
+                    sum += gk;
+                } else {
+                    // N.B. if determinant(gp.filter) is too small, we will
+                    // run into numerical problems.  But the filtering isn't
+                    // needed in that case anyway, so just don't filter.
+                    // This seems to only come up when the filter region is
+                    // tiny.
+                    sum += gabor_kernel (Gabor_Impulse_Weight, omega_i, phi_i, gup.a, x_k_i);  // 3D
+                }
+            } else {
+                // Since we skipped the sample, we still need to bump the rng as if we had
+                sfm::gabor_no_sample<AnisotropicT>(rng);
+            }
+
+        }
+
+        return sum;
+    }
+
+
+    // Sum the contributions of gabor impulses in all neighboring cells
+    // surrounding position x_g.
+    template<int AnisotropicT, typename FilterPolicyT, bool PeriodicT>
+    static OSL_FORCEINLINE Dual2<float>
+    gabor_grid (const sfm::GaborUniformParams &gup, const sfm::GaborParams &gp, const Dual2<Vec3> &x_g, int seed=0)
+    {
+        using pvt::floor;
+        Vec3 floor_x_g (floor (x_g));  // Vec3 because floor has no derivs
+        Dual2<Vec3> x_c = x_g - floor_x_g;
+        Dual2<float> sum = 0.0f;
+
+OSL_INTEL_PRAGMA(nounroll_and_jam)
+        for (int k = -1; k <= 1; k++) {
+OSL_INTEL_PRAGMA(nounroll_and_jam)
+            for (int j = -1; j <= 1; j++) {
+OSL_INTEL_PRAGMA(nounroll_and_jam)
+                for (int i = -1; i <= 1; i++) {
+                    Vec3 c (i,j,k);
+                    Vec3 c_i = floor_x_g + c;
+                    Dual2<Vec3> x_c_i = x_c - c;
+                    sum += sfm::gabor_cell<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, c_i, x_c_i, seed);
+                }
+            }
+        }
+#if 0 // Alternative to the above loop nest, keeping around for experimentation
+    {
+#if 1
+        const Vec3i c_ijk[27] = {
+            {-1,-1,-1}, {0,-1,-1}, {1,-1,-1},
+            {-1,0,-1}, {0,0,-1}, {1,0,-1},
+            {-1,1,-1}, {0,1,-1}, {1,1,-1},
+
+            {-1,-1,0}, {0,-1,0}, {1,-1,0},
+            {-1,0,0}, {0,0,0}, {1,0,0},
+            {-1,1,0}, {0,1,0}, {1,1,0},
+
+            {-1,-1,1}, {0,-1,1}, {1,-1,1},
+            {-1,0,1}, {0,0,1}, {1,0,1},
+            {-1,1,1}, {0,1,1}, {1,1,1},
+        };
+#endif
+#if 0
+        //for(int c_index=0; c_index < 27; ++c_index)
+        {
+            Vec3 c  = c_ijk[0];
+            //Vec3 c(-1,-1,-1);
+            Vec3 c_i = floor_x_g + c;
+            Dual2<Vec3> x_c_i = x_c - c;
+            sum += sfm::gabor_cell<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, c_i, x_c_i, seed);
+        }
+        {
+            Vec3 c  = c_ijk[1];
+            //Vec3 c(-1,-1,-1);
+            Vec3 c_i = floor_x_g + c;
+            Dual2<Vec3> x_c_i = x_c - c;
+            sum += sfm::gabor_cell<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, c_i, x_c_i, seed);
+        }
+        {
+            Vec3 c  = c_ijk[2];
+            //Vec3 c(-1,-1,-1);
+            Vec3 c_i = floor_x_g + c;
+            Dual2<Vec3> x_c_i = x_c - c;
+            sum += sfm::gabor_cell<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, c_i, x_c_i, seed);
+        }
+#else
+            //index_loop(c_index,27,
+            OSL_INTEL_PRAGMA(nounroll)
+            for(int c_index=0; c_index < 27; ++c_index)
+            {
+                Vec3 c  = c_ijk[c_index];
+                Vec3 c_i = floor_x_g + c;
+                Dual2<Vec3> x_c_i = x_c - c;
+                sum += sfm::gabor_cell<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, c_i, x_c_i, seed);
+            }
+            //);
+
+#endif
+        }
+
+#endif
+
+        return sum * gup.sqrt_lambda_inv;
+    }
+
+    template<int AnisotropicT, typename FilterPolicyT, bool PeriodicT, int SeedT>
+    static OSL_FORCEINLINE Dual2<float>
+    gabor_evaluate (const sfm::GaborUniformParams &gup, const sfm::GaborParams &gp, const Dual2<Vec3> &x)
+    {
+        Dual2<Vec3> x_g = x * gup.radius_inv;
+        return sfm::gabor_grid<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, x_g, SeedT);
+    }
+
+    template<int AnisotropicT, typename FilterPolicyT, bool PeriodicT>
+    static OSL_FORCEINLINE Dual2<float>
+    gabor_evaluate (const sfm::GaborUniformParams &gup, const sfm::GaborParams &gp, const Dual2<Vec3> &x, int seed)
+    {
+        Dual2<Vec3> x_g = x * gup.radius_inv;
+        return sfm::gabor_grid<AnisotropicT, FilterPolicyT, PeriodicT>(gup, gp, x_g, seed);
+    }
+
+    template<int AnisotropicT, typename FilterPolicyT>
+    static OSL_FORCEINLINE  Dual2<float>
+    scalar_gabor (const Dual2<Vec3> &P, const sfm::GaborUniformParams &gup, const Vec3 & direction)
+    {
+        sfm::GaborParams gp(direction);
+
+        if (FilterPolicyT::active)
+            sfm::gabor_setup_filter (P, gp);
+
+        Dual2<float> result = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false, 0 /*seed*/>(gup, gp, P);
+        float gabor_variance = 1.0f / (4.0f*sqrtf(2.0f) * (gup.a * gup.a * gup.a));
+        float scale = 1.0f / (3.0f*sqrtf(gabor_variance));
+        scale *= 0.5f;  // empirical -- make it fit in [-1..1]
+
+        return result * scale;
+    }
+
+    template<int AnisotropicT, typename FilterPolicyT>
+    static OSL_FORCEINLINE  Dual2<Vec3>
+    scalar_gabor3 (const Dual2<Vec3> &P, const sfm::GaborUniformParams &gup, const Vec3 & direction)
+    {
+        sfm::GaborParams gp(direction);
+
+        if (FilterPolicyT::active)
+            sfm::gabor_setup_filter (P, gp);
+
+#if 0
+        Dual2<Vec3> result = make_Vec3 (sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 0 /*seed*/),
+                                        sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 1 /*seed*/),
+                                        sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 2 /*seed*/));
+#else
+//        Dual2<float> rval = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 0 /*seed*/);
+//        Dual2<float> rdx = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 1 /*seed*/);
+//        Dual2<float> rdy = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, 2 /*seed*/);
+        Dual2<float> resultParts[3];
+        OSL_INTEL_PRAGMA(nounroll_and_jam)
+        for(int seed=0; seed<3; ++seed) {
+            resultParts[seed] = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, false /*periodic*/>(gup, gp, P, seed);
+        }
+
+        Dual2<Vec3> result = make_Vec3(resultParts[0], resultParts[1], resultParts[2]);
+#endif
+        float gabor_variance = 1.0f / (4.0f*sqrtf(2.0f) * (gup.a * gup.a * gup.a));
+        float scale = 1.0f / (3.0f*sqrtf(gabor_variance));
+        scale *= 0.5f;  // empirical -- make it fit in [-1..1]
+
+        return result * scale;
+    }
+
+    template<int AnisotropicT, typename FilterPolicyT>
+    static OSL_FORCEINLINE  Dual2<float>
+    scalar_pgabor (const Dual2<Vec3> &P, const Vec3 & Pperiod, const sfm::GaborUniformParams &gup, const Vec3 & direction)
+    {
+        sfm::GaborParams gp(direction);
+        gp.period = Pperiod;
+
+        if (FilterPolicyT::active)
+            sfm::gabor_setup_filter (P, gp);
+
+        Dual2<float> result = sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, true /*periodic*/, 0 /*seed*/>(gup, gp, P);
+        float gabor_variance = 1.0f / (4.0f*sqrtf(2.0f) * (gup.a * gup.a * gup.a));
+        float scale = 1.0f / (3.0f*sqrtf(gabor_variance));
+        scale *= 0.5f;  // empirical -- make it fit in [-1..1]
+
+        return result * scale;
+    }
+
+
+    template<int AnisotropicT, typename FilterPolicyT>
+    static OSL_FORCEINLINE  Dual2<Vec3>
+    scalar_pgabor3 (const Dual2<Vec3> &P, const Vec3 &Pperiod, const sfm::GaborUniformParams &gup, const Vec3 & direction)
+    {
+        sfm::GaborParams gp(direction);
+        gp.period = Pperiod;
+
+        if (FilterPolicyT::active)
+            sfm::gabor_setup_filter (P, gp);
+
+        Dual2<Vec3> result = make_Vec3 (sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, true /*periodic*/, 0 /*seed*/>(gup, gp, P),
+                                        sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, true /*periodic*/, 1 /*seed*/>(gup, gp, P),
+                                        sfm::gabor_evaluate<AnisotropicT, FilterPolicyT, true /*periodic*/, 2 /*seed*/>(gup, gp, P));
+        float gabor_variance = 1.0f / (4.0f*sqrtf(2.0f) * (gup.a * gup.a * gup.a));
+        float scale = 1.0f / (3.0f*sqrtf(gabor_variance));
+        scale *= 0.5f;  // empirical -- make it fit in [-1..1]
+
+        return result * scale;
+    }
+
+} // namespace sfm
+
+
+} // namespace __OSL_WIDE_PVT
+
+OSL_NAMESPACE_EXIT


### PR DESCRIPTION
Introduce sfm (SIMD Friendly Math) namespace with versions of math functions friendly to use inside SIMD loops.

Introduce IntHashBasedNoise to serve as base for HashNoise & CellNoise.
Reimplemented PeriodicHashNoise and PeriodicCellNose to use an adapter to wrap their input values and reuse existing HashNoise & CellNoise implementations.
Introduce code generation policies for Perlin based based functions and Noise objects in order to resuse the same perlin noise functions with or without SIMD intrinsics.  Using a "scalar"(non-intrinsic) version of the algorithm is required when calling from inside a SIMD loop.
Defined Scalar versions of any Noise objects that used SIMD intrinsics internally.
Provide optimized inthash, sfm_simplexnoise, sfm_gabornoise implementations suitable for use inside SIMD loops.
Introduce wide.h with Block<T, int Width> to store data as structure of arrays internally, more Wide and Masked wrappers to Block<T> be added in future.
Added osl::conjunction and osl::enable_if_type for compatibility with older C++ versions that do not have their equivalents defined in std::
Added OSL_NON_INTEL_CLANG = [0 | 1] to identify when compiler is a truely clang, as OSX still has __clang__ defined when using Intel compiler.
Added OSL_NODISCARD
Added OSL_OMP_PRAGMA(unquoted_text) that will only be emitted when -DOSL_OPENMP_SIMD and -DNDEBUG (disabled in debug builds)
Added OSL_FORCEINLINE_BLOCK on supported compilers will recursively inline the following statement
Split common portions of gabornoise.cpp into gabornoise.h that can be shared with sfm_gabornoise.h (the SIMD friendly version of gabornoise).



- [X ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

