### PR TITLE
Allow output params with lockgeom=0 to have auto userdata binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             transitive-assign
             transform transformc trig typecast
             unknown-instruction
+            userdata
             vararray-connect vararray-default
             vararray-deserialize vararray-param
             vecctr vector

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -222,7 +222,7 @@ LLVMGEN (llvm_gen_useparam)
         rop.llvm_run_connected_layers (sym, symindex, opnum, &already_run);
         // If it's an interpolated (userdata) parameter and we're
         // initializing them lazily, now we have to do it.
-        if (sym.symtype() == SymTypeParam
+        if ((sym.symtype() == SymTypeParam || sym.symtype() == SymTypeOutputParam)
                 && ! sym.lockgeom() && ! sym.typespec().is_closure()
                 && ! sym.connected() && ! sym.connected_down()
                 && rop.shadingsys().lazy_userdata()) {

--- a/testsuite/userdata/ref/out.txt
+++ b/testsuite/userdata/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled test.osl -> test.oso
+u = 0, v = 0  =>  s = 0, t = 0
+u = 1, v = 0  =>  s = 1, t = 0
+u = 0, v = 1  =>  s = 0, t = 1
+u = 1, v = 1  =>  s = 1, t = 1
+

--- a/testsuite/userdata/run.py
+++ b/testsuite/userdata/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+command = testshade("-g 2 2 test")

--- a/testsuite/userdata/test.osl
+++ b/testsuite/userdata/test.osl
@@ -1,0 +1,9 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+shader test (float s = 0 [[ int lockgeom=0 ]],
+             output float t = 0 [[ int lockgeom=0 ]])
+{
+    printf ("u = %g, v = %g  =>  s = %g, t = %g\n", u, v, s, t);
+}


### PR DESCRIPTION
Shader params declared with lockgeom=0

    surface foo (float bar = 0 [[ int lockgeom=0 ]]) { }

will generate code making underlying calls to RendererServices->get_userdata
to automatically bind userdata (a.k.a. interpolated "primitive variables")
that share the same name.

But, oddly, this was not true for output parameters:

    surface foo (output float bar = 0 [[ int lockgeom=0 ]]) { }

This was tripping some people up, and in retrospect seems strange.

This patch removes this restriction, allowing both input and output
parameters tagged with lockgeom=0 to attempt to retrieve userdata to get
their initial values.

Add test of userdata retrieval to make sure this works.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

