### PR TITLE
Add shader level annotation to disable range checking

### DIFF
--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -785,7 +785,7 @@ DECLFOLDER(constfold_aref)
         int cind = rop.add_constant (elemtype,
                         (char *)A.data() + index*elemtype.simpletype().size());
         rop.turn_into_assign (op, cind, "aref const fold: const_array[const]");
-        if (rop.shadingsys().range_checking() && index != orig_index) {
+        if (rop.inst()->master()->range_checking() && index != orig_index) {
             // the original index was out of range, and the user cares about reporting errors
             const int args_to_add[] = {
                     rop.add_constant(u_fmt_range_check),

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1150,7 +1150,7 @@ LLVMGEN (llvm_gen_compref)
     Symbol& Index = *rop.opargsym (op, 2);
 
     llvm::Value *c = rop.llvm_load_value(Index);
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < 3)) {
             llvm::Value *args[] = { c, rop.ll.constant(3),
@@ -1193,7 +1193,7 @@ LLVMGEN (llvm_gen_compassign)
     Symbol& Val = *rop.opargsym (op, 2);
 
     llvm::Value *c = rop.llvm_load_value(Index);
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < 3)) {
             llvm::Value *args[] = { c, rop.ll.constant(3),
@@ -1237,7 +1237,7 @@ LLVMGEN (llvm_gen_mxcompref)
 
     llvm::Value *row = rop.llvm_load_value (Row);
     llvm::Value *col = rop.llvm_load_value (Col);
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         llvm::Value *args[] = { row, rop.ll.constant(4),
                                 rop.ll.constant(M.name()),
                                 rop.sg_void_ptr(),
@@ -1282,7 +1282,7 @@ LLVMGEN (llvm_gen_mxcompassign)
 
     llvm::Value *row = rop.llvm_load_value (Row);
     llvm::Value *col = rop.llvm_load_value (Col);
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         llvm::Value *args[] = { row, rop.ll.constant(4),
                                 rop.ll.constant(Result.name()),
                                 rop.sg_void_ptr(),
@@ -1342,7 +1342,7 @@ LLVMGEN (llvm_gen_aref)
     llvm::Value *index = rop.loadLLVMValue (Index);
     if (! index)
         return false;
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < Src.typespec().arraylength())) {
             llvm::Value *args[] = { index,
@@ -1386,7 +1386,7 @@ LLVMGEN (llvm_gen_aassign)
     llvm::Value *index = rop.loadLLVMValue (Index);
     if (! index)
         return false;
-    if (rop.shadingsys().range_checking()) {
+    if (rop.inst()->master()->range_checking()) {
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < Result.typespec().arraylength())) {
             llvm::Value *args[] = { index,

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -422,19 +422,28 @@ OSOReaderToMaster::hint (string_view hintstring)
         }
         return;
     }
-    if (Strutil::parse_prefix (h, "%meta{") && m_master->m_symbols.size()) {
-        Symbol &sym (m_master->m_symbols.back());
+    if (Strutil::parse_prefix (h, "%meta{")) {
+        // parse type and name
         int ival = -1;
-        TypeDesc type (Strutil::parse_identifier (h, "", true));
-        Strutil::parse_char (h, ',');
-        string_view ident = Strutil::parse_identifier (h, "", true);
-        Strutil::parse_char (h, ',');
-        if (type == TypeDesc::TypeInt && ident == "lockgeom"
-                && Strutil::parse_int (h, ival) && ival >= 0)
-            sym.lockgeom (ival);
-        else if (type == TypeDesc::TypeInt && ident == "allowconnect"
-                && Strutil::parse_int (h, ival) && ival >= 0)
-            sym.allowconnect (ival);
+        TypeDesc type(Strutil::parse_identifier(h, "", true));
+        Strutil::parse_char(h, ',');
+        string_view ident = Strutil::parse_identifier(h, "", true);
+        Strutil::parse_char(h, ',');
+        if (m_master->m_symbols.size()) {
+            // metadata is attached to a particular symbol
+            Symbol& sym(m_master->m_symbols.back());
+            if (type == TypeDesc::TypeInt && ident == "lockgeom"
+                && Strutil::parse_int(h, ival) && ival >= 0)
+                sym.lockgeom(ival);
+            else if (type == TypeDesc::TypeInt && ident == "allowconnect"
+                     && Strutil::parse_int(h, ival) && ival >= 0)
+                sym.allowconnect(ival);
+        } else {
+            // metadata is attached at the shader level
+            if (type == TypeDesc::TypeInt && ident == "range_checking"
+                && Strutil::parse_int(h, ival) && ival >= 0)
+                m_master->range_checking(ival != 0);
+        }
         return;
     }
 }

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -42,7 +42,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 OSL_NAMESPACE_ENTER
 namespace pvt {   // OSL::pvt
 
-
+ShaderMaster::ShaderMaster(ShadingSystemImpl& shadingsys)
+    : m_shadingsys(shadingsys),
+      m_range_checking(shadingsys.range_checking()) {
+}
 
 ShaderMaster::~ShaderMaster ()
 {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -342,7 +342,7 @@ inline void stlfree (T &v)
 class ShaderMaster : public RefCnt {
 public:
     typedef OIIO::intrusive_ptr<ShaderMaster> ref;
-    ShaderMaster (ShadingSystemImpl &shadingsys) : m_shadingsys(shadingsys) { }
+    ShaderMaster (ShadingSystemImpl &shadingsys);
     ~ShaderMaster ();
 
     std::string print ();  // Debugging
@@ -389,6 +389,9 @@ public:
 
     int raytype_queries () const { return m_raytype_queries; }
 
+    bool range_checking() const { return m_range_checking; }
+    void range_checking(bool b) { m_range_checking = b; }
+
 private:
     ShadingSystemImpl &m_shadingsys;    ///< Back-ptr to the shading system
     ShaderType m_shadertype;            ///< Type of shader
@@ -407,6 +410,7 @@ private:
     int m_firstparam, m_lastparam;      ///< Subset of symbols that are params
     int m_maincodebegin, m_maincodeend; ///< Main shader code range
     int m_raytype_queries;              ///< Bitmask of raytypes queried
+    bool m_range_checking;              ///< Is range checking enabled for this shader?
 
     friend class OSOReaderToMaster;
     friend class ShaderInstance;


### PR DESCRIPTION
This patch adds the metadata annotation `"int range_checking=0"` at the shader level to mean that the shader author is certain that range checks can be safely omitted for this particular shader. This can help speedup particularly expensive shaders without needing to globally disable the checks in other shaders.

