### PR TITLE
Fix confusing TypeSpec::is_float_based vs is_floatbased

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -276,14 +276,6 @@ public:
              m_simple == TypeDesc::TypeNormal);
     }
 
-    /// Is this a simple type based on floats (including color/vector/etc)?  
-    /// This will return false for a closure or array (even if of floats)
-    /// or struct.
-    bool is_floatbased () const {
-        return ! is_closure() && ! is_array() &&
-            m_simple.basetype == TypeDesc::FLOAT;
-    }
-
     /// Is it a simple numeric type (based on float or int, even if an
     /// aggregate)?  This is false for a closure or array (even if of
     /// an underlying numeric type) or struct.
@@ -312,9 +304,10 @@ public:
     /// Is it based on a vector-like triple (point, vector, or normal)?
     /// (It's ok for it to be an array or closure.)
     bool is_vectriple_based () const {
-        return (m_simple.elementtype() == TypeDesc::TypePoint ||
-                m_simple.elementtype() == TypeDesc::TypeVector ||
-                m_simple.elementtype() == TypeDesc::TypeNormal);
+        auto elem = m_simple.elementtype();
+        return (elem == TypeDesc::TypePoint ||
+                elem == TypeDesc::TypeVector ||
+                elem == TypeDesc::TypeNormal);
     }
 
     /// Is it a simple matrix (but not an array or closure)?
@@ -339,8 +332,9 @@ public:
     friend bool assignable (const TypeSpec &dst, const TypeSpec &src) {
         if (dst.is_closure() || src.is_closure())
             return (dst.is_closure() && src.is_closure());
-        return equivalent (dst, src) || 
-            (dst.is_floatbased() && (src.is_float() || src.is_int()));
+        return equivalent (dst, src) ||
+            (dst.is_float_based() && !dst.is_array()
+             && (src.is_float() || src.is_int()));
     }
 
 private:

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -295,7 +295,7 @@ ASTNode::coerce (Symbol *sym, const TypeSpec &type, bool acceptfloat)
     }
 
     if (sym->symtype() == SymTypeConst && sym->typespec().is_int() &&
-            type.is_floatbased()) {
+            type.is_float_based() && !type.is_array()) {
         // It's not only the wrong type, it's a constant of the wrong
         // type. We need a new constant of the right type.
         ConstantSymbol *constsym = (ConstantSymbol *) sym;
@@ -1539,7 +1539,7 @@ ASTbinary_expression::codegen (Symbol *dest)
 
     // Promote ints to float-like types, for mixed arithmetic
     if ((m_op == Mul || m_op == Div || m_op == Add || m_op == Sub)) {
-        if (lsym->typespec().is_floatbased() && rsym->typespec().is_int()) {
+        if (lsym->typespec().is_float_based() && rsym->typespec().is_int()) {
             if (rsym->symtype() == SymTypeConst) {
                 float val = ((ConstantSymbol *)rsym)->floatval();
                 rsym = m_compiler->make_constant (val);
@@ -1548,7 +1548,7 @@ ASTbinary_expression::codegen (Symbol *dest)
                 rsym = m_compiler->make_temporary (lsym->typespec());
                 emitcode ("assign", rsym, tmp);  // type coercion
             }
-        } else if (lsym->typespec().is_int() && rsym->typespec().is_floatbased()) {
+        } else if (lsym->typespec().is_int() && rsym->typespec().is_float_based()) {
             if (lsym->symtype() == SymTypeConst) {
                 float val = ((ConstantSymbol *)lsym)->floatval();
                 lsym = m_compiler->make_constant (val);

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -172,7 +172,7 @@ BackendLLVM::llvm_zero_derivs (const Symbol &sym)
         return; // Closures don't have derivs
     // Just memset the derivs to zero, let LLVM sort it out.
     TypeSpec elemtype = sym.typespec().elementtype();
-    if (sym.has_derivs() && elemtype.is_floatbased()) {
+    if (sym.has_derivs() && elemtype.is_float_based()) {
         int len = sym.size();
         size_t align = sym.typespec().simpletype().basesize();
         ll.op_memset (llvm_void_ptr(sym,1), /* point to start of x deriv */
@@ -189,7 +189,7 @@ BackendLLVM::llvm_zero_derivs (const Symbol &sym, llvm::Value *count)
         return; // Closures don't have derivs
     // Same thing as the above version but with just the first count derivs
     TypeSpec elemtype = sym.typespec().elementtype();
-    if (sym.has_derivs() && elemtype.is_floatbased()) {
+    if (sym.has_derivs() && elemtype.is_float_based()) {
         size_t esize = sym.typespec().simpletype().elementsize();
         size_t align = sym.typespec().simpletype().basesize();
         count = ll.op_mul (count, ll.constant((int)esize));
@@ -645,7 +645,7 @@ BackendLLVM::llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
         return result;
 
     // Handle int<->float type casting
-    if (type.is_floatbased() && cast == TypeDesc::TypeInt)
+    if (type.is_float_based() && !type.is_array() && cast == TypeDesc::TypeInt)
         result = ll.op_float_to_int (result);
     else if (type.is_int() && cast == TypeDesc::TypeFloat)
         result = ll.op_int_to_float (result);
@@ -752,7 +752,7 @@ BackendLLVM::llvm_load_component_value (const Symbol& sym, int deriv,
         // Regardless of what object this is, if it doesn't have derivs but
         // we're asking for them, return 0.  Integers don't have derivs
         // so we don't need to worry about that case.
-        OSL_DASSERT (sym.typespec().is_floatbased() &&
+        OSL_DASSERT (sym.typespec().is_float_based() &&
                      "can't ask for derivs of an int");
         return ll.constant (0.0f);
     }
@@ -776,7 +776,7 @@ BackendLLVM::llvm_load_component_value (const Symbol& sym, int deriv,
 llvm::Value *
 BackendLLVM::llvm_load_arg (const Symbol& sym, bool derivs)
 {
-    OSL_DASSERT (sym.typespec().is_floatbased());
+    OSL_DASSERT (sym.typespec().is_float_based());
     if (sym.typespec().is_int() ||
         (sym.typespec().is_float() && !derivs)) {
         // Scalar case
@@ -1101,7 +1101,7 @@ BackendLLVM::llvm_assign_impl (Symbol &Result, Symbol &Src,
             // Result wants derivs but src didn't have them -- zero them
             if (dstcomp != -1) {
                 // memset the single deriv component's to zero
-                if (Result.has_derivs() && Result.typespec().elementtype().is_floatbased()) {
+                if (Result.has_derivs() && Result.typespec().elementtype().is_float_based()) {
                     // dx
                     ll.op_memset (ll.GEP(llvm_void_ptr(Result,1), dstcomp), 0, 1, rt.basesize());
                     // dy

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -554,7 +554,7 @@ LLVMGEN (llvm_gen_mul)
     Symbol& B = *rop.opargsym (op, 2);
 
     TypeDesc type = Result.typespec().simpletype();
-    bool is_float = !Result.typespec().is_closure_based() && Result.typespec().is_floatbased();
+    bool is_float = !Result.typespec().is_closure_based() && Result.typespec().is_float_based();
     int num_components = type.aggregate;
 
     // multiplication involving closures
@@ -641,7 +641,7 @@ LLVMGEN (llvm_gen_div)
     Symbol& B = *rop.opargsym (op, 2);
 
     TypeDesc type = Result.typespec().simpletype();
-    bool is_float = Result.typespec().is_floatbased();
+    bool is_float = Result.typespec().is_float_based();
     int num_components = type.aggregate;
 
     OSL_DASSERT (! Result.typespec().is_closure_based());
@@ -726,7 +726,7 @@ LLVMGEN (llvm_gen_modulus)
     Symbol& B = *rop.opargsym (op, 2);
 
     TypeDesc type = Result.typespec().simpletype();
-    bool is_float = Result.typespec().is_floatbased();
+    bool is_float = Result.typespec().is_float_based();
     int num_components = type.aggregate;
 
 #ifdef OSL_LLVM_NO_BITCODE
@@ -848,7 +848,7 @@ LLVMGEN (llvm_gen_mix)
     Symbol& X = *rop.opargsym (op, 3);
     TypeDesc type = Result.typespec().simpletype();
     OSL_DASSERT (!Result.typespec().is_closure_based() &&
-                 Result.typespec().is_floatbased());
+                 Result.typespec().is_float_based());
     int num_components = type.aggregate;
     int x_components = X.typespec().aggregate();
     bool derivs = (Result.has_derivs() &&
@@ -932,7 +932,7 @@ LLVMGEN (llvm_gen_select)
     Symbol& X = *rop.opargsym (op, 3);
     TypeDesc type = Result.typespec().simpletype();
     OSL_DASSERT (!Result.typespec().is_closure_based() &&
-            Result.typespec().is_floatbased());
+            Result.typespec().is_float_based());
     int num_components = type.aggregate;
     int x_components = X.typespec().aggregate();
     bool derivs = (Result.has_derivs() &&
@@ -1050,8 +1050,8 @@ LLVMGEN (llvm_gen_unary_op)
     bool dst_derivs = dst.has_derivs();
     int num_components = dst.typespec().simpletype().aggregate;
 
-    bool dst_float = dst.typespec().is_floatbased();
-    bool src_float = src.typespec().is_floatbased();
+    bool dst_float = dst.typespec().is_float_based();
+    bool src_float = src.typespec().is_float_based();
 
     for (int i = 0; i < num_components; i++) {
         // Get src1/2 component i
@@ -1802,7 +1802,7 @@ LLVMGEN (llvm_gen_compare_op)
     }
 
     int num_components = std::max (A.typespec().aggregate(), B.typespec().aggregate());
-    bool float_based = A.typespec().is_floatbased() || B.typespec().is_floatbased();
+    bool float_based = A.typespec().is_float_based() || B.typespec().is_float_based();
     TypeDesc cast (float_based ? TypeDesc::FLOAT : TypeDesc::UNKNOWN);
 
     llvm::Value* final_result = 0;

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -523,7 +523,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
             for (int i = 0; i < num_components; ++i, ++c) {
                 // Fill in the constant val
                 llvm::Value* init_val = 0;
-                if (elemtype.is_floatbased())
+                if (elemtype.is_float_based())
                     init_val = ll.constant (((float*)sym.data())[c]);
                 else if (elemtype.is_string())
                     init_val = ll.constant (((ustring*)sym.data())[c]);

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1583,7 +1583,7 @@ RuntimeOptimizer::peephole2 (int opnum, int op2num)
         Symbol *d = opargsym(next,1);
         if (a == d && b == c) {
             // Exclude the integer truncation case
-            if (! (a->typespec().is_int() && b->typespec().is_floatbased())) {
+            if (! (a->typespec().is_int() && b->typespec().is_float_based())) {
                 // std::cerr << "ping-pong assignment " << opnum << " of " 
                 //           << opargsym(op,0)->mangled() << " and "
                 //           << opargsym(op,1)->mangled() << "\n";
@@ -1609,8 +1609,8 @@ RuntimeOptimizer::peephole2 (int opnum, int op2num)
         Symbol *d = opargsym(next,1);
         if (a == d && assignable (c->typespec(), b->typespec())) {
             // Exclude the float=int=float case
-            if (! (a->typespec().is_int() && b->typespec().is_floatbased() &&
-                   c->typespec().is_floatbased())) {
+            if (! (a->typespec().is_int() && b->typespec().is_float_based() &&
+                   c->typespec().is_float_based() && !c->typespec().is_array())) {
                 turn_into_assign (next, inst()->arg(op.firstarg()+1),
                                   "daisy-chain assignments");
                 return 1;
@@ -2474,8 +2474,7 @@ RuntimeOptimizer::mark_symbol_derivatives (SymDependency &symdeps, SymIntSet &vi
             
             Symbol *s = inst()->symbol(r);
 
-            if (! s->typespec().is_closure_based() && 
-                    s->typespec().elementtype().is_floatbased())
+            if (s->typespec().elementtype().is_float_based())
                 s->has_derivs (true);
 
             mark_symbol_derivatives(symdeps, visited, r);
@@ -3064,10 +3063,8 @@ RuntimeOptimizer::run ()
         for (auto&& c : inst()->m_connections) {
             if (inst()->symbol(c.dst.param)->has_derivs()) {
                 Symbol *source = group()[c.srclayer]->symbol(c.src.param);
-                if (! source->typespec().is_closure_based() &&
-                    source->typespec().elementtype().is_floatbased()) {
+                if (source->typespec().elementtype().is_float_based())
                     source->has_derivs (true);
-                }
             }
         }
     }


### PR DESCRIPTION
I'm not sure how this happened, but TypeSpec had `is_float_based` and
`is_floatbased` methods, and they were subtly different (the latter is
false for float-based arrays). This has led to at least one bug.

A careful examination reveals that the vast majority of uses of
`is_floatbased` really intended `is_float_based`, so I changed those.

For the remainder, I renamed `is_floatbased` to `is_float_based_notarray`
for clarity.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

