### PR TITLE
LLVM_Util::prune_and_internalize_module

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -152,6 +152,9 @@ public:
     ///                              for devs to find crashes)
     ///    int llvm_output_bitcode  Output the full bitcode for each group,
     ///                              for debugging. (0)
+    ///    string llvm_prune_ir_strategy  Strategy for pruning unnecessary
+    ///                              IR (choices: "prune" [default],
+    ///                              "internalize", or "none").
     ///    int max_local_mem_KB   Error if shader group needs more than this
     ///                              much local storage to execute (1024K)
     ///    string debug_groupname Name of shader group -- debug only this one

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -565,6 +565,7 @@ public:
     int llvm_debug_layers () const { return m_llvm_debug_layers; }
     int llvm_debug_ops () const { return m_llvm_debug_ops; }
     int llvm_output_bitcode () const { return m_llvm_output_bitcode; }
+    ustring llvm_prune_ir_strategy () const { return m_llvm_prune_ir_strategy; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
     bool opt_texture_handle () const { return m_opt_texture_handle; }
     int opt_passes() const { return m_opt_passes; }
@@ -750,6 +751,7 @@ private:
     int m_llvm_debug_layers;              ///< Add layer enter/exit printfs
     int m_llvm_debug_ops;                 ///< Add printfs to every op
     int m_llvm_output_bitcode;            ///< Output bitcode for each group
+    ustring m_llvm_prune_ir_strategy;     ///< LLVM IR pruning strategy
     ustring m_debug_groupname;            ///< Name of sole group to debug
     ustring m_debug_layername;            ///< Name of sole layer to debug
     ustring m_opt_layername;              ///< Name of sole layer to optimize

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1139,6 +1139,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_SET ("llvm_debug_ops", int, m_llvm_debug_ops);
     ATTR_SET ("llvm_output_bitcode", int, m_llvm_output_bitcode);
+    ATTR_SET_STRING ("llvm_prune_ir_strategy", m_llvm_prune_ir_strategy);
     ATTR_SET ("strict_messages", int, m_strict_messages);
     ATTR_SET ("range_checking", int, m_range_checking);
     ATTR_SET ("unknown_coordsys_error", int, m_unknown_coordsys_error);


### PR DESCRIPTION
Previously, we had `LLVM_Util::internalize_module_functions` that
reduced the LLVM optimize + JIT work by finding function symbols in an
IR module that started with "osl_" and were not our known entry points
and marking them with "internal" visibility. This lets LLVM recognize
them, if they are not called internally to the module, as dead code
and discard them before spending any time optimizing or jitting those
functions.

This patch from Alex Wells adds an additional method,
`prune_and_internalize_module`, that is even more aggressive, pruning
all symbols that we don't think can be reached with our generated code
(are not "materialized", in LLVM parlance), and then marking
everything that is not a known entry point as "internal".

N.B. Some care is needed not to mark as internal a few symbols that
Cuda adds and which if removed will cause the OptiX shader to
fail. These seem to all contain the substring "rti_internal_".

This is indeed slightly better, and in extensive benchmarks of
production shaders, we're seeing about a 10% average reduction in LLVM
opt+jit time.  This is a tiny portion of a fully rendered scene, but
for interactive renders where you care about "time to first pixel", it
is more significant to reduce this compilation overhead as much as
possible.

I (LG) am a little hesitant to deprecate the old method right away, in
case any as-yet undiscovered flaw is found or just to aid
benchmarking. So I added a ShadingSystem string attribute
"llvm_prune_ir_strategy" that can take on any of the values "prune"
(default, the new way, full prune and aggressively internalize),
"internalize" (old way, just internalize function symbols that aren't
entry points), and "none" (don't do either -- just for benchmarking or
debugging).

I also benchmarked the "none" strategy, and it spends an average of over
2x longer in LLVM opt+jit than our old "internalize." So either strategy
helps substantially cut down on opt+jit time, though "prune" seems the
fastest, and is thus the new default. As we gain more confidence in it
in production, we may eventually deprecate and remove the "internalize"
strategy, leaving only "prune."

Signed-off-by: Larry Gritz <lg@larrygritz.com>
