### PR TITLE
Modifications to build against LLVM 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: "Linux VFXP-2019: gcc6 C++11 llvm7 py2.7 boost-1.66 exr-2.3 OIIO-2.1 sse2"
     runs-on: ubuntu-latest
     container:
-      image: aswf/ci-osl:2019
+      image: aswf/ci-osl:2019-clang7
     steps:
       - uses: actions/checkout@v2
       - name: all
@@ -53,7 +53,7 @@ jobs:
           path: build/*/testsuite/*/*.*
 
   vfxplatform-2020:
-    name: "Linux VFXP-2020 gcc6/C++14 llvm7 py3.7 boost-1.70 exr-2.4 OIIO-2.1 sse4"
+    name: "Linux VFXP-2020 gcc6/C++14 llvm10 py3.7 boost-1.70 exr-2.4 OIIO-2.1 sse4"
     runs-on: ubuntu-latest
     container:
       image: aswf/ci-osl:2020
@@ -77,10 +77,10 @@ jobs:
           path: build/*/testsuite/*/*.*
 
   vfxplatform-2021:
-    name: "Linux VFXP-2021 gcc9/C++17 llvm10 py3.7 boost-1.70 exr-2.5 OIIO-2.2 avx2"
+    name: "Linux VFXP-2021 gcc9/C++17 llvm11 py3.7 boost-1.70 exr-2.5 OIIO-2.2 avx2"
     runs-on: ubuntu-latest
     container:
-      image: aswf/ci-osl:2021
+      image: aswf/ci-osl:2021-clang11
     steps:
       - uses: actions/checkout@v2
       - name: all
@@ -182,8 +182,8 @@ jobs:
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
     # supported releases of everything else.
-    name: "Linux bleeding edge: gcc10, C++17, llvm10, oiio/ocio/exr/pybind-master, avx2"
-    runs-on: ubuntu-18.04
+    name: "Linux bleeding edge: gcc10, C++17, llvm11, oiio/ocio/exr/pybind-master, avx2"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: all
@@ -191,7 +191,8 @@ jobs:
           CXX: g++-10
           USE_CPP: 17
           CMAKE_CXX_STANDARD: 17
-          LLVM_VERSION: 10.0.0
+          LLVM_VERSION: 11.0.0
+          LLVM_DISTRO_NAME: ubuntu-20.04
           USE_SIMD: avx2,f16c
           OPENEXR_VERSION: master
           OPENIMAGEIO_VERSION: master
@@ -216,7 +217,7 @@ jobs:
     name: "Linux oldest everything: gcc6 C++11 llvm7 py2.7 boost-1.66 oiio-2.1 no-simd exr2.3"
     runs-on: ubuntu-latest
     container:
-      image: aswf/ci-osl:2019
+      image: aswf/ci-osl:2019-clang7
     steps:
       - uses: actions/checkout@v2
       - name: all

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 * A suitable C++11 compiler to build OSL itself, which may be any of:
    - GCC 4.8.5 or newer (tested through gcc 10)
-   - Clang 3.4 or newer (tested through clang 10)
+   - Clang 3.4 or newer (tested through clang 11)
    - Microsoft Visual Studio 2015 or newer
    - Intel C++ compiler icc version 13 (?) or newer
 
@@ -43,9 +43,9 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* [LLVM](http://www.llvm.org) 7, 8, 9, or 10, including clang libraries.
+* [LLVM](http://www.llvm.org) 7, 8, 9, 10, or 11, including clang libraries.
 
-  Note that LLVM 10 is not compatible with C++11, and requires C++14 or
+  Note that LLVM 10+ is not compatible with C++11, and requires C++14 or
   later. If you *must* build OSL with C++11, you need to use an LLVM that
   is LLVM 9 or earlier.
 

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -29,7 +29,7 @@ if [[ `uname` == "Linux" ]] ; then
     fi
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
-    if [ "$LLVM_VERSION" == "10.0.0" ] ; then
+    if [[ "$LLVM_VERSION" == "10.0.0" ]] || [[ "$LLVM_VERSION" == "11.0.0" ]] ; then
         # new
         curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
     else

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -17,6 +17,7 @@ namespace llvm = LLVM_NAMESPACE;
 
 namespace llvm {
   class BasicBlock;
+  class Constant;
   class ConstantFolder;
   class DIBuilder;
   class DICompileUnit;
@@ -563,6 +564,10 @@ public:
     /// (this is the actual type, for example when we allocate it).
     llvm::Type *llvm_vector_type (const OIIO::TypeDesc &typedesc);
 
+    // Wrapper for llvm::VectorType::get() that handles LLVM 11 API change
+    static llvm::VectorType* llvm_vector_type(llvm::Type *elementtype,
+                                              unsigned numelements);
+
     /// This will return a llvm::Type that is the same as a C union of
     /// the given types[].
     llvm::Type *type_union (const std::vector<llvm::Type *> &types);
@@ -602,24 +607,24 @@ public:
     std::string llvm_typenameof (llvm::Value *val) const;
 
     /// Return an llvm::Value holding the given floating point constant.
-    llvm::Value *constant (float f);
+    llvm::Constant* constant(float f);
 
     /// Return an llvm::Value holding the given integer constant.
-    llvm::Value *constant (int i);
+    llvm::Constant* constant(int i);
 
     /// Return an llvm::Value holding the given integer constant.
-    llvm::Value *constant8 (int i);
-    llvm::Value *constant16 (uint16_t i);
-    llvm::Value *constant64 (uint64_t i);
-    llvm::Value *constant128 (uint64_t i);
-    llvm::Value *constant128 (uint64_t left, uint64_t right);
+    llvm::Constant* constant8(int i);
+    llvm::Constant* constant16(uint16_t i);
+    llvm::Constant* constant64(uint64_t i);
+    llvm::Constant* constant128(uint64_t i);
+    llvm::Constant* constant128(uint64_t left, uint64_t right);
 
     /// Return an llvm::Value holding the given size_t constant.
-    llvm::Value *constant (size_t i);
+    llvm::Constant* constant(size_t i);
 
     /// Return an llvm::Value holding the given bool constant.
     /// Change the name so it doesn't get mixed up with int.
-    llvm::Value *constant_bool (bool b);
+    llvm::Constant* constant_bool(bool b);
 
     /// Return a constant void pointer to the given constant address.
     /// If the type specified is NULL, it will make a 'void *'.
@@ -647,13 +652,14 @@ public:
 
     /// Return an llvm::Value for a long long that is a packed
     /// representation of a TypeDesc.
-    llvm::Value *constant (const OIIO::TypeDesc &type);
+    llvm::Constant* constant(const OIIO::TypeDesc &type);
 
-    // Return "wide" (SIMD vector) constants of various types.
-    llvm::Value *wide_constant (float f);
-    llvm::Value *wide_constant (int i);
-    llvm::Value *wide_constant (size_t i);
-    llvm::Value *wide_constant_bool (bool b);
+    // Return "wide" (SIMD vector) constants of various types, with
+    // vector_width.
+    llvm::Constant* wide_constant(float f);
+    llvm::Constant* wide_constant(int i);
+    llvm::Constant* wide_constant(size_t i);
+    llvm::Constant* wide_constant_bool(bool b);
     llvm::Value *wide_constant (ustring s);
     llvm::Value *wide_constant (string_view s) {
         return wide_constant(ustring(s));
@@ -661,10 +667,14 @@ public:
 
     /// Return an llvm::Value holding wide version of the given scalar
     /// constant.
-    llvm::Value *wide_constant (llvm::Value *constant_val);
+    llvm::Constant* wide_constant(llvm::Constant* constant_val);
+
+    // Return wide (SIMD vector) constant with arbitrary width.
+    llvm::Constant* wide_constant(int width, int value);
+    llvm::Constant* wide_constant(int width, float value);
 
     /// Return an llvm::Value for a void* variable with value NULL.
-    llvm::Value *void_ptr_null ();
+    llvm::Constant* void_ptr_null();
 
     /// Cast the pointer variable specified by val to the kind of pointer
     /// described by type (as an llvm pointer type).

--- a/src/liboslexec/llvm_passes.h
+++ b/src/liboslexec/llvm_passes.h
@@ -63,8 +63,8 @@ public:
         llvm::Type* llvm_type_bool = llvm::Type::getInt1Ty (M.getContext());
         llvm::Type* llvm_type_int32 = llvm::Type::getInt32Ty (M.getContext());
 
-        m_llvm_mask_type = llvm::VectorType::get(llvm_type_bool, WidthT);
-
+#if OSL_LLVM_VERSION >= 110
+        m_llvm_mask_type = llvm::FixedVectorType::get(llvm_type_bool, WidthT);
         // NOTE:  OSL doesn't have any 16 bit data types, so 32bit version
         // of the mask promotion will always be correct here.  Should 16 bit
         // support be needed, this pass could be extended to look at the
@@ -72,10 +72,15 @@ public:
         // what the native mask type should be.  And if necessary maintain a
         // 16 bit and 32 bit native mask representation to be passed as a
         // livein.
+        m_native_mask_type = llvm::FixedVectorType::get(llvm_type_int32, WidthT);
+        m_wide_zero_initializer = llvm::ConstantVector::getSplat(
+                                    llvm::ElementCount(WidthT, false),
+                                    llvm::ConstantInt::get (M.getContext(), llvm::APInt(32,0)));
+#else
+        m_llvm_mask_type = llvm::VectorType::get(llvm_type_bool, WidthT);
         m_native_mask_type = llvm::VectorType::get(llvm_type_int32, WidthT);
-
         m_wide_zero_initializer = llvm::ConstantVector::getSplat(WidthT, llvm::ConstantInt::get (M.getContext(), llvm::APInt(32,0)));
-
+#endif
         return false; // I don't think we modified the module
     }
 
@@ -330,14 +335,20 @@ public:
         llvm::Type* llvm_type_bool = llvm::Type::getInt1Ty(M.getContext());
         llvm::Type* llvm_type_int32 = llvm::Type::getInt32Ty(M.getContext());
 
-        m_llvm_mask_type = llvm::VectorType::get(llvm_type_bool, WidthT);
-
+#if OSL_LLVM_VERSION >= 110
+        m_llvm_mask_type = llvm::FixedVectorType::get(llvm_type_bool, WidthT);
         // NOTE:  OSL doesn't have any 16 bit data types, so 32bit version
         // of the mask promotion will always be correct here.  Should 16 bit
         // support be needed, this pass could be extended.
+        m_native_mask_type = llvm::FixedVectorType::get(llvm_type_int32, WidthT);
+        m_wide_zero_initializer = llvm::ConstantVector::getSplat(
+                                    llvm::ElementCount(WidthT, false),
+                                    llvm::ConstantInt::get (M.getContext(), llvm::APInt(32,0)));
+#else
+        m_llvm_mask_type = llvm::VectorType::get(llvm_type_bool, WidthT);
         m_native_mask_type = llvm::VectorType::get(llvm_type_int32, WidthT);
-
         m_wide_zero_initializer = llvm::ConstantVector::getSplat(WidthT, llvm::ConstantInt::get (M.getContext(), llvm::APInt(32,0)));
+#endif
         return false; // I don't think we modified the module
     }
 


### PR DESCRIPTION
Change bleeding edge CI test to use LLVM 11.

A variety of changes were necessary to the code in LLVM_Util:

* `#if` guards for differing calls related to VectorType::get(),
  CreateShuffleVector.

* constant-generating functions now return llvm::Constant* instead of
  llvm::Value*.

* New wide_constant(width,value) functions for when you want a width other
  than the default vector_width.

* Renamed llvmVectorGet -> llvm_vector_type to be more symmetric with
  other methds we have.

* Simplified places that could have made calls to constant(),
  constant_bool(), wide_constant(), llvm_vector_type(), and
  call_function(), but instead did more complex llvm calls by hand.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
