### PR TITLE
static_foreach does not compile in GPU code

### DIFF
--- a/src/include/OSL/dual.h
+++ b/src/include/OSL/dual.h
@@ -42,7 +42,7 @@ OSL_NAMESPACE_ENTER
 // sequences with compile time known ConstIndex.  Otherwise for c++11,
 // a more limited manually unrolled loop to a fixed maximum __COUNT
 // works because dead code elimination prunes extraneous iterations.
-#if (OSL_CPLUSPLUS_VERSION >= 14) && !defined(__GNUC__)
+#if (OSL_CPLUSPLUS_VERSION >= 14) && !defined(__GNUC__) && !defined(__CUDACC__)
     // explanation of passing code block as macro argument to handle
     // nested comma operators that might break up the code block into
     // multiple macro arguments


### PR DESCRIPTION
## Description
static_foreach doesn't compile in device code so I've just ifdefed this out as such. Without this you'll get errors similar to the following.
`
dual.h:523:5: error: reference to __host__ function 'static_foreach<ConstIndex, 2, (lambda at C:/Users/russeld/Projects/osl-arnold/src/include\OSL/dual.h:523:5)>' in __host__ __device__ function
    OSL_INDEX_LOOP(i, P, {
    ^
`
<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->


<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

