### PR TITLE
Fix false positive in uninit test involving do-while loops

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -657,6 +657,14 @@ BackendLLVM::llvm_generate_debug_uninit (const Opcode &op)
             // don't generate uninit test code for it.
             continue;
         }
+        if (op.opname() == Strings::op_dowhile && i == 0) {
+            // The first argument of 'dowhile' is the condition temp, but
+            // most likely its initializer has not run yet. Unless there is
+            // no "condition" code block, in that case we should still test
+            // it for uninit.
+            if (op.jump(0) != op.jump(1))
+                continue;
+        }
 
         // Default: Check all elements of the variable being read
         llvm::Value *ncheck = ll.constant (int(t.numelements() * t.aggregate));


### PR DESCRIPTION
Work of Alex Wells.

Like we do already for "for" loops, when generating extra ops to test for
uninitialized values, "do-while" loops also need to skip testing of their
condition variable (which we know has not been written yet, under most
circumstances).
