### PR TITLE
Fix CMAKE Unknown arguments specified Error for Boost

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -169,7 +169,7 @@ endif ()
 
 # On Linux, Boost 1.55 and higher seems to need to link against -lrt
 if (CMAKE_SYSTEM_NAME MATCHES "Linux"
-      AND ${Boost_VERSION} VERSION_GREATER_EQUAL 105500)
+      AND "${Boost_VERSION}" VERSION_GREATER_EQUAL 105500)
     list (APPEND Boost_LIBRARIES "rt")
 endif ()
 


### PR DESCRIPTION
When you use ${Boost_VERSION} instead of "${Boost_VERSION}" you get the following error when boost is explicitly undefined:

[cmake] -- [31mNot using Boost -- disabled  [m
[cmake] CMake Error at src/cmake/externalpackages.cmake:171 (if):
[cmake]   if given arguments:
[cmake] 
[cmake]     "CMAKE_SYSTEM_NAME" "MATCHES" "Linux" "AND" "VERSION_GREATER_EQUAL" "105500"
[cmake] 
[cmake]   Unknown arguments specified
[cmake] Call Stack (most recent call first):
[cmake]   CMakeLists.txt:124 (include)

This PR fixes this issue.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

