### PR TITLE
Fix bug in understanding regex_search & regex_match parameter writes

### DIFF
--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -382,7 +382,7 @@ OSOReaderToMaster::hint (string_view hintstring)
         // This was a bug prior to 1.10.
         static ustring regex_search("regex_search");
         static ustring regex_match("regex_match");
-        if (opname == regex_search || opname == regex_search)
+        if ((opname == regex_search || opname == regex_match) && m_nargs > 3)
             m_master->m_ops.back().argwriteonly (2);
         return;
     }


### PR DESCRIPTION
There was an oslc bug a long time ago (prior to OSL 1.10) in which the
3-argument versions of regex_search and regex_match failed to mark
their 'results' parameter as write-only in the oso.

In addition to fixing the bug in oslc so that subsequently-produced
oso files are correct, in order to properly interpret these
historically-compiled oso's, we also look for this particular case
upon reading the oso, in loadshader.cpp, and mark it correctly. This
was PR #922.

Except...

1) We neglected to distinguish the 2-arg version from the 3-arg version,
only the latter of which should be so marked.

2) We tested for regex_search twice (!) instead of testing for
regex_search and also regex_match.

Apologies! Here is the fix.

Thanks to Alex Wells for identifying the problem.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
