### PR TITLE
CI/Mac: fix broken tests involving oslquery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,8 @@ jobs:
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
 
-  macos-py38:
-    name: "Mac py38"
+  macos-py39:
+    name: "Mac py39"
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
@@ -301,7 +301,7 @@ jobs:
           CXX: clang++
           USE_CPP: 14
           CMAKE_CXX_STANDARD: 14
-          PYTHON_VERSION: 3.8
+          PYTHON_VERSION: 3.9
           LLVM_BC_GENERATOR: /usr/bin/clang++
           OSL_CMAKE_FLAGS: -DLLVM_BC_GENERATOR=/usr/bin/clang++
             # ^^ Force bitcode compiles to use the system clang compiler by
@@ -310,7 +310,10 @@ jobs:
         run: |
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/install_homebrew_deps.bash
+            # OPENIMAGEIO_CMAKE_FLAGS="-DOIIO_BUILD_TESTS=0 -DUSE_OPENGL=0"
+            # source src/build-scripts/build_openimageio.bash
             brew install openimageio
+            PYTHONPATH=$PYTHONPATH:/usr/local/python${PYTHON_VERSION}/site-packages
             source src/build-scripts/ci-build-and-test.bash
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ test: build
 	    LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${LD_LIBRARY_PATH} \
 	    DYLD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${DYLD_LIBRARY_PATH} \
 	    OIIO_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${OIIO_LIBRARY_PATH} \
-	    PYTHONPATH=${working_dir}/${build_dir}/src/python:${PYTHONPATH} \
+	    PYTHONPATH=${working_dir}/${build_dir}/lib/python/site-packages:${PYTHONPATH} \
 	    ctest -E broken ${TEST_FLAGS} \
 	  )
 	@ ( if [[ "${CODECOV}" == "1" ]] ; then \

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -21,7 +21,7 @@ fi
 
 
 brew uninstall openssl
-#brew update >/dev/null
+brew update >/dev/null
 echo ""
 echo "Before my brew installs:"
 brew list --versions

--- a/testsuite/python-oslquery/src/test_oslquery.py
+++ b/testsuite/python-oslquery/src/test_oslquery.py
@@ -60,8 +60,15 @@ try:
     # Iterating over the query object itself is iterating over the
     # parameters to the shader:
     print ("  Parameters:")
-    for p in q :
-        printparam(p)
+    for i in range(len(q)) :
+        printparam(q[i])
+    # FIXME(pybind11): The following way of looping over params should work.
+    # But on Mac, with a combination of python 3.8/3.9 and pybind11 2.6, it
+    # crashes. Works with older pybind11, so I think it's a pybind11 bug
+    # that will get fixed at some point. Try it again later.
+    #
+    # for p in q :
+    #     printparam(p)
 
     print ("Done.")
 except Exception as detail:


### PR DESCRIPTION
The specific combination of Mac + Python 3.8/3.9 + the lastest
pybind11 release causes a crash in the testsuite/python-oslquery
test. It works on other platforms and with older versions of pybind11.

I've tried to understand exactly what's going wrong, and have come up
empty and can't justify spending more time on it. It's suspiciously
similar to several recently "fixed" pybind11+python interaction bugs,
I suspect there are a couple edge cases they missed and that it will
be fixed eventually in a future pybind11 release (or possibly a future
python patch, there does seem to be a problem that pybind11 uncovered
in the cpython code).

In the mean time, a slight rewrite of the loop avoids the problem for
the purposes of our CI tests.

Also a few adjustments to switch back to python 3.9 after some recent
Homebrew fixes that had made us revert back to 3.8 for a while.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

