### PR TITLE
LoadMemoryCompiledShader: ensure return false on parse failure

### DIFF
--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -637,7 +637,7 @@ ShadingSystemImpl::LoadMemoryCompiledShader (string_view shadername,
         errorf("Unable to parse preloaded shader \"%s\"", shadername);
     }
 
-    return true;
+    return ok;
 }
 
 


### PR DESCRIPTION
Most failures in this function returned false, but if it got as far as
parsing but failed that stage, it ended up returning true (success),
which is clearly wrong.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
