### PR TITLE
Add interface to  ShadingSystem for Batched Execution 

### DIFF
--- a/src/include/OSL/batched_shaderglobals.h
+++ b/src/include/OSL/batched_shaderglobals.h
@@ -11,13 +11,12 @@
 OSL_NAMESPACE_ENTER
 
 namespace pvt {
-    class BatchedBackendLLVM;
+class BatchedBackendLLVM;
 }
 
 struct UniformShaderGlobals {
-
-    UniformShaderGlobals() = default;
-    UniformShaderGlobals(const UniformShaderGlobals &other) = delete;
+    UniformShaderGlobals()                                  = default;
+    UniformShaderGlobals(const UniformShaderGlobals& other) = delete;
 
     /// There are three opaque pointers that may be set by the renderer here
     /// in the ShaderGlobals before shading execution begins, and then
@@ -45,7 +44,7 @@ struct UniformShaderGlobals {
     /// it can retrieve the output closure from after shader execution has
     /// completed.
     /// DESIGN DECISION:  NOT CURRENTLY SUPPORTING CLOSURES IN BATCH MODE
-    ClosureColor *Ci;
+    ClosureColor* Ci;
 
     /// Bit field of ray type flags.
     int raytype;
@@ -56,11 +55,12 @@ struct UniformShaderGlobals {
     int pad0;
     int pad1;
     int pad2;
-    
+
     void dump()
     {
-        #define __OSL_DUMP(VARIABLE_NAME) std::cout << #VARIABLE_NAME << " = " << VARIABLE_NAME << std::endl;
-        std::cout << "UniformShaderGlobals = {"  << std::endl;
+#define __OSL_DUMP(VARIABLE_NAME) \
+    std::cout << #VARIABLE_NAME << " = " << VARIABLE_NAME << std::endl;
+        std::cout << "UniformShaderGlobals = {" << std::endl;
         __OSL_DUMP(renderstate);
         __OSL_DUMP(tracedata);
         __OSL_DUMP(objdata);
@@ -70,19 +70,17 @@ struct UniformShaderGlobals {
         __OSL_DUMP(raytype);
 
         std::cout << "};" << std::endl;
-        #undef __OSL_DUMP
+#undef __OSL_DUMP
     }
 };
-static_assert(sizeof(UniformShaderGlobals)%64 == 0, "UniformShaderGlobals must be padded to a 64byte boundary");
+static_assert(sizeof(UniformShaderGlobals) % 64 == 0,
+              "UniformShaderGlobals must be padded to a 64byte boundary");
 
-template<int WidthT> 
-struct alignas(64) VaryingShaderGlobals {
+template<int WidthT> struct alignas(64) VaryingShaderGlobals {
+    VaryingShaderGlobals()                                  = default;
+    VaryingShaderGlobals(const VaryingShaderGlobals& other) = delete;
 
-    VaryingShaderGlobals() = default;
-    VaryingShaderGlobals(const VaryingShaderGlobals &other) = delete;
-
-    template<typename T>
-    using  Block = OSL::Block<T, WidthT>;
+    template<typename T> using Block = OSL::Block<T, WidthT>;
 
     /// Surface position (and its x & y differentials).
     Block<Vec3> P, dPdx, dPdy;
@@ -139,8 +137,8 @@ struct alignas(64) VaryingShaderGlobals {
 
     void dump()
     {
-        #define __OSL_DUMP(VARIABLE_NAME) VARIABLE_NAME.dump(#VARIABLE_NAME)
-        std::cout << "VaryingShaderGlobals = {"  << std::endl;
+#define __OSL_DUMP(VARIABLE_NAME) VARIABLE_NAME.dump(#VARIABLE_NAME)
+        std::cout << "VaryingShaderGlobals = {" << std::endl;
         __OSL_DUMP(P);
         __OSL_DUMP(dPdx);
         __OSL_DUMP(dPdy);
@@ -170,43 +168,40 @@ struct alignas(64) VaryingShaderGlobals {
         __OSL_DUMP(flipHandedness);
         __OSL_DUMP(backfacing);
         std::cout << "};" << std::endl;
-        #undef __OSL_DUMP
+#undef __OSL_DUMP
     }
-    
 };
 
-template<int WidthT>
-struct alignas(64) BatchedShaderGlobals
-{
-    BatchedShaderGlobals(){}
+template<int WidthT> struct alignas(64) BatchedShaderGlobals {
+    BatchedShaderGlobals() {}
 
     // Disallow copying
-    BatchedShaderGlobals(const BatchedShaderGlobals &) = delete;
+    BatchedShaderGlobals(const BatchedShaderGlobals&) = delete;
 
     UniformShaderGlobals uniform;
     VaryingShaderGlobals<WidthT> varying;
 
     void dump()
     {
-        std::cout << "BatchedShaderGlobals" << " = {"  << std::endl;
+        std::cout << "BatchedShaderGlobals"
+                  << " = {" << std::endl;
         uniform.dump();
         varying.dump();
         std::cout << "};" << std::endl;
     }
-
 };
 
 #define __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA) \
-using BatchedShaderGlobals = OSL::BatchedShaderGlobals<WIDTH_OF_OSL_DATA>; \
+    using BatchedShaderGlobals = OSL::BatchedShaderGlobals<WIDTH_OF_OSL_DATA>;
 
-#undef  OSL_USING_DATA_WIDTH
+#undef OSL_USING_DATA_WIDTH
 #ifdef __OSL_USING_BATCHED_TEXTURE
-#define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA) \
-    __OSL_USING_WIDE(WIDTH_OF_OSL_DATA) \
-    __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA)
+#    define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA) \
+        __OSL_USING_WIDE(WIDTH_OF_OSL_DATA)         \
+        __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA)
 #else
-    #define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA) \
-        __OSL_USING_WIDE(WIDTH_OF_OSL_DATA) \
+#    define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA)  \
+        __OSL_USING_WIDE(WIDTH_OF_OSL_DATA)          \
         __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA) \
         __OSL_USING_BATCHED_TEXTURE(WIDTH_OF_OSL_DATA)
 #endif

--- a/src/include/OSL/batched_shaderglobals.h
+++ b/src/include/OSL/batched_shaderglobals.h
@@ -1,0 +1,214 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+#pragma once
+
+#include <OSL/wide.h>
+
+#include <OSL/shaderglobals.h>
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {
+    class BatchedBackendLLVM;
+}
+
+struct UniformShaderGlobals {
+
+    UniformShaderGlobals() = default;
+    UniformShaderGlobals(const UniformShaderGlobals &other) = delete;
+
+    /// There are three opaque pointers that may be set by the renderer here
+    /// in the ShaderGlobals before shading execution begins, and then
+    /// retrieved again from the within the implementation of various
+    /// RendererServices methods. Exactly what they mean and how they are
+    /// used is renderer-dependent, but roughly speaking it's probably a
+    /// pointer to some internal renderer state (needed for, say, figuring
+    /// out how to retrieve userdata), state about the ray tree (needed to
+    /// resume for a trace() call), and information about the object being
+    /// shaded.
+    void* renderstate;
+    void* tracedata;
+    void* objdata;
+
+    /// Back-pointer to the ShadingContext (set and used by OSL itself --
+    /// renderers shouldn't mess with this at all).
+    ShadingContext* context;
+
+    /// Pointer to the RendererServices object. This is how OSL finds its
+    /// way back to the renderer for callbacks.
+    RendererServices* renderer;
+
+    /// The output closure will be placed here. The rendererer should
+    /// initialize this to NULL before shading execution, and this is where
+    /// it can retrieve the output closure from after shader execution has
+    /// completed.
+    /// DESIGN DECISION:  NOT CURRENTLY SUPPORTING CLOSURES IN BATCH MODE
+    ClosureColor *Ci;
+
+    /// Bit field of ray type flags.
+    int raytype;
+
+    // We want to manually pad this structure out to 64 byte boundary
+    // and make it simple to duplicate in LLVM without relying on
+    // compiler structure alignment rules
+    int pad0;
+    int pad1;
+    int pad2;
+    
+    void dump()
+    {
+        #define __OSL_DUMP(VARIABLE_NAME) std::cout << #VARIABLE_NAME << " = " << VARIABLE_NAME << std::endl;
+        std::cout << "UniformShaderGlobals = {"  << std::endl;
+        __OSL_DUMP(renderstate);
+        __OSL_DUMP(tracedata);
+        __OSL_DUMP(objdata);
+        __OSL_DUMP(context);
+        __OSL_DUMP(renderer);
+        __OSL_DUMP(Ci);
+        __OSL_DUMP(raytype);
+
+        std::cout << "};" << std::endl;
+        #undef __OSL_DUMP
+    }
+};
+static_assert(sizeof(UniformShaderGlobals)%64 == 0, "UniformShaderGlobals must be padded to a 64byte boundary");
+
+template<int WidthT> 
+struct alignas(64) VaryingShaderGlobals {
+
+    VaryingShaderGlobals() = default;
+    VaryingShaderGlobals(const VaryingShaderGlobals &other) = delete;
+
+    template<typename T>
+    using  Block = OSL::Block<T, WidthT>;
+
+    /// Surface position (and its x & y differentials).
+    Block<Vec3> P, dPdx, dPdy;
+    /// P's z differential, used for volume shading only.
+    Block<Vec3> dPdz;
+
+    /// Incident ray, and its x and y derivatives.
+    Block<Vec3> I, dIdx, dIdy;
+
+    /// Shading normal, already front-facing.
+    Block<Vec3> N;
+
+    /// True geometric normal.
+    Block<Vec3> Ng;
+
+    /// 2D surface parameter u, and its differentials.
+    Block<float> u, dudx, dudy;
+    /// 2D surface parameter v, and its differentials.
+    Block<float> v, dvdx, dvdy;
+
+    /// Surface tangents: derivative of P with respect to surface u and v.
+    Block<Vec3> dPdu, dPdv;
+
+    /// Time for this shading sample.
+    Block<float> time;
+    /// Time interval for the frame (or shading sample).
+    Block<float> dtime;
+    ///  Velocity vector: derivative of position P with respect to time.
+    Block<Vec3> dPdtime;
+
+    /// For lights or light attenuation shaders: the point being illuminated
+    /// (Ps), and its differentials.
+    Block<Vec3> Ps, dPsdx, dPsdy;
+
+    /// Opaque pointers set by the renderer before shader execution, to
+    /// allow later retrieval of the object->common and shader->common
+    /// transformation matrices, by the RendererServices
+    /// get_matrix/get_inverse_matrix methods. This doesn't need to point
+    /// to the 4x4 matrix itself; rather, it's just a pointer to whatever
+    /// structure the RenderServices::get_matrix() needs to (if and when
+    /// requested) generate the 4x4 matrix for the right time value.
+    Block<TransformationPtr> object2common;
+    Block<TransformationPtr> shader2common;
+
+    /// Surface area of the emissive object (used by light shaders for
+    /// energy normalization).
+    Block<float> surfacearea;
+
+    /// If nonzero, will flip the result of calculatenormal().
+    Block<int> flipHandedness;
+
+    /// If nonzero, we are shading the back side of a surface.
+    Block<int> backfacing;
+
+    void dump()
+    {
+        #define __OSL_DUMP(VARIABLE_NAME) VARIABLE_NAME.dump(#VARIABLE_NAME)
+        std::cout << "VaryingShaderGlobals = {"  << std::endl;
+        __OSL_DUMP(P);
+        __OSL_DUMP(dPdx);
+        __OSL_DUMP(dPdy);
+        __OSL_DUMP(dPdz);
+        __OSL_DUMP(I);
+        __OSL_DUMP(dIdx);
+        __OSL_DUMP(dIdy);
+        __OSL_DUMP(N);
+        __OSL_DUMP(Ng);
+        __OSL_DUMP(u);
+        __OSL_DUMP(dudx);
+        __OSL_DUMP(dudy);
+        __OSL_DUMP(v);
+        __OSL_DUMP(dvdx);
+        __OSL_DUMP(dvdy);
+        __OSL_DUMP(dPdu);
+        __OSL_DUMP(dPdv);
+        __OSL_DUMP(time);
+        __OSL_DUMP(dtime);
+        __OSL_DUMP(dPdtime);
+        __OSL_DUMP(Ps);
+        __OSL_DUMP(dPsdx);
+        __OSL_DUMP(dPsdy);
+        __OSL_DUMP(object2common);
+        __OSL_DUMP(shader2common);
+        __OSL_DUMP(surfacearea);
+        __OSL_DUMP(flipHandedness);
+        __OSL_DUMP(backfacing);
+        std::cout << "};" << std::endl;
+        #undef __OSL_DUMP
+    }
+    
+};
+
+template<int WidthT>
+struct alignas(64) BatchedShaderGlobals
+{
+    BatchedShaderGlobals(){}
+
+    // Disallow copying
+    BatchedShaderGlobals(const BatchedShaderGlobals &) = delete;
+
+    UniformShaderGlobals uniform;
+    VaryingShaderGlobals<WidthT> varying;
+
+    void dump()
+    {
+        std::cout << "BatchedShaderGlobals" << " = {"  << std::endl;
+        uniform.dump();
+        varying.dump();
+        std::cout << "};" << std::endl;
+    }
+
+};
+
+#define __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA) \
+using BatchedShaderGlobals = OSL::BatchedShaderGlobals<WIDTH_OF_OSL_DATA>; \
+
+#undef  OSL_USING_DATA_WIDTH
+#ifdef __OSL_USING_BATCHED_TEXTURE
+#define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA) \
+    __OSL_USING_WIDE(WIDTH_OF_OSL_DATA) \
+    __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA)
+#else
+    #define OSL_USING_DATA_WIDTH(WIDTH_OF_OSL_DATA) \
+        __OSL_USING_WIDE(WIDTH_OF_OSL_DATA) \
+        __OSL_USING_SHADERGLOBALS(WIDTH_OF_OSL_DATA) \
+        __OSL_USING_BATCHED_TEXTURE(WIDTH_OF_OSL_DATA)
+#endif
+
+OSL_NAMESPACE_EXIT

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -10,8 +10,7 @@
 #include <type_traits>
 
 #include <OSL/oslconfig.h>
-//#include "mask.h"
-#include "dual_vec.h"
+#include <OSL/dual_vec.h>
 #include <OSL/Imathx/Imathx.h>
 
 OSL_NAMESPACE_ENTER

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -59,6 +59,8 @@ struct Block;
 // on a system.
 // The data itself is stored in a SOA (Structure of Arrays) layout.
 // DataT may be Dual2<T>.
+// A Block should not be passed around, instead Wide<DataT, WidthT>
+// will hold a reference to a Block and provide access to its data.
 // DataT must NOT be an array, arrays are supported by having
 // and array of Block[].
 // Implementations should support the following interface:
@@ -80,6 +82,29 @@ struct Block;
 //    impl-defined-const-proxy operator[](int lane) const
 //
 //    void dump(const char *name) const;
+//};
+
+template <typename DataT, int WidthT>
+struct Wide;
+// Reference to Block that provides a proxy to access to DataT
+// for an individual data lane inside the Block.
+// Respects const correctness DataT, ie: Wide<const float, 16>.
+// Handles DataT being fixed size array [7], Wide: wide<const float[7], 16>
+// Handles DataT being unbounded array [], Wide: wide<cpmst float[], 16>
+// Implementations should support the following interface:
+//{
+//    static constexpr int width = WidthT;
+//
+//    impl-defined-proxy operator[](int lane);  // when DataT is not const
+//    impl-defined-const-proxy operator[](int lane) const
+//
+//    // When DataT is ElementType[] unbounded array
+//    typedef impl-defined ElementType;
+//    typedef impl-defined NonConstElementType;
+//    int length() const; // length of unbounded array
+//
+//    // Provide Wide access to individual array element
+//    Wide<ElementType, WidthT> get_element(int array_index) const
 //};
 
 // More wrappers will be added here to wrap a reference to Block data along with a mask...
@@ -1324,5 +1349,553 @@ assign_all(Block<DataT, WidthT> &wide_data, const DataT &value)
     }
 }
 
+namespace pvt {
+
+    template<typename DataT, int WidthT, bool IsConstT>
+    struct WideImpl; // undefined
+
+    template <typename DataT, int WidthT>
+    struct LaneProxy
+    {
+        typedef DataT const ValueType;
+
+        explicit OSL_FORCEINLINE
+        LaneProxy(Block<DataT, WidthT> & ref_wide_data, const int lane)
+        : m_ref_wide_data(ref_wide_data)
+        , m_lane(lane)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        LaneProxy(const LaneProxy &other)
+        : m_ref_wide_data(other.m_ref_wide_data)
+        , m_lane(other.m_lane)
+        {}
+
+        OSL_FORCEINLINE
+        operator ValueType () const
+        {
+            return m_ref_wide_data.get(m_lane);
+        }
+
+        OSL_FORCEINLINE const DataT &
+        operator = (const DataT & value) const
+        {
+            m_ref_wide_data.set(m_lane, value);
+            return value;
+        }
+
+    private:
+        Block<DataT, WidthT> & m_ref_wide_data;
+        const int m_lane;
+    };
+
+    template <typename ConstDataT, int WidthT>
+    struct ConstLaneProxy
+    {
+        typedef typename std::remove_const<ConstDataT>::type DataType;
+        typedef ConstDataT ValueType;
+
+        explicit OSL_FORCEINLINE
+        ConstLaneProxy(const Block<DataType, WidthT> & ref_wide_data, const int lane)
+        : m_ref_wide_data(ref_wide_data)
+        , m_lane(lane)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        ConstLaneProxy(const ConstLaneProxy &other)
+        : m_ref_wide_data(other.m_ref_wide_data)
+        , m_lane(other.m_lane)
+        {}
+
+        OSL_FORCEINLINE
+        operator ValueType () const
+        {
+            return m_ref_wide_data.get(m_lane);
+        }
+
+    private:
+        const Block<DataType, WidthT> & m_ref_wide_data;
+        const int m_lane;
+    };
+
+    template <typename ConstDataT, int ArrayLenT, int WidthT>
+    struct ConstWideArrayLaneProxy
+    {
+        typedef typename std::remove_const<ConstDataT>::type DataType;
+
+        explicit OSL_FORCEINLINE
+        ConstWideArrayLaneProxy(const Block<DataType, WidthT> * array_of_wide_data, int lane)
+        : m_array_of_wide_data(array_of_wide_data)
+        , m_lane(lane)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        ConstWideArrayLaneProxy(const ConstWideArrayLaneProxy &other)
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        , m_lane(other.m_lane)
+        {}
+
+        OSL_FORCEINLINE int
+        length() const { return ArrayLenT; }
+
+        OSL_FORCEINLINE ConstLaneProxy<ConstDataT, WidthT>
+        operator[](int array_index) const
+        {
+            OSL_DASSERT(array_index < ArrayLenT);
+            return ConstLaneProxy<ConstDataT, WidthT>(m_array_of_wide_data[array_index], m_lane);
+        }
+
+    private:
+        const Block<DataType, WidthT> * m_array_of_wide_data;
+        const int m_lane;
+    };
+
+    template <typename ConstDataT, int WidthT>
+    struct ConstWideUnboundedArrayLaneProxy
+    {
+        typedef typename std::remove_const<ConstDataT>::type DataType;
+
+        explicit OSL_FORCEINLINE
+        ConstWideUnboundedArrayLaneProxy(const Block<DataType, WidthT> * array_of_wide_data, int array_length, int lane)
+        : m_array_of_wide_data(array_of_wide_data)
+        , m_array_length(array_length)
+        , m_lane(lane)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        ConstWideUnboundedArrayLaneProxy(const ConstWideUnboundedArrayLaneProxy &other)
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        , m_array_length(other.m_array_length)
+        , m_lane(other.m_lane)
+        {}
+
+        OSL_FORCEINLINE int
+        length() const { return m_array_length; }
+
+        OSL_FORCEINLINE ConstLaneProxy<ConstDataT, WidthT>
+        operator[](int array_index) const
+        {
+            OSL_DASSERT(array_index < m_array_length);
+            return ConstLaneProxy<ConstDataT, WidthT>(m_array_of_wide_data[array_index], m_lane);
+        }
+
+    private:
+        const Block<DataType, WidthT> * m_array_of_wide_data;
+        int m_array_length;
+        const int m_lane;
+    };
+
+    template <typename ConstDataT, int WidthT>
+    struct ConstWideDual2UnboundedArrayLaneProxy
+    {
+        typedef typename std::remove_const<ConstDataT>::type DataType;
+        explicit OSL_FORCEINLINE
+        ConstWideDual2UnboundedArrayLaneProxy(const Block<DataType, WidthT> * array_of_wide_data, int array_length, int lane_index)
+        : m_array_of_wide_data(array_of_wide_data)
+        , m_array_length(array_length)
+        , m_lane_index(lane_index)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        ConstWideDual2UnboundedArrayLaneProxy(const ConstWideDual2UnboundedArrayLaneProxy &other)
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        , m_array_length(other.m_array_length)
+        , m_lane_index(other.m_lane_index)
+        {}
+
+        OSL_FORCEINLINE int
+        length() const { return m_array_length; }
+
+        struct ElementProxy
+        {
+            typedef typename std::remove_const<ConstDataT>::type DataType;
+            typedef Dual2<DataType> const ValueType;
+
+            explicit OSL_FORCEINLINE
+            ElementProxy(const Block<DataType, WidthT> *array_of_wide_data, const int lane_index, const int array_index, const int array_length)
+            : m_array_of_wide_data(array_of_wide_data)
+            , m_array_index(array_index)
+            , m_lane_index(lane_index)
+            , m_array_length(array_length)
+            {}
+
+            // Must provide user defined copy constructor to
+            // get compiler to be able to follow individual
+            // data members through back to original object
+            // when fully inlined the proxy should disappear
+            OSL_FORCEINLINE
+            ElementProxy(const ElementProxy &other)
+            : m_array_of_wide_data(other.m_array_of_wide_data)
+            , m_array_index(other.m_array_index)
+            , m_lane_index(other.m_lane_index)
+            , m_array_length(other.m_array_length)
+            {}
+
+            OSL_FORCEINLINE
+            operator ValueType () const
+            {
+                // Intentionally have local variables as an intermediate between the array accesses
+                // and the constructor of the return type.  As most constructors accept a const reference
+                // this can cause the array access itself to be forwarded through inlining to the constructor
+                // and at a minimum loose alignment tracking, but could cause other issues.
+                DataType val = m_array_of_wide_data[m_array_index].get(m_lane_index);
+                DataType dx = (m_array_of_wide_data+m_array_length)[m_array_index].get(m_lane_index);
+                DataType dy = (m_array_of_wide_data + 2*m_array_length)[m_array_index].get(m_lane_index);
+                return Dual2<DataType> (val, dx, dy);
+            }
+
+        private:
+            const Block<DataType, WidthT> * m_array_of_wide_data;
+            const int m_array_index;
+            const int m_lane_index;
+            const int m_array_length;
+        };
+
+        OSL_FORCEINLINE ElementProxy
+        operator[](int array_index) const
+        {
+            OSL_DASSERT(array_index < m_array_length);
+            return ElementProxy(m_array_of_wide_data, m_lane_index, array_index, m_array_length);
+        }
+
+    private:
+        const Block<DataType, WidthT> * m_array_of_wide_data;
+        int m_array_length;
+        const int m_lane_index;
+    };
+
+
+    template<typename DataT, int WidthT>
+    OSL_NODISCARD
+    Block<DataT, WidthT>* assume_aligned(Block<DataT, WidthT>* block_ptr)
+    {
+        static_assert(std::alignment_of<Block<DataT, WidthT>>::value == std::alignment_of<VecReg<WidthT>>::value, "Unexepected alignment");
+        return assume_aligned<VecReg<WidthT>::alignment>(block_ptr);
+    }
+
+    template<typename DataT, int WidthT>
+    OSL_NODISCARD
+    const Block<DataT, WidthT>* assume_aligned(const Block<DataT, WidthT>* block_ptr)
+    {
+        static_assert(std::alignment_of<Block<DataT, WidthT>>::value == std::alignment_of<VecReg<WidthT>>::value, "Unexepected alignment");
+        return assume_aligned<VecReg<WidthT>::alignment>(block_ptr);
+    }
+
+    template <typename DataT, int WidthT>
+    Block<DataT, WidthT> * block_cast(void *ptr_wide_data, int derivIndex = 0)
+    {
+        Block<DataT, WidthT> * block_ptr = &(reinterpret_cast<Block<DataT, WidthT> *>(ptr_wide_data)[derivIndex]);
+        return assume_aligned(block_ptr);
+    }
+
+    template <typename DataT, int WidthT>
+    const Block<DataT, WidthT> * block_cast(const void *ptr_wide_data)
+    {
+        const Block<DataT, WidthT> * block_ptr = reinterpret_cast<const Block<DataT, WidthT> *>(ptr_wide_data);
+        return assume_aligned(block_ptr);
+    }
+
+    template <typename DataT, int WidthT>
+    OSL_FORCEINLINE const Block<DataT, WidthT> & align_block_ref(const Block<DataT, WidthT> &ref) {
+        return *assume_aligned(&ref);
+    }
+
+    template <typename DataT, int WidthT>
+    OSL_FORCEINLINE Block<DataT, WidthT> & align_block_ref(Block<DataT, WidthT> &ref) {
+        return *assume_aligned(&ref);
+    }
+
+
+
+    template <typename DataT, int WidthT>
+    struct WideImpl<DataT, WidthT, false /*IsConstT */>
+    {
+        static_assert(std::is_const<DataT>::value == false, "Logic Bug:  Only meant for non-const DataT, const is meant to use specialized WideImpl");
+        static_assert(std::is_array<DataT>::value == false, "Logic Bug:  Only meant for non-array DataT, arrays are meant to use specialized WideImpl");
+        static constexpr int width = WidthT;
+        typedef DataT ValueType;
+
+        explicit OSL_FORCEINLINE
+        WideImpl(void *ptr_wide_data, int derivIndex=0)
+        : m_ref_wide_data(block_cast<DataT, WidthT>(ptr_wide_data)[derivIndex])
+        {}
+
+        // Allow implicit construction
+        OSL_FORCEINLINE
+        WideImpl(Block<DataT, WidthT> & ref_wide_data)
+        : m_ref_wide_data(align_block_ref(ref_wide_data))
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl &other) noexcept
+        : m_ref_wide_data(other.m_ref_wide_data)
+        {}
+
+
+        OSL_FORCEINLINE Block<DataT, WidthT> &  data() const { return m_ref_wide_data; }
+
+        typedef LaneProxy<DataT, WidthT> Proxy;
+        //typedef ConstLaneProxy<DataT, WidthT> ConstProxy;
+
+        OSL_FORCEINLINE Proxy
+        operator[](int lane) const
+        {
+            return Proxy(m_ref_wide_data, lane);
+        }
+
+    private:
+        Block<DataT, WidthT> & m_ref_wide_data;
+    };
+
+    template <typename ConstDataT, int WidthT>
+    struct WideImpl<ConstDataT, WidthT, true /*IsConstT */>
+    {
+        static_assert(std::is_array<ConstDataT>::value == false, "Only meant for non-array ConstDataT, arrays are meant to use specialized WideImpl");
+
+        static constexpr int width = WidthT;
+
+        typedef ConstDataT ValueType;
+        static_assert(std::is_const<ConstDataT>::value, "unexpected compiler behavior");
+        typedef typename std::remove_const<ConstDataT>::type DataT;
+        typedef DataT NonConstValueType;
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const void *ptr_wide_data, int derivIndex=0)
+        : m_ref_wide_data(block_cast<DataT, WidthT>(ptr_wide_data)[derivIndex])
+        {}
+
+        // Allow implicit construction
+        OSL_FORCEINLINE
+        WideImpl(const Block<DataT, WidthT> & ref_wide_data)
+        : m_ref_wide_data(align_block_ref(ref_wide_data))
+        {}
+
+        // Allow implicit conversion of const Wide from non-const Wide
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl<DataT, WidthT, false /*IsConstT */> &other)
+        : m_ref_wide_data(other.m_ref_wide_data)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl &other) noexcept
+        : m_ref_wide_data(other.m_ref_wide_data)
+        {}
+
+
+        typedef ConstLaneProxy<ConstDataT, WidthT> ConstProxy;
+
+        OSL_FORCEINLINE const Block<DataT, WidthT> &  data() const { return m_ref_wide_data; }
+
+        OSL_FORCEINLINE ConstProxy const
+        operator[](int lane) const
+        {
+            return ConstProxy(m_ref_wide_data, lane);
+        }
+
+    private:
+        const Block<DataT, WidthT> & m_ref_wide_data;
+    };
+
+    template <typename ElementT, int ArrayLenT, int WidthT>
+    struct WideImpl<const ElementT[ArrayLenT], WidthT, true /*IsConstT */>
+    {
+        static constexpr int width = WidthT;
+        static constexpr int ArrayLen = ArrayLenT;
+        static_assert(ArrayLen > 0, "OSL logic bug");
+        typedef const ElementT ElementType;
+        static_assert(std::is_const<ElementType>::value, "unexpected compiler behavior");
+        typedef ElementT NonConstElementType;
+        typedef ElementType ArrayType[ArrayLen];
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const void *ptr_wide_data)
+        : m_array_of_wide_data(block_cast<ElementT, WidthT>(ptr_wide_data))
+        {}
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const Block<ElementT, WidthT> *array_of_wide_data)
+        : m_array_of_wide_data(assume_aligned(array_of_wide_data))
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl &other) noexcept
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        {}
+
+        static constexpr OSL_FORCEINLINE int
+        length() { return ArrayLen; }
+
+
+        typedef ConstWideArrayLaneProxy<ElementType, ArrayLen, WidthT> Proxy;
+
+        OSL_FORCEINLINE Proxy const
+        operator[](int lane) const
+        {
+            return Proxy(m_array_of_wide_data, lane);
+        }
+
+        OSL_FORCEINLINE Wide<ElementType, WidthT>
+        get_element(int array_index) const
+        {
+            OSL_DASSERT(array_index < ArrayLen);
+            return Wide<ElementType, WidthT>(m_array_of_wide_data[array_index]);
+        }
+
+    private:
+        const Block<ElementT, WidthT> * m_array_of_wide_data;
+    };
+
+    template <typename ElementT, int WidthT>
+    struct WideImpl<const ElementT[], WidthT, true /*IsConstT */>
+    {
+        static constexpr int width = WidthT;
+        typedef const ElementT ElementType;
+        static_assert(std::is_const<ElementType>::value, "unexpected compiler behavior");
+        typedef ElementT NonConstElementType;
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const void *ptr_wide_data, int array_length)
+        : m_array_of_wide_data(block_cast<ElementT, WidthT>(ptr_wide_data))
+        , m_array_length(array_length)
+        {}
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const Block<ElementT, WidthT> *array_of_wide_data, int array_length)
+        : m_array_of_wide_data(assume_aligned(array_of_wide_data))
+        , m_array_length(array_length)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl &other) noexcept
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        , m_array_length(other.m_array_length)
+        {}
+
+        OSL_FORCEINLINE int
+        length() { return m_array_length; }
+
+
+        typedef ConstWideUnboundedArrayLaneProxy<ElementType, WidthT> Proxy;
+
+        OSL_FORCEINLINE Proxy const
+        operator[](int lane) const
+        {
+            return Proxy(m_array_of_wide_data, m_array_length, lane);
+        }
+
+        OSL_FORCEINLINE Wide<ElementType, WidthT>
+        get_element(int array_index) const
+        {
+            OSL_DASSERT(array_index < m_array_length);
+            return Wide<ElementType, WidthT>(m_array_of_wide_data[array_index]);
+        }
+
+    private:
+        const Block<ElementT, WidthT> * m_array_of_wide_data;
+        int m_array_length;
+    };
+
+    template <typename ElementT, int WidthT>
+    struct WideImpl<const Dual2<ElementT>[], WidthT, true /*IsConstT */>
+    {
+        static constexpr int width = WidthT;
+        typedef const Dual2<ElementT> ElementType;
+        typedef Dual2<ElementT> NonConstElementType;
+
+        explicit OSL_FORCEINLINE
+        WideImpl(const void *ptr_wide_data, int array_length)
+        : m_array_of_wide_data(block_cast<ElementT, WidthT>(ptr_wide_data))
+        , m_array_length(array_length)
+        {}
+
+        // Must provide user defined copy constructor to
+        // get compiler to be able to follow individual
+        // data members through back to original object
+        // when fully inlined the proxy should disappear
+        OSL_FORCEINLINE
+        WideImpl(const WideImpl &other) noexcept
+        : m_array_of_wide_data(other.m_array_of_wide_data)
+        , m_array_length(other.m_array_length)
+        {}
+
+        OSL_FORCEINLINE int
+        length() { return m_array_length; }
+
+        typedef ConstWideDual2UnboundedArrayLaneProxy<ElementT, WidthT> Proxy;
+
+        OSL_FORCEINLINE Proxy const
+        operator[](int lane_index) const
+        {
+            return Proxy(m_array_of_wide_data, m_array_length, lane_index);
+        }
+
+        // get_element doesn't work here as val, dx, dy will be separated
+        // in memory by m_array_length.  Perhaps could add get_val(), get_dx(), get_dy()
+        // similar to MaskedData in order to enable get_element.
+    private:
+        const Block<ElementT, WidthT> * m_array_of_wide_data;
+        int m_array_length;
+    };
+
+} // namespace pvt
+
+
+#if OSL_INTEL_COMPILER || OSL_GNUC_VERSION
+    // Workaround for error #3466: inheriting constructors must be inherited from a direct base class
+    #define __OSL_INHERIT_BASE_CTORS(DERIVED, BASE) \
+        using Base = typename DERIVED::BASE; \
+        using Base::BASE;
+#else
+    #define __OSL_INHERIT_BASE_CTORS(DERIVED, BASE) \
+        using Base = typename DERIVED::BASE; \
+        using Base::Base;
+#endif
+
+template <typename DataT, int WidthT>
+struct Wide
+: pvt::WideImpl<DataT, WidthT, std::is_const<DataT>::value>
+{
+    __OSL_INHERIT_BASE_CTORS(Wide,WideImpl)
+    static constexpr int width = WidthT;
+};
+
+
+#undef __OSL_INHERIT_BASE_CTORS
 
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -572,6 +572,9 @@ public:
     bool allow_shader_replacement() const { return m_allow_shader_replacement; }
     ustring commonspace_synonym () const { return m_commonspace_synonym; }
 
+    bool llvm_jit_fma() const { return m_llvm_jit_fma; }
+    ustring llvm_jit_target () const { return m_llvm_jit_target; }
+
     ustring debug_groupname() const { return m_debug_groupname; }
     ustring debug_layername() const { return m_debug_layername; }
 
@@ -739,7 +742,7 @@ private:
     bool m_llvm_jit_fma;                  ///< Allow fused multiply/add in JIT
     bool m_llvm_jit_aggressive;           ///< Turn on llvm "aggressive" JIT
     bool m_optimize_nondebug;             ///< Fully optimize non-debug!
-    ustring m_llvm_jit_target;            ///< JIT based on host target
+    ustring m_llvm_jit_target;            ///< ISA target for JIT
     int m_vector_width;                   ///< SIMD width maximum (8)
     int m_opt_passes;                     ///< Opt passes per layer
     int m_llvm_optimize;                  ///< OSL optimization strategy

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -442,7 +442,7 @@ ShadingSystem::symbol_address (const ShadingContext &ctx,
 bool
 ShadingSystem::supports_batch_execution_at(int width)
 {
-    auto requestedISA = LLVM_Util::lookup_isa_by_name(m_impl->llvm_jit_target().c_str());
+    auto requestedISA = LLVM_Util::lookup_isa_by_name(m_impl->llvm_jit_target());
     OSL_MAYBE_UNUSED bool target_requested = (requestedISA != TargetISA::UNKNOWN);
     OSL_MAYBE_UNUSED bool jit_fma = !m_impl->llvm_jit_fma();
 

--- a/src/osltoy/qtutils.h
+++ b/src/osltoy/qtutils.h
@@ -171,7 +171,7 @@ private:
         double ss = m_fixed_step;
         if (m_variable_step_digits) {
             ss        = m_variable_min_step;
-            double av = fabs(valsize);
+            double av = ::fabs(valsize);
             for (int d = 6; d > -4; --d) {
                 double p = pow(10.0, double(d));
                 if (av > p * 1.1) {

--- a/src/osltoy/qtutils.h
+++ b/src/osltoy/qtutils.h
@@ -171,7 +171,7 @@ private:
         double ss = m_fixed_step;
         if (m_variable_step_digits) {
             ss        = m_variable_min_step;
-            double av = ::fabs(valsize);
+            double av = std::fabs(valsize);
             for (int d = 6; d > -4; --d) {
                 double p = pow(10.0, double(d));
                 if (av > p * 1.1) {


### PR DESCRIPTION
Introduce template<int WidthT> struct BatchedShaderGlobals to store up to WidthT instances of ShaderGlobal data.  The data for a batch is divided into underlying uniform and varying data structures.  Uniform section contains a fixed set of shader global values that are shared between all instances.  Varying has Block<DataT, WidthT> members so each instance can hold a different value.  The Block data structure is specialized to hold the underlying data type in a SIMD friendly Structure of Arrays (SOA) data layout but provides an array subscript interface to a proxy that can import/export the DataT in its orignal data layout.

Introduce template<int WidthT> class ShadingSystem::BatchedExecutor as an interface to execute batches of shader globals through a shader network.  BatchedExecutor provides similar set of execute methods, but they accept a BatchedShaderGlobals and batchSize instead of individual ShaderGlobal(s). This is just the interface, batched backend implemention to follow in subsequent pull requests.

Introduce template<typename DataT, int WidthT> Wide to hold a reference to Block<DataT, WidthT> and provide access to the underlying SOA data layout.  Wide can handle array types and const correctness.  The Wide adapter is lightweight and can be copied by value, used as function parameter.  Future pull requests will add SIMD versions of OSL library functions and Wide will be the primary was to access SOA data.

Once batched execution finishes, the resulting symbol address can be passed to a Wide<DataT, Width> to access the resulting data in a type safe manner.

Updated testshade with command line option "--batched" causing batched execution of 16 or 8 instances through the shader network and to extract the results.  A later pull request will add batched interface to renderer services.

Replaced use of std::bind in testshade in favor of c++11 lambda function.


