### PR TITLE
Matrix function naming cleanup

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -338,13 +338,14 @@ DECL (osl_normalize_vv, "xXX")
 DECL (osl_normalize_dvdv, "xXX")
 #endif
 
-DECL (osl_mul_mm, "xXXX")
-DECL (osl_mul_mf, "xXXf")
-DECL (osl_mul_m_ff, "xXff")
-DECL (osl_div_mm, "xXXX")
-DECL (osl_div_mf, "xXXf")
-DECL (osl_div_fm, "xXfX")
-DECL (osl_div_m_ff, "xXff")
+
+DECL (osl_mul_mmm, "xXXX")
+DECL (osl_mul_mmf, "xXXf")
+
+DECL (osl_div_mmm, "xXXX")
+DECL (osl_div_mmf, "xXXf")
+DECL (osl_div_mfm, "xXfX")
+
 DECL (osl_get_from_to_matrix, "iXXss")
 DECL (osl_transpose_mm, "xXX")
 DECL (osl_determinant_fm, "fX")

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -604,18 +604,16 @@ LLVMGEN (llvm_gen_mul)
     // multiplication involving matrices
     if (Result.typespec().is_matrix()) {
         if (A.typespec().is_float()) {
-            if (B.typespec().is_float())
-                rop.llvm_call_function ("osl_mul_m_ff", Result, A, B);
-            else if (B.typespec().is_matrix())
-                rop.llvm_call_function ("osl_mul_mf", Result, B, A);
-            else OSL_DASSERT(0);
+            if (B.typespec().is_matrix())
+                rop.llvm_call_function ("osl_mul_mmf", Result, B, A);
+            else OSL_ASSERT(0 && "frontend should not allow");
         } else if (A.typespec().is_matrix()) {
             if (B.typespec().is_float())
-                rop.llvm_call_function ("osl_mul_mf", Result, A, B);
+                rop.llvm_call_function ("osl_mul_mmf", Result, A, B);
             else if (B.typespec().is_matrix())
-                rop.llvm_call_function ("osl_mul_mm", Result, A, B);
-            else OSL_DASSERT(0);
-        } else OSL_DASSERT (0);
+                rop.llvm_call_function ("osl_mul_mmm", Result, A, B);
+            else OSL_ASSERT(0 && "frontend should not allow");
+        } else OSL_ASSERT (0 && "frontend should not allow");
         if (Result.has_derivs())
             rop.llvm_zero_derivs (Result);
         return true;
@@ -675,18 +673,17 @@ LLVMGEN (llvm_gen_div)
     // division involving matrices
     if (Result.typespec().is_matrix()) {
         if (A.typespec().is_float()) {
-            if (B.typespec().is_float())
-                rop.llvm_call_function ("osl_div_m_ff", Result, A, B);
-            else if (B.typespec().is_matrix())
-                rop.llvm_call_function ("osl_div_fm", Result, A, B);
-            else OSL_DASSERT (0);
+            OSL_ASSERT (!B.typespec().is_float() && "frontend should not allow");
+            if (B.typespec().is_matrix())
+                rop.llvm_call_function ("osl_div_mfm", Result, A, B);
+            else OSL_ASSERT (0);
         } else if (A.typespec().is_matrix()) {
             if (B.typespec().is_float())
-                rop.llvm_call_function ("osl_div_mf", Result, A, B);
+                rop.llvm_call_function ("osl_div_mmf", Result, A, B);
             else if (B.typespec().is_matrix())
-                rop.llvm_call_function ("osl_div_mm", Result, A, B);
-            else OSL_DASSERT (0);
-        } else OSL_DASSERT (0);
+                rop.llvm_call_function ("osl_div_mmm", Result, A, B);
+            else OSL_ASSERT (0);
+        } else OSL_ASSERT (0);
         if (Result.has_derivs())
             rop.llvm_zero_derivs (Result);
         return true;

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -55,40 +55,32 @@ namespace pvt {
 // Matrix ops
 
 OSL_SHADEOP OSL_HOSTDEVICE void
-osl_mul_mm (void *r, void *a, void *b)
+osl_mul_mmm (void *r, void *a, void *b)
 {
     MAT(r) = MAT(a) * MAT(b);
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void
-osl_mul_mf (void *r, void *a, float b)
+osl_mul_mmf (void *r, void *a, float b)
 {
     MAT(r) = MAT(a) * b;
 }
 
-OSL_SHADEOP OSL_HOSTDEVICE void
-osl_mul_m_ff (void *r, float a, float b)
-{
-    float f = a * b;
-    MAT(r) = Matrix44 (f,0,0,0, 0,f,0,0, 0,0,f,0, 0,0,0,f);
-}
-
-
 
 OSL_SHADEOP OSL_HOSTDEVICE void
-osl_div_mm (void *r, void *a, void *b)
+osl_div_mmm (void *r, void *a, void *b)
 {
     MAT(r) = MAT(a) * MAT(b).inverse();
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void
-osl_div_mf (void *r, void *a, float b)
+osl_div_mmf (void *r, void *a, float b)
 {
     MAT(r) = MAT(a) * (1.0f/b);
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void
-osl_div_fm (void *r, float a, void *b)
+osl_div_mfm (void *r, float a, void *b)
 {
     MAT(r) = a * MAT(b).inverse();
 }


### PR DESCRIPTION
Some of the internal matrix ops didn't use the usual naming
convention.  Fix. Also remove at least one that is never used because
it's a combination that oslc will never output.

Submitted on behalf of Alex Wells