### PR TITLE
Windows compile fixes

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -75,7 +75,7 @@ enum class TargetISA
 /// tied to OSL internals at all.
 class OSLEXECPUBLIC LLVM_Util {
 public:
-    struct PerThreadInfo {
+    struct OSLEXECPUBLIC PerThreadInfo {
         PerThreadInfo() {}
         ~PerThreadInfo();
     private:
@@ -94,7 +94,7 @@ public:
     // controlled by the the existence of ScopedJitMemoryUser objects.
     // When the last ScopedJitMemoryUser goes out of scope or is deleted,
     // then the underlying memory managers will be deleted
-    struct ScopedJitMemoryUser {
+    struct OSLEXECPUBLIC ScopedJitMemoryUser {
         ScopedJitMemoryUser();
         ~ScopedJitMemoryUser();
     };

--- a/src/liboslcomp/CMakeLists.txt
+++ b/src/liboslcomp/CMakeLists.txt
@@ -22,7 +22,6 @@ target_include_directories(${local_lib}
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
         ${ILMBASE_INCLUDES}
     )
-target_compile_definitions (${local_lib} PRIVATE OSL_EXPORTS)
 target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO
@@ -31,6 +30,11 @@ target_link_libraries (${local_lib}
         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
         ${LLVM_SYSTEM_LIBRARIES})
+
+# link with (system) library to prevent missing symbols inside clangDriver.lib
+if (MSVC)
+    target_link_libraries (${local_lib} PRIVATE "Version.lib")
+endif()
 
 set_target_properties (${local_lib}
     PROPERTIES

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -203,6 +203,10 @@ else ()
                                  PROPERTIES COMPILE_FLAGS "-fno-rtti")
 endif()
 
+# link with (system) library to prevent missing symbols inside clangDriver.lib
+if (MSVC)
+    target_link_libraries (${local_lib} PRIVATE "Version.lib")
+endif()
 
 target_link_libraries (${local_lib}
     PUBLIC

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -7,7 +7,10 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <bitset>
+
+#ifdef __GNUC__
 #include <cxxabi.h>
+#endif
 
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/sysutil.h>

--- a/src/liboslquery/CMakeLists.txt
+++ b/src/liboslquery/CMakeLists.txt
@@ -15,7 +15,6 @@ target_include_directories (${local_lib}
         ${ILMBASE_INCLUDES}
     PRIVATE
         ../liboslexec)
-target_compile_definitions (${local_lib} PRIVATE OSL_EXPORTS)
 target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO


### PR DESCRIPTION
## Description

This PR fixes various small issues when trying to build OSL on Windows (issue #1261).

- dllimport/export attributes should be defined on nested classes (prevent missing symbols)
- MSVC does not has cxxabi.h so do not try to import it (fixes compile error)
- oslcomp/oslquery were defining OSL_EXPORTS while they should import (prevent missing symbols)
- link with `Version.lib` (system library) to prevent missing symbols inside ClangDriver.


## Tests

master now compiles better on MSVC.
Still not 100% clean for me (shaders is giving errors) but core is fully functional

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/). <-- **send today (October 8th 2020)**
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ x] My code follows the prevailing code style of this project.

