### PR TITLE
CI: Lock down on clang-format 10 for CI format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
     name: "clang-format verification"
     runs-on: ubuntu-18.04
     container:
-      image: aswf/ci-osl:2021
+      image: aswf/ci-osl:2021-clang10
     steps:
       - uses: actions/checkout@v2
       - name: all


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>
