### PR TITLE
Add plumbing through ShadyingSystem into Context to support Batched Execution

### DIFF
--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -486,4 +486,6 @@ DataT* assume_aligned(DataT* ptr)
 
 #endif
 
+static constexpr int MaxSupportedSimdLaneCount = 16;
+
 OSL_NAMESPACE_EXIT

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -119,8 +119,6 @@ assign_all(Block<DataT, WidthT>&, const DataT&);
 // NOTE: additional constructors & helpers functions exist in the implementation
 // that were not specified in the descriptions above for brevity.
 
-static constexpr int MaxSupportedSimdLaneCount = 16;
-
 /// Type for an opaque pointer to whatever the renderer uses to represent a
 /// coordinate transformation.
 typedef const void* TransformationPtr;

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -487,6 +487,7 @@ public:
         , m_layer(-1)
         , m_scope(0)
         , m_dataoffset(-1)
+        , m_wide_dataoffset(-1)
         , m_initializers(0)
         , m_node(declaration_node)
         , m_alias(NULL)
@@ -607,6 +608,9 @@ public:
 
     void dataoffset(int d) { m_dataoffset = d; }
     int dataoffset() const { return m_dataoffset; }
+
+    void wide_dataoffset (int d) { m_wide_dataoffset = d; }
+    int wide_dataoffset () const { return m_wide_dataoffset; }
 
     void initializers(int d) { m_initializers = d; }
     int initializers() const { return m_initializers; }
@@ -828,6 +832,7 @@ protected:
     short m_layer;                ///< Layer (within the group) this belongs to
     int m_scope;                  ///< Scope where this symbol was declared
     int m_dataoffset;             ///< Offset of the data (-1 for unknown)
+    int m_wide_dataoffset;        ///< Offset of the wide data (-1 for unknown)
     int m_initializers;           ///< Number of default initializers
     ASTNode* m_node;              ///< Ptr to the declaration of this symbol
     Symbol* m_alias;              ///< Another symbol that this is an alias for

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -609,8 +609,8 @@ public:
     void dataoffset(int d) { m_dataoffset = d; }
     int dataoffset() const { return m_dataoffset; }
 
-    void wide_dataoffset (int d) { m_wide_dataoffset = d; }
-    int wide_dataoffset () const { return m_wide_dataoffset; }
+    void wide_dataoffset(int d) { m_wide_dataoffset = d; }
+    int wide_dataoffset() const { return m_wide_dataoffset; }
 
     void initializers(int d) { m_initializers = d; }
     int initializers() const { return m_initializers; }

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -5,10 +5,15 @@
 #include <vector>
 #include <string>
 #include <cstdio>
+#include <cstdint>
 
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
 #include <OpenImageIO/thread.h>
+
+#include <OSL/batched_shaderglobals.h>
+#include <OSL/mask.h>
+#include <OSL/wide.h>
 
 #include "oslexec_pvt.h"
 
@@ -17,11 +22,23 @@ OSL_NAMESPACE_ENTER
 static mutex buffered_errors_mutex;
 
 
+namespace pvt {
+
+template <size_t ByteAlignmentT, typename T>
+inline bool is_aligned(const T *pointer)
+{
+    static_assert(OSL_CPLUSPLUS_VERSION >= 11, "std::uintptr_t is optional yet ubiquitous C++11 feature");
+    std::uintptr_t ptrAsUint = reinterpret_cast<std::uintptr_t>(pointer);
+    return (ptrAsUint%ByteAlignmentT==0);
+}
+
+} // namespace pvt
 
 ShadingContext::ShadingContext (ShadingSystemImpl &shadingsys,
                                 PerThreadInfo *threadinfo)
     : m_shadingsys(shadingsys), m_renderer(m_shadingsys.renderer()),
-      m_group(NULL), m_max_warnings(shadingsys.max_warnings_per_thread()), m_dictionary(NULL)
+      m_group(NULL), m_max_warnings(shadingsys.max_warnings_per_thread()),
+      m_dictionary(NULL), m_execution_is_batched(false)
 {
     m_shadingsys.m_stat_contexts += 1;
     m_threadinfo = threadinfo ? threadinfo : shadingsys.get_perthread_info ();
@@ -44,6 +61,7 @@ ShadingContext::execute_init (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
 {
     if (m_group)
         execute_cleanup ();
+    m_execution_is_batched = false;
     m_group = &sgroup;
     m_ticks = 0;
 
@@ -186,6 +204,171 @@ ShadingContext::execute (ShaderGroup &sgroup, ShaderGlobals &ssg, bool run)
     return result;
 }
 
+template<int WidthT>
+bool
+ShadingContext::Batched<WidthT>::execute_init
+(ShaderGroup &sgroup, int batch_size, BatchedShaderGlobals<WidthT> &bsg, bool run)
+{
+    if (context().m_group)
+        context().execute_cleanup ();
+
+    context().m_execution_is_batched = true;
+    context().m_group = &sgroup;
+    context().m_ticks = 0;
+
+    // Optimize if we haven't already
+    if (sgroup.nlayers()) {
+        sgroup.start_running ();
+        if (! sgroup.batch_jitted()) {
+            shadingsys().template batched<WidthT>().jit_group(sgroup, &context());
+            if (shadingsys().m_greedyjit && shadingsys().m_groups_to_compile_count) {
+                // If we are greedily JITing, optimize/JIT everything now
+                shadingsys().template batched<WidthT>().jit_all_groups();
+            }
+        }
+        // To handle layers that were not used but still possibly had
+        // render outputs, we always generate a run function even for
+        // do nothing groups, so that a GroupData on the heap gets built
+        // and the run function can broadcast default values there.
+        //
+        // Observation is that nothing ever overwrites that default value
+        // so we could just run it once, or deal with broadcasting the
+        // default value ourselves
+
+    } else {
+       // empty shader - nothing to do!
+       return false;
+    }
+
+    int profile = shadingsys().m_profile;
+    OIIO::Timer timer (profile ? OIIO::Timer::StartNow : OIIO::Timer::DontStartNow);
+
+    // Allocate enough space on the heap
+    size_t heap_size_needed = sgroup.llvm_groupdata_wide_size();
+    context().reserve_heap(heap_size_needed);
+    // Zero out the heap memory we will be using
+    if (shadingsys().m_clearmemory)
+        memset (context().m_heap.get(), 0, heap_size_needed);
+
+    // Set up closure storage
+    context().m_closure_pool.clear();
+
+    // Clear the message blackboard
+    context().m_messages.clear ();
+    // TODO: implement batched_messages
+    //context().batched_messages(WidthOf<WidthT>()).clear ();
+
+    // Clear miscellaneous scratch space
+    context().m_scratch_pool.clear ();
+
+    // Zero out stats for this execution
+    context().clear_runtime_stats ();
+
+    if (run) {
+        bsg.uniform.context = &context();
+        bsg.uniform.renderer = context().renderer();
+        bsg.uniform.Ci = NULL;
+        RunLLVMGroupFuncWide run_func = sgroup.llvm_compiled_wide_init();
+        OSL_DASSERT (run_func);
+        OSL_DASSERT (sgroup.llvm_groupdata_wide_size() <= context().m_heapsize);
+
+        if(batch_size > 0) {
+            Mask<WidthT> run_mask(false);
+            for(int ri=0; ri < batch_size; ++ri)
+            {
+                run_mask.set_on(ri);
+            }
+
+            run_func (&bsg, context().m_heap.get(), run_mask.value());
+        }
+    }
+
+    if (profile)
+        context().m_ticks += timer.ticks();
+    return true;
+}
+
+template<int WidthT>
+bool
+ShadingContext::Batched<WidthT>::execute_layer (int batch_size, BatchedShaderGlobals<WidthT> &bsg, int layernumber)
+{
+    if (!group() || group()->nlayers() == 0 || group()->does_nothing())
+        return false;
+    OSL_DASSERT (bsg.uniform.context == &context() && bsg.uniform.renderer == context().renderer());
+
+    int profile = shadingsys().m_profile;
+    OIIO::Timer timer (profile ? OIIO::Timer::StartNow : OIIO::Timer::DontStartNow);
+
+    size_t prev_end_of_errors = context().m_buffered_errors.size();
+
+    RunLLVMGroupFuncWide run_func = group()->llvm_compiled_wide_layer (layernumber);
+    if (! run_func)
+        return false;
+
+    OSL_ASSERT(pvt::is_aligned<64>(&bsg));
+    OSL_ASSERT(pvt::is_aligned<64>(context().m_heap.get()));
+
+    if (batch_size > 0) {
+        Mask<WidthT> run_mask(false);
+        for(int ri=0; ri < batch_size; ++ri)
+        {
+            run_mask.set_on(ri);
+        }
+
+        run_func (&bsg, context().m_heap.get(), run_mask.value());
+    }
+
+    if (profile)
+        context().m_ticks += timer.ticks();
+
+    size_t new_end_of_errors = context().m_buffered_errors.size();
+    if (new_end_of_errors != prev_end_of_errors) {
+        context().m_buffered_error_batches.push_back(
+            ErrorBatch{static_cast<int>(prev_end_of_errors),
+                       static_cast<int>(new_end_of_errors)});
+    }
+
+    return true;
+}
+
+
+template<int WidthT>
+bool
+ShadingContext::Batched<WidthT>::execute(ShaderGroup &sgroup, int batch_size, BatchedShaderGlobals<WidthT> &bsg, bool run)
+{
+    OSL_ASSERT(is_aligned<64>(&bsg));
+    int n = sgroup.m_exec_repeat;
+
+    Block<Vec3,WidthT> Psave, Nsave;   // for repeats
+    bool repeat = (n > 1);
+    if (repeat) {
+        // If we're going to repeat more than once, we need to save any
+        // globals that might get modified.
+        Psave = bsg.varying.P;
+        Nsave = bsg.varying.N;
+        if (! run)
+            n = 1;
+    }
+
+    bool result = true;
+    while (1) {
+        if (! execute_init (sgroup, batch_size, bsg, run))
+            return false;
+        if (run && n)
+            execute_layer (batch_size, bsg, group()->nlayers()-1);
+        result = context().execute_cleanup ();
+        if (--n < 1)
+            break;   // done
+        if (repeat) {
+            // Going around for another pass... restore things as best as we
+            // can.
+            bsg.varying.P = Psave;
+            bsg.varying.N = Nsave;
+            bsg.uniform.Ci = NULL;
+        }
+    }
+    return result;
+}
 
 
 void
@@ -199,11 +382,48 @@ ShadingContext::record_error (ErrorHandler::ErrCode code,
 }
 
 
+// separate declaration from definition of template function
+// to ensure noinline is respected
+template<typename ErrorsT, typename TestFunctorT>
+static OSL_NOINLINE void process_errors_helper (ShadingSystemImpl &shading_sys, const ErrorsT &errors, int startAtError, int endBeforeError, const TestFunctorT & test_func);
+
+// Given array of ErrorItems emit errors within the range startAtError to
+// endBeforeError if and only if the test_func passed each ErrorItem's mask
+// returns true.  This allows the same batch of errors to be processed for
+// each data lane separately effectively serializing emission of errors,
+// warnings, info, and messages
+template<typename ErrorsT, typename TestFunctorT>
+void process_errors_helper (ShadingSystemImpl &shading_sys, const ErrorsT &errors, int startAtError, int endBeforeError, const TestFunctorT & test_func)
+{
+    for (int i = startAtError;  i < endBeforeError;  ++i) {
+        const auto & error_item = errors[i];
+        if (test_func(error_item.mask)) {
+            switch (errors[i].err_code) {
+            case ErrorHandler::EH_MESSAGE :
+            case ErrorHandler::EH_DEBUG :
+                shading_sys.message (error_item.msgString);
+                break;
+            case ErrorHandler::EH_INFO :
+                shading_sys.info (error_item.msgString);
+                break;
+            case ErrorHandler::EH_WARNING :
+                shading_sys.warning (error_item.msgString);
+                break;
+            case ErrorHandler::EH_ERROR :
+            case ErrorHandler::EH_SEVERE :
+                shading_sys.error (error_item.msgString);
+                break;
+            default:
+                break;
+            }
+        }
+    }
+}
 
 void
 ShadingContext::process_errors () const
 {
-    size_t nerrors = m_buffered_errors.size();
+    int nerrors(m_buffered_errors.size());
     if (! nerrors)
         return;
 
@@ -212,25 +432,69 @@ ShadingContext::process_errors () const
     // interleaved with other threads.
     lock_guard lock (buffered_errors_mutex);
 
-    for (size_t i = 0;  i < nerrors;  ++i) {
-        switch (m_buffered_errors[i].first) {
-        case ErrorHandler::EH_MESSAGE :
-        case ErrorHandler::EH_DEBUG :
-           shadingsys().message (m_buffered_errors[i].second);
-            break;
-        case ErrorHandler::EH_INFO :
-            shadingsys().info (m_buffered_errors[i].second);
-            break;
-        case ErrorHandler::EH_WARNING :
-            shadingsys().warning (m_buffered_errors[i].second);
-            break;
-        case ErrorHandler::EH_ERROR :
-        case ErrorHandler::EH_SEVERE :
-            shadingsys().error (m_buffered_errors[i].second);
-            break;
-        default:
-            break;
-        }
+    if (false == m_execution_is_batched) {
+        // Non-batch errors are recorded with a mask with all lanes on.
+        // Ignore the mask, just print them out once
+        OSL_INTEL_PRAGMA(noinline)
+        process_errors_helper(shadingsys(), m_buffered_errors, 0, nerrors,
+            // Test Function returns true to process the ErrorItem
+            [=](Mask<MaxSupportedSimdLaneCount> mask OSL_MAYBE_UNUSED)->bool
+            {
+                OSL_DASSERT(mask.all_on());
+                return true;
+            });
+    } else {
+
+        int boundaryIndex = 0;
+        int errorIndex=0;
+        do {
+
+            // We need to process all errors belonging to the same batch before moving on
+            // to the next to get the output order correct.
+            ErrorBatch error_batch;
+            if (boundaryIndex < static_cast<int>(m_buffered_error_batches.size())) {
+                error_batch = m_buffered_error_batches[boundaryIndex++];
+            } else {
+                // No further batches are explicitly defined,
+                // We we must not be buffering, so process the errors as batch
+                // otherwise process as unbatched (so no need to print once per
+                // data lane
+                error_batch.startAt = 0;
+                error_batch.endBefore = nerrors;
+            }
+
+            OSL_DASSERT(error_batch.startAt == errorIndex);
+            OSL_DASSERT(error_batch.endBefore >= errorIndex);
+            OSL_DASSERT(error_batch.endBefore >= error_batch.startAt);
+
+            // Process non-batched errors up to the start of the batch
+
+            OSL_INTEL_PRAGMA(noinline)
+            process_errors_helper(shadingsys(), m_buffered_errors, errorIndex, error_batch.startAt,
+                // Test Function returns true to process the ErrorItem
+                [=](Mask<MaxSupportedSimdLaneCount> mask OSL_MAYBE_UNUSED)->bool
+                {
+                    OSL_DASSERT(mask.all_on());
+                    return true;
+                });
+            errorIndex = error_batch.startAt;
+
+            // the printf call always sends a valid mask over, it could be 0x0000 to 0xFFFF
+
+            // Now for batched, process each data lane separately and in the correct order
+            for(int lane_mask=0; lane_mask < MaxSupportedSimdLaneCount; ++lane_mask) {
+                OSL_INTEL_PRAGMA(noinline)
+                process_errors_helper(shadingsys(), m_buffered_errors, errorIndex, error_batch.endBefore,
+                    // Test Function returns true to process the ErrorItem
+                    [=](Mask<MaxSupportedSimdLaneCount> mask)->bool
+                    {
+                        return mask.is_on(lane_mask);
+                    });
+            }
+            errorIndex = error_batch.endBefore;
+        } while (errorIndex < nerrors);
+
+        m_buffered_error_batches.clear();
     }
     m_buffered_errors.clear();
 }
@@ -252,9 +516,16 @@ ShadingContext::symbol_data (const Symbol &sym) const
     if (! sgroup.optimized())
         return NULL;   // can't retrieve symbol if we didn't optimize it
 
-    if (sym.dataoffset() >= 0 && (int)m_heapsize > sym.dataoffset()) {
-        // lives on the heap
-        return m_heap.get() + sym.dataoffset();
+    if (m_execution_is_batched) {
+        if (sym.wide_dataoffset() >= 0 && (int)m_heapsize > sym.wide_dataoffset()) {
+            // lives on the heap
+            return m_heap.get() + sym.wide_dataoffset();
+        }
+    } else {
+        if (sym.dataoffset() >= 0 && (int)m_heapsize > sym.dataoffset()) {
+            // lives on the heap
+            return m_heap.get() + sym.dataoffset();
+        }
     }
 
     // doesn't live on the heap
@@ -324,6 +595,9 @@ osl_incr_layers_executed (ShaderGlobals *sg)
     ShadingContext *ctx = (ShadingContext *)sg->context;
     ctx->incr_layers_executed ();
 }
+
+template class ShadingContext::Batched<16>;
+template class ShadingContext::Batched<8>;
 
 
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1952,19 +1952,11 @@ private:
         Mask<MaxSupportedSimdLaneCount> mask;
     };
     mutable std::vector<ErrorItem> m_buffered_errors;
-    // Track which entries in m_buffered_errors came from
-    // batched execution as those ranges need to processed multiple
-    // times, once per active data lane
-    struct ErrorBatch
-    {
-        int startAt;
-        int endBefore;
-    };
-    mutable std::vector<ErrorBatch> m_buffered_error_batches;
 
     // When interpreting symbol addresses we need to know if the
     // wide data offsets should be used
-    bool m_execution_is_batched;
+    int batch_size_executed;
+    bool execution_is_batched() const { return batch_size_executed != 0; }
 };
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -40,6 +40,7 @@
 #include <OSL/shaderglobals.h>
 #include <OSL/dual.h>
 #include <OSL/dual_vec.h>
+#include <OSL/mask.h>
 #include "osl_pvt.h"
 #include "constantpool.h"
 #include "opcolor.h"
@@ -108,6 +109,7 @@ void print_closure (std::ostream &out, const ClosureColor *closure, ShadingSyste
 /// Signature of the function that LLVM generates to run the shader
 /// group.
 typedef void (*RunLLVMGroupFunc)(void* /* shader globals */, void*);
+typedef void (*RunLLVMGroupFuncWide)(void* /* batched shader globals */, void*, int run_mask_value);
 
 /// Signature of a constant-folding method
 typedef int (*OpFolder) (RuntimeOptimizer &rop, int opnum);
@@ -646,6 +648,28 @@ public:
     template <typename Color> bool
     ocio_transform (StringParam fromspace, StringParam tospace,
                     const Color& C, Color& Cout);
+
+    // Group all batched methods behind a templated interface
+    // so we can support multiple widths
+    template<int WidthT>
+    class Batched {
+        ShadingSystemImpl & m_ssi;
+    public:
+        explicit OSL_FORCEINLINE Batched(ShadingSystemImpl & ssi)
+        : m_ssi(ssi)
+        {}
+        OSL_FORCEINLINE Batched(const Batched&) = default;
+
+        /// Ensure that the group has been JITed.
+        void jit_group (ShaderGroup &group, ShadingContext *ctx);
+
+        void jit_all_groups (int nthreads=0, int mythread=0, int totalthreads=1);
+    };
+
+    template<int WidthT>
+    OSL_FORCEINLINE Batched<WidthT> batched() {
+        return Batched<WidthT>(*this);
+    }
 
 private:
     void printstats () const;
@@ -1433,8 +1457,14 @@ public:
     int jitted () const { return m_jitted; }
     void jitted (int jitted) { m_jitted = jitted; }
 
+    int batch_jitted () const { return m_batch_jitted; }
+    void batch_jitted (int batch_jitted) { m_batch_jitted = batch_jitted; }
+
     size_t llvm_groupdata_size () const { return m_llvm_groupdata_size; }
     void llvm_groupdata_size (size_t size) { m_llvm_groupdata_size = size; }
+
+    size_t llvm_groupdata_wide_size () const { return m_llvm_groupdata_wide_size; }
+    void llvm_groupdata_wide_size (size_t size) { m_llvm_groupdata_wide_size = size; }
 
     RunLLVMGroupFunc llvm_compiled_version() const {
         return m_llvm_compiled_version;
@@ -1458,7 +1488,30 @@ public:
             m_llvm_compiled_layers[layer] = func;
     }
 
-    /// Is this shader group equivalent to ret void?
+    // Hold onto wide versions of llvm functions side by side with scalar
+    RunLLVMGroupFuncWide llvm_compiled_wide_version() const {
+        return m_llvm_compiled_wide_version;
+    }
+    void llvm_compiled_wide_version (RunLLVMGroupFuncWide func) {
+        m_llvm_compiled_wide_version = func;
+    }
+    RunLLVMGroupFuncWide llvm_compiled_wide_init() const {
+        return m_llvm_compiled_wide_init;
+    }
+    void llvm_compiled_wide_init (RunLLVMGroupFuncWide func) {
+        m_llvm_compiled_wide_init = func;
+    }
+    RunLLVMGroupFuncWide llvm_compiled_wide_layer (int layer) const {
+        return layer < (int)m_llvm_compiled_wide_layers.size()
+                            ? m_llvm_compiled_wide_layers[layer] : NULL;
+    }
+    void llvm_compiled_wide_layer (int layer, RunLLVMGroupFuncWide func) {
+        m_llvm_compiled_wide_layers.resize ((size_t)nlayers(), NULL);
+        if (layer < nlayers())
+            m_llvm_compiled_wide_layers[layer] = func;
+    }
+
+    // Is this shader group equivalent to ret void?
     bool does_nothing() const {
         return m_does_nothing;
     }
@@ -1537,12 +1590,17 @@ private:
     volatile int m_optimized = 0;    ///< Is it already optimized?
     volatile int m_jitted = 0;       ///< Is it already jitted?
     bool m_does_nothing = false;     ///< Is the shading group just func() { return; }
+    volatile int m_batch_jitted = 0; ///< Is it already jitted for batch execution?
     size_t m_llvm_groupdata_size = 0;///< Heap size needed for its groupdata
+    size_t m_llvm_groupdata_wide_size = 0;    ///< Heap size needed for its wide groupdata
     int m_id;                        ///< Unique ID for the group
     int m_num_entry_layers = 0;      ///< Number of marked entry layers
     RunLLVMGroupFunc m_llvm_compiled_version = nullptr;
     RunLLVMGroupFunc m_llvm_compiled_init = nullptr;
     std::vector<RunLLVMGroupFunc> m_llvm_compiled_layers;
+    RunLLVMGroupFuncWide m_llvm_compiled_wide_version = nullptr;
+    RunLLVMGroupFuncWide m_llvm_compiled_wide_init = nullptr;
+    std::vector<RunLLVMGroupFuncWide> m_llvm_compiled_wide_layers;
     std::vector<ShaderInstanceRef> m_layers;
     ustring m_name;
     int m_exec_repeat = 1;           ///< How many times to execute group
@@ -1612,6 +1670,74 @@ public:
     /// Execute the shader group, including init, run of single entry point
     /// layer, and cleanup. (See similarly named method of ShadingSystem.)
     bool execute (ShaderGroup &group, ShaderGlobals &globals, bool run=true);
+
+    // Group all batched methods behind a templated interface
+    // so we can support multiple widths
+    template<int WidthT>
+    class OSLEXECPUBLIC Batched {
+        ShadingContext & m_sc;
+        OSL_FORCEINLINE ShadingContext & context() { return m_sc; }
+    public:
+        explicit OSL_FORCEINLINE Batched(ShadingContext & sc)
+        : m_sc(sc)
+        {}
+        OSL_FORCEINLINE Batched(const Batched&) = default;
+
+        OSL_FORCEINLINE ShadingSystemImpl & shadingsys () { return context().m_shadingsys; }
+        OSL_FORCEINLINE ShaderGroup *group () { return context().m_group; }
+        OSL_FORCEINLINE BatchedRendererServices<WidthT> * renderer() {
+            // turn templated call to polymorphic virtual function call
+            return context().m_renderer->batched(WidthOf<WidthT>());
+        }
+
+        /// Bind a shader group and batched of globals to this context and prepare to
+        /// execute. (See similarly named method of ShadingSystem.)
+        bool execute_init (ShaderGroup &group, int batch_size, BatchedShaderGlobals<WidthT> &bsg, bool run=true);
+
+        /// Execute the layer whose index is specified. (See similarly named
+        /// method of ShadingSystem.)
+        bool execute_layer (int batch_size, BatchedShaderGlobals<WidthT> &bsg, int layer);
+
+        /// Execute the shader group, including init, run of single entry point
+        /// layer, and cleanup. (See similarly named method of ShadingSystem.)
+        bool execute(ShaderGroup &group, int batch_size, BatchedShaderGlobals<WidthT> &bsg, bool run=true);
+
+        template<typename ...ArgListT>
+        inline
+        void errorf(Mask<WidthT> mask, const char* fmt, ArgListT... args) const
+        {
+            m_sc.record_error(ErrorHandler::EH_ERROR, Strutil::sprintf (fmt, args...), static_cast<Mask<MaxSupportedSimdLaneCount>>(mask));
+        }
+
+        template<typename ...ArgListT>
+        inline
+        void warningf(Mask<WidthT> mask, const char* fmt, ArgListT... args) const
+        {
+            m_sc.record_error(ErrorHandler::EH_WARNING, Strutil::sprintf (fmt, args...), static_cast<Mask<MaxSupportedSimdLaneCount>>(mask));
+        }
+
+        template<typename ...ArgListT>
+        inline
+        void infof(Mask<WidthT> mask, const char* fmt, ArgListT... args) const
+        {
+            m_sc.record_error(ErrorHandler::EH_INFO, Strutil::sprintf (fmt, args...), static_cast<Mask<MaxSupportedSimdLaneCount>>(mask));
+        }
+
+        template<typename ...ArgListT>
+        inline
+        void messagef(Mask<WidthT> mask, const char* fmt, ArgListT... args) const
+        {
+            m_sc.record_error(ErrorHandler::EH_MESSAGE, Strutil::sprintf (fmt, args...), static_cast<Mask<MaxSupportedSimdLaneCount>>(mask));
+        }
+
+        // TODO: implement messages in subsequent PR
+        //BatchedMessageList<WidthT> & messages () { return m_sc.batched_messages(WidthOf<WidthT>()); }
+    };
+
+    template<int WidthT>
+    OSL_FORCEINLINE Batched<WidthT> batched() {
+        return Batched<WidthT>(*this);
+    }
 
     ClosureComponent * closure_component_allot(int id, size_t prim_size, const Color3 &w) {
         // Allocate the component and the mul back to back
@@ -1809,8 +1935,36 @@ private:
     Dictionary *m_dictionary;
 
     // Buffering of error messages and printfs
-    typedef std::pair<ErrorHandler::ErrCode, std::string> ErrorItem;
+    struct ErrorItem
+    {
+        ErrorItem() = default;
+        ErrorItem(ErrorHandler::ErrCode err_code_,
+                  std::string msgString_,
+                  Mask<MaxSupportedSimdLaneCount> mask_ =
+                      Mask<MaxSupportedSimdLaneCount>(true))
+        : err_code(err_code_)
+        , msgString(msgString_)
+        , mask(mask_)
+        {}
+
+        ErrorHandler::ErrCode err_code;
+        std::string msgString;
+        Mask<MaxSupportedSimdLaneCount> mask;
+    };
     mutable std::vector<ErrorItem> m_buffered_errors;
+    // Track which entries in m_buffered_errors came from
+    // batched execution as those ranges need to processed multiple
+    // times, once per active data lane
+    struct ErrorBatch
+    {
+        int startAt;
+        int endBefore;
+    };
+    mutable std::vector<ErrorBatch> m_buffered_error_batches;
+
+    // When interpreting symbol addresses we need to know if the
+    // wide data offsets should be used
+    bool m_execution_is_batched;
 };
 
 


### PR DESCRIPTION
Add Symbol::wide_dataoffset() to track offset in heap to wide version of symbol's data

Add count to Context to track batch size of last execution 

Add template<int WidthT> ShadingContext::Batched interface to group together batched versions of execute_init, execute_layer, and execute methods.  Instantiate ShadingCOntext::Batched<8> and ShadingContext::Batched<16>.

Refactor std::vector<std::pair<ErrorHandler::ErrCode, std::string> m_buffered_errors to use proper ErrorItem class with optional Mask to identify which data lanes the Error message applies to.

Refactored ShadingContext::process_errors into a templated helper to serialize batched or non-batched errors up to the ShadingSystem.

Modify ShadingContext::symbol_data to use the symbol's wide_dataoffset() when last execution was batched.
Add RunLLVMGroupFuncWide to model a a function pointer to a batched verson of a JIT'd shader function that accepts batched shader globals and an integer representing the mask (active data lanes) to execute on.
To hold onto wide versions of llvm functions side by side with scalar, added llvm_compiled_wide_version, llvm_compiled_wide_init, llvm_compiled_wide_layer.

Added ShadingSystemImpl::Batched<int WidthT> interface to group together batched methods jit_group, and jit_all_groups
Instantiate ShadingSystemImpl::Batched<8> and ShadingSystemImpl::Batched<16>
Added ShaderGroup::batch_jitted to track if a group had been jitted for batching (separately from scalar jit)
Added ShaderGroup::llvm_groupdata_wide_size to track amount of heap space needed for a wide version of the group data structure.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

