### PR TITLE
Fix osoparse & osolex from two independent liboslexec.so

### DIFF
--- a/src/cmake/flexbison.cmake
+++ b/src/cmake/flexbison.cmake
@@ -22,8 +22,12 @@ checked_find_package (FLEX REQUIRED)
 
 if ( FLEX_EXECUTABLE AND BISON_EXECUTABLE )
     macro ( FLEX_BISON flexsrc bisonsrc prefix srclist compiler_headers )
+        # mangle osoparse & osolex symbols to avoid multiple library conflicts
+        add_definitions(-D${prefix}parse=${PROJ_NAMESPACE_V}_${prefix}parse -D${prefix}lex=${PROJ_NAMESPACE_V}_${prefix}lex)
+
         if (VERBOSE)
             message (STATUS "FLEX_BISON flex=${flexsrc} bison=${bisonsrc} prefix=${prefix}")
+            message (STATUS "FLEX_SYMBOLS ${PROJ_NAMESPACE_V}_${prefix}parse ${PROJ_NAMESPACE_V}_${prefix}lex")
         endif ()
         get_filename_component ( bisonsrc_we ${bisonsrc} NAME_WE )
         set ( bisonoutputcxx "${CMAKE_CURRENT_BINARY_DIR}/${bisonsrc_we}.cpp" )

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -281,6 +281,7 @@ OSOReader::parse_file (const std::string &filename)
     fclose (osoin);
     std::locale::global (oldlocale);  // Restore the original locale.
 
+    osoreader = nullptr; // Dont leave a dangling pointer to this
     return ok;
 }
 
@@ -314,6 +315,7 @@ OSOReader::parse_memory (const std::string &buffer)
     std::locale::global (oldlocale);  // Restore the original locale.
 #endif
 
+    osoreader = nullptr; // Dont leave a dangling pointer to this
     return ok;
 }
 


### PR DESCRIPTION
## Description
When two OSL distributions are loaded, they will both use the same `osoparse` and `osolex`functions.

Problematic because the OSOReader::parse_XXX function from _liboslexec_A.so_ will set the static variable `osoreader = this`, but then call `osoparse` in _liboslexec_B.so_, where the `osoreader` static is still NULL.

https://github.com/marsupial/OpenShadingLanguage/blob/62797a9032a73162a62e19d03261d7d8bd3a8ded/src/liboslexec/osolex.l#L263
https://github.com/marsupial/OpenShadingLanguage/blob/62797a9032a73162a62e19d03261d7d8bd3a8ded/src/liboslexec/osolex.l#L287

