### PR TITLE
Use single shared clang-cpp library starting with LLVM 9

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -79,6 +79,18 @@ if (NOT LLVM_LIBRARY)
     set (LLVM_LIBRARY "${LLVM_LIBRARIES}")
 endif ()
 
+execute_process (COMMAND ${LLVM_CONFIG} --shared-mode
+       OUTPUT_VARIABLE LLVM_SHARED_MODE
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (LLVM_VERSION VERSION_GREATER_EQUAL 9.0 AND (LLVM_SHARED_MODE STREQUAL "shared"))
+    find_library ( _CLANG_CPP_LIBRARY
+		  NAMES "clang-cpp"
+		  PATHS ${LLVM_LIB_DIR})
+    if (_CLANG_CPP_LIBRARY)
+        list (APPEND CLANG_LIBRARIES ${_CLANG_CPP_LIBRARY})
+    endif ()
+endif ()
+
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST clangBasic
                    clangEdit clangLex)


### PR DESCRIPTION
Since 9.0 LLVM defaults to building a single clang-cpp library for
non-developer builds.

As this is just the default, and some distributions enable it only with
LLVM 10 (e.g. Fedora), make the clang-cpp search dependent on the build
mode.

Compile tested with openSUSE Tumbleweed (LLVM 10) and Leap 15.2 (LLVM 7).

For some background, see https://fedoraproject.org/wiki/Changes/Stop-Shipping-Individual-Component-Libraries-In-clang-lib-Package and https://llvm.org/docs/CMake.html, option "BUILD_SHARED_LIBS".

Fixes the clang-cpp isssue mentioned in #1155 

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

