### PR TITLE
"error: 'ListT': parameter pack must be expanded in this context" on windows

### DIFF
--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -199,15 +199,20 @@ reference_inthash (const unsigned int k[N]) {
     return c;
 }
 
-
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 template<typename HeadT, typename... ListT>
-using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT> >::value...>::type;
+using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT>...>::value>::type;
+#endif
 
 // Allow any number of arguments to be adapted to the array based reference_inthash
 // and leave door open for overloads of inthash with specific parameters.
 // NOTE: only accept unsigned int's so that overloads with unsigned int's will be chosen.
 // Callers with "int" parameters will need to static_cast<unsigned int>(param)
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
 template<typename ...ListT, typename = RequireAllSame<unsigned int, ListT...> >
+#else
+template<typename ...ListT, typename = typename std::enable_if<conjunction<std::is_same<ListT, unsigned int>...>::value>::type >
+#endif
 OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
 inthash (ListT... uintList)  {
     const int count = sizeof...(uintList);

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -199,27 +199,6 @@ reference_inthash (const unsigned int k[N]) {
     return c;
 }
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
-template<typename HeadT, typename... ListT>
-using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT>...>::value>::type;
-#endif
-
-// Allow any number of arguments to be adapted to the array based reference_inthash
-// and leave door open for overloads of inthash with specific parameters.
-// NOTE: only accept unsigned int's so that overloads with unsigned int's will be chosen.
-// Callers with "int" parameters will need to static_cast<unsigned int>(param)
-#if defined(_MSC_VER) && (_MSC_VER >= 1920)
-template<typename ...ListT, typename = RequireAllSame<unsigned int, ListT...> >
-#else
-template<typename ...ListT, typename = typename std::enable_if<conjunction<std::is_same<ListT, unsigned int>...>::value>::type >
-#endif
-OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
-inthash (ListT... uintList)  {
-    const int count = sizeof...(uintList);
-	const unsigned int iv[count] = {uintList...};
-	return reference_inthash<count>(iv);
-}
-
 #if (__OSL_USE_REFERENCE_INT_HASH == 0)
 	// Do not rely on compilers to fully optimizing the
 	// reference_inthash<int N> template above.

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -201,7 +201,7 @@ reference_inthash (const unsigned int k[N]) {
 
 
 template<typename HeadT, typename... ListT>
-using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT>...>::value>::type;
+using RequireAllSame = typename std::enable_if<conjunction<std::is_same<ListT, HeadT> >::value...>::type;
 
 // Allow any number of arguments to be adapted to the array based reference_inthash
 // and leave door open for overloads of inthash with specific parameters.


### PR DESCRIPTION
## Description
For some reason this line doesn't compile on windows (at least with MSVC14) and throws the following error.
`
oslnoise.h(204): error C3520: 'ListT': parameter pack must be expanded in this context
`
The modification allows this to build and doesn't cause any issues in the testing I've done. I'm not entirely clear what the logic does so would be good if somebody could verify the new logic is correct.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

