### PR TITLE
Changes for LLVM-11.

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -149,6 +149,14 @@ ifeq (${SP_OS}, rhel7)
         LLVM_DIRECTORY := /shots/spi/home/software/packages/llvm/9.0.1-1/${SPI_COMPILER_PLATFORM}
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
                           -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+    else ifeq (${COMPILER},clang10)
+        LLVM_DIRECTORY := /shots/spi/home/software/packages/llvm/10.0.0-1/${SPI_COMPILER_PLATFORM}
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
+                          -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+    else ifeq (${COMPILER},clang11)
+        LLVM_DIRECTORY := /shots/spi/home/software/packages/llvm/11.0.0-rc1/${SPI_COMPILER_PLATFORM}
+        MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
+                          -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER}, gcc6)


### PR DESCRIPTION
For the most part, standard innocuous LLVM-style API changes, but:

`llvm::ConstantVector` constructor has changed, and while looking into how to migrate I came across `llvm::ConstantDataVector` which according to the docs uses less memory.  The only difference being that `llvm::ConstantVector` has a `llvm::Value` for each element, but it doesn't look like those individual `llvm::Value`s are used/needed ?