### PR TITLE
Add LLVM_Util methods to detect appropriate ISA for the host CPU.

### DIFF
--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -355,7 +355,7 @@
 #endif
 
 // OSL_FALLTHROUGH at the end of a `case` label's statements documents that
-// he switch statement case is intentionally falling through to the code for
+// the switch statement case is intentionally falling through to the code for
 // the next case.
 #if OSL_CPLUSPLUS_VERSION >= 17 || __has_cpp_attribute(fallthrough)
 #    define OSL_FALLTHROUGH [[fallthrough]]

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -211,11 +211,26 @@ test_big_func (bool do_print=false)
 
 
 
+void
+test_isa_features()
+{
+    OSL::pvt::LLVM_Util ll;
+    ll.detect_cpu_features();
+
+    // Make sure it matches what OIIO's cpuid queries reveal
+    OIIO_CHECK_EQUAL(ll.supports_avx(), OIIO::cpu_has_avx());
+    OIIO_CHECK_EQUAL(ll.supports_avx2(), OIIO::cpu_has_avx2());
+    OIIO_CHECK_EQUAL(ll.supports_avx512f(), OIIO::cpu_has_avx512f());
+}
+
+
 
 int
 main (int argc, char *argv[])
 {
     getargs (argc, argv);
+
+    test_isa_features();
 
     // Test simple functions
     test_int_func();


### PR DESCRIPTION
We don't use this quite yet, but are staging it for easy review.

Work by Alex Wells. Some refactoring and minor edits by LG.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

