### PR TITLE
Remove stlfree -- not used

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -297,19 +297,6 @@ inline off_t vectorbytes (const std::vector<T> &v)
 }
 
 
-/// Template to fully deallocate a stl container using the swap trick.
-///
-template<class T>
-inline void stlfree (T &v)
-{
-    T tmp;
-    std::swap (tmp, v);
-    // Now v is no allocated space, and tmp has v's old allocated space.
-    // When tmp leaves scope as we return, that space will be freed.
-}
-
-
-
 
 /// ShaderMaster is the full internal representation of a complete
 /// shader that would be a .oso file on disk: symbols, instructions,


### PR DESCRIPTION
Obsolete since C++11, where vector::shrink_to_fit() does the same thing.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

