### PR TITLE
Re-enable RTTI

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -446,26 +446,6 @@ endif ()
 
 
 ###########################################################################
-# Enable/disable RTTI
-#
-# NOTE: LLVM builds without RTTI by default so beware if you find the need
-# to turn this on, to use OSL in a project that requires RTTI for example,
-# you need to build LLVM with RRTI, otherwise OSL classes extending LLVM
-# ones will cause linker errors.
-#
-set (ENABLE_RTTI OFF CACHE BOOL "Build with RTTI. Requires a LLVM build with RTTI enabled.")
-set (${PROJECT_NAME}_RTTI_OPTIONS "")
-if (NOT ENABLE_RTTI)
-    if (MSVC)
-        set (${PROJECT_NAME}_RTTI_OPTIONS /GR-)
-    else ()
-        set (${PROJECT_NAME}_RTTI_OPTIONS -fno-rtti)
-    endif()
-    add_compile_options (${${PROJECT_NAME}_RTTI_OPTIONS})
-endif()
-
-
-###########################################################################
 # Another way to sneak in custom compiler and DSO linking flags.
 #
 set (EXTRA_CPP_ARGS "" CACHE STRING "Extra C++ command line definitions")

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -190,9 +190,16 @@ if (partio_FOUND)
     target_compile_definitions (${local_lib} PRIVATE USE_PARTIO=1)
 endif ()
 
-# Propagate our library's RTTI options to downstream clients of this library
-# This is very important for proper linkage with LLVM.
-target_compile_options(${local_lib} PUBLIC ${${PROJECT_NAME}_RTTI_OPTIONS})
+# Disable RTTI from just the one module where we have classes that inherit
+# from LLVM classes.
+if (MSVC)
+    set_source_files_properties (llvm_util.cpp
+                                 PROPERTIES COMPILE_FLAGS "/GR-")
+else ()
+    set_source_files_properties (llvm_util.cpp
+                                 PROPERTIES COMPILE_FLAGS "-fno-rtti")
+endif()
+
 
 target_link_libraries (${local_lib}
     PUBLIC


### PR DESCRIPTION
We had disabled RTTI throughout the OSL code base to avoid linkage
problems against LLVM, which builds with RTTI disabled by default.

But it's actually ok to mix code modules with differing RTTI status --
that's fine. It's just that you can't mix RTTI status within a class
inheritance hierarchy.

We observe that

  * The only classes we inherit from RTTI-free LLVM are solely defined
    and used within llvm_util.cpp.

  * The only classes exposed in llvm_util.h have no virtual functions
    and aren't designed to be subclassed.

So in fact, it appears that we can get by with only using no-rtti when
compiling that one module, and don't need to mess with rtti anywhere
else (including downstream users). This is an important step to
supporting python bindings, since pybind11 requires RTTI.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
