### PR TITLE
[CMake] Move PUGIXML_LIBRARY outside PUGIXML_INCLUDE_DIR check.

### DIFF
--- a/src/cmake/modules/FindPugiXML.cmake
+++ b/src/cmake/modules/FindPugiXML.cmake
@@ -24,11 +24,10 @@ if (NOT PUGIXML_INCLUDE_DIR AND (OPENIMAGEIO_INCLUDES OR OpenImageIO_ROOT))
                PATHS ${OpenImageIO_ROOT}/include/OpenImageIO
                      ${OPENIMAGEIO_INCLUDES}
                PATH_SUFFIXES OpenImageIO)
-    if (PUGIXML_INCLUDE_DIR)
-        set (PUGIXML_LIBRARY ${OPENIMAGEIO_LIBRARIES})
-    endif ()
 endif ()
-
+if (NOT PUGIXML_LIBRARY AND (OPENIMAGEIO_INCLUDES OR OpenImageIO_ROOT) AND PUGIXML_INCLUDE_DIR)
+    set (PUGIXML_LIBRARY ${OPENIMAGEIO_LIBRARIES})
+endif ()
 
 # Support the REQUIRED and QUIET arguments, and set PUGIXML_FOUND if found.
 include (FindPackageHandleStandardArgs)


### PR DESCRIPTION
CMake seems to cache **PUGIXML_INCLUDE_DIR** and on a reconfigure **PUGIXML_LIBRARY** may never be set.
