### PR TITLE
Change all bare std::ofstream/ifstream to OIIO::ofstream/ifstream

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -125,18 +125,11 @@ OSLCompilerImpl::preprocess_file (const std::string &filename,
                                   std::string &result)
 {
     // Read file contents into a string
-    std::ifstream instream;
-    OIIO::Filesystem::open(instream, filename);
-    if (! instream.is_open()) {
+    std::string instring;
+    if (! OIIO::Filesystem::read_text_file (filename, instring)) {
         errorf(ustring(filename), 0, "Could not open \"%s\"\n", filename);
         return false;
     }
-
-    instream.unsetf (std::ios::skipws);
-    std::string instring (std::istreambuf_iterator<char>(instream.rdbuf()),
-                          std::istreambuf_iterator<char>());
-    instream.close ();
-
     return preprocess_buffer (instring, filename, stdoslpath, defines,
                               includepaths, result);
 }
@@ -474,7 +467,7 @@ OSLCompilerImpl::compile (string_view filename,
             if (m_output_filename.size() == 0)
                 m_output_filename = default_output_filename ();
 
-            std::ofstream oso_output;
+            OIIO::ofstream oso_output;
             OIIO::Filesystem::open (oso_output, m_output_filename);
             if (! oso_output.good()) {
                 errorf(ustring(), 0, "Could not open \"%s\"",

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1334,10 +1334,11 @@ BackendLLVM::run ()
         if (safegroup.size() > 235)
             safegroup = Strutil::sprintf ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
         std::string name = Strutil::sprintf ("%s.ll", safegroup);
-        std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
-        if (out.good()) {
+        OIIO::ofstream out;
+        OIIO::Filesystem::open(out, name);
+        if (out) {
             out << ll.bitcode_string (ll.module());
-            shadingsys().infof("Wrote  pre-optimized bitcode to '%s'", name);
+            shadingsys().infof("Wrote pre-optimized bitcode to '%s'", name);
         } else {
             shadingsys().errorf("Could not write to '%s'", name);
         }
@@ -1366,8 +1367,9 @@ BackendLLVM::run ()
         if (safegroup.size() > 235)
             safegroup = Strutil::sprintf ("TRUNC_%s_%d", safegroup.substr(safegroup.size()-235), group().id());
         std::string name = Strutil::sprintf ("%s_O%d.ll", safegroup, shadingsys().llvm_optimize());
-        std::ofstream out (name, std::ios_base::out | std::ios_base::trunc);
-        if (out.good()) {
+        OIIO::ofstream out;
+        OIIO::Filesystem::open(out, name);
+        if (out) {
             out << ll.bitcode_string (ll.module());
             shadingsys().infof("Wrote post-optimized bitcode to '%s'", name);
         } else {

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3263,7 +3263,7 @@ ShadingSystemImpl::archive_shadergroup (ShaderGroup& group, string_view filename
 
     bool ok = true;
     std::string groupfilename = tmpdir + "/shadergroup";
-    std::ofstream groupfile;
+    OIIO::ofstream groupfile;
     OIIO::Filesystem::open(groupfile, groupfilename);
     if (groupfile.good()) {
         groupfile << group.serialize();

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -188,12 +188,11 @@ main (int argc, const char *argv[])
             ok = compiler.compile_buffer (sourcecode, osobuffer, args, "",
                                           shader_path);
         if (ok) {
-            std::ofstream file;
+            OIIO::ofstream file;
             OIIO::Filesystem::open (file, compiler.output_filename());
-            if (file.good()) {
+            if (file)
                 file << osobuffer;
-                file.close ();
-            }
+            ok = file.good();
         }
     } else {
         // Ordinary compile from file

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -707,12 +707,10 @@ OSLToyMainWindow::action_save ()
     }
     std::string text = texteditor->text_string();
 
-    std::ofstream out (filename, std::ios_base::out | std::ios_base::trunc);
-    if (out.good()) {
+    OIIO::ofstream out;
+    OIIO::Filesystem::open (out, filename);
+    if (out)
         out << text;
-        out.close ();
-    }
-
     if (out.fail()) {
         std::string msg = OIIO::Strutil::sprintf ("Could not write %s", filename);
         QErrorMessage err (nullptr);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -482,9 +482,11 @@ OptixRaytracer::make_optix_materials ()
         }
 
         if (options.get_int("saveptx")) {
-            std::ofstream out (group_name + "_" + std::to_string(mtl_id++) + ".ptx");
+            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
+                                                    mtl_id++);
+            OIIO::ofstream out;
+            OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
-            out.close();
         }
 
         // Create Programs from the init and group_entry functions,
@@ -636,9 +638,8 @@ OptixRaytracer::make_optix_materials ()
     create_optix_pg(&sphere_fillSG_desc, 1, &program_options, &sphere_fillSG_dc);
 
     // Create materials
+    int mtl_id = 0;
     for (const auto& groupref : shaders()) {
-        const int mtl_id = shader_groups.size()/2;
-
         std::string group_name, init_name, entry_name;
         shadingsys->getattribute (groupref.get(), "groupname",        group_name);
         shadingsys->getattribute (groupref.get(), "group_init_name",  init_name);
@@ -670,9 +671,11 @@ OptixRaytracer::make_optix_materials ()
         }
 
         if (options.get_int ("saveptx")) {
-            std::ofstream out (group_name + "_" + std::to_string(mtl_id) + ".ptx");
+            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
+                                                    mtl_id++);
+            OIIO::ofstream out;
+            OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
-            out.close();
         }
 
         OptixModule optix_module;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -411,9 +411,11 @@ OptixGridRenderer::make_optix_materials ()
         }
 
         if (options.get_int("saveptx")) {
-            std::ofstream out (group_name + "_" + std::to_string(mtl_id++) + ".ptx");
+            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx",
+                                                          group_name, mtl_id++);
+            OIIO::ofstream out;
+            OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
-            out.close();
         }
 
         // Create Programs from the init and group_entry functions,
@@ -570,9 +572,11 @@ OptixGridRenderer::make_optix_materials ()
         }
 
         if (options.get_int("saveptx")) {
-            std::ofstream out (group_name + "_" + std::to_string(mtl_id++) + ".ptx");
+            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
+                                                    mtl_id++);
+            OIIO::ofstream out;
+            OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
-            out.close();
         }
 
         OptixModule optix_module;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -133,24 +133,6 @@ set_shadingsys_options ()
 
 
 
-/// Read the entire contents of the named file and place it in str,
-/// returning true on success, false on failure.
-inline bool
-read_text_file (string_view filename, std::string &str)
-{
-    std::ifstream in (filename.c_str(), std::ios::in | std::ios::binary);
-    if (in) {
-        std::ostringstream contents;
-        contents << in.rdbuf();
-        in.close ();
-        str = contents.str();
-        return true;
-    }
-    return false;
-}
-
-
-
 static void
 compile_buffer (const std::string &sourcecode,
                 const std::string &shadername)
@@ -182,7 +164,7 @@ shader_from_buffers (std::string shadername)
     if (! OIIO::Strutil::ends_with (oslfilename, ".osl"))
         oslfilename += ".osl";
     std::string sourcecode;
-    if (! read_text_file (oslfilename, sourcecode)) {
+    if (! OIIO::Filesystem::read_text_file (oslfilename, sourcecode)) {
         std::cerr << "Could not open \"" << oslfilename << "\"\n";
         exit (EXIT_FAILURE);
     }


### PR DESCRIPTION
Because they are UTF-8 safe and work properly on MinGW.

Simplified a bit more as I went -- some reading idioms could be
replaced by a single call to Filesystem::read_text_file, some close()
calls were redundant because streams close upon destruction / scope
exit, some open flags unnecessary because the default write mode
already will truncate an existing file.

Closes #1187 

Signed-off-by: Larry Gritz <lg@larrygritz.com>
