### PR TITLE
Refactor jit mem manager and perthread to prevent leaks

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -67,7 +67,7 @@ check_cwd (ShadingSystemImpl &shadingsys)
 BackendLLVM::BackendLLVM (ShadingSystemImpl &shadingsys,
                           ShaderGroup &group, ShadingContext *ctx)
     : OSOProcessorBase (shadingsys, group, ctx),
-      ll(llvm_debug(), shadingsys.m_vector_width),
+      ll(ctx->llvm_thread_info(), llvm_debug(), shadingsys.m_vector_width),
       m_stat_total_llvm_time(0), m_stat_llvm_setup_time(0),
       m_stat_llvm_irgen_time(0), m_stat_llvm_opt_time(0),
       m_stat_llvm_jit_time(0)

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -60,7 +60,8 @@ void
 test_int_func ()
 {
     // Setup
-    OSL::pvt::LLVM_Util ll;
+    OSL::pvt::LLVM_Util::PerThreadInfo  pti;
+    OSL::pvt::LLVM_Util ll(pti);
 
     // Make a function with prototype:   int myadd (int arg1, int arg2)
     // and make it the current function.
@@ -107,7 +108,8 @@ void
 test_triple_func ()
 {
     // Setup
-    OSL::pvt::LLVM_Util ll;
+    OSL::pvt::LLVM_Util::PerThreadInfo pti;
+    OSL::pvt::LLVM_Util ll(pti);
 
     // Make a function with prototype:   int myadd (int arg1, int arg2)
     // and make it the current function.
@@ -164,7 +166,8 @@ IntFuncOfTwoInts
 test_big_func (bool do_print=false)
 {
     // Setup
-    OSL::pvt::LLVM_Util ll;
+    OSL::pvt::LLVM_Util::PerThreadInfo pti;
+    OSL::pvt::LLVM_Util ll(pti);
 
     // Make a function with prototype:  int myadd (int arg1, int arg2)
     // and make it the current function in the current module.
@@ -214,7 +217,9 @@ test_big_func (bool do_print=false)
 void
 test_isa_features()
 {
-    OSL::pvt::LLVM_Util ll;
+    OSL::pvt::LLVM_Util::PerThreadInfo pti;
+    OSL::pvt::LLVM_Util ll(pti);
+
     ll.detect_cpu_features();
 
     // Make sure it matches what OIIO's cpuid queries reveal
@@ -234,6 +239,10 @@ int
 main (int argc, char *argv[])
 {
     getargs (argc, argv);
+
+    // This dummy object is the "owner" of the memory holding JITed code.
+    // It must outlive any LLVM_Util (and its PerThreadInfo).
+    OSL::pvt::LLVM_Util::ScopedJitMemoryUser llvm_jit_memory_user;
 
     test_isa_features();
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -33,6 +33,7 @@
 #endif
 
 #include <OSL/genclosure.h>
+#include <OSL/llvm_util.h>
 #include <OSL/oslexec.h>
 #include <OSL/oslclosure.h>
 #include <OSL/dual.h>
@@ -81,6 +82,7 @@ struct PerThreadInfo
     ShadingContext *pop_context ();  ///< Get the pool top and then pop
 
     std::stack<ShadingContext *> context_pool;
+    LLVM_Util::PerThreadInfo llvm_thread_info;
 };
 
 
@@ -854,6 +856,8 @@ private:
     atomic_int m_threads_currently_compiling;
     mutable std::map<ustring,long long> m_group_profile_times;
     // N.B. group_profile_times is protected by m_stat_mutex.
+
+    LLVM_Util::ScopedJitMemoryUser m_llvm_jit_memory_user;
 
     friend class OSL::ShadingContext;
     friend class ShaderMaster;
@@ -1686,6 +1690,10 @@ public:
 
     void texture_thread_info (TextureSystem::Perthread *t) {
         m_texture_thread_info = t;
+    }
+
+    const LLVM_Util::PerThreadInfo &llvm_thread_info () const {
+        return thread_info()->llvm_thread_info;
     }
 
     TextureOpt *texture_options_ptr () { return &m_textureopt; }


### PR DESCRIPTION
Work by Alex Wells.

Leaks are prevented now, though at the cost of a bit more housekeeping
on the part of the user of LLVM_Util.  Each thread must have its own
LLVM_Util::PerThreadInfo, which must outlive any LLVM_Util (and which
must be passed a reference of the PerThreadInfo). Also, there must
somewhere in the app exist a ScopedJitMemoryUser that must outlive all
of the LLVM_Utils.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
