### PR TITLE
adding OIIO namespace to Strutil uses in OptiX renderers

### DIFF
--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -482,8 +482,8 @@ OptixRaytracer::make_optix_materials ()
         }
 
         if (options.get_int("saveptx")) {
-            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
-                                                    mtl_id++);
+            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx", group_name,
+                                                          mtl_id++);
             OIIO::ofstream out;
             OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
@@ -671,8 +671,8 @@ OptixRaytracer::make_optix_materials ()
         }
 
         if (options.get_int ("saveptx")) {
-            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
-                                                    mtl_id++);
+            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx", group_name,
+                                                          mtl_id++);
             OIIO::ofstream out;
             OIIO::Filesystem::open (out, filename);
             out << osl_ptx;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -572,8 +572,8 @@ OptixGridRenderer::make_optix_materials ()
         }
 
         if (options.get_int("saveptx")) {
-            std::string filename = Strutil::sprintf("%s_%d.ptx", group_name,
-                                                    mtl_id++);
+            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx", group_name,
+                                                          mtl_id++);
             OIIO::ofstream out;
             OIIO::Filesystem::open (out, filename);
             out << osl_ptx;


### PR DESCRIPTION
## Description

This fixes some namespace/compilation errors I was seeing when building the OptiX test renders.

## Tests

no changes in existing tests

## Checklist:

- [x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

