### PR TITLE
Add GPU CI test to build with USE_OPTIX=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   vfxplatform-2020:
     name: "Linux VFXP-2020 gcc6/C++14 llvm10 py3.7 boost-1.70 exr-2.4 OIIO-2.1 sse4"
@@ -74,7 +76,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   vfxplatform-2021:
     name: "Linux VFXP-2021 gcc9/C++17 llvm11 py3.7 boost-1.70 exr-2.5 OIIO-2.2 avx2"
@@ -100,7 +104,42 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
+
+  # Build for OptiX, but don't run tests (will need a GPU instance for that)
+  gpu-optix7-2019:
+    name: "Linux GPU VFXP-2019 Cuda10 gcc6/C++14 llvm10 py2.7 boost-1.70 exr-2.4 OIIO-master avx2"
+    runs-on: ubuntu-latest
+    container:
+      image: aswftesting/ci-osl:2019-clang10
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++
+          CC: gcc
+          CMAKE_CXX_STANDARD: 14
+          PYTHON_VERSION: 2.7
+          USE_SIMD: avx2,f16c
+          OPENIMAGEIO_VERSION: master
+          OSL_CMAKE_FLAGS: -DUSE_OPTIX=1
+          OPTIX_VERSION: "7.0"
+          SKIP_TESTS: 1
+        run: |
+            rm -rf /usr/local/include/OpenImageIO
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps-centos.bash
+            source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
+            optix.h
 
   linux-debug-gcc7-llvm8:
     name: "Linux Debug gcc7, C++14, llvm8, OIIO release, sse4, exr2.4"
@@ -116,7 +155,7 @@ jobs:
           OPENEXR_VERSION: v2.4.1
           OPENIMAGEIO_VERSION: release
           USE_SIMD: sse4.2
-          MY_CMAKE_FLAGS: -DCMAKE_BUILD_TYPE=Debug
+          OSL_CMAKE_FLAGS: -DCMAKE_BUILD_TYPE=Debug
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps.bash
@@ -125,7 +164,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   linux-clang9-llvm9:
     name: "Linux clang9, C++14, llvm9, oiio release, avx, exr2.4, avx"
@@ -151,7 +192,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   linux-2021ish-gcc8-llvm10:
     name: "Linux gcc8, C++17, llvm10, oiio master, avx2, exr2.5, avx2"
@@ -177,7 +220,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
@@ -209,7 +254,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
@@ -240,7 +287,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   macos-py38:
     name: "Mac py38"
@@ -260,7 +309,7 @@ jobs:
             # upstream in LLVM, but not yet fixed in Homebrew. Hopefully
             # a subsequent 10.0.x or 11.x will fix it, but for now, just
             # fall back to llvm@9.
-          MY_CMAKE_FLAGS: -DLLVM_BC_GENERATOR=/usr/bin/clang++
+          OSL_CMAKE_FLAGS: -DLLVM_BC_GENERATOR=/usr/bin/clang++
             # ^^ Force bitcode compiles to use the system clang compiler by
             # preemptively telling it the LLVM_BC_GENERATOR, to avoid some
             # library mismatches we tend to see on GH CI's Mac images.
@@ -275,7 +324,9 @@ jobs:
         if: failure()
         with:
           name: ${{ github.job }}
-          path: build/*/testsuite/*/*.*
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMakeCache.txt
 
   # windows:
   #   name: "Windows"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ option (OSL_BUILD_MATERIALX "Build MaterialX shaders" OFF)
 option (USE_OPTIX "Include OptiX support" OFF)
 set (OPTIX_EXTRA_LIBS CACHE STRING "Extra lib targets needed for OptiX")
 set (CUDA_EXTRA_LIBS CACHE STRING "Extra lib targets needed for CUDA")
-set (CUDA_TARGET_ARCH "sm_50" CACHE STRING "CUDA GPU architecture (e.g. sm_50)")
+set (CUDA_TARGET_ARCH "sm_60" CACHE STRING "CUDA GPU architecture (e.g. sm_50)")
 set (OSL_SHADER_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/shaders"
      CACHE STRING "Directory where shaders will be installed")
 set (OSL_PTX_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/ptx"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ option (OSL_BUILD_MATERIALX "Build MaterialX shaders" OFF)
 option (USE_OPTIX "Include OptiX support" OFF)
 set (OPTIX_EXTRA_LIBS CACHE STRING "Extra lib targets needed for OptiX")
 set (CUDA_EXTRA_LIBS CACHE STRING "Extra lib targets needed for CUDA")
-set (CUDA_TARGET_ARCH "sm_35" CACHE STRING "CUDA GPU architecture (e.g. sm_35)")
+set (CUDA_TARGET_ARCH "sm_50" CACHE STRING "CUDA GPU architecture (e.g. sm_50)")
 set (OSL_SHADER_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/shaders"
      CACHE STRING "Directory where shaders will be installed")
 set (OSL_PTX_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/ptx"

--- a/src/build-scripts/ci-build-and-test.bash
+++ b/src/build-scripts/ci-build-and-test.bash
@@ -19,10 +19,10 @@ fi
 mkdir -p build/$PLATFORM dist/$PLATFORM && true
 
 if [[ "$USE_SIMD" != "" ]] ; then
-    MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DUSE_SIMD=$USE_SIMD"
+    OSL_CMAKE_FLAGS="$OSL_CMAKE_FLAGS -DUSE_SIMD=$USE_SIMD"
 fi
 if [[ "$DEBUG" == "1" ]] ; then
-    MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DCMAKE_BUILD_TYPE=Debug"
+    OSL_CMAKE_FLAGS="$OSL_CMAKE_FLAGS -DCMAKE_BUILD_TYPE=Debug"
 fi
 
 pushd build/$PLATFORM
@@ -34,7 +34,7 @@ cmake ../.. -G "$CMAKE_GENERATOR" \
         -DPYTHON_VERSION="$PYTHON_VERSION" \
         -DCMAKE_INSTALL_LIBDIR="$OSL_ROOT/lib" \
         -DCMAKE_CXX_STANDARD="$CMAKE_CXX_STANDARD" \
-        $MY_CMAKE_FLAGS -DVERBOSE=1
+        $OSL_CMAKE_FLAGS -DVERBOSE=1
 time cmake --build . --target ${BUILDTARGET:=install} --config ${CMAKE_BUILD_TYPE}
 popd
 #make $MAKEFLAGS VERBOSE=1 $BUILD_FLAGS config

--- a/src/build-scripts/gh-installdeps-centos.bash
+++ b/src/build-scripts/gh-installdeps-centos.bash
@@ -26,14 +26,23 @@ sudo yum install -y Field3D Field3D-devel && true
 #sudo yum install -y ffmpeg ffmpeg-devel && true
 
 
-
-if [[ "$LLVM_BRANCH" != ""  || "$LLVM_VERSION" != "" ]] ; then
-    source src/build-scripts/build_llvm.bash
+if [[ "$OPTIX_VERSION" != "" ]] ; then
+    echo "Requested OPTIX_VERSION = '${OPTIX_VERSION}'"
+    mkdir -p $LOCAL_DEPS_DIR/dist/include/internal
+    OPTIXLOC=https://developer.download.nvidia.com/redist/optix/v${OPTIX_VERSION}
+    for f in optix.h optix_device.h optix_function_table.h \
+             optix_function_table_definition.h optix_host.h \
+             optix_stack_size.h optix_stubs.h optix_types.h optix_7_device.h \
+             optix_7_host.h optix_7_types.h \
+             internal/optix_7_device_impl.h \
+             internal/optix_7_device_impl_exception.h \
+             internal/optix_7_device_impl_transformations.h
+        do
+        curl --retry 100 -m 120 --connect-timeout 30 \
+            $OPTIXLOC/include/$f > $LOCAL_DEPS_DIR/dist/include/$f
+    done
+    export OptiX_ROOT=$LOCAL_DEPS_DIR/dist
 fi
-
-
-# Build or download LLVM
-#source src/build-scripts/build_llvm.bash
 
 source src/build-scripts/build_pybind11.bash
 

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -25,7 +25,7 @@ export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/lib"
 
-# export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+# export OSL_CMAKE_FLAGS="$OSL_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 # export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
 ls -l "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC"
@@ -79,7 +79,7 @@ cd $INT_DIR
 cmake ../.. -G "$CMAKE_GENERATOR" -DCMAKE_CONFIGURATION_TYPES="$CMAKE_BUILD_TYPE" -DCMAKE_PREFIX_PATH="$DEP_DIR" -DCMAKE_INSTALL_PREFIX="$DEP_DIR"
 cmake --build . --config $CMAKE_BUILD_TYPE --target install
 popd
-export MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DZLIB_LIBRARY=$DEP_DIR/lib/zlib.lib"
+export OSL_CMAKE_FLAGS="$OSL_CMAKE_FLAGS -DZLIB_LIBRARY=$DEP_DIR/lib/zlib.lib"
 export OPENEXR_CMAKE_FLAGS="$OPENEXR_CMAKE_FLAGS -DZLIB_LIBRARY=$DEP_DIR/lib/zlib.lib"
 
 source src/build-scripts/build_pybind11.bash
@@ -131,4 +131,4 @@ if [[ "$PYTHON_VERSION" == "3.6" ]] ; then
 fi
 
 # For CI on Windows, prefer to pick up static libs where possible
-MY_CMAKE_FLAGS="$MY_CMAKE_FLAGS -DLINKSTATIC=1 -DBUILD_SHARED_LIBS=0"
+OSL_CMAKE_FLAGS="$OSL_CMAKE_FLAGS -DLINKSTATIC=1 -DBUILD_SHARED_LIBS=0"

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -175,10 +175,6 @@ if (USE_CUDA OR USE_OPTIX)
         message (FATAL_ERROR "NVPTX target is not available in the provided LLVM build")
     endif()
 
-    if (${CUDA_VERSION} VERSION_GREATER 8 AND ${LLVM_VERSION} VERSION_LESS 6)
-        message (FATAL_ERROR "CUDA ${CUDA_VERSION} requires LLVM 6.0 or greater")
-    endif ()
-
     set (CUDA_LIB_FLAGS "--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
 
     find_library(cuda_lib NAMES cudart

--- a/src/cmake/modules/FindOptiX.cmake
+++ b/src/cmake/modules/FindOptiX.cmake
@@ -7,7 +7,7 @@
 #
 # This module will set
 #   OPTIX_FOUND          True, if OptiX is found
-#   OPTIX_INCLUDE_DIR    directory where OptiX headers are found
+#   OPTIX_INCLUDES       directory where OptiX headers are found
 #   OPTIX_LIBRARIES      libraries for OptiX
 #
 # Special inputs:
@@ -52,16 +52,18 @@ macro(OPTIX_find_api_library name version)
     endif()
 endmacro()
 
-# Pull out the API version from optix.h
-file(STRINGS ${OPTIX_INCLUDE_DIR}/optix.h OPTIX_VERSION_LINE LIMIT_COUNT 1 REGEX "define OPTIX_VERSION")
-string(REGEX MATCH "([0-9]+)" OPTIX_VERSION_STRING "${OPTIX_VERSION_LINE}")
-math(EXPR OPTIX_VERSION_MAJOR "${OPTIX_VERSION_STRING}/10000")
-math(EXPR OPTIX_VERSION_MINOR "(${OPTIX_VERSION_STRING}%10000)/100")
-math(EXPR OPTIX_VERSION_MICRO "${OPTIX_VERSION_STRING}%100")
-set(OPTIX_VERSION "${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR}.${OPTIX_VERSION_MICRO}")
+if (OPTIX_INCLUDE_DIR)
+    # Pull out the API version from optix.h
+    file(STRINGS ${OPTIX_INCLUDE_DIR}/optix.h OPTIX_VERSION_LINE LIMIT_COUNT 1 REGEX "define OPTIX_VERSION")
+    string(REGEX MATCH "([0-9]+)" OPTIX_VERSION_STRING "${OPTIX_VERSION_LINE}")
+    math(EXPR OPTIX_VERSION_MAJOR "${OPTIX_VERSION_STRING}/10000")
+    math(EXPR OPTIX_VERSION_MINOR "(${OPTIX_VERSION_STRING}%10000)/100")
+    math(EXPR OPTIX_VERSION_MICRO "${OPTIX_VERSION_STRING}%100")
+    set(OPTIX_VERSION "${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR}.${OPTIX_VERSION_MICRO}")
+endif ()
 
 # OptiX 7 doesn't link to any libraries
-if (${OPTIX_VERSION_MAJOR} LESS 7)
+if (OPTIX_VERSION VERSION_LESS 7)
     OPTIX_find_api_library(optix ${OPTIX_VERSION})
     OPTIX_find_api_library(optixu ${OPTIX_VERSION})
     OPTIX_find_api_library(optix_prime ${OPTIX_VERSION})

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -185,6 +185,7 @@ target_include_directories (${local_lib}
 target_compile_definitions (${local_lib}
     PRIVATE
         OSL_EXPORTS
+        CUDA_TARGET_ARCH="${CUDA_TARGET_ARCH}"
         OSL_CUDA_VERSION="${CUDA_VERSION}"
         OSL_OPTIX_VERSION="${OPTIX_VERSION}"
     )

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -5321,10 +5321,12 @@ LLVM_Util::ptx_compile_group (llvm::Module* lib_module, const std::string& name,
     options.StackAlignmentOverride                 = 0;
     options.UseInitArray                           = 0;
 
+#define STRINGIFY(x) #x
     llvm::TargetMachine* target_machine = llvm_target->createTargetMachine(
-        target_triple, "sm_35", "+ptx50", options,
+        target_triple, STRINGIFY(CUDA_TARGET_ARCH), "+ptx50", options,
         llvm::Reloc::Static, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive);
     OSL_ASSERT (target_machine && "PTX compile error: Unable to create target machine -- is NVPTX enabled in LLVM?");
+#undef STRINGIFY
 
     // Setup the optimization passes
     llvm::legacy::FunctionPassManager fn_pm (linked_module);

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -5321,12 +5321,10 @@ LLVM_Util::ptx_compile_group (llvm::Module* lib_module, const std::string& name,
     options.StackAlignmentOverride                 = 0;
     options.UseInitArray                           = 0;
 
-#define STRINGIFY(x) #x
     llvm::TargetMachine* target_machine = llvm_target->createTargetMachine(
-        target_triple, STRINGIFY(CUDA_TARGET_ARCH), "+ptx50", options,
+        target_triple, CUDA_TARGET_ARCH, "+ptx50", options,
         llvm::Reloc::Static, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive);
     OSL_ASSERT (target_machine && "PTX compile error: Unable to create target machine -- is NVPTX enabled in LLVM?");
-#undef STRINGIFY
 
     // Setup the optimization passes
     llvm::legacy::FunctionPassManager fn_pm (linked_module);


### PR DESCRIPTION
It can't run the tests, because there is no GPU on the GHA
instance. But at least we can tell if a PR will breake the build
itself. Later we will find a way to execute these via ASWF's AWS
instances that are for this purpose.

Includes the following changes:

* Download optix headers when needed. The ASWF docker container we're
  running on already has Cuda.

* Use CUDA_TARGET_ARCH CMake variable instead of hard coding in
  llvm_util.cpp.

* Bump cuda target default to sm_50.

* Make CI failure artifacts include CMakeCache.txt for inspection.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
