### PR TITLE
Build: Require exact version if PYTHON_VERSION is specified

### DIFF
--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -20,10 +20,12 @@ macro (find_python)
 
     # Attempt to find the desired version, but fall back to other
     # additional versions.
+    unset (_req)
     if (USE_PYTHON)
         set (_req REQUIRED)
-    else ()
-        unset (_req)
+        if (PYTHON_VERSION)
+            list (APPEND _req EXACT)
+        endif ()
     endif ()
     checked_find_package (Python ${PYTHON_VERSION}
                           ${_req}


### PR DESCRIPTION
Fixes issues on Mac when there are several Homebrew python versions installed.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
