### PR TITLE
CI python touch-ups

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -157,6 +157,7 @@ jobs:
           USE_SIMD: avx2,f16c
           OPENEXR_VERSION: 2.5.0
           OPENIMAGEIO_BRANCH: master
+          PYBIND11_VERSION: 2.5.0
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
@@ -223,8 +224,8 @@ jobs:
           name: ${{ github.job }}
           path: build/*/testsuite/*/*.*
 
-  macos-py37:
-    name: "Mac py37"
+  macos-py38:
+    name: "Mac py38"
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
@@ -233,7 +234,7 @@ jobs:
           CXX: clang++
           USE_CPP: 14
           CMAKE_CXX_STANDARD: 14
-          PYTHON_VERSION: 3.7
+          PYTHON_VERSION: 3.8
           LLVM_BC_GENERATOR: /usr/bin/clang++
           MY_CMAKE_FLAGS: -DLLVM_BC_GENERATOR=/usr/bin/clang++
             # ^^ Force bitcode compiles to use the system clang compiler by

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,6 +58,11 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * (optional) [Partio](https://www.disneyanimation.com/technology/partio.html)
   If it is not found at build time, the OSL `pointcloud` functions will not
   be operative.
+* (optional) Python: If you are building the Python bindings or running the
+   testsuite:
+     * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8)
+     * pybind11 >= 2.4.2 (Tested through 2.5)
+     * NumPy
 * (optional) Qt >= 5.6 (tested through 5.15).  If not found at build time,
   the `osltoy` application will be disabled.
 

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -53,7 +53,7 @@ fi
 
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
-export PATH=/usr/local/opt/qt5/bin:$PATH ;
-export PATH=/usr/local/opt/python/libexec/bin:$PATH ;
-export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH ;
-export PATH=/usr/local/Cellar/llvm/9.0.0*/bin:$PATH ;
+export PATH=/usr/local/opt/qt5/bin:$PATH
+export PATH=/usr/local/opt/python/libexec/bin:$PATH
+export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH
+export PATH=/usr/local/opt/llvm/bin:$PATH

--- a/src/liboslquery/py_osl.h
+++ b/src/liboslquery/py_osl.h
@@ -115,7 +115,7 @@ C_to_tuple<TypeDesc>(cspan<TypeDesc> vals)
     size_t size = vals.size();
     py::tuple result(size);
     for (size_t i = 0; i < size; ++i)
-        result[i] = py::cast<TypeDesc>(vals[i]);
+        result[i] = py::cast(vals[i]);
     return result;
 }
 


### PR DESCRIPTION
* Fix template casting reference to work properly with the latest
  pybind11 master.

* Mac CI: use Python 3.8 (easier for homebrew)
