### PR TITLE
Change Vec3 [] to .xyz

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -729,8 +729,8 @@ OSLCompilerImpl::write_oso_const_value (const ConstantSymbol *sym) const
             osof("%.9g%s", sym->floatval(i), nelements>1 ? " " : "");
     else if (equivalent (elemtype, TypeDesc::TypeVector))
         for (int i = 0;  i < nelements;  ++i)
-            osof("%.9g %.9g %.9g%s", sym->vecval(i)[0], sym->vecval(i)[1],
-                 sym->vecval(i)[2], nelements>1 ? " " : "");
+            osof("%.9g %.9g %.9g%s", sym->vecval(i).x, sym->vecval(i).y,
+                 sym->vecval(i).z, nelements>1 ? " " : "");
     else {
         OSL_ASSERT (0 && "Don't know how to output this constant type");
     }

--- a/src/liboslexec/closure.cpp
+++ b/src/liboslexec/closure.cpp
@@ -87,13 +87,13 @@ print_component (std::ostream &out, const ClosureComponent *comp, ShadingSystemI
 {
     const ClosureRegistry::ClosureEntry *clentry = ss->find_closure(comp->id);
     OSL_ASSERT(clentry);
-    out << "(" << weight[0]*comp->w[0] << ", " << weight[1]*comp->w[1] << ", " << weight[2]*comp->w[2] << ") * ";
+    out << "(" << weight.x*comp->w.x << ", " << weight.y*comp->w.y << ", " << weight.z*comp->w.z << ") * ";
     out << clentry->name.c_str() << " (";
     for (int i = 0, nparams = clentry->params.size() - 1; i < nparams; ++i) {
         if (i) out << ", ";
         const ClosureParam& param = clentry->params[i];
         if (param.key != 0)
-        	out << "\"" << param.key << "\", ";
+            out << "\"" << param.key << "\", ";
         if (param.type.numelements() > 1) out << "[";
         for (size_t j = 0; j < param.type.numelements(); ++j) {
             if (j) out << ", ";

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -179,9 +179,9 @@ osl_##name##_vv (void *r_, void *a_)                                \
 {                                                                   \
     Vec3 &r (VEC(r_));                                              \
     Vec3 &a (VEC(a_));                                              \
-    r[0] = floatfunc (a[0]);                                        \
-    r[1] = floatfunc (a[1]);                                        \
-    r[2] = floatfunc (a[2]);                                        \
+    r.x = floatfunc (a.x);                                          \
+    r.y = floatfunc (a.y);                                          \
+    r.z = floatfunc (a.z);                                          \
 }                                                                   \
                                                                     \
 OSL_SHADEOP void                                                    \
@@ -222,9 +222,9 @@ OSL_SHADEOP void osl_##name##_vvv (void *r_, void *a_, void *b_) {  \
     Vec3 &r (VEC(r_));                                              \
     Vec3 &a (VEC(a_));                                              \
     Vec3 &b (VEC(b_));                                              \
-    r[0] = floatfunc (a[0], b[0]);                                  \
-    r[1] = floatfunc (a[1], b[1]);                                  \
-    r[2] = floatfunc (a[2], b[2]);                                  \
+    r.x = floatfunc (a.x, b.x);                                     \
+    r.y = floatfunc (a.y, b.y);                                     \
+    r.z = floatfunc (a.z, b.z);                                     \
 }                                                                   \
                                                                     \
 OSL_SHADEOP void osl_##name##_dvdvdv (void *r_, void *a_, void *b_) \
@@ -264,9 +264,9 @@ OSL_SHADEOP void osl_##name##_dvdvv (void *r_, void *a_, void *b_)  \
 OSL_SHADEOP void osl_##name##_vvf (void *r_, void *a_, float b) {       \
     Vec3 &r (VEC(r_));                                                  \
     Vec3 &a (VEC(a_));                                                  \
-    r[0] = floatfunc (a[0], b);                                         \
-    r[1] = floatfunc (a[1], b);                                         \
-    r[2] = floatfunc (a[2], b);                                         \
+    r.x = floatfunc (a.x, b);                                           \
+    r.y = floatfunc (a.y, b);                                           \
+    r.z = floatfunc (a.z, b);                                           \
 }                                                                       \
                                                                         \
 OSL_SHADEOP void osl_##name##_dvdvdf (void *r_, void *a_, void *b_)     \
@@ -384,11 +384,14 @@ OSL_SHADEOP void osl_sincos_dfdfdf(void *x_, void *s_, void *c_)
 
 OSL_SHADEOP void osl_sincos_vvv(void *x_, void *s_, void *c_)
 {
-    for (int i = 0; i < 3; i++)
 #if OSL_FAST_MATH
-        OIIO::fast_sincos(VEC(x_)[i], &VEC(s_)[i], &VEC(c_)[i]);
+        OIIO::fast_sincos(VEC(x_).x, &VEC(s_).x, &VEC(c_).x);
+        OIIO::fast_sincos(VEC(x_).y, &VEC(s_).y, &VEC(c_).y);
+        OIIO::fast_sincos(VEC(x_).z, &VEC(s_).z, &VEC(c_).z);
 #else
-        OIIO::sincos(VEC(x_)[i], &VEC(s_)[i], &VEC(c_)[i]);
+        OIIO::sincos(VEC(x_).x, &VEC(s_).x, &VEC(c_).x);
+        OIIO::sincos(VEC(x_).y, &VEC(s_).y, &VEC(c_).y);
+        OIIO::sincos(VEC(x_).z, &VEC(s_).z, &VEC(c_).z);
 #endif
 }
 
@@ -398,6 +401,7 @@ OSL_SHADEOP void osl_sincos_dvdvv(void *x_, void *s_, void *c_)
     Dual2<Vec3> &sine   = DVEC(s_);
     Vec3        &cosine = VEC(c_);
 
+#if 0 // older version using [i] deprecated to avoid potential aliasing issues
     for (int i = 0; i < 3; i++) {
         float s_f, c_f;
 #if OSL_FAST_MATH
@@ -409,6 +413,22 @@ OSL_SHADEOP void osl_sincos_dvdvv(void *x_, void *s_, void *c_)
         sine.val()[i] = s_f; sine.dx()[i] =  c_f * xdx; sine.dy()[i] =  c_f * xdy;
         cosine[i] = c_f;
     }
+#else
+    auto sincos_comp = [](const Dual2<float> & x, float &sine_val, float &sine_dx, float &sine_dy, float &cosine_val) {
+        float s_f, c_f;
+#if OSL_FAST_MATH
+        OIIO::fast_sincos(x.val(), &s_f, &c_f);
+#else
+        OIIO::sincos(x.val(), &s_f, &c_f);
+#endif
+        sine_val = s_f; sine_dx =  c_f * x.dx(); sine_dy =  c_f * x.dy();
+        cosine_val = c_f;
+    };
+
+    sincos_comp(comp_x(x), sine.val().x, sine.dx().x, sine.dy().x, cosine.x);
+    sincos_comp(comp_y(x), sine.val().y, sine.dx().y, sine.dy().y, cosine.y);
+    sincos_comp(comp_z(x), sine.val().z, sine.dx().z, sine.dy().z, cosine.z);
+#endif
 }
 
 OSL_SHADEOP void osl_sincos_dvvdv(void *x_, void *s_, void *c_)
@@ -417,6 +437,7 @@ OSL_SHADEOP void osl_sincos_dvvdv(void *x_, void *s_, void *c_)
     Vec3        &sine   = VEC(s_);
     Dual2<Vec3> &cosine = DVEC(c_);
 
+#if 0  // older version using [i] deprecated to avoid potential aliasing issues
     for (int i = 0; i < 3; i++) {
         float s_f, c_f;
 #if OSL_FAST_MATH
@@ -428,6 +449,23 @@ OSL_SHADEOP void osl_sincos_dvvdv(void *x_, void *s_, void *c_)
         sine[i] = s_f;
         cosine.val()[i] = c_f; cosine.dx()[i] = -s_f * xdx; cosine.dy()[i] = -s_f * xdy;
     }
+#else
+    auto sincos_comp = [](const Dual2<float> & x, float &sine_val, float &cosine_val, float &cosine_dx, float &cosine_dy) {
+        float s_f, c_f;
+#if OSL_FAST_MATH
+        OIIO::fast_sincos(x.val(), &s_f, &c_f);
+#else
+        OIIO::sincos(x.val(), &s_f, &c_f);
+#endif
+        sine_val = s_f;
+        cosine_val = c_f; cosine_dx = -s_f * x.dx(); cosine_dy = -s_f * x.dy();
+    };
+
+    sincos_comp(comp_x(x), sine.x, cosine.val().x, cosine.dx().x, cosine.dy().x);
+    sincos_comp(comp_y(x), sine.y, cosine.val().y, cosine.dx().y, cosine.dy().y);
+    sincos_comp(comp_z(x), sine.z, cosine.val().z, cosine.dx().z, cosine.dy().z);
+
+#endif
 }
 
 OSL_SHADEOP void osl_sincos_dvdvdv(void *x_, void *s_, void *c_)
@@ -436,6 +474,7 @@ OSL_SHADEOP void osl_sincos_dvdvdv(void *x_, void *s_, void *c_)
     Dual2<Vec3> &sine   = DVEC(s_);
     Dual2<Vec3> &cosine = DVEC(c_);
 
+#if 0  // older version using [i] deprecated to avoid potential aliasing issues
     for (int i = 0; i < 3; i++) {
         float s_f, c_f;
 #if OSL_FAST_MATH
@@ -447,6 +486,24 @@ OSL_SHADEOP void osl_sincos_dvdvdv(void *x_, void *s_, void *c_)
           sine.val()[i] = s_f;   sine.dx()[i] =  c_f * xdx;   sine.dy()[i] =  c_f * xdy;
         cosine.val()[i] = c_f; cosine.dx()[i] = -s_f * xdx; cosine.dy()[i] = -s_f * xdy;
     }
+#else
+    auto sincos_comp = [](const Dual2<float> & x, float &sine_val, float &sine_dx, float &sine_dy, float &cosine_val, float &cosine_dx, float &cosine_dy) {
+        float s_f, c_f;
+#if OSL_FAST_MATH
+        OIIO::fast_sincos(x.val(), &s_f, &c_f);
+#else
+        OIIO::sincos(x.val(), &s_f, &c_f);
+#endif
+        sine_val = s_f;     sine_dx =  c_f * x.dx();   sine_dy =  c_f * x.dy();
+        cosine_val = c_f; cosine_dx = -s_f * x.dx(); cosine_dy = -s_f * x.dy();
+    };
+
+    sincos_comp(comp_x(x), sine.val().x, sine.dx().x, sine.dy().x, cosine.val().x, cosine.dx().x, cosine.dy().x);
+    sincos_comp(comp_y(x), sine.val().y, sine.dx().y, sine.dy().y, cosine.val().y, cosine.dx().y, cosine.dy().y);
+    sincos_comp(comp_z(x), sine.val().z, sine.dx().z, sine.dy().z, cosine.val().z, cosine.dx().z, cosine.dy().z);
+
+
+#endif
 }
 
 #if OSL_FAST_MATH
@@ -479,35 +536,35 @@ MAKE_UNARY_PERCOMPONENT_OP     (inversesqrt, OIIO::safe_inversesqrt, inversesqrt
 OSL_SHADEOP float osl_logb_ff (float x) { return OIIO::fast_logb(x); }
 OSL_SHADEOP void osl_logb_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (OIIO::fast_logb(x[0]), OIIO::fast_logb(x[1]), OIIO::fast_logb(x[2]));
+    VEC(r).setValue (OIIO::fast_logb(x.x), OIIO::fast_logb(x.y), OIIO::fast_logb(x.z));
 }
 
 OSL_SHADEOP float osl_floor_ff (float x) { return floorf(x); }
 OSL_SHADEOP void osl_floor_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (floorf(x[0]), floorf(x[1]), floorf(x[2]));
+    VEC(r).setValue (floorf(x.x), floorf(x.y), floorf(x.z));
 }
 OSL_SHADEOP float osl_ceil_ff (float x) { return ceilf(x); }
 OSL_SHADEOP void osl_ceil_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (ceilf(x[0]), ceilf(x[1]), ceilf(x[2]));
+    VEC(r).setValue (ceilf(x.x), ceilf(x.y), ceilf(x.z));
 }
 OSL_SHADEOP float osl_round_ff (float x) { return roundf(x); }
 OSL_SHADEOP void osl_round_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (roundf(x[0]), roundf(x[1]), roundf(x[2]));
+    VEC(r).setValue (roundf(x.x), roundf(x.y), roundf(x.z));
 }
 OSL_SHADEOP float osl_trunc_ff (float x) { return truncf(x); }
 OSL_SHADEOP void osl_trunc_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (truncf(x[0]), truncf(x[1]), truncf(x[2]));
+    VEC(r).setValue (truncf(x.x), truncf(x.y), truncf(x.z));
 }
 OSL_SHADEOP float osl_sign_ff (float x) {
     return x < 0.0f ? -1.0f : (x==0.0f ? 0.0f : 1.0f);
 }
 OSL_SHADEOP void osl_sign_vv (void *r, void *x_) {
     const Vec3 &x (VEC(x_));
-    VEC(r).setValue (osl_sign_ff(x[0]), osl_sign_ff(x[1]), osl_sign_ff(x[2]));
+    VEC(r).setValue (osl_sign_ff(x.x), osl_sign_ff(x.y), osl_sign_ff(x.z));
 }
 OSL_SHADEOP float osl_step_fff (float edge, float x) {
     return x < edge ? 0.0f : 1.0f;
@@ -688,9 +745,9 @@ osl_distance_fvv (void *a_, void *b_)
 {
     const Vec3 &a (VEC(a_));
     const Vec3 &b (VEC(b_));
-    float x = a[0] - b[0];
-    float y = a[1] - b[1];
-    float z = a[2] - b[2];
+    float x = a.x - b.x;
+    float y = a.y - b.y;
+    float z = a.z - b.z;
     return sqrtf (x*x + y*y + z*z);
 }
 

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -325,8 +325,8 @@ osl_texture3d (void *sg_, const char *name, void *handle,
 
     // Correct our str texture space gradients into xyz-space gradients
     if (derivs) {
-        OIIO::simd::float4 dresultdx_simd = dresultds_simd * dPdx[0] + dresultdt_simd * dPdx[1] + dresultdr_simd * dPdx[2];
-        OIIO::simd::float4 dresultdy_simd = dresultds_simd * dPdy[0] + dresultdt_simd * dPdy[1] + dresultdr_simd * dPdy[2];
+        OIIO::simd::float4 dresultdx_simd = dresultds_simd * dPdx.x + dresultdt_simd * dPdx.y + dresultdr_simd * dPdx.z;
+        OIIO::simd::float4 dresultdy_simd = dresultds_simd * dPdy.x + dresultdt_simd * dPdy.y + dresultdr_simd * dPdy.z;
         if (dresultdx) {
             for (int i = 0;  i < chans;  ++i)
                 ((float *)dresultdx)[i] = dresultdx_simd[i];

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -56,7 +56,7 @@ const Vec3 veps (eps,eps,eps);
 
 namespace std {   // hack!
 inline float abs (const Vec3& a) {
-    return std::max (std::max (abs(a[0]), abs(a[1])), abs(a[2]));
+    return std::max (std::max (abs(a.x), abs(a.y)), abs(a.z));
 }
 }
 
@@ -71,27 +71,31 @@ inline float abs (const Vec3& a) {
                 float t = float(y)/imgres * imgscale;                   \
                 for (int x = 0; x < imgres; ++x) {                      \
                     float s = float(x)/imgres * imgscale;               \
-                    Vec3 r;                                             \
+                    float r_comp[3];                                    \
                     if (outdim == 1) {                                  \
                         if (indim == 1)                                 \
-                            r[0] = noisename(s);                        \
+                            r_comp[0] = noisename(s);                   \
                         else if (indim == 2)                            \
-                            r[0] = noisename(s,t);                      \
+                            r_comp[0] = noisename(s,t);                 \
                         else if (indim == 3)                            \
-                            r[0] = noisename(Vec3(s,t,1.0));            \
+                            r_comp[0] = noisename(Vec3(s,t,1.0));       \
                         else                                            \
-                            r[0] = noisename(Vec3(s,t,1.0),2.0);        \
+                            r_comp[0] = noisename(Vec3(s,t,1.0),2.0);   \
                     } else {                                            \
+                        Vec3 r_color;                                   \
                         if (indim == 1)                                 \
-                            r = v ## noisename(s);                      \
+                            r_color = v ## noisename(s);                \
                         else if (indim == 2)                            \
-                            r = v ## noisename(s,t);                    \
+                            r_color = v ## noisename(s,t);              \
                         else if (indim == 3)                            \
-                            r = v ## noisename(Vec3(s,t,1.0));          \
+                            r_color = v ## noisename(Vec3(s,t,1.0));    \
                         else                                            \
-                            r = v ## noisename(Vec3(s,t,1.0),2.0);      \
+                            r_color = v ## noisename(Vec3(s,t,1.0),2.0);\
+                        r_comp[0]=r_color.x;                            \
+                        r_comp[1]=r_color.y;                            \
+                        r_comp[2]=r_color.z;                            \
                     }                                                   \
-                    img.setpixel (x, y, &r[0]);                         \
+                    img.setpixel (x, y, r_comp);                        \
                 }                                                       \
             }                                                           \
             img.write (Strutil::sprintf ("osl_%s_%d_%d.tif", #noisename, outdim, indim)); \


### PR DESCRIPTION
Avoid potential aliasing issues by avoiding use of Vec3::operator[]
which does a reinterpret_cast and instead explicitly use data member
names .x, .y, .z.

This doesn't matter much for scalar code, but when loops are
explicitly or automatically vectorized, using myvec[0] can confuse the
compiler enough to inhibit vectorization, whereas myvec.x does not.

