### PR TITLE
Propagate rtti compile options to exported cmake config

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -454,12 +454,14 @@ endif ()
 # ones will cause linker errors.
 #
 set (ENABLE_RTTI OFF CACHE BOOL "Build with RTTI. Requires a LLVM build with RTTI enabled.")
+set (${PROJECT_NAME}_RTTI_OPTIONS "")
 if (NOT ENABLE_RTTI)
     if (MSVC)
-        add_compile_options (/GR-)
+        set (${PROJECT_NAME}_RTTI_OPTIONS /GR-)
     else ()
-        add_compile_options (-fno-rtti)
+        set (${PROJECT_NAME}_RTTI_OPTIONS -fno-rtti)
     endif()
+    add_compile_options (${${PROJECT_NAME}_RTTI_OPTIONS})
 endif()
 
 

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -190,6 +190,10 @@ if (partio_FOUND)
     target_compile_definitions (${local_lib} PRIVATE USE_PARTIO=1)
 endif ()
 
+# Propagate our library's RTTI options to downstream clients of this library
+# This is very important for proper linkage with LLVM.
+target_compile_options(${local_lib} PUBLIC ${${PROJECT_NAME}_RTTI_OPTIONS})
+
 target_link_libraries (${local_lib}
     PUBLIC
         ${OPENIMAGEIO_LIBRARIES} ${ILMBASE_LIBRARIES}


### PR DESCRIPTION
People linking against oslexec needed to know to use -fno-rtti when
building their apps. Very brittle. This correctly adds the flag as
an interface compile flag in our exported CMake config files.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

