### PR TITLE
Proposal for debugging of invalid globals

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -238,6 +238,8 @@ BackendLLVM::llvm_global_symbol_ptr (ustring name)
     // we use the name of the global to find the index of the field within
     // the ShaderGlobals struct.
     int sg_index = ShaderGlobalNameToIndex (name);
+    if (sg_index < 0)
+        std::cerr << "shader global: " << name << " could not be found...." << std::endl;
     OSL_ASSERT (sg_index >= 0);
     return ll.void_ptr (ll.GEP (sg_ptr(), 0, sg_index));
 }


### PR DESCRIPTION
## Description

This PR is a suggestion to add something for debugging of invalid globals being added to shaders.

Currently, whenever an unknown global is encountered, the following is printed to the shell:
`llvm_global_symbol_ptr: Assertion 'sg_index >= 0' failed.`
and the entire process fails, which I think is probably too extreme.

It would be good to at least be able to identify when a global is invalid, and print some useful debug information to be able to track this down.

I doubt you'd want to put this in verbatim, however, consider it a simple identification of the issue, and a potential example of something that you might want to do.

## Tests

No, since this is just a suggestion.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

