### PR TITLE
Build against OpenEXR 3.0 + Imath 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
       - '**.tex'
   schedule:
     # Full nightly build
-    - cron: "0 4 * * *"
+    - cron: "0 8 * * *"
 
 
 jobs:
@@ -97,6 +97,36 @@ jobs:
           OPENEXR_VERSION: v2.5.3
           OPENIMAGEIO_VERSION: RB-2.2
         run: |
+            source src/build-scripts/ci-startup.bash
+            source src/build-scripts/gh-installdeps-centos.bash
+            source src/build-scripts/ci-build-and-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMake*.{txt,log}
+
+  vfxplatform-2021-exrmaster:
+    name: "Linux VFXP-2021 gcc9/C++17 llvm11 py3.7 boost-1.70 exr-3.0 OIIO-2.2 avx2"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-osl:2021-clang11
+    steps:
+      - uses: actions/checkout@v2
+      - name: all
+        env:
+          CXX: g++
+          CC: gcc
+          CMAKE_CXX_STANDARD: 17
+          PYTHON_VERSION: 3.7
+          USE_SIMD: avx2,f16c
+          OPENEXR_VERSION: master
+          OPENIMAGEIO_VERSION: RB-2.2
+        run: |
+            sudo rm -rf /usr/local/include/OpenEXR
+            sudo rm -rf /usr/local/lib64/cmake/{IlmBase,OpenEXR}
             source src/build-scripts/ci-startup.bash
             source src/build-scripts/gh-installdeps-centos.bash
             source src/build-scripts/ci-build-and-test.bash

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -6,10 +6,12 @@
 
 include(CMakeFindDependencyMacro)
 
-# add here all the public dependencies using find_dependency() whenever
-# switching to config based dependencies e.g. if switching to Boost::Boost
-# instead of using ${Boost_LIBRARY_DIRS} then add:
-#     find_dependency(Boost @Boost_VERSION@)
+# add here all the find_dependency() whenever switching to config based dependencies
+if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.5)
+    find_dependency(OpenEXR @OpenEXR_VERSION@)
+    # N.B. Only do this for OpenEXR >= 2.5, difficult to rely on their
+    # exported configs before that.
+endif ()
 
 find_dependency(OpenImageIO @OpenImageIO_VERSION@ REQUIRED)
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -79,10 +79,8 @@ link_directories ("${Boost_LIBRARY_DIRS}")
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
 
 # IlmBase & OpenEXR
-checked_find_package (OpenEXR 2.0 REQUIRED)
-# We use Imath so commonly, may as well include it everywhere.
-include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
-                     "${ILMBASE_INCLUDES}/OpenEXR")
+checked_find_package (OpenEXR 2.0 REQUIRED
+                      PRINT IMATH_INCLUDES)
 if (CMAKE_COMPILER_IS_CLANG AND OPENEXR_VERSION VERSION_LESS 2.3)
     # clang C++ >= 11 doesn't like 'register' keyword in old exr headers
     add_compile_options (-Wno-deprecated-register)

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -2,17 +2,109 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/imageworks/OpenShadingLanguage
 
-# Module to find OpenEXR.
+# Module to find OpenEXR and Imath.
 #
-# This module will set
+# I'm afraid this is a mess, due to needing to support a wide range of
+# OpenEXR versions.
+#
+# For OpenEXR & Imath 3.0, this will establish the following imported
+# targets:
+#
+#    Imath::Imath
+#    Imath::Half
+#    OpenEXR::OpenEXR
+#    OpenEXR::Iex
+#    OpenEXR::IlmThread
+#
+# For OpenEXR 2.4 & 2.5, it will establish the following imported targets:
+#
+#    IlmBase::Imath
+#    IlmBase::Half
+#    IlmBase::Iex
+#    IlmBase::IlmThread
+#    OpenEXR::IlmImf
+#
+# For all versions -- but for OpenEXR < 2.4 the only thing this sets --
+# are the following CMake variables:
+#
 #   OPENEXR_FOUND          true, if found
-#   OPENEXR_INCLUDES       directory where headers are found
+#   OPENEXR_INCLUDES       directory where OpenEXR headers are found
 #   OPENEXR_LIBRARIES      libraries for OpenEXR + IlmBase
-#   ILMBASE_LIBRARIES      libraries just IlmBase
 #   OPENEXR_VERSION        OpenEXR version (accurate for >= 2.0.0,
 #                              otherwise will just guess 1.6.1)
+#   IMATH_INCLUDES         directory where Imath headers are found
+#   ILMBASE_INCLUDES       directory where IlmBase headers are found
+#   ILMBASE_LIBRARIES      libraries just IlmBase
 #
 #
+
+# First, try to fine just the right config files
+find_package(Imath CONFIG)
+if (NOT TARGET Imath::Imath)
+    # Couldn't find Imath::Imath, maybe it's older and has IlmBase?
+    find_package(IlmBase CONFIG)
+endif ()
+find_package(OpenEXR CONFIG)
+
+if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
+    # OpenEXR 3.x if both of these targets are found
+    if (NOT OpenEXR_FIND_QUIETLY)
+        message (STATUS "Found CONFIG for OpenEXR 3 (OPENEXR_VERSION=${OpenEXR_VERSION})")
+    endif ()
+
+    # Mimic old style variables
+    set (OPENEXR_VERSION ${OpenEXR_VERSION})
+    get_target_property(IMATH_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_INCLUDES Imath::Imath INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(IMATH_LIBRARY Imath::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_IEX_LIBRARY OpenEXR::Iex INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_ILMTHREAD_LIBRARY OpenEXR::IlmThread INTERFACE_LINK_LIBRARIES)
+    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY})
+    set (ILMBASE_FOUND true)
+
+    get_target_property(OPENEXR_INCLUDES OpenEXR::OpenEXR INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::OpenEXR INTERFACE_LINK_LIBRARIES)
+    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_LIBRARIES})
+    set (OPENEXR_FOUND true)
+
+    # Link with pthreads if required
+    find_package (Threads)
+    if (CMAKE_USE_PTHREADS_INIT)
+        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4)
+    # OpenEXR 2.4 or 2.5 with exported config
+    if (NOT OpenEXR_FIND_QUIETLY)
+        message (STATUS "Found CONFIG for OpenEXR 2 (OPENEXR_VERSION=${OpenEXR_VERSION})")
+    endif ()
+
+    # Mimic old style variables
+    get_target_property(ILMBASE_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ILMBASE_Imath_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(ILMBASE_IMATH_LIBRARY IlmBase::Imath INTERFACE_LINK_LIBRARIES)
+    get_target_property(ILMBASE_HALF_LIBRARY IlmBase::Half INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_IEX_LIBRARY IlmBase::Iex INTERFACE_LINK_LIBRARIES)
+    get_target_property(OPENEXR_ILMTHREAD_LIBRARY IlmBase::IlmThread INTERFACE_LINK_LIBRARIES)
+    set (ILMBASE_LIBRARIES ${ILMBASE_IMATH_LIBRARY} ${ILMBASE_HALF_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY})
+    set (ILMBASE_FOUND true)
+
+    get_target_property(OPENEXR_INCLUDES OpenEXR::IlmImfConfig INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(OPENEXR_ILMIMF_LIBRARY OpenEXR::IlmImf INTERFACE_LINK_LIBRARIES)
+    set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES})
+    set (OPENEXR_FOUND true)
+
+    # Link with pthreads if required
+    find_package (Threads)
+    if (CMAKE_USE_PTHREADS_INIT)
+        list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+else ()
+    # OpenEXR 2.x older versions without a config or whose configs we don't
+    # trust.
 
 # Other standard issue macros
 include (FindPackageHandleStandardArgs)
@@ -135,17 +227,20 @@ find_package_handle_standard_args (OpenEXR
     REQUIRED_VARS ILMBASE_INCLUDE_PATH OPENEXR_INCLUDE_PATH
                   OPENEXR_IMATH_LIBRARY OPENEXR_ILMIMF_LIBRARY
                   OPENEXR_IEX_LIBRARY OPENEXR_HALF_LIBRARY
-    VERSION_VAR   OPENEXR_VERSION
     )
 
 if (OPENEXR_FOUND)
+    set (OpenEXR_VERSION ${OPENEXR_VERSION})
     set (ILMBASE_FOUND TRUE)
     set (ILMBASE_INCLUDES ${ILMBASE_INCLUDE_PATH})
+    set (IMATH_INCLUDES ${ILMBASE_INCLUDE_PATH})
     set (OPENEXR_INCLUDES ${OPENEXR_INCLUDE_PATH})
     set (ILMBASE_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
+    set (IMATH_INCLUDE_DIR ${ILMBASE_INCLUDE_PATH})
     set (OPENEXR_INCLUDE_DIR ${OPENEXR_INCLUDE_PATH})
     set (ILMBASE_LIBRARIES ${OPENEXR_IMATH_LIBRARY} ${OPENEXR_IEX_LIBRARY} ${OPENEXR_HALF_LIBRARY} ${OPENEXR_ILMTHREAD_LIBRARY} ${ILMBASE_PTHREADS} CACHE STRING "The libraries needed to use IlmBase")
     set (OPENEXR_LIBRARIES ${OPENEXR_ILMIMF_LIBRARY} ${ILMBASE_LIBRARIES} ${ZLIB_LIBRARIES} CACHE STRING "The libraries needed to use OpenEXR")
+    set (FINDOPENEXR_FALLBACK TRUE)
 endif ()
 
 mark_as_advanced(
@@ -157,3 +252,5 @@ mark_as_advanced(
 
 # Restore the original CMAKE_FIND_LIBRARY_SUFFIXES
 set (CMAKE_FIND_LIBRARY_SUFFIXES ${_openexr_orig_suffixes})
+
+endif ()

--- a/src/include/OSL/matrix22.h
+++ b/src/include/OSL/matrix22.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#define OSL_MATRIX22_H
 
 #include <OSL/oslconfig.h>
 

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -11,14 +11,27 @@
 
 
 // All the things we need from Imath.
-// We've replicated some Imath files in OSL/Imathx, adding the decorations
-// needed for them to be safe to compile with Cuda (and sometimes other
-// improvements). We will eventually push all of these fixes to OpenEXR.
-#include <OSL/Imathx/ImathLimits.h>
-#include <OSL/Imathx/ImathVec.h>
-#include <OSL/Imathx/ImathMatrix.h>
-#include <OSL/Imathx/ImathColor.h>
-#include <OSL/matrix22.h>
+#include <OpenEXR/OpenEXRConfig.h>
+#define OSL_OPENEXR_VERSION ((10000*OPENEXR_VERSION_MAJOR) + \
+                             (100*OPENEXR_VERSION_MINOR) + \
+                             OPENEXR_VERSION_PATCH)
+#if OSL_OPENEXR_VERSION >= 20599 /* 2.5.99: pre-3.0 */
+#   include <Imath/ImathLimits.h>
+#   include <Imath/ImathVec.h>
+#   include <Imath/ImathMatrix.h>
+#   include <Imath/ImathColor.h>
+#   define OSL_USING_IMATH 3
+#else
+    // OpenEXR 2.x lacks the Cuda decorators we need, so we replicated some
+    // Imath files in OSL/Imathx, adding the decorations needed for them to
+    // be safe to compile with Cuda (and sometimes other improvements).
+#   include <OSL/Imathx/ImathLimits.h>
+#   include <OSL/Imathx/ImathVec.h>
+#   include <OSL/Imathx/ImathMatrix.h>
+#   include <OSL/Imathx/ImathColor.h>
+#   include <OSL/matrix22.h>
+#   define OSL_USING_IMATH 2
+#endif
 
 // The fmt library causes trouble for Cuda. Work around by disabling it from
 // oiio headers (OIIO <= 2.1) or telling fmt not to use the troublesome
@@ -60,13 +73,17 @@ typedef float Float;
 /// matrices have the same data layout as Float[n][n]; and (c) your
 /// classes have most of the obvious constructors and overloaded
 /// operators one would expect from a C++ vector/matrix/color class.
-typedef Imath::Vec3<Float>     Vec3;
-typedef Imath::Matrix33<Float> Matrix33;
-typedef Imath::Matrix44<Float> Matrix44;
-typedef Imath::Color3<Float>   Color3;
-typedef Imath::Vec2<Float>     Vec2;
+using Vec2     = Imath::Vec2<Float>;
+using Vec3     = Imath::Vec3<Float>;
+using Color3   = Imath::Color3<Float>;
+using Matrix33 = Imath::Matrix33<Float>;
+using Matrix44 = Imath::Matrix44<Float>;
 
-typedef Imathx::Matrix22<Float> Matrix22;
+#if OSL_USING_IMATH >= 3
+using Matrix22 = Imath::Matrix22<Float>;
+#else
+using Matrix22 = Imathx::Matrix22<Float>;
+#endif
 
 
 /// Assume that we are dealing with OpenImageIO's texture system.  It

--- a/src/liboslcomp/CMakeLists.txt
+++ b/src/liboslcomp/CMakeLists.txt
@@ -20,11 +20,20 @@ add_library (${local_lib} ${lib_src})
 target_include_directories(${local_lib}
     PUBLIC
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-        ${ILMBASE_INCLUDES}
+        ${IMATH_INCLUDES}
     )
 target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO
+        # For OpenEXR/Imath 3.x:
+        $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+        $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+        # For OpenEXR >= 2.4/2.5 with reliable exported targets
+        $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+        $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+        $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+        $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+        # For OpenEXR <= 2.3:
         ${ILMBASE_LIBRARIES}
     PRIVATE
         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -99,6 +99,9 @@ macro ( LLVM_COMPILE llvm_src srclist )
     #    endif ()
     #endif ()
 
+    list (TRANSFORM IMATH_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_IMATH_INCLUDES)
+
     # Command to turn the .cpp file into LLVM assembly language .s, into
     # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
     add_custom_command ( OUTPUT ${llvm_bc_cpp}
@@ -108,8 +111,7 @@ macro ( LLVM_COMPILE llvm_src srclist )
           "-I${CMAKE_SOURCE_DIR}/src/include"
           "-I${CMAKE_BINARY_DIR}/include"
           "-I${OpenImageIO_INCLUDES}"
-          "-I${ILMBASE_INCLUDES}"
-          "-I${OPENEXR_INCLUDES}"
+          ${ALL_IMATH_INCLUDES}
           "-isystem ${Boost_INCLUDE_DIRS}"
           -DOSL_COMPILING_TO_BITCODE=1
           -Wno-deprecated-register
@@ -217,6 +219,15 @@ endif()
 target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO
+        # For OpenEXR/Imath 3.x:
+        $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+        $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+        # For OpenEXR >= 2.4/2.5 with reliable exported targets
+        $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+        $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+        $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+        $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+        # For OpenEXR <= 2.3:
         ${ILMBASE_LIBRARIES}
     PRIVATE
         pugixml::pugixml

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -83,7 +83,6 @@ typedef long double max_align_t;
 #include <OSL/dual_vec.h>
 using namespace OSL;
 
-#include <OpenEXR/ImathFun.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/simd.h>
 

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -26,7 +26,6 @@ static bool make_images = false;
 const int imgres = 64;
 const float imgscale = 8.0;
 const float eps = 0.001;   // Comparison threshold for results
-const Vec3 veps (eps,eps,eps);
 
 
 

--- a/src/liboslquery/py_osl.h
+++ b/src/liboslquery/py_osl.h
@@ -23,9 +23,13 @@
 // Avoid a compiler warning from a duplication in tiffconf.h/pyconfig.h
 #undef SIZEOF_LONG
 
-#include <OpenEXR/half.h>
-
 #include <OSL/oslquery.h>
+
+#if OSL_USING_IMATH >= 3
+#    include <Imath/half.h>
+#else
+#    include <OpenEXR/half.h>
+#endif
 
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>


### PR DESCRIPTION
As OpenEXR works toward their 3.0 release, which includes splitting
Imath (the vector, matrix, math, and 'half' stuff) out into a separate
repo, their top of tree master finally breaks our "bleeding edge"
build.

This is a little tricky, because now our support of this dependency is
attempting to span 3 eras: 3.0 with the full split of openexr from
imath, recent openexr+ilmbase 2.x that supplies reliable exported
cmake configs, and older 2.x that predates cmake configs. Eventually
we'll phase out older versions and clean up.

Fixes in this patch generally include:

* Add a new CI test of VFX2021 + openexr/imath master. (This will go away
  when 3.0 is released and that's what we use for the main 2021 case.)

* For new enough versions of OpenEXR, use the exported config file and
  targets, rather than the old style OPENEXR_LIBRARIES style variables.
  We have kind of a mixed idiom use because we're still supporting older
  versions that predate use of the config files.

* Deal with the fact that the Imath headers now live inside
  `<Imath/ImathBlah.h>` rather than `<OpenEXR/ImathBlah.h>`. But of
  course, you need to start including things just to find out the
  version. It's tricky.  The logic is to look at
  `<OpenEXR/OpenEXRConfig.h>` to determine the version we're dealing
  with, then include Imath stuff from one or the other depending on
  what we found. I rearranged quite a few includes to ensure that all
  this logic only happens in a couple spots and the rest gets included
  transitively. As it turns out, quite a few of our `#include`s of
  Imath headers were redundant.

* OSL's exported config needs to look for OpenEXR.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
