### PR TITLE
Let Mac CI use llvm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   vfxplatform-2020:
     name: "Linux VFXP-2020 gcc6/C++14 llvm10 py3.7 boost-1.70 exr-2.4 OIIO-2.1 sse4"
@@ -78,7 +78,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   vfxplatform-2021:
     name: "Linux VFXP-2021 gcc9/C++17 llvm11 py3.7 boost-1.70 exr-2.5 OIIO-2.2 avx2"
@@ -106,7 +106,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   # Build for OptiX, but don't run tests (will need a GPU instance for that)
   gpu-optix7-2019:
@@ -138,7 +138,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
             optix.h
 
   linux-debug-gcc7-llvm8:
@@ -166,7 +166,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   linux-clang9-llvm9:
     name: "Linux clang9, C++14, llvm9, oiio release, avx, exr2.4, avx"
@@ -194,7 +194,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   linux-2021ish-gcc8-llvm10:
     name: "Linux gcc8, C++17, llvm10, oiio master, avx2, exr2.5, avx2"
@@ -222,7 +222,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   linux-bleeding-edge:
     # Test against development master for relevant dependencies, latest
@@ -256,7 +256,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   linux-oldest:
     # Oldest versions of the dependencies that we can muster, and various
@@ -289,7 +289,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   macos-py38:
     name: "Mac py38"
@@ -303,12 +303,6 @@ jobs:
           CMAKE_CXX_STANDARD: 14
           PYTHON_VERSION: 3.8
           LLVM_BC_GENERATOR: /usr/bin/clang++
-          LLVMBREWVER: "@9"
-            # ^^ There's a bug in the current Homebrew llvm 10.0.1 where
-            # it fails to link because of missing libxml2.tbd. It's fixed
-            # upstream in LLVM, but not yet fixed in Homebrew. Hopefully
-            # a subsequent 10.0.x or 11.x will fix it, but for now, just
-            # fall back to llvm@9.
           OSL_CMAKE_FLAGS: -DLLVM_BC_GENERATOR=/usr/bin/clang++
             # ^^ Force bitcode compiles to use the system clang compiler by
             # preemptively telling it the LLVM_BC_GENERATOR, to avoid some
@@ -316,9 +310,7 @@ jobs:
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/install_homebrew_deps.bash
-            brew uninstall llvm
-            OPENIMAGEIO_CMAKE_FLAGS="-DOIIO_BUILD_TESTS=0 -DUSE_OPENGL=0"
-            source src/build-scripts/build_openimageio.bash
+            brew install openimageio
             source src/build-scripts/ci-build-and-test.bash
       - uses: actions/upload-artifact@v2
         if: failure()
@@ -326,7 +318,7 @@ jobs:
           name: ${{ github.job }}
           path: |
             build/*/testsuite/*/*.*
-            build/*/CMakeCache.txt
+            build/*/CMake*.{txt,log}
 
   # windows:
   #   name: "Windows"


### PR DESCRIPTION
Also make the error artifact include CMake log files.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
