### PR TITLE
Support partio string attributes on particles

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -263,8 +263,10 @@ ifeq (${SP_OS}, rhel7)
             -DOPENEXR_LIBRARY_DIR=/usr/lib64/OpenEXR2
     endif
 
-    Partio_ROOT := ${SPCOMP2_ROOT}/partio/rhel7-gcc48m64-boost155/v4
-    MY_CMAKE_FLAGS += -DPartio_ROOT="${Partio_ROOT}"
+    Partio_VERSION ?= 1.10.3
+    partio_ROOT ?= ${REZ_PACKAGE_ROOT}/partio/${Partio_VERSION}/${SPI_COMPILER_PLATFORM}/python-${PYTHON_VERSION}/boost-${BOOSTVERSSP}
+    MY_CMAKE_FLAGS += -Dpartio_ROOT="${partio_ROOT}"
+    $(info -Dpartio_ROOT="${partio_ROOT}")
 
     # set up OSL distribution environment
     SPARCH=${SP_OS}-$(SPCOMP2_COMPILER)$(CPPSTDSUFFIX)-boost$(subst .,,$(BOOSTVERSSP))
@@ -432,8 +434,8 @@ space:= $(empty) $(empty)
 #INSTALL_SPCOMP2_CURRENT = $(SPCOMP2_INSTALL_ROOT)/OSL/$(SPARCH)/v$(OSL_SPCOMP2_VERSION)
 #INSTALL_BIN_LOCATION = $(INSTALL_SPCOMP2_CURRENT)/bin
 
-SPCOMP2_RPATH_OPT ?= ${OpenImageIO_ROOT}/lib:${Partio_ROOT}/lib
-SPCOMP2_RPATH_DEBUG ?= ${OpenImageIO_ROOT}/lib:${Partio_ROOT}/lib/debug
+SPCOMP2_RPATH_OPT ?= ${OpenImageIO_ROOT}/lib:${partio_ROOT}/lib
+SPCOMP2_RPATH_DEBUG ?= ${OpenImageIO_ROOT}/lib:${partio_ROOT}/lib/debug
 #PYSPCOMP2_RPATH_OPT ?= ${SPCOMP2_RPATH_OPT}:${OSL_SPCOMP2_PATH}/lib:${PYTHON_LIBRARY_DIR}
 #PYSPCOMP2_RPATH_DEBUG ?= ${SPCOMP2_RPATH_DEBUG}:${OSL_SPCOMP2_PATH}/lib/debug:${PYTHON_LIBRARY_DIR}
 

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -194,6 +194,9 @@ TypeDescOfPartioType (const Partio::ParticleAttribute *ptype)
         if (ptype->count != 3)
             type = TypeDesc::UNKNOWN;  // Must be 3: punt
         break;
+    case Partio::INDEXEDSTR:
+        type = TypeDesc::STRING;
+        break;
     default:
         break;   // Any other future types -- return UNKNOWN
     }
@@ -366,8 +369,24 @@ RendererServices::pointcloud_get (ShaderGlobals *sg,
     // then copy them back to the caller's indices.
 
     // Actual data query
-    const_cast<Partio::ParticlesData *>(cloud)->data (*attr, count, (Partio::ParticleIndex *)indices,
-                 true, out_data);
+    if (partio_type == OIIO::TypeString) {
+        // strings are special cases because they are stored as int index
+        std::unique_ptr<int[]> strindices(new int[count]);
+        const_cast<Partio::ParticlesData*>(cloud)->data (*attr, count,
+                    (const Partio::ParticleIndex *)indices, true, (void*)strindices.get());
+        const auto& strings = cloud->indexedStrs(*attr);
+        int sicount = int(strings.size());
+        for (size_t i = 0; i < count; ++i) {
+            int ind = strindices[i];
+            if (ind >= 0 && ind < sicount)
+                ((ustring *)out_data)[i] = ustring(strings[ind]);
+            else
+                ((ustring *)out_data)[i] = ustring();
+        }
+    } else {
+        const_cast<Partio::ParticlesData*>(cloud)->data (*attr, count,
+                    (const Partio::ParticleIndex *)indices, true, out_data);
+    }
     return 1;
 #else
     return 0;
@@ -435,8 +454,13 @@ RendererServices::pointcloud_write (ShaderGlobals* /*sg*/,
             case Partio::INT :
                 *(int *)cloud->dataWrite<int>(*a, p) = *(int *)(data[i]);
                 break;
-            case Partio::INDEXEDSTR :
-                // FIXME? do we care?
+            case Partio::INDEXEDSTR : {
+                const char* s = *(const char**)(data[i]);
+                int index = cloud->lookupIndexedStr(*a, s);
+                if (index == -1)
+                    index = cloud->registerIndexedStr(*a, s);
+                *(int *)cloud->dataWrite<int>(*a, p) = index;
+                }
                 break;
             case Partio::NONE :
                 break;


### PR DESCRIPTION
We previously did not support indexed strings (only int, float, vector).

Also some SPI adjustments to partio finding, the rest of you can
ignore that part.
