### PR TITLE
Remove null check from symbol_address for performance

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -387,6 +387,7 @@ const void*
 ShadingSystem::symbol_address (const ShadingContext &ctx,
                                const ShaderSymbol *sym) const
 {
+    OSL_DASSERT(sym != nullptr);
     return ctx.symbol_data (*(const Symbol *)sym);
 }
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -387,7 +387,7 @@ const void*
 ShadingSystem::symbol_address (const ShadingContext &ctx,
                                const ShaderSymbol *sym) const
 {
-    return sym ? ctx.symbol_data (*(const Symbol *)sym) : NULL;
+    return ctx.symbol_data (*(const Symbol *)sym);
 }
 
 


### PR DESCRIPTION
## Description

In the case that an implementation designer wants to use the following pattern:

- Define "renderer_outputs" for a group to stop them from being optimized away
- compile the group
- collect the output parameters using ShadingSystem::find_symbol and store them somewhere in the renderer
- at runtime, after calling ShaderGlobals::execute, we call ShadingSystem::symbol_address for each output parameter to obtain our results

This being the case, we already know due to calling find_symbol that the symbols we later call symbol_address with are valid, so the overhead of a conditional for each and every call to symbol_address could be extremely high considering in this particular use case, the conditional will never be false, especially in a tight render loop where we collect a lot of results.

## Tests

TODO: validate that this change doesn't break anything.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

