### PR TITLE
Remove the failed attribute query cache

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1788,19 +1788,6 @@ private:
 
     Dictionary *m_dictionary;
 
-    // Struct for holding a record of getattributes we've tried and
-    // failed, to speed up subsequent getattributes calls.
-    struct GetAttribQuery {
-        void *objdata;
-        ustring obj_name, attr_name;
-        TypeDesc attr_type;
-        int array_lookup, index;
-        GetAttribQuery () : objdata(NULL), array_lookup(0), index(0) { }
-    };
-    static const int FAILED_ATTRIBS = 16;
-    GetAttribQuery m_failed_attribs[FAILED_ATTRIBS];
-    int m_next_failed_attrib;
-
     // Buffering of error messages and printfs
     typedef std::pair<ErrorHandler::ErrCode, std::string> ErrorItem;
     mutable std::vector<ErrorItem> m_buffered_errors;


### PR DESCRIPTION
This caching layer was added a long time ago when the renderer at SPI took a long time to find
out that an attribute query failed. This is no longer the case, and our usage of attribute lookups
has changed enough as to make the caching no longer helpful (and sometimes hurtful, such as
when a shader performs many successful queries). Renderers that need the caching behavior
can re-implement it internally to their RendererServices class.

