### PR TITLE
Example of using OSL as a deformer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             derivs derivs-muldiv-clobber
             draw_string
             error-dupes error-serialized
+            example-deformer
             exit exponential
             fprintf
             function-earlyreturn function-simple function-outputelem

--- a/testsuite/example-deformer/CMakeLists.txt
+++ b/testsuite/example-deformer/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+cmake_minimum_required (VERSION 3.12)
+project (osldeformer
+         LANGUAGES CXX)
+
+if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE "Release")
+endif ()
+
+message (STATUS "Building ${PROJECT_NAME} ${PROJECT_VERSION} - ${CMAKE_BUILD_TYPE}")
+
+# Make the build area layout look like we expect
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Use C++11
+set (CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to prefer (11, 14, 17, etc.)")
+set (CMAKE_CXX_STANDARD_REQUIRD ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
+
+
+# Make sure we have dependencies we need
+find_package (OSL REQUIRED)
+
+
+add_executable(osldeformer osldeformer.cpp)
+target_link_libraries (osldeformer
+                       PRIVATE OSL::oslexec OSL::oslquery)

--- a/testsuite/example-deformer/getP.osl
+++ b/testsuite/example-deformer/getP.osl
@@ -1,0 +1,11 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+// This trivial shader just produces an output `out` that defaults to
+// being a copy of the shader global P.
+
+shader getP (output point out = P)
+{
+}

--- a/testsuite/example-deformer/osldeformer.cpp
+++ b/testsuite/example-deformer/osldeformer.cpp
@@ -1,0 +1,270 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+/*
+
+This is an example of using OSL to perform calculations on a bunch of
+points, perhaps as you would to run a deformer.
+
+We set up an example of the following:
+
+* We're going to execute the shader on a collection of points.
+* Each point has a position (the OSL global variable P).
+* There's an input parameter `amplitude` which we presume to be a varying
+  interpolated value, attribute, or something like that.
+* Our shader network computes a noise value based on the position and the
+  amplitude parameter, adds it to P and and stores it in an output variable
+  `out`.
+
+Thus, the point of our shader network is to look at the position P and a
+userdata value `amplitude`, and produce a new output `out`.
+
+This could easily be implemented as just one simple shader, but for
+illustrative purposes we will set it up as a 3-node shader network.
+
+
+To build:
+
+    mkdir build
+    cd build
+    cmake --config Release ..
+    cmake --build .
+    cd ..
+
+Note that you must have OSL_ROOT set to an installed OSL in order for CMake
+to find it properly.
+
+To run:
+
+    build/bin/osldeformer
+
+*/
+
+
+
+#include <OSL/oslexec.h>
+#include <OSL/oslquery.h>
+
+
+// Define a userdata structure that holds any varying per-point values that
+// might be retrieved by shader (interpolated data, etc.). This example is
+// hard-coded, but you could also imagine that if it wasn't a fixed set
+// of values, it could hold dynamic data like a name->value hash table
+// or something. This is a stand-in for prim-specific or interpolatd data.
+struct MyUserData {
+    float amplitude = 0.0f;
+
+    // Make a retrieve-by-name function.
+    bool retrieve (OSL::ustring name, OSL::TypeDesc type, void *val,
+                   bool derivatives)
+    {
+        // For speed, it wants to use ustrings (special unique strings that
+        // can be equality tested at the cost of a simple pointer compare
+        // without needing to examine the characters). But they are
+        // expensive to create, so we use static variables to hold any of
+        // these constant strings.
+        static OSL::ustring uamplitude("amplitude");
+
+        // Check if the name and type is something we know how to supply.
+        if (name == uamplitude && type == OIIO::TypeFloat) {
+            // Found! Fill in the value. The renderer may ask for
+            // derivatives. If that's not something we know how to compute,
+            // just set them to zero. They will always just be the next two
+            // slots after the value. If derivatives is false, don't write
+            // to that memory!
+            ((float*)val)[0] = amplitude;
+            if (derivatives) {
+                ((float*)val)[1] = 0.0f;
+                ((float*)val)[2] = 0.0f;
+            }
+            return true;
+        }
+        // Not a named value we know about, so just return false.
+        return false;
+    }
+};
+
+
+
+// RendererServices is the interface through which OSL requests things back
+// from the app (called a "renderer", but it doesn't have to literally be
+// one). The important feature we are concerned about here is that this is
+// how "userdata" is retrieved. We set up a subclass that overloads
+// get_userdata() to retrieve it from a per-point MyUserData that whose
+// pointer is stored in shaderglobals.renderstate.
+class MyRendererServices : public OSL::RendererServices {
+public:
+    virtual bool get_userdata (bool derivatives, OSL::ustring name,
+                               OSL::TypeDesc type, OSL::ShaderGlobals *sg,
+                               void *val)
+    {
+        // In this case, our implementation of get_userdata just requests
+        // it from the MyUserData, which we have arranged is pointed to
+        // by shaderglobals.renderstate.
+        MyUserData* userdata = (MyUserData*)sg->renderstate;
+        return userdata ? userdata->retrieve (name, type, val, derivatives)
+                        : false;
+    }
+};
+
+
+
+int
+main (int argc, char *argv[])
+{
+    // Create a shading system. Note: the constructor can override with
+    // optional pointers to your custom RendererServices, TextureSystem,
+    // and ErrorHandler. In this case, we do supply our own subclass of
+    // RendererServices, so that we can retrieve userdata.
+    MyRendererServices renderer;
+    std::unique_ptr<OSL::ShadingSystem> shadsys (new OSL::ShadingSystem (&renderer));
+
+    // Let's create a simple deformer as a displacement shader that
+    // computes P+noise(P):
+    //
+    //    +-------+                    +-----+
+    //    | getP  |--+---------------->| add |
+    //    +-------+  |                 |     |----> out
+    //               |              +->|     |
+    //               |              |  +-----+
+    //               |  +--------+  |
+    //               +->| vfBm3d |--+
+    //   amplitude----->|        |
+    //                  +--------+
+    //
+    // Of course you'd never split this simple functionality into three
+    // nodes, but I am trying to illustrate how to set up the multi-node
+    // case.
+
+    OSL::ShaderGroupRef mygroup = shadsys->ShaderGroupBegin ("my_noise_deformer");
+    shadsys->Shader (*mygroup, "displacement", "getP", "layer1");
+    shadsys->Parameter (*mygroup, "amplitude", 1.0f, /*lockgeom=*/false);
+    shadsys->Shader (*mygroup, "displacement", "vfBm3d", "layer2");
+    shadsys->ConnectShaders (*mygroup, "layer1", "out", "layer2", "position");
+    shadsys->Shader (*mygroup, "displacement", "vadd", "layer3");
+    shadsys->ConnectShaders (*mygroup, "layer1", "out", "layer3", "a");
+    shadsys->ConnectShaders (*mygroup, "layer2", "out", "layer3", "b");
+    shadsys->ShaderGroupEnd (*mygroup);
+
+    // Note: we could have used a serialized version equivalently:
+    //
+    //     std::string serialized =
+    //         "shader getP layer1 ;\n"
+    //         "param float amplitude 1.0 [[ int lockgeom = 0 ]];\n"
+    //         "shader vfBm3d layer2 ;\n"
+    //         "connect layer1.out layer2.position ;\n"
+    //         "shader vadd layer3 ;\n"
+    //         "connect layer1.out layer3.a ;\n"
+    //         "connect layer2.out layer3.b ;\n"
+    //     mygroup = shadsys->ShaderGroupBegin ("my_noise_addr", "displacement",
+    //                                          serialized);
+    //     shadsys->ShaderGroupEnd (*mygroup);
+    //
+    // Also, if we had those commands in a text file, let's say it is called
+    // "material.oslgroup", then we can also specify it by filename:
+    //
+    //     mygroup = shadsys->ShaderGroupBegin ("my_noise_addr", "displacement",
+    //                                          "material.oslgroup");
+    //     shadsys->ShaderGroupEnd (*mygroup);
+
+
+    // Tell the shading system the list of preserved outputs for this group.
+    // Pass as an array of char*'s.
+    // Note that shader outputs that are not listed here and not connected
+    // to downstream layers will be optimized away, so this is important!
+#if 0
+    // This just adds one manually
+    const char* output_names[] = { "out" };
+    shadsys->attribute (mygroup.get(), "renderer_outputs",
+                        OSL::TypeDesc(OSL::TypeDesc::STRING,1),
+                        &output_names);
+#else
+    // This fancier version adds all output parameters of the final layer
+    // as renderer outputs. This may not be what you want! But we're doing
+    // it just to show how it can be done with oslquery:
+    {
+        int numlayers = 1;
+        shadsys->getattribute (mygroup.get(), "num_layers", numlayers);
+        std::vector<OSL::ustring> output_names;
+        OSL::OSLQuery oslquery (mygroup.get(), numlayers-1);
+        for (size_t i = 0; i < oslquery.nparams(); ++i) {
+            auto p = oslquery.getparam(i);
+            if (p && p->isoutput)
+                output_names.push_back(p->name);
+        }
+        shadsys->attribute (mygroup.get(), "renderer_outputs",
+                            OSL::TypeDesc(OSL::TypeDesc::STRING,output_names.size()),
+                            output_names.data());
+    }
+#endif
+
+
+    // Now we want to create a context in which we can execute the shader.
+    // We need one context per thread. A context can be used over and over
+    // to shade multiple points, but it should never be used by more than
+    // one thread (and thus, one context cannot be used to run two shader
+    // executions simultaneously). But you are free to make a PerThreadInfo
+    // and a ShadingContext for *each* thread, and those separate contexts
+    // may execute concurrently. For this sample program, though, we will
+    // only use one thread, and thus need only one context.
+    OSL::PerThreadInfo *perthread = shadsys->create_thread_info();
+    OSL::ShadingContext *ctx = shadsys->get_context(perthread);
+
+    // Get a ShaderSymbol* handle to the final output we care about. This
+    // will greatly speed up retrieving the value later, rather than by
+    // looking it up by name on every shade.
+    // The group must already be optimized before we call find_symbol,
+    // so we force that to happen now.
+    shadsys->optimize_group (mygroup.get(), ctx);
+    const OSL::ShaderSymbol *outsym =
+        shadsys->find_symbol (*mygroup.get(), OSL::ustring("layer3"),
+                              OSL::ustring("out"));
+    OSL_ASSERT(outsym);
+
+    // For illustration, let's loop over running this on points
+    //     (0.1*i, 0, 0)   for i in [0,20]
+    for (int i = 0; i < 20; ++i) {
+
+        // First, we need a ShaderGlobals struct:
+        OSL::ShaderGlobals shaderglobals;
+
+        // Make a userdata record. Make sure the shaderglobals points to it.
+        MyUserData userdata;
+        shaderglobals.renderstate = &userdata;
+
+        // Set up inputs.
+
+        // Example of initializing a global: the position, P. It just lives
+        // as a hard-coded field in the ShaderGlobals itself.
+        OSL::Vec3 Pin (0.1f*i, 0.0f, 0.0f);
+        shaderglobals.P = Pin;
+
+        // Example of initializing a varying or interpolated parameter. We
+        // MUST have declared this as a "lockgeom=0" parameter (either in
+        // the shader source itself, or when we instanced it with the
+        // ShadingSystem::Parameter() call) or this won't work!
+        userdata.amplitude = 0.0f + 1.0f*powf(i/20.0f, 3.0f);
+
+        // Run the shader (will automagically optimize and JIT the first
+        // time it executes).
+        shadsys->execute (ctx, *mygroup.get(), shaderglobals);
+
+        // Retrieve the result. This is fast, it's just combining the data
+        // area address known by the context with the offset-within-data
+        // that is known in that `outsym` we retrieved once for the group.
+        OSL::Vec3 Pout = *(OSL::Vec3*)shadsys->symbol_address (*ctx, outsym);
+
+        // Print some results to prove that we generated an expected Pout.
+        std::cout << "i = " << i << "\n";
+        std::cout << "Undeformed P = " << Pin << "  amplitude = " 
+                  << userdata.amplitude << "\n";
+        std::cout << "Deformed " << Pin << "  -->  " << Pout << "\n";
+        std::cout << "\n";
+    }
+
+    // All done. Release the contexts and threadinfo for each thread:
+    shadsys->release_context (ctx);
+    shadsys->destroy_thread_info (perthread);
+}

--- a/testsuite/example-deformer/ref/out.txt
+++ b/testsuite/example-deformer/ref/out.txt
@@ -1,0 +1,83 @@
+Compiled getP.osl -> getP.oso
+Compiled vadd.osl -> vadd.oso
+Compiled vfBm3d.osl -> vfBm3d.oso
+i = 0
+Undeformed P = (0 0 0)  amplitude = 0
+Deformed (0 0 0)  -->  (0 0 0)
+
+i = 1
+Undeformed P = (0.1 0 0)  amplitude = 0.000125
+Deformed (0.1 0 0)  -->  (0.0999991 -9.45666e-07 -1.12243e-05)
+
+i = 2
+Undeformed P = (0.2 0 0)  amplitude = 0.001
+Deformed (0.2 0 0)  -->  (0.199954 -4.5502e-05 -0.000139523)
+
+i = 3
+Undeformed P = (0.3 0 0)  amplitude = 0.003375
+Deformed (0.3 0 0)  -->  (0.299622 -0.000378342 -0.000453787)
+
+i = 4
+Undeformed P = (0.4 0 0)  amplitude = 0.008
+Deformed (0.4 0 0)  -->  (0.398504 -0.00149629 -0.000648592)
+
+i = 5
+Undeformed P = (0.5 0 0)  amplitude = 0.015625
+Deformed (0.5 0 0)  -->  (0.496164 -0.00383594 0)
+
+i = 6
+Undeformed P = (0.6 0 0)  amplitude = 0.027
+Deformed (0.6 0 0)  -->  (0.592761 -0.00723896 0.002189)
+
+i = 7
+Undeformed P = (0.7 0 0)  amplitude = 0.042875
+Deformed (0.7 0 0)  -->  (0.689429 -0.0105711 0.00576478)
+
+i = 8
+Undeformed P = (0.8 0 0)  amplitude = 0.064
+Deformed (0.8 0 0)  -->  (0.788158 -0.0118416 0.00892945)
+
+i = 9
+Undeformed P = (0.9 0 0)  amplitude = 0.091125
+Deformed (0.9 0 0)  -->  (0.891128 -0.00887187 0.00818247)
+
+i = 10
+Undeformed P = (1 0 0)  amplitude = 0.125
+Deformed (1 0 0)  -->  (1 0 0)
+
+i = 11
+Undeformed P = (1.1 0 0)  amplitude = 0.166375
+Deformed (1.1 0 0)  -->  (1.11746 0.0149395 -0.0174569)
+
+i = 12
+Undeformed P = (1.2 0 0)  amplitude = 0.216
+Deformed (1.2 0 0)  -->  (1.24979 0.0301369 -0.0497937)
+
+i = 13
+Undeformed P = (1.3 0 0)  amplitude = 0.274625
+Deformed (1.3 0 0)  -->  (1.3985 0.0369248 -0.0984964)
+
+i = 14
+Undeformed P = (1.4 0 0)  amplitude = 0.343
+Deformed (1.4 0 0)  -->  (1.55611 0.0278084 -0.156115)
+
+i = 15
+Undeformed P = (1.5 0 0)  amplitude = 0.421875
+Deformed (1.5 0 0)  -->  (1.70714 0 -0.207141)
+
+i = 16
+Undeformed P = (1.6 0 0)  amplitude = 0.512
+Deformed (1.6 0 0)  -->  (1.83303 -0.0415099 -0.233034)
+
+i = 17
+Undeformed P = (1.7 0 0)  amplitude = 0.614125
+Deformed (1.7 0 0)  -->  (1.92026 -0.0825725 -0.220261)
+
+i = 18
+Undeformed P = (1.8 0 0)  amplitude = 0.729
+Deformed (1.8 0 0)  -->  (1.96805 -0.101712 -0.168054)
+
+i = 19
+Undeformed P = (1.9 0 0)  amplitude = 0.857375
+Deformed (1.9 0 0)  -->  (1.98996 -0.0769869 -0.0899601)
+

--- a/testsuite/example-deformer/run.py
+++ b/testsuite/example-deformer/run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+
+command += run_app ("cmake --config Release data >> build.txt", silent=True)
+command += run_app ("cmake --build . >> build.txt", silent=True)
+command += run_app ("bin/osldeformer >> out.txt")

--- a/testsuite/example-deformer/vadd.osl
+++ b/testsuite/example-deformer/vadd.osl
@@ -1,0 +1,14 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+// Simple shader node that just adds two inputs `a` and `b`, yielding output
+// `out`.
+
+shader vadd (vector a = 0,
+             vector b = 0,
+             output vector out = 0)
+{
+    out = a + b;
+}

--- a/testsuite/example-deformer/vfBm3d.osl
+++ b/testsuite/example-deformer/vfBm3d.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+// Note: the metadata [[int lockgeom = 0]] says that a particular parameter
+// is expected to be a per-point varying value (such as for an interpolted
+// variable or a per-point retrievable "user data" value), and therefore
+// should not be constant-folded away at runtime.
+
+shader vfBm3d (point position = P [[ int lockgeom = 0 ]],
+               float frequency = 1,
+               float amplitude = 1 [[ int lockgeom = 0 ]],
+               int octaves = 1,
+               float lacunarity = 2,
+               float gain = 0.5,
+               string noisetype = "snoise",
+               output vector out = 0)
+{
+    vector r = 0;
+    point p = position * frequency;
+    float amp = amplitude;
+    for (int i = 0; i < octaves; ++i) {
+        r += amp * (vector)noise (noisetype, p);
+        p *= lacunarity;
+        amp *= gain;
+    }
+    out = r;
+}

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -146,6 +146,15 @@ def text_diff (fromfile, tofile, diff_file=None):
 
 
 
+def run_app (app, silent=False, concat=True) :
+    command = app
+    if not silent :
+        command += redirect
+    if concat:
+        command += " ;\n"
+    return command
+
+
 def osl_app (app):
     apath = os.path.join(OSL_BUILD_DIR, "bin")
     if (platform.system () == 'Windows'):


### PR DESCRIPTION
Many times, people can ask how they can use OSL to make more general
computational engines (not a classic renderer), and one use case that
comes up frequently is to use it to control deformations. This patch
includes a new testsuite example that does exactly this, for a test
case -- setting up a small shader network that operates on a series
of points.

It's a completely self-contained example of how to do this. There is a
lot of boilerplate for such a simple task, but I was really trying to
make sure to provide examples of all the little pieces you'd need to
do a more complex use use.

To make sure it builds, I added it to the testsuite itself, as
testsuite/example-deformer.

Interestingly, it is our first testsuite entry that needs compilation
and linking with OSL -- and not using OSL's own build system! So not
only does it test the code functionality itself, but it also serves as
a test for our exported CMake config.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
