### PR TITLE
Use .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Start using clang-format on OSL code base (#1215)
+630b4c042d696c94ec9b2a1b6f5adc250bd61e05
+
+# More clang-format (#1218)
+bdb473cbdb119f3d9060d48f75f965cbd45f6d7a
+
+# More clang-format: liboslquery, oslinfo, oslc, osl.imageio, osltoy (#1220)
+bf366d7a90c46599b82071dac6dbef7c5e3ca157


### PR DESCRIPTION
This new file contains the hashes of commits whose only function was
to reformat large amounts of code.

Ordinarily, this would make for confusing 'git blame' output, by
making old code written by author A appear to have a new modification
date and authorship by B, when in fact we know that B just did some
reformatting. This can make it especially hard to discern code history
after after commits that establish the use of "clang-format".

A new git feature (requiring git >= 2.23) allows pointing to a file
containing hashes of commits to be ignored by git blame:

    git blame --ignore-revs-file .git-blame-ignore-revs

To avoid having to remember this all the time, consider adding this to
your git config:

    git config blame.ignoreRevsFile .git-blame-ignore-revs

Note that git supports this feature but does not dictate the name of
the file. I'm just following the convention I'm seeing pop up in other
projects of calling it ".git-blame-ignore-revs".

Signed-off-by: Larry Gritz <lg@larrygritz.com>
