### PR TITLE
Fix fmt vs Cuda incompatibility

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -20,10 +20,12 @@
 #include <OSL/Imathx/ImathColor.h>
 #include <OSL/matrix22.h>
 
-// Temporary bug fix: having trouble with cuda complaining about {fmt} lib.
-// Work around by disabling it from oiio headers.
+// The fmt library causes trouble for Cuda. Work around by disabling it from
+// oiio headers (OIIO <= 2.1) or telling fmt not to use the troublesome
+// int128 that Cuda doesn't understand (OIIO >= 2.2).
 #ifdef __CUDA_ARCH__
 #    define OIIO_USE_FMT 0
+#    define FMT_USE_INT128 0
 #endif
 
 // All the things we need from OpenImageIO


### PR DESCRIPTION
We used to disable fmt and fall back to tinyformat, when using Cuda.
The new OIIO 2.2 removes tinyformat and the OIIO_USE_FMT preprocessor
symbol. So make sure that we also tell fmt to avoid using the int128
type, not supported by Cuda. That seems to be enough to let it use
the rest of fmt without trouble.

