### PR TITLE
Fix warnings about unused varables

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -1110,9 +1110,8 @@ ASTNode::check_arglist (const char * /*funcname*/, ASTNode::ref arg,
             ASTcompound_initializer::TypeAdjuster ta(
                 m_compiler, ASTcompound_initializer::TypeAdjuster::no_errors);
 
-            TypeSpec itype = ta.typecheck(
-                static_cast<ASTcompound_initializer*>(arg.get()), formaltype);
-
+            OSL_MAYBE_UNUSED TypeSpec itype =
+                ta.typecheck(static_cast<ASTcompound_initializer*>(arg.get()), formaltype);
             OSL_DASSERT (!ta.success() || (formaltype == itype));
 
             // ~TypeAdjuster will set the proper type for the list on success.

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -773,8 +773,7 @@ BackendLLVM::llvm_load_component_value (const Symbol& sym, int deriv,
     if (!result)
         return NULL;  // Error
 
-    TypeDesc t = sym.typespec().simpletype();
-    OSL_DASSERT (t.aggregate != TypeDesc::SCALAR);
+    OSL_DASSERT (sym.typespec().simpletype().aggregate != TypeDesc::SCALAR);
     // cast the Vec* to a float*
     result = ll.ptr_cast (result, ll.type_float_ptr());
     result = ll.GEP (result, component);  // get the component
@@ -885,8 +884,7 @@ BackendLLVM::llvm_store_component_value (llvm::Value* new_val,
     if (!result)
         return false;  // Error
 
-    TypeDesc t = sym.typespec().simpletype();
-    OSL_DASSERT (t.aggregate != TypeDesc::SCALAR);
+    OSL_DASSERT (sym.typespec().simpletype().aggregate != TypeDesc::SCALAR);
     // cast the Vec* to a float*
     result = ll.ptr_cast (result, ll.type_float_ptr());
     result = ll.GEP (result, component);  // get the component


### PR DESCRIPTION
They aren't used in release builds, and some compilers will warn about
that.

By Alex Wells, with edits by Larry Gritz.

