### PR TITLE
Add `#pragma error` and `warning` to OSL preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
             oslc-err-struct-array-init oslc-err-struct-ctr
             oslc-err-struct-dup oslc-err-struct-print
             oslc-err-unknown-ctr
+            oslc-pragma-warnerr
             oslc-warn-commainit
             oslc-variadic-macro
             oslc-version

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -870,7 +870,10 @@ directives, including:
     #else
     #endif
     #include
+    #pragma error "message"
     #pragma once
+    #pragma osl ...
+    #pragma warning "message"
 \end{code}
 
 \noindent Additionally, the following preprocessor symbols will already be

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -311,7 +311,27 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
         // pragma
         OIIO::string_view line (p+6);
         string_view pragmatype = OIIO::Strutil::parse_word (line);
-        if (OIIO::Strutil::iequals (pragmatype, "osl")) {
+        if (pragmatype == "error") {
+            string_view msg;
+            if (OIIO::Strutil::parse_string(line, msg))
+                oslcompiler->errorf(oslcompiler->filename(),
+                                    oslcompiler->lineno(), "%s", msg);
+            else
+                oslcompiler->errorf(oslcompiler->filename(),
+                                    oslcompiler->lineno(),
+                                    "<unknown error>");
+        }
+        else if (pragmatype == "warning") {
+            string_view msg;
+            if (OIIO::Strutil::parse_string(line, msg))
+                oslcompiler->warningf(oslcompiler->filename(),
+                                      oslcompiler->lineno(), "%s", msg);
+            else
+                oslcompiler->warningf(oslcompiler->filename(),
+                                      oslcompiler->lineno(),
+                                      "<unknown warning>");
+        }
+        else if (OIIO::Strutil::iequals (pragmatype, "osl")) {
             string_view pragmaname = OIIO::Strutil::parse_word (line);
             if (pragmaname == "nowarn") {
                 oslcompiler->pragma_nowarn ();
@@ -320,7 +340,7 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
                                       "Unknown pragma '%s'", pragmaname);
             }
         }
-        // N.B. Pragmas that don't start with "osl" are ignored
+        // N.B. Any other pragmas that don't start with "osl" are ignored
         oslcompiler->incr_lineno();  // the pragma ends with an EOLN
     } else {  /* probably the line number and filename */
         if (! strncmp (p, "line", 4))

--- a/testsuite/oslc-pragma-warnerr/NOOPTIMIZE
+++ b/testsuite/oslc-pragma-warnerr/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-pragma-warnerr/NOOPTIX
+++ b/testsuite/oslc-pragma-warnerr/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-pragma-warnerr/ref/out.txt
+++ b/testsuite/oslc-pragma-warnerr/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:2: warning: this is a warning
+test.osl:7: error: this is an error
+FAILED test.osl

--- a/testsuite/oslc-pragma-warnerr/run.py
+++ b/testsuite/oslc-pragma-warnerr/run.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-pragma-warnerr/test.osl
+++ b/testsuite/oslc-pragma-warnerr/test.osl
@@ -1,0 +1,8 @@
+
+#pragma warning "this is a warning"
+
+
+shader test ()
+{
+    #pragma error "this is an error"
+}


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>
