### PR TITLE
Add gcc9 and gcc10 tests to CI matrix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,6 +59,26 @@ jobs:
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash
 
+  vfxplatform-2021:
+    name: "Linux VFXP-2021 gcc9/C++17 llvm10 py3.7 boost-1.70 exr-2.5 OIIO-master avx2"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-osl:2021
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++
+          CC: gcc
+          CMAKE_CXX_STANDARD: 17
+          PYTHON_VERSION: 3.7
+          USE_SIMD: avx2,f16c
+          OPENEXR_VERSION: 2.5.0
+        run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps-centos.bash
+            source src/build-scripts/ci-build-and-test.bash
+
   linux-debug-gcc7-llvm8:
     name: "Linux Debug gcc7, C++14, llvm8, OIIO master, sse4, exr2.4"
     runs-on: ubuntu-18.04
@@ -117,13 +137,15 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-bleeding-edge:
-    name: "Linux bleeding edge: gcc8, C++17, llvm10, oiio/exr/pybind-master, avx2"
+    # Test against development master for relevant dependencies, latest
+    # supported releases of everything else.
+    name: "Linux bleeding edge: gcc10, C++17, llvm10, oiio/ocio/exr/pybind-master, avx2"
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: all
         env:
-          CXX: g++-8
+          CXX: g++-10
           USE_CPP: 17
           CMAKE_CXX_STANDARD: 17
           LLVM_VERSION: 10.0.0
@@ -139,6 +161,8 @@ jobs:
             source src/build-scripts/ci-build-and-test.bash
 
   linux-oldest:
+    # Oldest versions of the dependencies that we can muster, and various
+    # things disabled.
     name: "Linux oldest everything: gcc6 C++11 llvm7 py2.7 boost-1.66 oiio-2.0 no-simd exr2.3"
     runs-on: ubuntu-latest
     container:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,13 +15,14 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * Build system: [CMake](https://cmake.org/) 3.12 or newer
 
 * A suitable C++11 compiler to build OSL itself, which may be any of:
-   - GCC 4.8.5 or newer (through gcc 8)
+   - GCC 4.8.5 or newer (through gcc 10)
    - Clang 3.4 or newer (through clang 10)
    - Microsoft Visual Studio 2015 or newer
    - Intel C++ compiler icc version 13 (?) or newer
 
   OSL should compile also properly with C++14 or C++17, but they are not
-  required.
+  required (unless you are using LLVM >= 10, in which case at least C++14
+  is needed).
 
 * **[OpenImageIO](http://openimageio.org) 2.0 or newer**
 
@@ -45,8 +46,12 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * **[LLVM](http://www.llvm.org) 7, 8, 9, or 10**, including
   clang libraries.
 
-* [Boost](www.boost.org) 1.55 or newer.
-* [Ilmbase](http://openexr.com/downloads.html) 2.0 or newer
+  Note that LLVM 10 is not compatible with C++11, and requires C++14 or
+  later. If you *must* build OSL with C++11, you need to use an LLVM that
+  is LLVM 9 or earlier.
+
+* [Boost](www.boost.org) 1.55 or newer (tested through boost 1.72)
+* [Ilmbase](http://openexr.com/downloads.html) 2.0 or newer (tested through 2.5)
 * [Flex](https://github.com/westes/flex) and
   [GNU Bison](https://www.gnu.org/software/bison/)
 * [PugiXML](http://pugixml.org/)

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -44,6 +44,8 @@ elif [[ "$CXX" == "g++-8" ]] ; then
     time sudo apt-get install -y g++-8
 elif [[ "$CXX" == "g++-9" ]] ; then
     time sudo apt-get install -y g++-9
+elif [[ "$CXX" == "g++-10" ]] ; then
+    time sudo apt-get install -y g++-10
 fi
 
 # time sudo apt-get install -y clang

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -98,7 +98,7 @@ using namespace OSL::pvt;
 
 // flex itself will generate fatal warnings about signed vs unsigned.
 // Bypass that nonsense.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 6
+#if OSL_GNUC_VERSION >= 60000
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 
@@ -106,6 +106,10 @@ using namespace OSL::pvt;
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
 #endif
+#if OSL_GNUC_VERSION >= 90000
+#pragma GCC diagnostic ignored "-Wregister"
+#endif
+
 
 void preprocess (const char *yytext);
 

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2852,6 +2852,10 @@ DECLFOLDER(constfold_noise)
             return 0;  // optional args starting, we don't fold them yet
     }
 
+#if OSL_GNUC_VERSION >= 90000
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     if (name == u_cellnoise || name == u_cell) {
         CellNoise cell;
         if (outdim == 1) {
@@ -2883,6 +2887,9 @@ DECLFOLDER(constfold_noise)
             return 1;
         }
     }
+#if OSL_GNUC_VERSION >= 90000
+#    pragma GCC diagnostic pop
+#endif
 
     return 0;
 }

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -96,13 +96,16 @@ using namespace OSL::pvt;
 
 // flex itself will generate fatal warnings about signed vs unsigned.
 // Bypass that nonsense.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 6
+#if OSL_GNUC_VERSION >= 60000
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
 
 // flex uses the 'register' keyword, warned because it's deprecated in C++17.
 #if defined(__clang__)
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
+#endif
+#if OSL_GNUC_VERSION >= 90000
+#pragma GCC diagnostic ignored "-Wregister"
 #endif
 
 %}


### PR DESCRIPTION
* Use the new ASWF VFX Platform 2021 docker image for gcc9/py37/llvm10/C++17

* Alter the "bleeding edge" CI test to use gcc10

* Fix some new warnings that pop up with gcc9 and gcc10

Signed-off-by: Larry Gritz <lg@larrygritz.com>
