### PR TITLE
Add code to actually run the LLVM function passes on the module

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -544,8 +544,11 @@ LLVM_Util::do_optimize (std::string *out_err)
 #endif
 
     m_llvm_func_passes->doInitialization();
-    m_llvm_module_passes->run (*m_llvm_module);
+    for (auto&& I : m_llvm_module->functions())
+        if (!I.isDeclaration())
+            m_llvm_func_passes->run(I);
     m_llvm_func_passes->doFinalization();
+    m_llvm_module_passes->run (*m_llvm_module);
 }
 
 


### PR DESCRIPTION
While looking at #1114, I noticed a totally unrelated issue which is that we don't seem to be making any use of the function optimization passes that LLVM is making for us.

This might be a side effect of the old set of hand picked passes we used before.

Looking at other projects that JIT using LLVM I found what I think is the more correct idiom to use.

Benchmarks indicate no change to either JIT time or runtime (either adding _or_ removing the function passes entirely), so maybe its not that important, but it seems better to call the passes that LLVM is giving us?