### PR TITLE
CI on GitHub Actions improvements

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,22 @@
 # https://github.com/imageworks/OpenShadingLanguage
 
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    # Skip jobs when only documentation files are changed
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.tex'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.tex'
+  schedule:
+    # Full nightly build
+    - cron: "0 4 * * *"
 
 
 jobs:
@@ -184,6 +199,7 @@ jobs:
       - name: all
         env:
           CXX: clang++
+          USE_CPP: 14
           PYTHON_VERSION: 3.7
           LLVM_BC_GENERATOR: /usr/bin/clang++
             # ^^ Force bitcode compiles to use the system clang compiler by

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
       - name: "MacOS (latest Apple clang, llvm 7, OIIO master, latest homebrew libs"
         os: osx
         compiler: clang
-        env: PYTHON_VERSION=3.7
+        env: PYTHON_VERSION=3.7 USE_CPP=14
       - name: "VFX Platform 2017 (gcc48, c++11), llvm 7, OIIO release, OpenEXR 2.3, sse4.2"
         os: linux
         dist: trusty


### PR DESCRIPTION
* Fix newly broken Mac CI -- GHA's default homebrew now has llvm 10, which
  requires C++14.

* Schedule a nightly cron job for CI.

* Do not launch full builds and tests for pushes that only change
  documentation (md, rst, and tex files).

