### PR TITLE
Make debug_nan and debug_uninit work more accurately for matrices

### DIFF
--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -5,3 +5,6 @@ ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:
 ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 1 'color', arg 1)
 ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 2 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
+ERROR: Detected possible use of uninitialized value in float[3] ___330_A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 6 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color ___331_C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix ___332_M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'mxcompref', arg 1)

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -5,3 +5,6 @@ ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:
 ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 4 'color', arg 1)
 ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 5 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
+ERROR: Detected possible use of uninitialized value in float[3] ___330_A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color ___331_C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix ___332_M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 21 'mxcompref', arg 1)

--- a/testsuite/debug-uninit/test.osl
+++ b/testsuite/debug-uninit/test.osl
@@ -13,4 +13,25 @@ test (output color Cout = 0)
     string s_uninit;
     Cout = color (f_uninit, (float)i_uninit, 0);
     Cout *= texture (s_uninit, u, v);
+
+    float x = 0;
+    {
+        float A[3];         // uninitialized
+        A[1] = 1;           // initialize one element
+        x += A[1];          // NOT an error
+        x += A[2];          // An error
+    }
+    {
+        color C;            // uninitialized
+        C[1] = 1;           // initialize one element
+        x += C[1];          // NOT an error
+        x += C[2];          // An error
+    }
+    {
+        matrix M;           // uninitialized
+        M[1][2] = 1;        // initialize one element
+        x += M[1][2];       // NOT an error
+        x += M[0][0];       // An error
+    }
+    Cout[0] += x;  // force x results to not be optimized away
 }


### PR DESCRIPTION
Both were plagued by checking the entirety of the matrix, when in fact
only one element needs to be checked. This is wasteful because it
checks elements that aren't read or written by the op we are checking,
and it can also lead to "false positives", errors about elements that
are not touched by the present op.

Refinement of the debug_nan and debug_uninit cases was by Alex Wells.
LG added comments to clarify the implementation of these functions.

LG also amended the testsuite/debug-uninit to specifically test
arrays, triples, and matrices (checking for true positives and check
against false positives). In the process, he noticed another bug (!)
where float-based arrays were not being correctly initialized with
their uninitialized value sentinels, and thus were not detecting use
of uninitialized values therein, because instead of calling
is_float_based, we called is_floatbased, which excludes arrays.
(The similar names are yet ANOTHER bug, or at least unintended to be
so confusing, and this will be addressed in a separate PR).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

