### PR TITLE
Only range check matrix component access when necessary

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1217,18 +1217,28 @@ LLVMGEN (llvm_gen_mxcompref)
     llvm::Value *row = rop.llvm_load_value (Row);
     llvm::Value *col = rop.llvm_load_value (Col);
     if (rop.inst()->master()->range_checking()) {
-        llvm::Value *args[] = { row, rop.ll.constant(4),
-                                rop.ll.constant(M.name()),
-                                rop.sg_void_ptr(),
-                                rop.ll.constant(op.sourcefile()),
-                                rop.ll.constant(op.sourceline()),
-                                rop.ll.constant(rop.group().name()),
-                                rop.ll.constant(rop.layer()),
-                                rop.ll.constant(rop.inst()->layername()),
-                                rop.ll.constant(rop.inst()->shadername()) };
-        row = rop.ll.call_function ("osl_range_check", args);
-        args[0] = col;
-        col = rop.ll.call_function ("osl_range_check", args);
+        if (! (Row.is_constant() && Col.is_constant() &&
+               *(int *)Row.data() >= 0 && *(int *)Row.data() < 4 &&
+               *(int *)Col.data() >= 0 && *(int *)Col.data() < 4)) {
+            llvm::Value *args[] = { row, rop.ll.constant(4),
+                                    rop.ll.constant(M.name()),
+                                    rop.sg_void_ptr(),
+                                    rop.ll.constant(op.sourcefile()),
+                                    rop.ll.constant(op.sourceline()),
+                                    rop.ll.constant(rop.group().name()),
+                                    rop.ll.constant(rop.layer()),
+                                    rop.ll.constant(rop.inst()->layername()),
+                                    rop.ll.constant(rop.inst()->shadername()) };
+            if (! (Row.is_constant() &&
+                   *(int *)Row.data() >= 0 && *(int *)Row.data() < 4)) {
+                row = rop.ll.call_function ("osl_range_check", args);
+            }
+            if (! (Col.is_constant() &&
+                   *(int *)Col.data() >= 0 && *(int *)Col.data() < 4)) {
+                args[0] = col;
+                col = rop.ll.call_function ("osl_range_check", args);
+            }
+        }
     }
 
     llvm::Value *val = NULL; 
@@ -1262,18 +1272,28 @@ LLVMGEN (llvm_gen_mxcompassign)
     llvm::Value *row = rop.llvm_load_value (Row);
     llvm::Value *col = rop.llvm_load_value (Col);
     if (rop.inst()->master()->range_checking()) {
-        llvm::Value *args[] = { row, rop.ll.constant(4),
-                                rop.ll.constant(Result.name()),
-                                rop.sg_void_ptr(),
-                                rop.ll.constant(op.sourcefile()),
-                                rop.ll.constant(op.sourceline()),
-                                rop.ll.constant(rop.group().name()),
-                                rop.ll.constant(rop.layer()),
-                                rop.ll.constant(rop.inst()->layername()),
-                                rop.ll.constant(rop.inst()->shadername()) };
-        row = rop.ll.call_function ("osl_range_check", args);
-        args[0] = col;
-        col = rop.ll.call_function ("osl_range_check", args);
+        if (! (Row.is_constant() && Col.is_constant() &&
+               *(int *)Row.data() >= 0 && *(int *)Row.data() < 4 &&
+               *(int *)Col.data() >= 0 && *(int *)Col.data() < 4)) {
+            llvm::Value *args[] = { row, rop.ll.constant(4),
+                                    rop.ll.constant(Result.name()),
+                                    rop.sg_void_ptr(),
+                                    rop.ll.constant(op.sourcefile()),
+                                    rop.ll.constant(op.sourceline()),
+                                    rop.ll.constant(rop.group().name()),
+                                    rop.ll.constant(rop.layer()),
+                                    rop.ll.constant(rop.inst()->layername()),
+                                    rop.ll.constant(rop.inst()->shadername()) };
+            if (! (Row.is_constant() &&
+                   *(int *)Row.data() >= 0 && *(int *)Row.data() < 4)) {
+                row = rop.ll.call_function ("osl_range_check", args);
+            }
+            if (! (Col.is_constant() &&
+                   *(int *)Col.data() >= 0 && *(int *)Col.data() < 4)) {
+                args[0] = col;
+                col = rop.ll.call_function ("osl_range_check", args);
+            }
+        }
     }
 
     llvm::Value *val = rop.llvm_load_value (Val, 0, 0, TypeDesc::TypeFloat);


### PR DESCRIPTION
Point/color and array accesses were range checked at runtime EXCEPT
when the indices were constant and known to be within legal range.

But matrix component access (m[r][c] = x, x = m[r][c]) were always
range checked.

This patch from Alex Wells (and then enhanced by LG) skips the range
checking on the row or column indices, or both, when they are constant
and >= 0 and < 4, which is probably a lot of the time, thus speeding
up matrix component access a little by skipping the range checking
when it's safe to do so.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

