### PR TITLE
Bump LLVM minimum to 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
         os: osx
         compiler: clang
         env: PYTHON_VERSION=3.7
-      - name: "VFX Platform 2017 (gcc48, c++11), llvm 6, OIIO release, OpenEXR 2.3, sse4.2"
+      - name: "VFX Platform 2017 (gcc48, c++11), llvm 7, OIIO release, OpenEXR 2.3, sse4.2"
         os: linux
         dist: trusty
         compiler: gcc
@@ -113,8 +113,8 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.0 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=release OPENEXR_VERSION=2.3.0 BUILD_CMAKE=1
-      - name: "Older things: OIIO 2.0, llvm 6, boost 1.58, OpenEXR 2.2"
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=7.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=release OPENEXR_VERSION=2.3.0 BUILD_CMAKE=1
+      - name: "Older things: OIIO 2.0, llvm 7, boost 1.58, OpenEXR 2.2"
         os: linux
         dist: trusty
         compiler: gcc
@@ -124,7 +124,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=6.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
+        env: WHICHGCC=4.8 USE_CPP=11 LLVM_VERSION=7.0.1 USE_SIMD=sse4.2 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
       - name: "gcc7, llvm7, C++14"
         os: linux
@@ -160,7 +160,7 @@ matrix:
               - *common-boost-packages
               - g++-6
         env: DEBUG=1 WHICHGCC=6 LLVM_VERSION=7.0.0 OPENIMAGEIO_BRANCH=master BUILD_CMAKE=1
-      - name: "Oldest everything: gcc4.8, LLVM 6, OIIO 2.0, OpenEXR 2.2, no simd"
+      - name: "Oldest everything: gcc4.8, LLVM 7, OIIO 2.0, OpenEXR 2.2, no simd"
         os: linux
         dist: trusty
         compiler: gcc
@@ -170,7 +170,7 @@ matrix:
             packages:
               - *common-packages
               - *old-boost-packages
-        env: USE_SIMD=0 LLVM_VERSION=6.0.1 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
+        env: USE_SIMD=0 LLVM_VERSION=7.0.1 OPENIMAGEIO_BRANCH=RB-2.0 OPENEXR_VERSION=2.2.0 BUILD_CMAKE=1
         if: branch =~ /(master|RB|travis)/ OR type = pull_request
 
 notifications:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X) and then OSL's build scripts will be able
     to find it.
 
-* **[LLVM](http://www.llvm.org) 6.0, 7.0, 8.0, 9.0, or 10.0**, including
+* **[LLVM](http://www.llvm.org) 7, 8, 9, or 10**, including
   clang libraries.
 
 * [Boost](www.boost.org) 1.55 or newer.

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -23,11 +23,7 @@ if [[ `uname` == "Linux" ]] ; then
     else
         LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=error}
     fi
-    if [ "$LLVM_VERSION" == "5.0.0" ] ; then
-        LLVMTAR=clang+llvm-${LLVM_VERSION}-linux-x86_64-${LLVM_DISTRO_NAME}.tar.xz
-    else
-        LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
-    fi
+    LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
     if [ "$LLVM_VERSION" == "10.0.0" ] ; then
         # new

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -229,7 +229,7 @@ checked_find_package (PugiXML REQUIRED)
 
 
 # LLVM library setup
-checked_find_package (LLVM 6.0 REQUIRED
+checked_find_package (LLVM 7.0 REQUIRED
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")


### PR DESCRIPTION
Four major releases of LLVM (7, 8, 9, and 10) ought to be enough, so let's drop support for llvm 6 and clean up the cruft. That also simplifies some upcoming changes from Alex if it doesn't need to support llvm6.
