### PR TITLE
Bug fix: optimizer interaction with output param that also is userdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             transitive-assign
             transform transformc trig typecast
             unknown-instruction
-            userdata
+            userdata userdata-passthrough
             vararray-connect vararray-default
             vararray-deserialize vararray-param
             vecctr vector

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -395,6 +395,14 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
         return true;
     }
 
+    if (const OIIO::ParamValue* p = userdata.find_pv(name, type)) {
+        size_t size = p->type().size();
+        memcpy(val, p->data(), size);
+        if (derivatives)
+            memcpy(val, (char*)p->data() + size, 2 * size);
+        return true;
+    }
+
     return false;
 }
 

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -109,6 +109,7 @@ public:
 
     ShadingSystem *shadingsys = nullptr;
     OIIO::ParamValueList options;
+    OIIO::ParamValueList userdata;
 
 protected:
     // Camera parameters

--- a/testsuite/debug-uninit/ref/out-opt2.txt
+++ b/testsuite/debug-uninit/ref/out-opt2.txt
@@ -1,10 +1,10 @@
 Compiled test.osl -> test.oso
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 0 'assign', arg 1)
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 1 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 2 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 1 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 2 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 3 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
-ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 6 'aref', arg 1)
-ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'compref', arg 1)
-ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'mxcompref', arg 1)
+ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 7 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 12 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 17 'mxcompref', arg 1)

--- a/testsuite/debug-uninit/ref/out.txt
+++ b/testsuite/debug-uninit/ref/out.txt
@@ -1,10 +1,10 @@
 Compiled test.osl -> test.oso
 
 Output Cout to Cout.tif
-ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 3 'assign', arg 1)
-ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 4 'color', arg 1)
-ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 5 'texture', arg 1)
+ERROR: Detected possible use of uninitialized value in int i_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 4 'assign', arg 1)
+ERROR: Detected possible use of uninitialized value in float f_uninit at test.osl:14 (group unnamed_group_1, layer 0 test_0, shader test, op 5 'color', arg 1)
+ERROR: Detected possible use of uninitialized value in string s_uninit at test.osl:15 (group unnamed_group_1, layer 0 test_0, shader test, op 6 'texture', arg 1)
 ERROR: [RendererServices::texture] ImageInput::create() called with no filename
-ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 11 'aref', arg 1)
-ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 16 'compref', arg 1)
-ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 21 'mxcompref', arg 1)
+ERROR: Detected possible use of uninitialized value in float[3] A at test.osl:22 (group unnamed_group_1, layer 0 test_0, shader test, op 12 'aref', arg 1)
+ERROR: Detected possible use of uninitialized value in color C at test.osl:28 (group unnamed_group_1, layer 0 test_0, shader test, op 17 'compref', arg 1)
+ERROR: Detected possible use of uninitialized value in matrix M at test.osl:34 (group unnamed_group_1, layer 0 test_0, shader test, op 22 'mxcompref', arg 1)

--- a/testsuite/userdata-passthrough/ref/out.txt
+++ b/testsuite/userdata-passthrough/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled test.osl -> test.oso
+
+Output Cd to Cd.tif
+Pixel (0, 0):
+  Cd : 1 1 1

--- a/testsuite/userdata-passthrough/run.py
+++ b/testsuite/userdata-passthrough/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+command = testshade("--userdata:type=vector Cd 1,1,1 -o Cd Cd.tif --print test")

--- a/testsuite/userdata-passthrough/test.osl
+++ b/testsuite/userdata-passthrough/test.osl
@@ -1,0 +1,26 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+// This is testing the specific combination of an output parameter (which
+// is presumed to be a renderer output or otherwise definitely used) which
+// gets its value from userdata (lockgeom=0).
+//
+// Cd is what we call a "pass-through" value: its initial value is from an
+// input, it gets modified, but it's also an output.
+//
+// Here's the interesting bug, prior to 1.12: If scale is non-1, all is
+// fine, the output will be scale*input_Cd. But when scale is exactly 1.0,
+// the `Cd *= scale` will be optimized away, leaving no ops in the shader
+// that read Cd, and therefore get_userdata will never be called to retrieve
+// the value, and so the output value of Cd will be its default here, 0. But
+// in fact, it should still hold whatever value it has from teh userdata.
+
+
+shader test (float scale = 1,
+             output vector Cd = 0 [[ int lockgeom=0 ]]
+    )
+{
+    Cd *= scale;
+}


### PR DESCRIPTION
There's a "pass-through parameter" idiom, where an output param gets
its initial value from an input, it gets modified by the shader, but
it's also an output.

If the modification is optimized away -- say, if it was originally
`theparam *= scale` and scale is 1 -- then it may be that you end up
with no ops in the shader that read from the parameter. If the
parameter was hooked up to userdata, then get_userdata will never be
called to retrieve the value (because it's usually lazy, only doing
the callback the first time it's needed), and so the output value of
parameter will be its parameter default value in the shader, NOT the
value of the interpolated variable, which was never retrieved and
copied into it.

This patch adjusts the logic somewhat so that if that output parameter
is connected downstream or is a renderer output, then we definitely
initialize it with a useparam op, even if it is otherwise apparently
not read from within the shader, and also that a shader consisting of
*only* that particular flavor of useparam is not marked as "does
nothing" (thus skipping any code generation at all).

Added a new test for this specific case.

Modified testshade to allow arbitrary command line-specificed userdata,
to make constructing this kind of test easier, by adding a `--userdata`
command which constructs a ParamValueList that will be used to look up
"userdata" from the shader.

Also necessitated update to reference output of debug_uninit test,
only because the extra useparam op caused some of the instruction
numbering to change.
