### PR TITLE
Remove unused (and also deprecated) retrieval of pixmap

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,9 +55,11 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * [Flex](https://github.com/westes/flex) and
   [GNU Bison](https://www.gnu.org/software/bison/)
 * [PugiXML](http://pugixml.org/)
-* [Partio](https://www.disneyanimation.com/technology/partio.html) --
-  optional, but if it is not found at build time, the OSL `pointcloud`
-  functions will not be operative.
+* (optional) [Partio](https://www.disneyanimation.com/technology/partio.html)
+  If it is not found at build time, the OSL `pointcloud` functions will not
+  be operative.
+* (optional) Qt >= 5.6 (tested through 5.15).  If not found at build time,
+  the `osltoy` application will be disabled.
 
 
 

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -197,9 +197,6 @@ class OSLToyRenderView : public QLabel {
     bool getPixel(QPoint pos, PixelInfo& info) {
         if (! m_framebuffer.initialized())
             return false;
-        const auto* pmap = pixmap();
-        if (! pmap )
-            return false;
         const auto& spec = m_framebuffer.spec();
         info.x = pos.x();
         info.y = pos.y();


### PR DESCRIPTION
Critical fix to compile cleanly with Qt 5.15

Signed-off-by: Larry Gritz <lg@larrygritz.com>

