### PR TITLE
Option to generate full debugging and profiling info.

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -134,6 +134,11 @@ public:
     ///                              figure out what the host can do. ("")
     ///    int llvm_jit_aggressive  Use LLVM "aggressive" JIT mode. (0)
     ///    int vector_width       Vector width to allow for SIMD ops (4).
+    ///    int llvm_debugging_symbols  When JITing, generate debug symbols
+    ///                             that associate machine code with shader
+    ///                             source and lines. (0)
+    ///    int llvm_profiling_events  When JITing, generate events to enable
+    ///                             full profiling of shaders. (0)
     ///    int lockgeom           Default 'lockgeom' value for shader params
     ///                              that don't specify it (1).  Lockgeom
     ///                              means a param CANNOT be overridden by

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -967,6 +967,10 @@ public:
                && std::equal(&a.m_jump[0], &a.m_jump[max_jumps], &b.m_jump[0]);
     }
 
+    /// Runtime optimizer may have case to transmute an op to a
+    /// different form.  Only opname is changed.
+    void transmute_opname(ustring opname) { m_op = opname; }
+
 private:
     ustring m_op;                   ///< Name of opcode
     int m_firstarg;                 ///< Index of first argument

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2924,7 +2924,11 @@ DECLFOLDER(constfold_functioncall)
     } else if (! has_return) {
         // The function is just a straight-up execution, no return
         // statement, so kill the "function" op.
-        rop.turn_into_nop (op, "'function' not necessary");
+        if (rop.keep_no_return_function_calls()) {
+            rop.turn_into_functioncall_nr (op, "'functioncall' transmuted to 'no return' version");
+        } else {
+            rop.turn_into_nop (op, "'function' not necessary");
+        }
         ++changed;
     }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -554,6 +554,8 @@ public:
     int llvm_debug_layers () const { return m_llvm_debug_layers; }
     int llvm_debug_ops () const { return m_llvm_debug_ops; }
     int llvm_target_host () const { return m_llvm_target_host; }
+    int llvm_debugging_symbols () const { return m_llvm_debugging_symbols; }
+    int llvm_profiling_events () const { return m_llvm_profiling_events; }
     int llvm_output_bitcode () const { return m_llvm_output_bitcode; }
     ustring llvm_prune_ir_strategy () const { return m_llvm_prune_ir_strategy; }
     bool fold_getattribute () const { return m_opt_fold_getattribute; }
@@ -746,6 +748,8 @@ private:
     int m_llvm_debug_layers;              ///< Add layer enter/exit printfs
     int m_llvm_debug_ops;                 ///< Add printfs to every op
     int m_llvm_target_host;               ///< Target specific host architecture
+    int m_llvm_debugging_symbols;         ///< Generate GDB compatible debug info during JIT
+    int m_llvm_profiling_events;          ///< Emit Intel profiling events during JIT
     int m_llvm_output_bitcode;            ///< Output bitcode for each group
     int m_llvm_dumpasm;                   ///< Output CPU asm of the JIT
     ustring m_llvm_prune_ir_strategy;     ///< LLVM IR pruning strategy

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -29,6 +29,7 @@ static ustring u_nop    ("nop"),
                u_while  ("while"),
                u_dowhile("dowhile"),
                u_functioncall ("functioncall"),
+               u_functioncall_nr("functioncall_nr"),
                u_break ("break"),
                u_continue ("continue"),
                u_return ("return"),
@@ -96,6 +97,7 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
       m_opt_assign(shadingsys.m_opt_assign),
       m_opt_mix(shadingsys.m_opt_mix),
       m_opt_middleman(shadingsys.m_opt_middleman),
+      m_keep_no_return_function_calls(shadingsys.m_llvm_debugging_symbols),
       m_pass(0),
       m_next_newconst(0), m_next_newtemp(0),
       m_stat_opt_locking_time(0), m_stat_specialization_time(0),
@@ -104,6 +106,13 @@ RuntimeOptimizer::RuntimeOptimizer (ShadingSystemImpl &shadingsys,
 {
     memset ((char *)&m_shaderglobals, 0, sizeof(ShaderGlobals));
     m_shaderglobals.context = shadingcontext();
+
+    // Disable no_function_return_calls for OptiX renderers, because we
+    // aren't yet set up to support use of debugging symbols for PTX.
+    // FIXME: some day, we are going to want debugging symbols for PTX, and
+    // will need some refactoring of the debugging symbol code.
+    if (shadingsys.renderer()->supports("OptiX"))
+        m_keep_no_return_function_calls = false;
 }
 
 
@@ -468,6 +477,20 @@ RuntimeOptimizer::turn_into_nop (int begin, int end, string_view why)
     return changed;
 }
 
+// Turn the op into a no-op functioncall
+// We keep want to keep the jumps indices so we can correctly
+// model an inlined function call for the debugger
+int
+RuntimeOptimizer::turn_into_functioncall_nr (Opcode &op, string_view why)
+{
+    if (op.opname() == u_functioncall) {
+        if (debug() > 1)
+            debug_turn_into (op, 1, "functioncall_nr", -1, -1, -1, why);
+        op.transmute_opname (u_functioncall_nr);
+        return 1;
+    }
+    return 0;
+}
 
 
 void
@@ -1044,6 +1067,11 @@ OSOProcessorBase::find_basic_blocks ()
 
     for (size_t opnum = 0;  opnum < code.size();  ++opnum) {
         Opcode &op (code[opnum]);
+        if (op.opname() == u_functioncall_nr)
+        {   // Treat the 'no return' function call as if it were a nop.
+            // we use later to generate correct inline debug information.
+            continue;
+        }
         // Anyplace that's the target of a jump instruction starts a basic block
         for (int j = 0;  j < (int)Opcode::max_jumps;  ++j) {
             if (op.jump(j) >= 0)
@@ -1197,7 +1225,7 @@ RuntimeOptimizer::simple_sym_assign (int sym, int opnum)
         FastIntMap::iterator i = m_stale_syms.find(sym);
         if (i != m_stale_syms.end()) {
             Opcode &uselessop (inst()->ops()[i->second]);
-            if (uselessop.opname() != u_nop)
+            if (uselessop.opname() != u_nop && uselessop.opname() != u_functioncall_nr)
                 turn_into_nop (uselessop,
                            debug() > 1 ? Strutil::sprintf("remove stale value assignment to %s, reassigned on op %d",
                                                          opargsym(uselessop,0)->name(), opnum).c_str() : "");
@@ -1553,7 +1581,7 @@ RuntimeOptimizer::next_block_instruction (int opnum)
 {
     int end = (int)inst()->ops().size();
     for (int n = opnum+1; n < end && m_bblockids[n] == m_bblockids[opnum]; ++n)
-        if (inst()->ops()[n].opname() != u_nop)
+        if (inst()->ops()[n].opname() != u_nop && inst()->ops()[n].opname() != u_functioncall_nr)
             return n;   // Found it!
     return 0;   // End of ops or end of basic block
 }
@@ -2103,7 +2131,7 @@ RuntimeOptimizer::optimize_ops (int beginop, int endop,
             }
         }
         // Nothing below here to do for no-ops, take early out.
-        if (op->opname() == u_nop)
+        if (op->opname() == u_nop || op->opname() == u_functioncall_nr)
             continue;
         // De-alias the readable args to the op and figure out if
         // there are any constants involved.
@@ -2156,7 +2184,7 @@ RuntimeOptimizer::optimize_ops (int beginop, int endop,
             break;
         // Peephole optimization involving pair of instructions (the second
         // instruction will be in the same basic block.
-        if (optimize() >= 2 && m_opt_peephole && op->opname() != u_nop) {
+        if (optimize() >= 2 && m_opt_peephole && op->opname() != u_nop && op->opname() != u_functioncall_nr) {
             // Find the next instruction in the same basic block
             int op2num = next_block_instruction (opnum);
             if (op2num) {

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -133,6 +133,13 @@ public:
     /// of instructions that were altered.
     int turn_into_nop (int begin, int end, string_view why=NULL);
 
+
+    /// Transmute regulare function call into a 'no return' function call
+    /// The funcationcall_nr is useful to generate debug info for the inlined
+    /// function call.  Its existence shouldn't otherwise modify resulting
+    /// code generation.
+    int turn_into_functioncall_nr (Opcode &op, string_view why=nullptr);
+
     void debug_opt_impl (string_view message) const;
 
     template<typename... Args>
@@ -349,6 +356,10 @@ public:
     /// Are special optimizations to 'mix' requested?
     bool opt_mix () const { return m_opt_mix; }
 
+    /// Should no return function calls be kept in order to
+    /// generate correct inline function debug info
+    bool keep_no_return_function_calls() const { return m_keep_no_return_function_calls; }
+
     /// Which optimization pass are we on?
     int optimization_pass () const { return m_pass; }
 
@@ -406,6 +417,7 @@ private:
     bool m_opt_assign;                    ///< Do various assign optimizations?
     bool m_opt_mix;                       ///< Do mix optimizations?
     bool m_opt_middleman;                 ///< Do middleman optimizations?
+    bool m_keep_no_return_function_calls; ///< To generate debug info, keep no return function calls
     ShaderGlobals m_shaderglobals;        ///< Dummy ShaderGlobals
 
     // Keep track of some things for the whole shader group:

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -83,6 +83,10 @@ set_shadingsys_options ()
         shadingsys->attribute ("options", extraoptions);
     if (texoptions.size())
         shadingsys->texturesys()->attribute ("options", texoptions);
+    // Always generate llvm debugging info and profiling events
+    shadingsys->attribute ("llvm_debugging_symbols", 1);
+    shadingsys->attribute ("llvm_profiling_events", 1);
+
     shadingsys_options_set = true;
 }
 


### PR DESCRIPTION
Add support for generating debug information to track function call
stack, source file, and line number inside generated LLVM module.
When enabled, can debug with source and line numbers.  Also Intel(r)
VTune(tm) Profiler associated assembly to shader source and line
number.

The big upshot here is that when this debugging is enabled,

  * gdb/lldb can debug a renderer app, all the way down to inside JITed
    shaders.

  * Stack dumps upon a crash will show you the full stack trace
    including where you were in a shader.

  * Profilers such as vtune can be used to accurately profile shaders.

The profiling only works if your LLVM was built with the option
`-DLLVM_USE_INTEL_JITEVENTS=ON`.

Due to some ABI changes on the LLVM side, the debugging symbols only
work properly if you are using LLVM >= 7.1.

Some other specifics that got rolled into this:

New ShadingSystem attributes to control this: `llvm_debugging_symbols`
and `llvm_profiling_events`. Both default to 0 ordinarily, a renderer
needs to enable them, which we only recommend doing if the renderer
itself is compiled for debugging or profiling.  The testshade and
testrender program automatically enable these options.

Debugging features to dump struct layouts and validate LLVM struct
representation based off expected offsets populated from host versions
of the data structures:

    void dump_struct_data_layout(llvm::Type *Ty);
    void validate_struct_data_layout(llvm::Type *Ty,
    const vector & expected_offset_by_index);

Added op_functioncall_nr to as a noop with the name of the function
that was inlined. Previously constfolding would eliminate a
op_functioncall if it had no return value.  Now we transmute into a
op_functioncall_nr. There should be no real shader execution cost to
this, but now can debug through nested OSL shader level function
calls. We needed the op_functioncall_nr to trigger the creation of
debug info for an inlined function call.

When not debugging, don't waste by naming basic blocks.
