### PR TITLE
Fix duplicate cudaMalloc symbol error when compiling with CUDA9+

### DIFF
--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -80,7 +80,7 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
             "-I${ILMBASE_INCLUDE_DIR}"
             "-I${Boost_INCLUDE_DIRS}"
             ${LLVM_COMPILE_FLAGS} ${CUDA_LIB_FLAGS}
-            -D__CUDACC__ -DOSL_COMPILING_TO_BITCODE=1 -DNDEBUG -DOIIO_NO_SSE
+            -D__CUDACC__ -DOSL_COMPILING_TO_BITCODE=1 -DNDEBUG -DOIIO_NO_SSE -D__CUDADEVRT_INTERNAL__
             --language=cuda --cuda-device-only --cuda-gpu-arch=${CUDA_TARGET_ARCH}
             -Wno-deprecated-register -Wno-format-security
             -O3 -fno-math-errno -ffast-math -S -emit-llvm ${extra_clang_args}


### PR DESCRIPTION


## Description

Something changed in the CUDA headers between 8 and 9 and you now need the `__CUDADEVRT_INTERNAL__` define when compiling the gpu bitcode to avoid duplicate cudaMalloc symbol errors.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

