### PR TITLE
Disentangle namespace declaration from use to avoid double decl.

### DIFF
--- a/src/include/OSL/oslversion.h.in
+++ b/src/include/OSL/oslversion.h.in
@@ -88,11 +88,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OSL_SHADERGLOBALS_HAS_RENDERER_PTR 1
 
 
+// Establish the name spaces
+namespace @PROJ_NAMESPACE_V@ { }
+namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
+
 // Macros to use in each file to enter and exit the right name spaces.
 #define @PROJ_NAME@_NAMESPACE @PROJ_NAMESPACE_V@
 #define @PROJ_NAME@_NAMESPACE_STRING "@PROJ_NAMESPACE_V@"
 #define @PROJ_NAME@_NAMESPACE_ENTER namespace @PROJ_NAMESPACE_V@ {
-#define @PROJ_NAME@_NAMESPACE_EXIT } namespace @PROJ_NAME@ = @PROJ_NAMESPACE_V@;
+#define @PROJ_NAME@_NAMESPACE_EXIT }
+
 
 // Which CPP standard (11, 14, etc.) was this copy of OIIO *built* with?
 #define @PROJ_NAME@_BUILD_CPP @CMAKE_CXX_STANDARD@


### PR DESCRIPTION
For some reason, the namespace declaration was attached to the end of
OSL_NAMESPACE_EXIT. Which would make an error in any source module that
had multiple OSL_NAMESPACE_ENTER/EXIT blocks.
