### PR TITLE
Fix memory leak when using the JIT Event listener

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -22,6 +22,7 @@ namespace llvm {
   class Function;
   class FunctionType;
   class SectionMemoryManager;
+  class JITEventListener;
   class Linker;
   class LLVMContext;
   class Module;
@@ -615,6 +616,7 @@ private:
     llvm::legacy::PassManager *m_llvm_module_passes;
     llvm::legacy::FunctionPassManager *m_llvm_func_passes;
     llvm::ExecutionEngine *m_llvm_exec;
+    llvm::JITEventListener *m_vtune_profiler;
     TargetISA m_target_isa = TargetISA::UNKNOWN;
     std::vector<llvm::BasicBlock *> m_return_block;     // stack for func call
     std::vector<llvm::BasicBlock *> m_loop_after_block; // stack for break

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -237,7 +237,7 @@ LLVM_Util::LLVM_Util (int debuglevel, int vector_width)
       m_builder(NULL), m_llvm_jitmm(NULL),
       m_current_function(NULL),
       m_llvm_module_passes(NULL), m_llvm_func_passes(NULL),
-      m_llvm_exec(NULL),
+      m_llvm_exec(NULL), m_vtune_profiler(NULL),
       m_vector_width(vector_width)
 {
     SetupLLVM ();
@@ -847,9 +847,9 @@ LLVM_Util::make_jit_execengine (std::string *err)
     // in code quality or JIT time. It is only enabled, however, if your copy
     // of LLVM was build with -DLLVM_USE_INTEL_JITEVENTS=ON, otherwise
     // createIntelJITEventListener() is a stub that just returns nullptr.
-    auto vtuneProfiler = llvm::JITEventListener::createIntelJITEventListener();
-    if (vtuneProfiler)
-        m_llvm_exec->RegisterJITEventListener (vtuneProfiler);
+    m_vtune_profiler = llvm::JITEventListener::createIntelJITEventListener();
+    if (m_vtune_profiler)
+        m_llvm_exec->RegisterJITEventListener(m_vtune_profiler);
 
     // Force it to JIT as soon as we ask it for the code pointer,
     // don't take any chances that it might JIT lazily, since we
@@ -866,6 +866,9 @@ LLVM_Util::execengine (llvm::ExecutionEngine *exec)
 {
     delete m_llvm_exec;
     m_llvm_exec = exec;
+
+    delete m_vtune_profiler;
+    m_vtune_profiler = nullptr;
 }
 
 


### PR DESCRIPTION
The execution engine does not take ownership of this object, so we need to be cleaning it up ourselves.

I discovered this when running address sanitizer on our renderer and noticed that every test using OSL was failing.