### PR TITLE
Demangle symbol names for certain runtime error messages.

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -450,6 +450,13 @@ public:
     /// a globally unique name.
     std::string mangled () const;
 
+    /// Return an unmangled version of the symbol name. This should be the
+    /// same as name() in the compiler, but in the runtime, everything has
+    /// been mangled by their scopes, and this will restore the unmangled
+    /// name by removing the scope prefix. Human readable error messages at
+    /// render time should always use the unmangled version for clarity.
+    string_view unmangled() const;
+
     /// Data type of this symbol.
     ///
     const TypeSpec &typespec () const { return m_typespec; }

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -19,9 +19,24 @@ namespace pvt {   // OSL::pvt
 std::string
 Symbol::mangled () const
 {
-    // FIXME: De-alias
-    return scope() ? Strutil::sprintf ("___%d_%s", scope(), m_name)
+    std::string result = scope()
+        ? Strutil::sprintf ("___%d_%s", scope(), m_name)
         : m_name.string();
+    return result;  // Force NRVO (named value return optimization)
+}
+
+
+
+string_view
+Symbol::unmangled () const
+{
+    string_view result(m_name);
+    if (Strutil::parse_prefix(result, "___")) {
+        int val;
+        Strutil::parse_int(result, val);
+        Strutil::parse_char(result, '_');
+    }
+    return result;
 }
 
 

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -263,7 +263,7 @@ BackendLLVM::getLLVMSymbolBase (const Symbol &sym)
     AllocationMap::iterator map_iter = named_values().find (mangled_name);
     if (map_iter == named_values().end()) {
         shadingcontext()->errorf("Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
-                                 mangled_name, dealiased->name());
+                                 mangled_name, dealiased->unmangled());
         return 0;
     }
     return (llvm::Value*) map_iter->second;

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -767,7 +767,7 @@ DECLFOLDER(constfold_aref)
             const int args_to_add[] = {
                     rop.add_constant(u_fmt_range_check),
                     rop.add_constant(orig_index),
-                    rop.add_constant(A.name()),
+                    rop.add_constant(A.unmangled()),
                     rop.add_constant(length - 1),
                     rop.add_constant(op.sourcefile()),
                     rop.add_constant(op.sourceline()),

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -508,10 +508,11 @@ ShaderInstance::copy_code_from_master (ShaderGroup &group)
 
 
 std::string
-ConnectedParam::str (const ShaderInstance *inst)
+ConnectedParam::str (const ShaderInstance *inst, bool unmangle)
 {
     const Symbol *s = inst->symbol(param);
-    return Strutil::sprintf ("%s%s%s (%s)", s->name(),
+    return Strutil::sprintf ("%s%s%s (%s)",
+                            unmangle ? s->unmangled() : string_view(s->name()),
                             arrayindex >= 0 ? Strutil::sprintf("[%d]", arrayindex) : std::string(),
                             channel >= 0 ? Strutil::sprintf("[%d]", channel) : std::string(),
                             type);
@@ -520,10 +521,11 @@ ConnectedParam::str (const ShaderInstance *inst)
 
 
 std::string
-Connection::str (const ShaderGroup &group, const ShaderInstance *dstinst)
+Connection::str (const ShaderGroup &group, const ShaderInstance *dstinst,
+                 bool unmangle)
 {
-    return Strutil::sprintf ("%s -> %s", src.str (group[srclayer]),
-                            dst.str (dstinst));
+    return Strutil::sprintf ("%s -> %s", src.str(group[srclayer], unmangle),
+                             dst.str(dstinst, unmangle));
 }
 
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -1133,7 +1133,7 @@ LLVMGEN (llvm_gen_compref)
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < 3)) {
             llvm::Value *args[] = { c, rop.ll.constant(3),
-                                    rop.ll.constant(Val.name()),
+                                    rop.ll.constant(Val.unmangled()),
                                     rop.sg_void_ptr(),
                                     rop.ll.constant(op.sourcefile()),
                                     rop.ll.constant(op.sourceline()),
@@ -1176,7 +1176,7 @@ LLVMGEN (llvm_gen_compassign)
         if (! (Index.is_constant() &&  *(int *)Index.data() >= 0 &&
                *(int *)Index.data() < 3)) {
             llvm::Value *args[] = { c, rop.ll.constant(3),
-                                    rop.ll.constant(Result.name()),
+                                    rop.ll.constant(Result.unmangled()),
                                     rop.sg_void_ptr(),
                                     rop.ll.constant(op.sourcefile()),
                                     rop.ll.constant(op.sourceline()),
@@ -1346,7 +1346,7 @@ LLVMGEN (llvm_gen_aref)
                *(int *)Index.data() < Src.typespec().arraylength())) {
             llvm::Value *args[] = { index,
                                     rop.ll.constant(Src.typespec().arraylength()),
-                                    rop.ll.constant(Src.name()),
+                                    rop.ll.constant(Src.unmangled()),
                                     rop.sg_void_ptr(),
                                     rop.ll.constant(op.sourcefile()),
                                     rop.ll.constant(op.sourceline()),
@@ -1390,7 +1390,7 @@ LLVMGEN (llvm_gen_aassign)
                *(int *)Index.data() < Result.typespec().arraylength())) {
             llvm::Value *args[] = { index,
                                     rop.ll.constant(Result.typespec().arraylength()),
-                                    rop.ll.constant(Result.name()),
+                                    rop.ll.constant(Result.unmangled()),
                                     rop.sg_void_ptr(),
                                     rop.ll.constant(op.sourcefile()),
                                     rop.ll.constant(op.sourceline()),
@@ -3346,7 +3346,7 @@ LLVMGEN (llvm_gen_closure)
         } else {
             rop.shadingcontext()->errorf("Incompatible formal argument %d to '%s' closure (%s %s, expected %s). Prototypes don't match renderer registry (%s:%d).",
                                          carg + 1, closure_name,
-                                         sym.typespec(), sym.name(), p.type,
+                                         sym.typespec(), sym.unmangled(), p.type,
                                          op.sourcefile(), op.sourceline());
         }
     }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -465,7 +465,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
             llvm::Value *args[] = { ll.constant(ncomps), llvm_void_ptr(sym),
                                     ll.constant((int)sym.has_derivs()), sg_void_ptr(),
                                     ll.constant(ustring(inst()->shadername())),
-                                    ll.constant(0), ll.constant(sym.name()),
+                                    ll.constant(0), ll.constant(sym.unmangled()),
                                     ll.constant(0), ll.constant(ncomps),
                                     ll.constant("<get_userdata>")
             };
@@ -609,7 +609,7 @@ BackendLLVM::llvm_generate_debugnan (const Opcode &op)
                                 sg_void_ptr(),
                                 ll.constant(op.sourcefile()),
                                 ll.constant(op.sourceline()),
-                                ll.constant(sym.name()),
+                                ll.constant(sym.unmangled()),
                                 offset,
                                 ncheck,
                                 ll.constant(op.opname())
@@ -713,7 +713,7 @@ BackendLLVM::llvm_generate_debug_uninit (const Opcode &op)
                                 ll.constant(int(&op - &inst()->ops()[0])),
                                 ll.constant(op.opname()),
                                 ll.constant(i),
-                                ll.constant(sym.name()),
+                                ll.constant(sym.unmangled()),
                                 offset,
                                 ncheck
                               };
@@ -939,7 +939,7 @@ BackendLLVM::build_llvm_instance (bool groupentry)
                 llvm::Value *args[] = { ll.constant(ncomps), llvm_void_ptr(s),
                      ll.constant((int)s.has_derivs()), sg_void_ptr(), 
                      ll.constant(ustring(inst()->shadername())),
-                     ll.constant(0), ll.constant(s.name()),
+                     ll.constant(0), ll.constant(s.unmangled()),
                      ll.constant(0), ll.constant(ncomps),
                      ll.constant("<none>")
                 };

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -897,7 +897,7 @@ struct ConnectedParam {
     }
 
     // Debug output of ConnectedParam
-    std::string str (const ShaderInstance *inst);
+    std::string str (const ShaderInstance *inst, bool unmangle);
 };
 
 
@@ -924,7 +924,8 @@ struct Connection {
     bool is_complete () const { return src.is_complete() && dst.is_complete(); }
 
     // Debug output of ConnectedParam
-    std::string str (const ShaderGroup &group, const ShaderInstance *dstinst);
+    std::string str (const ShaderGroup &group, const ShaderInstance *dstinst,
+                     bool unmangle);
 };
 
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1320,7 +1320,7 @@ RuntimeOptimizer::make_param_use_instanceval (Symbol *R, string_view why)
 {
     if (debug() > 1)
         std::cout << "Turning " << R->valuesourcename() << ' '
-                  << R->typespec().c_str() << ' ' << R->name()
+                  << R->typespec() << ' ' << R->name()
                   << " into an instance value "
                   << why << "\n";
 
@@ -1394,7 +1394,7 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
                 m_opt_elide_unconnected_outputs) {
             make_param_use_instanceval (R, Strutil::sprintf("- written once, with a constant (%s), before any reads", const_value_as_string(*A)));
             replace_param_value (R, A->data(), A->typespec());
-            turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
+            turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name()).c_str() : "");
             return true;
         }
     }
@@ -1404,7 +1404,7 @@ RuntimeOptimizer::outparam_assign_elision (int opnum, Opcode &op)
     // assignment at all. Note that unread_after() does take into
     // consideration whether it's a renderer output.
     if (unread_after(R,opnum)) {
-        turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name().c_str()).c_str() : "");
+        turn_into_nop (op, debug() > 1 ? Strutil::sprintf("oparam %s never subsequently read or connected", R->name()).c_str() : "");
         return true;
     }
 
@@ -1789,7 +1789,7 @@ RuntimeOptimizer::remove_unused_params ()
         if (param_never_used(s) && s.has_init_ops()) {
             std::string why;
             if (debug() > 1)
-                why = Strutil::sprintf ("remove init ops of unused param %s %s", s.typespec().c_str(), s.name());
+                why = Strutil::sprintf ("remove init ops of unused param %s %s", s.typespec(), s.name());
             turn_into_nop (s.initbegin(), s.initend(), why);
             s.set_initrange (0, 0);
             s.clear_rw();   // mark as totally unused

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -85,6 +85,10 @@ public:
     int add_constant (ustring s) { return add_constant(TypeDesc::TypeString, &s); }
     int add_constant (const Matrix44 &c) { return add_constant(TypeDesc::TypeMatrix, &c); }
     int add_constant (const Color3 &c) { return add_constant(TypeDesc::TypeColor, &c); }
+    int add_constant (string_view s) {
+        ustring u(s);
+        return add_constant(TypeDesc::TypeString, &s);
+    }
 
     /// Create a new temporary variable of the given type, return its index.
     int add_temp (const TypeSpec &type);

--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -5,6 +5,6 @@ ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:
 ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 1 'color', arg 1)
 ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 2 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
-ERROR: Detected possible use of uninitialized value in float[3] ___330_A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 6 'aref', arg 1)
-ERROR: Detected possible use of uninitialized value in color ___331_C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'compref', arg 1)
-ERROR: Detected possible use of uninitialized value in matrix ___332_M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'mxcompref', arg 1)
+ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 6 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'mxcompref', arg 1)

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -5,6 +5,6 @@ ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:
 ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 4 'color', arg 1)
 ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 5 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
-ERROR: Detected possible use of uninitialized value in float[3] ___330_A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'aref', arg 1)
-ERROR: Detected possible use of uninitialized value in color ___331_C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'compref', arg 1)
-ERROR: Detected possible use of uninitialized value in matrix ___332_M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 21 'mxcompref', arg 1)
+ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 21 'mxcompref', arg 1)


### PR DESCRIPTION
In the compiler, symbol.name() is the human-readable name and
symbol.mangled() is a mangled symbol that keeps identical names in
different scopes from clashing. We use mangled() in the oso file but
name() in error messages.

However... at runtime, it reads the pre-mangled name from the oso, and
doesn't know the original name, so name() and mangled() are identical
and are both the mangled version. That's fine for almost everything,
but there are just a few runtime errors that involve the symbol name,
and we would prefer that these be the unmangled version, for the sake
of clarity when communicating errors to the user.

So we add a Symbol::unmangled() that trims the mangling from the front
of a mangled symbol, and in runtime error messages we use this to strip
the mangling.

I also modified Symbol::mangled() slightly, to make sure NVRO is used.
The observed behavior doesn't change, only the idiom.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
