### PR TITLE
Include link for compilation on macOS Catalina

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,3 +99,8 @@ Here are the steps to check out, build, and test the OSL distribution:
    test suite with:
 
         make test
+        
+Troubleshooting
+----------------
+
+- [Build issues on macOS Catalina (fatal error: 'wchar.h' file not found)](https://github.com/imageworks/OpenShadingLanguage/issues/1055#issuecomment-581920327)


### PR DESCRIPTION
Just a small addition to the INSTALL.md linking to the issue about compiling OSL on macOS Catalina.