### PR TITLE
pugixml build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           OPENEXR_VERSION: v2.5.3
           OPENIMAGEIO_VERSION: master
           OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
+          PUGIXML_VERSION: v1.10
           PYBIND11_VERSION: v2.5.0
         run: |
             source src/build-scripts/ci-startup.bash
@@ -196,6 +197,7 @@ jobs:
           OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=master
           OPENCOLORIO_VERSION: master
           PYBIND11_VERSION: master
+          PUGIXML_VERSION: master
           OSL_BUILD_MATERIALX: 1
         run: |
             source src/build-scripts/ci-startup.bash
@@ -225,6 +227,7 @@ jobs:
           USE_SIMD: 0
           USE_PYTHON: 0
           OPENIMAGEIO_VERSION: RB-2.1
+          PUGIXML_VERSION: v1.8
         run: |
             # Remove pesky wrong installed OIIO version
             rm -rf /usr/local/include/OpenImageIO

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -11,15 +11,15 @@ set -ex
 
 # Repo and branch/tag/commit of pugixml to download if we don't have it yet
 PUGIXML_REPO=${PUGIXML_REPO:=https://github.com/zeux/pugixml.git}
-PUGIXML_VERSION=${PUGIXML_VERSION:=1.10}
-PUGIXML_BRANCH=${PUGIXML_BRANCH:=v${PUGIXML_VERSION}}
+PUGIXML_VERSION=${PUGIXML_VERSION:=v1.10}
 
 # Where to put pugixml repo source (default to the ext area)
 PUGIXML_SRC_DIR=${PUGIXML_SRC_DIR:=${PWD}/ext/pugixml}
 # Temp build area (default to a build/ subdir under source)
 PUGIXML_BUILD_DIR=${PUGIXML_BUILD_DIR:=${PUGIXML_SRC_DIR}/build}
 # Install area for pugixml (default to ext/dist)
-PUGIXML_INSTALL_DIR=${PUGIXML_INSTALL_DIR:=${PWD}/ext/dist}
+LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
+PUGIXML_INSTALL_DIR=${PUGIXML_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 #PUGIXML_BUILD_OPTS=${PUGIXML_BUILD_OPTS:=}
 
 pwd
@@ -34,14 +34,15 @@ if [[ ! -e ${PUGIXML_SRC_DIR} ]] ; then
     git clone ${PUGIXML_REPO} ${PUGIXML_SRC_DIR}
 fi
 cd ${PUGIXML_SRC_DIR}
-echo "git checkout ${PUGIXML_BRANCH} --force"
-git checkout ${PUGIXML_BRANCH} --force
+echo "git checkout ${PUGIXML_VERSION} --force"
+git checkout ${PUGIXML_VERSION} --force
 
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}
 time cmake --config Release \
            -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
+           -DBUILD_SHARED_LIBS=ON \
            -DBUILD_TESTS=OFF \
            ${PUGIXML_BUILD_OPTS} ..
 time cmake --build . --config Release --target install
@@ -55,4 +56,4 @@ popd
 # Set up paths. These will only affect the caller if this script is
 # run with 'source' rather than in a separate shell.
 export pugixml_ROOT=$PUGIXML_INSTALL_DIR
-
+export LD_LIBRARY_PATH=$pugixml_ROOT/lib:$pugixml_ROOT/lib64:$LD_LIBRARY_PATH

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -40,6 +40,14 @@ popd
 #make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config
 #make $MAKEFLAGS $PAR_MAKEFLAGS $BUILD_FLAGS $BUILDTARGET
 
+if [[ "${DEBUG_CI:=0}" != "0" ]] ; then
+    echo "PATH=$PATH"
+    echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+    echo "PYTHONPATH=$PYTHONPATH"
+    echo "ldd testshade"
+    ldd $OSL_ROOT/bin/testshade
+fi
+
 if [[ "$SKIP_TESTS" == "" ]] ; then
     $OSL_ROOT/bin/testshade --help
     export OIIO_LIBRARY_PATH=$OSL_ROOT/lib:$OIIO_LIBRARY_PATH

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -68,10 +68,18 @@ export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:=${PARALLEL}}
 export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:=${PARALLEL}}
 
 export LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=$HOME/ext}
-export CMAKE_PREFIX_PATH=${LOCAL_DEPS_DIR}:${CMAKE_PREFIX_PATH}
+export CMAKE_PREFIX_PATH=${LOCAL_DEPS_DIR}/dist:${CMAKE_PREFIX_PATH}
+export LD_LIBRARY_PATH=${LOCAL_DEPS_DIR}/dist/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${LOCAL_DEPS_DIR}/dist/lib64:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=${LOCAL_DEPS_DIR}/dist/lib:$DYLD_LIBRARY_PATH
 
-uname -a
-uname -n
+echo "HOME = $HOME"
+echo "PWD = $PWD"
+echo "LOCAL_DEPS_DIR = $LOCAL_DEPS_DIR"
+echo "uname -a: " `uname -a`
+echo "uname -m: " `uname -m`
+echo "uname -s: " `uname -s`
+echo "uname -n: " `uname -n`
 pwd
 ls
 env | sort

--- a/src/build-scripts/gh-installdeps-centos.bash
+++ b/src/build-scripts/gh-installdeps-centos.bash
@@ -37,7 +37,7 @@ fi
 
 source src/build-scripts/build_pybind11.bash
 
-CXXFLAGS=-fPIC src/build-scripts/build_pugixml.bash
+source src/build-scripts/build_pugixml.bash
 
 # Only build OpenEXR if a specific version is requested
 if [[ "$OPENEXR_VERSION" != "" ]] ; then

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -62,7 +62,7 @@ source src/build-scripts/build_llvm.bash
 # Build pybind11
 CXX="ccache $CXX" source src/build-scripts/build_pybind11.bash
 
-CXXFLAGS=-fPIC src/build-scripts/build_pugixml.bash
+source src/build-scripts/build_pugixml.bash
 
 if [[ "$OPENEXR_VERSION" != "" ]] ; then
     CXX="ccache $CXX" source src/build-scripts/build_openexr.bash

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -8,23 +8,8 @@
 
 # When not in VERBOSE mode, try to make things as quiet as possible
 if (NOT VERBOSE)
-    set (Bison_FIND_QUIETLY true)
-    set (Boost_FIND_QUIETLY true)
-    set (Curses_FIND_QUIETLY true)
-    set (Flex_FIND_QUIETLY true)
-    # set (LLVM_FIND_QUIETLY true)
-    set (OpenEXR_FIND_QUIETLY true)
-    # set (OpenImageIO_FIND_QUIETLY true)
-    # set (Partio_FIND_QUIETLY true)
     set (PkgConfig_FIND_QUIETLY true)
-    set (PugiXML_FIND_QUIETLY TRUE)
-    set (PythonInterp_FIND_QUIETLY true)
-    set (PythonLibs_FIND_QUIETLY true)
-    set (Qt5_FIND_QUIETLY true)
     set (Threads_FIND_QUIETLY true)
-    set (ZLIB_FIND_QUIETLY true)
-    set (CUDA_FIND_QUIETLY true)
-    set (OptiX_FIND_QUIETLY true)
 endif ()
 
 message (STATUS "${ColorBoldWhite}")
@@ -111,7 +96,7 @@ endif ()
 checked_find_package (OpenImageIO 2.1.9 REQUIRED)
 
 
-checked_find_package (pugixml REQUIRED)
+checked_find_package (pugixml 1.8 REQUIRED)
 
 
 # LLVM library setup

--- a/src/cmake/modules/Findpugixml.cmake
+++ b/src/cmake/modules/Findpugixml.cmake
@@ -1,0 +1,81 @@
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+# Find the pugixml XML parsing library.
+#
+# Sets the usual variables expected for find_package scripts:
+#
+# PUGIXML_INCLUDES - header location
+# PUGIXML_LIBRARIES - library to link against
+# PUGIXML_FOUND - true if pugixml was found.
+
+# First try the config files and hope they're good enough
+find_package (pugixml CONFIG)
+
+if (TARGET pugixml::pugixml)
+    # New pugixml (>= 1.11) has nice config files we can rely on and makes a
+    # pugixml::pugixml target.
+    message (STATUS "Found CONFIG for pugixml (>=1.11)")
+
+    set (PUGIXML_FOUND true)
+    set (pugixml_FOUND true)
+    get_target_property(PUGIXML_INCLUDES pugixml::pugixml INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(PUGIXML_LIBRARIES pugixml::pugixml INTERFACE_LINK_LIBRARIES)
+
+# elseif (TARGET pugixml)
+#     # But older pugixml (<= 1.10) has mediocre config files that are not
+#     # reliable in practice. They also only define a "pugixml" target but
+#     # not "pugixml::pugixml". So just fall through to the "no config" case
+#     # below, and figure everything out by hand.
+
+else ()
+    # If no config file is found for PugiXML, do it the old fashioned way.
+    find_path (PUGIXML_INCLUDE_DIR
+               NAMES pugixml.hpp
+               #HINTS ${OpenImageIO_INCLUDE_DIR}/detail/pugixml
+               PATH_SUFFIXES pugixml-1.8 pugixml-1.9 pugixml-1.10)
+    message(STATUS "1 PUGIXML_INCLUDE_DIR ${PUGIXML_INCLUDE_DIR}")
+    set (pugixml_required_vars PUGIXML_INCLUDE_DIR)
+    find_library (PUGIXML_LIBRARY
+                  NAMES pugixml
+                  PATH_SUFFIXES pugixml-1.8 pugixml-1.9 pugixml-1.10)
+    message(STATUS "1 PUGIXML_LIBRARY ${PUGIXML_LIBRARY}")
+
+    if (PUGIXML_INCLUDE_DIR)
+        file (STRINGS "${PUGIXML_INCLUDE_DIR}/pugixml.hpp" TMP REGEX "define PUGIXML_VERSION .*$")
+        string (REGEX MATCHALL "[0-9]+" PUGIXML_CODED_VERSION ${TMP})
+        if (PUGIXML_CODED_VERSION VERSION_GREATER_EQUAL 1000)
+            math (EXPR PUGIXML_VERSION_MAJOR "${PUGIXML_CODED_VERSION} / 1000")
+            math (EXPR PUGIXML_VERSION_MINOR "(${PUGIXML_CODED_VERSION} % 1000) / 10")
+        else ()
+            math (EXPR PUGIXML_VERSION_MAJOR "${PUGIXML_CODED_VERSION} / 100")
+            math (EXPR PUGIXML_VERSION_MINOR "(${PUGIXML_CODED_VERSION} % 100) / 10")
+        endif ()
+        set (PUGIXML_VERSION ${PUGIXML_VERSION_MAJOR}.${PUGIXML_VERSION_MINOR})
+    endif ()
+
+    # Support the REQUIRED and QUIET arguments, and set PUGIXML_FOUND if found.
+    include (FindPackageHandleStandardArgs)
+    find_package_handle_standard_args (pugixml DEFAULT_MSG
+                                       #PUGIXML_LIBRARY
+                                       PUGIXML_INCLUDE_DIR)
+
+    if (PUGIXML_FOUND OR pugixml_FOUND)
+        set (PUGIXML_INCLUDES ${PUGIXML_INCLUDE_DIR})
+        set (PUGIXML_LIBRARIES ${PUGIXML_LIBRARY})
+
+        if (NOT TARGET pugixml::pugixml)
+            add_library(pugixml::pugixml UNKNOWN IMPORTED)
+            set_target_properties(pugixml::pugixml PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${PUGIXML_INCLUDES}")
+            if (PUGIXML_LIBRARIES)
+                set_property(TARGET pugixml::pugixml APPEND PROPERTY
+                    IMPORTED_LOCATION "${PUGIXML_LIBRARIES}")
+            endif ()
+        endif ()
+    endif ()
+
+    mark_as_advanced (PUGIXML_LIBRARY PUGIXML_INCLUDE_DIR)
+
+endif()

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -213,7 +213,7 @@ target_link_libraries (${local_lib}
         OpenImageIO::OpenImageIO
         ${ILMBASE_LIBRARIES}
     PRIVATE
-        pugixml
+        pugixml::pugixml
         ${ZLIB_LIBRARIES}
         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES}

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -148,13 +148,12 @@ Dictionary::get_document_index (ustring dictionaryname)
         pugi::xml_document *doc = new pugi::xml_document;
         m_documents.push_back (doc);
         pugi::xml_parse_result parse_result;
-        if (Strutil::ends_with (dictionaryname.string(), ".xml")) {
+        if (Strutil::ends_with(dictionaryname, ".xml")) {
             // xml file -- read it
             parse_result = doc->load_file (dictionaryname.c_str());
         } else {
             // load xml directly from the string
-            parse_result = doc->load_buffer (dictionaryname.c_str(),
-                                             dictionaryname.length());
+            parse_result = doc->load_string(dictionaryname.c_str());
         }
         if (! parse_result) {
             m_context->errorf("XML parsed with errors: %s, at offset %d",

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -44,7 +44,7 @@ add_executable (testrender ${testrender_srcs})
 target_link_libraries (testrender
     PRIVATE
         oslexec oslquery
-        pugixml)
+        pugixml::pugixml)
 
 osl_optix_target (testrender)
 


### PR DESCRIPTION
In OIIO land, some users pointed out deficiencies in our build
scripts and how they find (or fail to find) pugixml on some platforms and
circumstances. This is an OSL side copy of the approach that seems to
fix things.

* Bring back the idea of a Findpugixml.cmake file because it turns out
  that (for pugixml <= 1.10) the exported config files are not reliable.

* Fix CI scripts to build PugiXML (with a few different versions). We
  previously were relying on the embedded version for all CI tests, which
  masked problems associated with using an external PugiXML.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

