### PR TITLE
Use 'final' liberally

### DIFF
--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -422,7 +422,7 @@ private:
 
 
 
-class ASTshader_declaration : public ASTNode {
+class ASTshader_declaration final : public ASTNode {
 public:
     ASTshader_declaration(OSLCompilerImpl* comp, int stype, ustring name,
                           ASTNode* form, ASTNode* stmts, ASTNode* meta);
@@ -444,7 +444,7 @@ private:
 
 
 
-class ASTfunction_declaration : public ASTNode {
+class ASTfunction_declaration final : public ASTNode {
 public:
     ASTfunction_declaration(OSLCompilerImpl* comp, TypeSpec type, ustring name,
                             ASTNode* form, ASTNode* stmts, ASTNode* meta,
@@ -474,7 +474,7 @@ private:
 
 
 
-class ASTvariable_declaration : public ASTNode {
+class ASTvariable_declaration final : public ASTNode {
 public:
     ASTvariable_declaration(OSLCompilerImpl* comp, const TypeSpec& type,
                             ustring name, ASTNode* init, bool isparam,
@@ -531,7 +531,7 @@ private:
 
 
 
-class ASTvariable_ref : public ASTNode {
+class ASTvariable_ref final : public ASTNode {
 public:
     ASTvariable_ref(OSLCompilerImpl* comp, ustring name);
     const char* nodetypename() const { return "variable_ref"; }
@@ -550,7 +550,7 @@ private:
 
 
 
-class ASTpreincdec : public ASTNode {
+class ASTpreincdec final : public ASTNode {
 public:
     ASTpreincdec(OSLCompilerImpl* comp, int op, ASTNode* expr);
     const char* nodetypename() const
@@ -566,7 +566,7 @@ public:
 
 
 
-class ASTpostincdec : public ASTNode {
+class ASTpostincdec final : public ASTNode {
 public:
     ASTpostincdec(OSLCompilerImpl* comp, int op, ASTNode* expr);
     const char* nodetypename() const
@@ -582,7 +582,7 @@ public:
 
 
 
-class ASTindex : public ASTNode {
+class ASTindex final : public ASTNode {
 public:
     // ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index);
     // ASTindex (OSLCompilerImpl *comp, ASTNode *expr, ASTNode *index, ASTNode *index2);
@@ -617,7 +617,7 @@ public:
 
 
 
-class ASTstructselect : public ASTNode {
+class ASTstructselect final : public ASTNode {
 public:
     ASTstructselect(OSLCompilerImpl* comp, ASTNode* expr, ustring field);
     const char* nodetypename() const { return "structselect"; }
@@ -653,7 +653,7 @@ private:
 
 
 
-class ASTconditional_statement : public ASTNode {
+class ASTconditional_statement final : public ASTNode {
 public:
     ASTconditional_statement(OSLCompilerImpl* comp, ASTNode* cond,
                              ASTNode* truestmt, ASTNode* falsestmt = NULL)
@@ -674,7 +674,7 @@ public:
 
 
 
-class ASTloop_statement : public ASTNode {
+class ASTloop_statement final : public ASTNode {
 public:
     enum LoopType { LoopWhile, LoopDo, LoopFor };
 
@@ -695,7 +695,7 @@ public:
 
 
 
-class ASTloopmod_statement : public ASTNode {
+class ASTloopmod_statement final : public ASTNode {
 public:
     enum LoopModType { LoopModBreak, LoopModContinue };
 
@@ -713,7 +713,7 @@ public:
 
 
 
-class ASTreturn_statement : public ASTNode {
+class ASTreturn_statement final : public ASTNode {
 public:
     ASTreturn_statement(OSLCompilerImpl* comp, ASTNode* expr)
         : ASTNode(return_statement_node, comp, 0, expr)
@@ -763,7 +763,8 @@ public:
 };
 
 
-class ASTcompound_initializer : public ASTtype_constructor {
+
+class ASTcompound_initializer final : public ASTtype_constructor {
     bool m_ctor;
 
     TypeSpec typecheck(TypeSpec expected, unsigned mode);
@@ -787,7 +788,7 @@ public:
 
 
 
-class ASTassign_expression : public ASTNode {
+class ASTassign_expression final : public ASTNode {
 public:
     ASTassign_expression(OSLCompilerImpl* comp, ASTNode* var, Operator op,
                          ASTNode* expr);
@@ -804,7 +805,7 @@ public:
 
 
 
-class ASTunary_expression : public ASTNode {
+class ASTunary_expression final : public ASTNode {
 public:
     ASTunary_expression(OSLCompilerImpl* comp, int op, ASTNode* expr);
 
@@ -823,7 +824,7 @@ private:
 
 
 
-class ASTbinary_expression : public ASTNode {
+class ASTbinary_expression final : public ASTNode {
 public:
     ASTbinary_expression(OSLCompilerImpl* comp, Operator op, ASTNode* left,
                          ASTNode* right);
@@ -847,7 +848,7 @@ private:
 
 
 
-class ASTternary_expression : public ASTNode {
+class ASTternary_expression final : public ASTNode {
 public:
     ASTternary_expression(OSLCompilerImpl* comp, ASTNode* cond,
                           ASTNode* trueexpr, ASTNode* falseexpr)
@@ -867,7 +868,7 @@ public:
 
 
 
-class ASTcomma_operator : public ASTNode {
+class ASTcomma_operator final : public ASTNode {
 public:
     ASTcomma_operator(OSLCompilerImpl* comp, ASTNode* exprlist)
         : ASTNode(comma_operator_node, comp, Nothing, exprlist)
@@ -884,7 +885,7 @@ public:
 
 
 
-class ASTtypecast_expression : public ASTNode {
+class ASTtypecast_expression final : public ASTNode {
 public:
     ASTtypecast_expression(OSLCompilerImpl* comp, TypeSpec typespec,
                            ASTNode* expr)
@@ -903,7 +904,7 @@ public:
 
 
 
-class ASTfunction_call : public ASTNode {
+class ASTfunction_call final : public ASTNode {
 public:
     ASTfunction_call(OSLCompilerImpl* comp, ustring name, ASTNode* args,
                      FunctionSymbol* funcsym = nullptr);
@@ -1019,7 +1020,7 @@ private:
 
 
 
-class ASTliteral : public ASTNode {
+class ASTliteral final : public ASTNode {
 public:
     ASTliteral(OSLCompilerImpl* comp, int i)
         : ASTNode(literal_node, comp), m_i(i)

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -34,7 +34,7 @@ typedef std::vector<std::shared_ptr<StructSpec>> StructList;
 /// Subclass of Symbol used just for functions, which are different
 /// because they can be polymorphic, and also need to carry around more
 /// information than other symbols.
-class FunctionSymbol : public Symbol {
+class FunctionSymbol final : public Symbol {
 public:
     FunctionSymbol(ustring n, TypeSpec type, ASTNode* node = NULL)
         : Symbol(n, type, SymTypeFunction, node)
@@ -112,7 +112,7 @@ private:
 /// general case (like arrays), it allocates memory and uses the
 /// parent class's fields m_data and m_data_free, which will also cause
 /// the parent class to properly free it upon destruction.
-class ConstantSymbol : public Symbol {
+class ConstantSymbol final : public Symbol {
 public:
     ConstantSymbol(ustring n, ustring val)
         : Symbol(n, TypeDesc::TypeString, SymTypeConst)

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -19,7 +19,7 @@ typedef struct
 
 // This is a fake AOV implementation. It will just keep track
 // of what test cases wrote to it
-class MyAov : public Aov
+class MyAov final : public Aov
 {
     public:
         MyAov(const TestPath *test, int id)

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -28,7 +28,7 @@ namespace pvt {   // OSL::pvt
 
 /// OSOProcessor that generates LLVM IR and JITs it to give machine
 /// code to implement a shader group.
-class BackendLLVM : public OSOProcessorBase {
+class BackendLLVM final : public OSOProcessorBase {
 public:
     BackendLLVM (ShadingSystemImpl &shadingsys, ShaderGroup &group,
                 ShadingContext *context);

--- a/src/liboslexec/llvm_passes.h
+++ b/src/liboslexec/llvm_passes.h
@@ -38,7 +38,7 @@ namespace {
 // Also if future LLVM version takes on the work of this optimization pass,
 // then it may be removed.
 template <int WidthT>
-class PreventBitMasksFromBeingLiveinsToBasicBlocks
+class PreventBitMasksFromBeingLiveinsToBasicBlocks final
     : public llvm::FunctionPass
 {
     typedef llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> IRBuilder;
@@ -307,7 +307,7 @@ public:
 
 
 template <int WidthT>
-class PrePromoteLogicalOpsOnBitMasks
+class PrePromoteLogicalOpsOnBitMasks final
     : public llvm::FunctionPass
 {
     typedef llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> IRBuilder;

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -214,7 +214,7 @@ LLVM_Util::total_jit_memory_held ()
 /// MemoryManager - Create a shell that passes on requests
 /// to a real LLVMMemoryManager underneath, but can be retained after the
 /// dummy is destroyed.  Also, we don't pass along any deallocations.
-class LLVM_Util::MemoryManager : public LLVMMemoryManager {
+class LLVM_Util::MemoryManager final : public LLVMMemoryManager {
 protected:
     LLVMMemoryManager *mm;  // the real one
 public:
@@ -290,7 +290,7 @@ public:
 
 
 
-class LLVM_Util::IRBuilder : public llvm::IRBuilder<llvm::ConstantFolder,
+class LLVM_Util::IRBuilder final : public llvm::IRBuilder<llvm::ConstantFolder,
                                                llvm::IRBuilderDefaultInserter> {
     typedef llvm::IRBuilder<llvm::ConstantFolder,
                             llvm::IRBuilderDefaultInserter> Base;

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -25,7 +25,7 @@ namespace pvt {   // OSL::pvt
 
 /// Custom subclass of OSOReader that provide callbacks that set all the
 /// right fields in the ShaderMaster.
-class OSOReaderToMaster : public OSOReader
+class OSOReaderToMaster final : public OSOReader
 {
 public:
     OSOReaderToMaster (ShadingSystemImpl &shadingsys)

--- a/src/liboslexec/lpexp.h
+++ b/src/liboslexec/lpexp.h
@@ -65,7 +65,7 @@ class LPexp {
 
 
 /// LPexp concatenation
-class Cat : public LPexp {
+class Cat final : public LPexp {
     public:
         virtual ~Cat();
         void append(LPexp *regexp);
@@ -80,7 +80,7 @@ class Cat : public LPexp {
 
 
 /// Basic symbol like G or 'customlabel'
-class Symbol : public LPexp {
+class Symbol final : public LPexp {
     public:
         Symbol(ustring sym) { m_sym = sym; };
         virtual ~Symbol() {};
@@ -99,7 +99,7 @@ class Symbol : public LPexp {
 /// Wildcard regexp
 ///
 /// Named like this to avoid confusion with the automata Wildcard class
-class Wildexp : public LPexp {
+class Wildexp final : public LPexp {
     public:
         Wildexp(SymbolSet &minus):m_wildcard(minus) {};
         virtual ~Wildexp() {};
@@ -116,7 +116,7 @@ class Wildexp : public LPexp {
 
 
 /// Ored list of expressions
-class Orlist : public LPexp {
+class Orlist final : public LPexp {
     public:
         virtual ~Orlist();
         void append(LPexp *regexp);
@@ -131,7 +131,7 @@ class Orlist : public LPexp {
 
 
 // Unlimited repeat: (exp)*
-class Repeat : public LPexp {
+class Repeat final : public LPexp {
     public:
         Repeat(LPexp *child):m_child(child) {};
         virtual ~Repeat() { delete m_child; };
@@ -146,7 +146,7 @@ class Repeat : public LPexp {
 
 
 // Bounded repeat: (exp){m,n}
-class NRepeat : public LPexp {
+class NRepeat final : public LPexp {
     public:
         NRepeat(LPexp *child, int min, int max):m_child(child),m_min(min),m_max(max) {};
         virtual ~NRepeat() { delete m_child; };

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -304,7 +304,7 @@ inline off_t vectorbytes (const std::vector<T> &v)
 /// shader that would be a .oso file on disk: symbols, instructions,
 /// arguments, you name it.  A master copy is shared by all the
 /// individual instances of the shader.
-class ShaderMaster : public RefCnt {
+class ShaderMaster final : public RefCnt {
 public:
     typedef OIIO::intrusive_ptr<ShaderMaster> ref;
     ShaderMaster (ShadingSystemImpl &shadingsys);

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -32,7 +32,7 @@ typedef std::set<int> FastIntSet;
 
 
 /// OSOProcessor that does runtime optimization on shaders.
-class RuntimeOptimizer : public OSOProcessorBase {
+class RuntimeOptimizer final : public OSOProcessorBase {
 public:
     RuntimeOptimizer (ShadingSystemImpl &shadingsys, ShaderGroup &group,
                       ShadingContext *context);

--- a/src/liboslquery/oslquery.cpp
+++ b/src/liboslquery/oslquery.cpp
@@ -25,7 +25,7 @@ namespace pvt {
 
 // Custom subclass of OSOReader that just reads the .oso file and fills
 // out the right fields in the OSLQuery.
-class OSOReaderQuery : public OSOReader {
+class OSOReaderQuery final : public OSOReader {
 public:
     OSOReaderQuery(OSLQuery& query)
         : m_query(query), m_reading_param(false), m_default_values(0)

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -55,7 +55,7 @@ OSL_NAMESPACE_ENTER
 ///
 
 
-class OSLInput : public ImageInput {
+class OSLInput final : public ImageInput {
 public:
     OSLInput();
     virtual ~OSLInput();
@@ -137,7 +137,7 @@ OIIO_PLUGIN_EXPORTS_END
 namespace pvt {
 
 
-class OIIO_RendererServices : public RendererServices {
+class OIIO_RendererServices final : public RendererServices {
 public:
     OIIO_RendererServices(TextureSystem* texsys = NULL)
         : RendererServices(texsys)
@@ -192,7 +192,7 @@ public:
 
 
 
-class ErrorRecorder : public OIIO::ErrorHandler {
+class ErrorRecorder final : public OIIO::ErrorHandler {
 public:
     ErrorRecorder() : ErrorHandler() {}
     virtual void operator()(int errcode, const std::string& msg)

--- a/src/oslc/oslcmain.cpp
+++ b/src/oslc/oslcmain.cpp
@@ -53,7 +53,7 @@ namespace {  // anonymous
 // Subclass ErrorHandler because we want our messages to appear somewhat
 // differant than the default ErrorHandler base class, in order to match
 // typical compiler command line messages.
-class OSLC_ErrorHandler : public ErrorHandler {
+class OSLC_ErrorHandler final : public ErrorHandler {
 public:
     virtual void operator()(int errcode, const std::string& msg)
     {

--- a/src/osltoy/codeeditor.h
+++ b/src/osltoy/codeeditor.h
@@ -52,7 +52,7 @@ class QWidget;
 class LineNumberArea;
 
 
-class CodeEditor : public QPlainTextEdit {
+class CodeEditor final : public QPlainTextEdit {
     Q_OBJECT
 
 public:
@@ -90,7 +90,7 @@ private:
 
 
 
-class LineNumberArea : public QWidget {
+class LineNumberArea final : public QWidget {
 public:
     LineNumberArea(CodeEditor* editor) : QWidget(editor)
     {

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -52,7 +52,7 @@
 OSL_NAMESPACE_ENTER
 using namespace QtUtils;
 
-class ValueSlider : public QSlider {
+class ValueSlider final : public QSlider {
 public:
     ValueSlider(Qt::Orientation orientation, QWidget* parent)
         : QSlider(orientation, parent)
@@ -101,7 +101,7 @@ struct PixelInfo {
 };
 
 
-class Magnifier : public QWidget {
+class Magnifier final : public QWidget {
     QLabel* m_image;
     QLabel* m_info;
     OSLToyRenderView* m_renderview;
@@ -196,7 +196,7 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
 };
 
-class OSLToyRenderView : public QLabel {
+class OSLToyRenderView final : public QLabel {
     Magnifier* m_magnifier;
     OIIO::ImageBuf m_framebuffer;
 
@@ -803,7 +803,7 @@ OSLToyMainWindow::osl_do_rerender(float /*frametime*/)
 
 
 
-class MyOSLCErrorHandler : public OIIO::ErrorHandler {
+class MyOSLCErrorHandler final : public OIIO::ErrorHandler {
 public:
     MyOSLCErrorHandler(OSLToyMainWindow* osltoy) : osltoy(osltoy) {}
     virtual void operator()(int /*errcode*/, const std::string& msg)

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -38,7 +38,7 @@ class OSLToyRenderer;
 
 
 
-class ParamRec : public OSLQuery::Parameter {
+class ParamRec final : public OSLQuery::Parameter {
 public:
     using Parameter = OSLQuery::Parameter;
     // Inherits everything from OSLQuery::Parameter, and...
@@ -53,7 +53,7 @@ public:
 
 class OSLToyRenderView;
 
-class OSLToyMainWindow : public QMainWindow {
+class OSLToyMainWindow final : public QMainWindow {
     Q_OBJECT
 
 

--- a/src/osltoy/osltoyrenderer.h
+++ b/src/osltoy/osltoyrenderer.h
@@ -18,7 +18,7 @@ OSL_NAMESPACE_ENTER
 
 
 
-class OSLToyRenderer : public RendererServices {
+class OSLToyRenderer final : public RendererServices {
 public:
     // Just use 4x4 matrix for transformations
     typedef Matrix44 Transformation;

--- a/src/osltoy/qtutils.h
+++ b/src/osltoy/qtutils.h
@@ -122,7 +122,7 @@ ImageBuf_to_QImage(const OIIO::ImageBuf& ib)
 /// * KeyboardTracking turned off by default, so if you edit the value as
 ///   text, the change doesn't take effect until you hit enter or focus
 ///   on a different widget.
-class DoubleSpinBox : public QDoubleSpinBox {
+class DoubleSpinBox final : public QDoubleSpinBox {
 public:
     typedef QDoubleSpinBox parent_t;
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -15,7 +15,7 @@
 OSL_NAMESPACE_ENTER
 
 
-class OptixRaytracer : public SimpleRaytracer
+class OptixRaytracer final : public SimpleRaytracer
 {
 public:
     // Just use 4x4 matrix for transformations

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -146,7 +146,7 @@ private:
 };
 
 
-struct Sphere : public Primitive {
+struct Sphere final : public Primitive {
     Sphere(Vec3 c, float r, int shaderID, bool isLight)
         : Primitive(shaderID, isLight), c(c), r2(r * r) {
         OSL_DASSERT(r > 0);
@@ -274,7 +274,7 @@ private:
 
 
 
-struct Quad : public Primitive {
+struct Quad final : public Primitive {
     Quad(const Vec3& p, const Vec3& ex, const Vec3& ey, int shaderID, bool isLight)
         : Primitive(shaderID, isLight), p(p), ex(ex), ey(ey) {
         n = ex.cross(ey);

--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -107,7 +107,7 @@ OSL_NAMESPACE_EXIT
 namespace { // anonymous namespace
 
 template <int trans>
-struct Diffuse : public BSDF, DiffuseParams {
+struct Diffuse final : public BSDF, DiffuseParams {
     Diffuse(const DiffuseParams& params) : BSDF(), DiffuseParams(params) { if (trans) N = -N; }
     virtual float eval  (const OSL::ShaderGlobals& /*sg*/, const OSL::Vec3& wi, float& pdf) const {
         pdf = std::max(N.dot(wi), 0.0f) * float(M_1_PI);
@@ -121,7 +121,7 @@ struct Diffuse : public BSDF, DiffuseParams {
     }
 };
 
-struct OrenNayar : public BSDF, OrenNayarParams {
+struct OrenNayar final : public BSDF, OrenNayarParams {
    OrenNayar(const OrenNayarParams& params) : BSDF(), OrenNayarParams(params) {
       // precompute some constants
       float s2 = sigma * sigma;
@@ -164,7 +164,7 @@ private:
    float A, B;
 };
 
-struct Phong : public BSDF, PhongParams {
+struct Phong final : public BSDF, PhongParams {
     Phong(const PhongParams& params) : BSDF(), PhongParams(params) {}
     virtual float eval  (const OSL::ShaderGlobals& sg, const OSL::Vec3& wi, float& pdf) const {
         float cosNI =  N.dot(wi);
@@ -205,7 +205,7 @@ struct Phong : public BSDF, PhongParams {
     }
 };
 
-struct Ward : public BSDF, WardParams {
+struct Ward final : public BSDF, WardParams {
     Ward(const WardParams& params) : BSDF(), WardParams(params) {}
     virtual float eval  (const OSL::ShaderGlobals& sg, const OSL::Vec3& wi, float& pdf) const {
         float cosNO = -N.dot(sg.I);
@@ -389,7 +389,7 @@ struct BeckmannDist {
 
 
 template <typename Distribution, int Refract>
-struct Microfacet : public BSDF, MicrofacetParams {
+struct Microfacet final : public BSDF, MicrofacetParams {
     Microfacet(const MicrofacetParams& params) : BSDF(),
         MicrofacetParams(params),
         tf(U == Vec3(0) || xalpha == yalpha ? TangentFrame(N) : TangentFrame(N, U)) { }
@@ -599,7 +599,7 @@ typedef Microfacet<BeckmannDist, 0> MicrofacetBeckmannRefl;
 typedef Microfacet<BeckmannDist, 1> MicrofacetBeckmannRefr;
 typedef Microfacet<BeckmannDist, 2> MicrofacetBeckmannBoth;
 
-struct Reflection : public BSDF, ReflectionParams {
+struct Reflection final : public BSDF, ReflectionParams {
     Reflection(const ReflectionParams& params) : BSDF(), ReflectionParams(params) {}
     virtual float albedo(const ShaderGlobals& sg) const {
         float cosNO = -N.dot(sg.I);
@@ -623,7 +623,7 @@ struct Reflection : public BSDF, ReflectionParams {
     }
 };
 
-struct Refraction : public BSDF, RefractionParams {
+struct Refraction final : public BSDF, RefractionParams {
     Refraction(const RefractionParams& params) : BSDF(), RefractionParams(params) {}
     virtual float albedo(const ShaderGlobals& sg) const {
         float cosNO = -N.dot(sg.I);
@@ -639,7 +639,7 @@ struct Refraction : public BSDF, RefractionParams {
     }
 };
 
-struct Transparent : public BSDF {
+struct Transparent final : public BSDF {
     Transparent(const int& /*dummy*/) : BSDF() {}
     virtual float eval  (const OSL::ShaderGlobals& /*sg*/, const OSL::Vec3& /*wi*/, float& pdf) const {
         return pdf = 0;

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -29,7 +29,7 @@ static TypeDesc TypeIntArray2 (TypeDesc::INT, 2);
 
 
 // Subclass ErrorHandler
-class SimpleRaytracer::ErrorHandler : public OIIO::ErrorHandler
+class SimpleRaytracer::ErrorHandler final : public OIIO::ErrorHandler
 {
 public:
     ErrorHandler (SimpleRaytracer& rend) : m_rend(rend) { }

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -15,7 +15,7 @@
 OSL_NAMESPACE_ENTER
 
 
-class OptixGridRenderer : public SimpleRenderer
+class OptixGridRenderer final : public SimpleRenderer
 {
 public:
     // Just use 4x4 matrix for transformations

--- a/testsuite/example-deformer/osldeformer.cpp
+++ b/testsuite/example-deformer/osldeformer.cpp
@@ -94,7 +94,7 @@ struct MyUserData {
 // how "userdata" is retrieved. We set up a subclass that overloads
 // get_userdata() to retrieve it from a per-point MyUserData that whose
 // pointer is stored in shaderglobals.renderstate.
-class MyRendererServices : public OSL::RendererServices {
+class MyRendererServices final : public OSL::RendererServices {
 public:
     virtual bool get_userdata (bool derivatives, OSL::ustring name,
                                OSL::TypeDesc type, OSL::ShaderGlobals *sg,


### PR DESCRIPTION
This is good for optimization, allowing "de-virtualization" of function
calls in cases when the compiler can be sure that there can be no further
subclassing.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
