### PR TITLE
Allow OSL to compile with LLVM 10.x

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -364,7 +364,11 @@ BackendLLVM::addCUDAVariable(const std::string& name, int size, int alignment,
 
     OSL_DASSERT (g_var && "Unable to create GlobalVariable");
 
+#if OSL_LLVM_VERSION >= 100
+    g_var->setAlignment  (llvm::MaybeAlign(alignment));
+#else
     g_var->setAlignment  (alignment);
+#endif
     g_var->setLinkage    (llvm::GlobalValue::ExternalLinkage);
     g_var->setVisibility (llvm::GlobalValue::DefaultVisibility);
     g_var->setInitializer(constant);


### PR DESCRIPTION
The release of LLVM 10.x is imminent, there are just a few API changes that impact OSL.