### PR TITLE
Remove rendererservices.h and batched_shaderglobals.h from oslexec.h

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -8,16 +8,13 @@
 
 #include <OSL/oslconfig.h>
 #include <OSL/shaderglobals.h>
-#include <OSL/rendererservices.h>
-
-#include <OSL/batched_shaderglobals.h>
 
 #include <OpenImageIO/refcnt.h>
-#include <OpenImageIO/ustring.h>
 
 
 OSL_NAMESPACE_ENTER
 
+// Various forward declarations
 class RendererServices;
 class ShaderGroup;
 typedef std::shared_ptr<ShaderGroup> ShaderGroupRef;
@@ -25,6 +22,7 @@ struct ClosureParam;
 struct PerThreadInfo;
 class ShadingContext;
 class ShaderSymbol;
+template<int WidthT> struct alignas(64) BatchedShaderGlobals;
 
 
 

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -9,8 +9,6 @@
 
 #include <OSL/oslconfig.h>
 
-#include <OpenImageIO/ustring.h>
-
 
 OSL_NAMESPACE_ENTER
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -36,6 +36,8 @@
 #include <OSL/llvm_util.h>
 #include <OSL/oslexec.h>
 #include <OSL/oslclosure.h>
+#include <OSL/rendererservices.h>
+#include <OSL/shaderglobals.h>
 #include <OSL/dual.h>
 #include <OSL/dual_vec.h>
 #include "osl_pvt.h"

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -16,6 +16,7 @@
 
 #include <OSL/oslcomp.h>
 #include <OSL/oslexec.h>
+#include <OSL/rendererservices.h>
 
 using namespace OIIO;
 

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -14,6 +14,7 @@
 
 #include <OSL/oslconfig.h>
 #include <OSL/oslquery.h>
+#include <OSL/rendererservices.h>
 
 #include <QAction>
 #include <QMainWindow>

--- a/src/osltoy/osltoyrenderer.h
+++ b/src/osltoy/osltoyrenderer.h
@@ -13,6 +13,7 @@
 #include <OpenImageIO/ustring.h>
 
 #include <OSL/oslexec.h>
+#include <OSL/rendererservices.h>
 
 OSL_NAMESPACE_ENTER
 

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -12,6 +12,7 @@
 #include <OpenImageIO/ustring.h>
 
 #include <OSL/oslexec.h>
+#include <OSL/rendererservices.h>
 #include "raytracer.h"
 #include "sampling.h"
 #include "background.h"

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -12,6 +12,7 @@
 #include <OpenImageIO/imagebuf.h>
 
 #include <OSL/oslexec.h>
+#include <OSL/rendererservices.h>
 
 
 OSL_NAMESPACE_ENTER

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -30,6 +30,7 @@
 #include <OSL/oslexec.h>
 #include <OSL/oslcomp.h>
 #include <OSL/oslquery.h>
+#include <OSL/batched_shaderglobals.h>
 #include "optixgridrender.h"
 #include "simplerend.h"
 

--- a/testsuite/example-deformer/osldeformer.cpp
+++ b/testsuite/example-deformer/osldeformer.cpp
@@ -46,6 +46,7 @@ To run:
 
 #include <OSL/oslexec.h>
 #include <OSL/oslquery.h>
+#include <OSL/rendererservices.h>
 
 
 // Define a userdata structure that holds any varying per-point values that


### PR DESCRIPTION
With just a few minor adjustments, we're able to eliminate these two
headers (and everything else they pull in) from every client of
oslexec.h.  For the purposes of oslexec.h's declarations, all uses are
either pointers or references, so we only need the names
forward-declared, but we don't need the implementations revealed to
everybody including oslexec.h.

In particular, this hides the RendererServices and BatchedShaderGlobals
from a lot of translation units, should cut down on compile time and
reduce exposure of certain semi-internals to only the modules that
need them.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
