### PR TITLE
Fix new Parameter call -- didn't call the group-specific version

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -407,20 +407,20 @@ public:
     // Shortcuts for param passing a single int, float, or string.
     bool Parameter (ShaderGroup& group, string_view name,
                     int val, bool lockgeom=true) {
-        return Parameter (name, TypeDesc::INT, &val, lockgeom);
+        return Parameter (group, name, TypeDesc::INT, &val, lockgeom);
     }
     bool Parameter (ShaderGroup& group, string_view name,
                     float val, bool lockgeom=true) {
-        return Parameter (name, TypeDesc::FLOAT, &val, lockgeom);
+        return Parameter (group, name, TypeDesc::FLOAT, &val, lockgeom);
     }
     bool Parameter (ShaderGroup& group, string_view name,
                     const std::string& val, bool lockgeom=true) {
         const char *s = val.c_str();
-        return Parameter (name, TypeDesc::STRING, &s, lockgeom);
+        return Parameter (group, name, TypeDesc::STRING, &s, lockgeom);
     }
     bool Parameter (ShaderGroup& group, string_view name,
                     ustring val, bool lockgeom=true) {
-        return Parameter (name, TypeDesc::STRING, (const char**)&val, lockgeom);
+        return Parameter (group, name, TypeDesc::STRING, (const char**)&val, lockgeom);
     }
 
     /// Append a new shader instance onto the specified group. The shader


### PR DESCRIPTION
Amendment to #1195, I called the wrong/deprecated version of Parameter.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
