### PR TITLE
JIT code for the specific host target

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -172,7 +172,8 @@ public:
                                        const std::vector<std::string> &moreexceptions);
 
     /// Setup LLVM optimization passes.
-    void setup_optimization_passes (int optlevel);
+    /// if targetHost is true, passes to target the host will be added
+    void setup_optimization_passes (int optlevel, bool target_host=true);
 
     /// Run the optimization passes.
     void do_optimize (std::string *err = NULL);

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -198,4 +198,13 @@ static OSL_FORCEINLINE void static_foreach(const FunctorT &iFunctor) {
 #endif
 
 
+// During development it can be useful to output extra information
+// NOTE:  internal use only
+#ifdef OSL_DEV
+    #define OSL_DEV_ONLY(STUFF) STUFF
+#else
+    #define OSL_DEV_ONLY(STUFF)
+#endif
+
+
 OSL_NAMESPACE_EXIT

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -201,9 +201,9 @@ static OSL_FORCEINLINE void static_foreach(const FunctorT &iFunctor) {
 // During development it can be useful to output extra information
 // NOTE:  internal use only
 #ifdef OSL_DEV
-    #define OSL_DEV_ONLY(STUFF) STUFF
+    #define OSL_DEV_ONLY(...) __VA_ARGS__
 #else
-    #define OSL_DEV_ONLY(STUFF)
+    #define OSL_DEV_ONLY(...)
 #endif
 
 

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -150,6 +150,7 @@ public:
     ///                              layer functions.
     ///    int llvm_debug_ops     Extra printfs for each OSL op (helpful
     ///                              for devs to find crashes)
+    //     int llvm_target_host   Target the specific host architecture. (1)
     ///    int llvm_output_bitcode  Output the full bitcode for each group,
     ///                              for debugging. (0)
     ///    string llvm_prune_ir_strategy  Strategy for pruning unnecessary

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1077,7 +1077,10 @@ BackendLLVM::build_llvm_instance (bool groupentry)
 void
 BackendLLVM::initialize_llvm_group ()
 {
-    ll.setup_optimization_passes (shadingsys().llvm_optimize());
+    // Set up optimization passes. Don't target the host if we're building
+    // for OptiX.
+    ll.setup_optimization_passes (shadingsys().llvm_optimize(),
+                                  shadingsys().llvm_target_host() && !use_optix());
 
     // Clear the shaderglobals and groupdata types -- they will be
     // created on demand.

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -191,7 +191,7 @@ test_big_func (bool do_print=false)
     //     std::cout << "Generated the following bitcode:\n"
     //               << ll.bitcode_string(func) << "\n";
 
-    ll.setup_optimization_passes (0);
+    ll.setup_optimization_passes (0, true /*targetHost*/);
     ll.do_optimize ();
 
     if (do_print)

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -551,6 +551,7 @@ public:
     int llvm_debug () const { return m_llvm_debug; }
     int llvm_debug_layers () const { return m_llvm_debug_layers; }
     int llvm_debug_ops () const { return m_llvm_debug_ops; }
+    int llvm_target_host () const { return m_llvm_target_host; }
     int llvm_output_bitcode () const { return m_llvm_output_bitcode; }
     ustring llvm_prune_ir_strategy () const { return m_llvm_prune_ir_strategy; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
@@ -737,6 +738,7 @@ private:
     int m_llvm_debug;                     ///< More LLVM debugging output
     int m_llvm_debug_layers;              ///< Add layer enter/exit printfs
     int m_llvm_debug_ops;                 ///< Add printfs to every op
+    int m_llvm_target_host;               ///< Target specific host architecture
     int m_llvm_output_bitcode;            ///< Output bitcode for each group
     ustring m_llvm_prune_ir_strategy;     ///< LLVM IR pruning strategy
     ustring m_debug_groupname;            ///< Name of sole group to debug

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -720,6 +720,7 @@ ShadingSystemImpl::ShadingSystemImpl (RendererServices *renderer,
       m_llvm_optimize(1),
       m_debug(0), m_llvm_debug(0),
       m_llvm_debug_layers(0), m_llvm_debug_ops(0),
+      m_llvm_target_host(1),
       m_llvm_output_bitcode(0),
       m_commonspace_synonym("world"),
       m_max_local_mem_KB(2048),
@@ -1138,6 +1139,7 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
     ATTR_SET ("llvm_debug", int, m_llvm_debug);
     ATTR_SET ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_SET ("llvm_debug_ops", int, m_llvm_debug_ops);
+    ATTR_SET ("llvm_target_host", int, m_llvm_target_host);
     ATTR_SET ("llvm_output_bitcode", int, m_llvm_output_bitcode);
     ATTR_SET_STRING ("llvm_prune_ir_strategy", m_llvm_prune_ir_strategy);
     ATTR_SET ("strict_messages", int, m_strict_messages);
@@ -1275,6 +1277,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     ATTR_DECODE ("llvm_debug", int, m_llvm_debug);
     ATTR_DECODE ("llvm_debug_layers", int, m_llvm_debug_layers);
     ATTR_DECODE ("llvm_debug_ops", int, m_llvm_debug_ops);
+    ATTR_DECODE ("llvm_target_host", int, m_llvm_target_host);
     ATTR_DECODE ("llvm_output_bitcode", int, m_llvm_output_bitcode);
     ATTR_DECODE ("strict_messages", int, m_strict_messages);
     ATTR_DECODE ("error_repeats", int, m_error_repeats);
@@ -1747,7 +1750,9 @@ ShadingSystemImpl::getstats (int level) const
     INTOPT (llvm_debug);
     BOOLOPT (llvm_debug_layers);
     BOOLOPT (llvm_debug_ops);
+    BOOLOPT (llvm_target_host);
     BOOLOPT (llvm_output_bitcode);
+    BOOLOPT (llvm_prune_ir_strategy);
     BOOLOPT (lazylayers);
     BOOLOPT (lazyglobals);
     BOOLOPT (lazyunconnected);


### PR DESCRIPTION
We aren't saving object files like an offline C compiler; we are
JITing and immediately executing on a specific machine, so we may as
well have LLVM optimize for that very chip. This patch from Alex Wells
adds optimization passes that do so.

LG amended it to make it a shading system option "llvm_target_host"
(defaulting to true).  And we force it to off when compiling for
OptiX, since obviously the GPU is not the host architecture.

Production benchmarks do not show a noticeable speed gain in scalar
code. (Nor does it slow down.) There is no harm in targeting the
specific host CPU, and it may be more helpful when we are dealing with
vectorized code down the road.

Alex also added a developer only macro OSL_DEV_ONLY(STUFF) to leave
developer debugging/tracing code around and only have it active if
compiled with -DOSL_DEV

Signed-off-by: Larry Gritz <lg@larrygritz.com>
