### PR TITLE
Update ref output after recent OIIO change

### DIFF
--- a/testsuite/gettextureinfo/ref/out-oiio2.2-opt.txt
+++ b/testsuite/gettextureinfo/ref/out-oiio2.2-opt.txt
@@ -12,7 +12,8 @@ Executing...
 ../common/textures/grid.tx unknown constantcolor
 ../common/textures/grid.tx unknown constantalpha
 ../common/textures/grid.tx foobar: not found (0)
-ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 ../common/textures/grid.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -29,7 +30,8 @@ win.exr unknown averagealpha
 win.exr unknown constantcolor
 win.exr unknown constantalpha
 win.exr foobar: not found (0)
-ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 win.exr exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -46,7 +48,8 @@ green.tx averagealpha: 1
 green.tx constantcolor: 0.101961 0.501961 0.101961
 green.tx constantalpha: 1
 green.tx foobar: not found (0)
-ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 green.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)

--- a/testsuite/gettextureinfo/ref/out-oiio2.2.txt
+++ b/testsuite/gettextureinfo/ref/out-oiio2.2.txt
@@ -13,6 +13,7 @@ Executing...
 ../common/textures/grid.tx unknown constantalpha
 ../common/textures/grid.tx foobar: not found (0)
 ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 ../common/textures/grid.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -30,6 +31,7 @@ win.exr unknown constantcolor
 win.exr unknown constantalpha
 win.exr foobar: not found (0)
 ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 win.exr exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -47,6 +49,7 @@ green.tx constantcolor: 0.101961 0.501961 0.101961
 green.tx constantalpha: 1
 green.tx foobar: not found (0)
 ERROR: [RendererServices::get_texture_info] Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
+
 badfile data: not found (0)
 green.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)

--- a/testsuite/gettextureinfo/ref/out-opt.txt
+++ b/testsuite/gettextureinfo/ref/out-opt.txt
@@ -13,7 +13,6 @@ Executing...
 ../common/textures/grid.tx unknown constantalpha
 ../common/textures/grid.tx foobar: not found (0)
 ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
-
 badfile data: not found (0)
 ../common/textures/grid.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -31,7 +30,6 @@ win.exr unknown constantcolor
 win.exr unknown constantalpha
 win.exr foobar: not found (0)
 ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
-
 badfile data: not found (0)
 win.exr exists? 1 (return 1)
 badfile3 exists? 0 (return 1)
@@ -49,7 +47,6 @@ green.tx constantcolor: 0.101961 0.501961 0.101961
 green.tx constantalpha: 1
 green.tx foobar: not found (0)
 ERROR: Shader error [test]: Invalid image file "badfile": Image "badfile" does not exist. Also, it is not the name of an image format that OpenImageIO recognizes.
-
 badfile data: not found (0)
 green.tx exists? 1 (return 1)
 badfile3 exists? 0 (return 1)


### PR DESCRIPTION
A change in OIIO master eliminated some spurious newlines in certain
error messages.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

