### PR TITLE
CMake refactoring and subproject friendliness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,11 @@ set (${PROJECT_NAME}_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 set (${PROJECT_NAME}_SUPPORTED_RELEASE 0)  # Change to 1 after release branch
 set (PROJECT_AUTHORS "Contributors to the Open Shading Language project")
 
-message (STATUS "Building ${PROJECT_NAME} ${PROJECT_VERSION}")
-message (STATUS "CMake version is ${CMAKE_VERSION}")
+# Identify whether this is included as a subproject of something else
+if (NOT "${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
+    set (${PROJECT_NAME}_IS_SUBPROJECT ON)
+    message (STATUS "${PROJECT_NAME} is configuring as a CMake subproject")
+endif ()
 
 if (NOT CMAKE_BUILD_TYPE)
     set (CMAKE_BUILD_TYPE "Release")
@@ -130,19 +133,21 @@ include (colors)
 include (check_is_enabled)
 include (checked_find_package)
 
-# All the C++ and compiler related options and adjustments live here
+# All the C++ and compiler related options and adjustments
 include (compiler)
 
-# Utilities related to finding python and making python bindings
+# Utilities and options related to finding python and making python bindings
 include (pythonutils)
 
 include (externalpackages)
 include (flexbison)
 include (cuda_macros)
 
-# We want CTest for testing, so this must be added before all the calls to
-# add_subdirectory, or their add_test commands will not register.
-include (CTest)
+# Include all our testing apparatus and utils, but not if it's a subproject
+if (${PROJECT_NAME}_BUILD_TESTS AND NOT ${PROJECT_NAME}_IS_SUBPROJECT)
+    include (testing)
+endif ()
+
 
 
 include_directories (
@@ -250,294 +255,9 @@ install (EXPORT OSL_EXPORTED_TARGETS
 
 
 
-
-#########################################################################
-# Testing
-
-# Make a build/platform/testsuite directory, and copy the master runtest.py
-# there. The rest is up to the tests themselves.
-file (MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/testsuite")
-file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/testsuite/common"
-      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/testsuite")
-add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        "${CMAKE_SOURCE_DIR}/testsuite/runtest.py"
-                        "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
-                    MAIN_DEPENDENCY "${CMAKE_SOURCE_DIR}/testsuite/runtest.py")
-add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
-
-# add_one_testsuite() - set up one testsuite entry
-#
-# Usage:
-#   add_one_testsuite ( testname
-#                  testsrcdir - Current test directory in ${CMAKE_SOURCE_DIR}
-#                  testdir    - Current test sandbox in ${CMAKE_BINARY_DIR}
-#                  [ENV env1=val1 env2=val2 ... ]  - env vars to set
-#                  [COMMAND cmd...] - optional override of launch command
-#                 )
-#
-macro (add_one_testsuite testname testsrcdir)
-    cmake_parse_arguments (_tst "" "" "ENV;COMMAND" ${ARGN})
-    set (testsuite "${CMAKE_SOURCE_DIR}/testsuite")
-    set (testdir "${CMAKE_BINARY_DIR}/testsuite/${testname}")
-    if (NOT _tst_COMMAND)
-        set (_tst_COMMAND ${Python_EXECUTABLE} "${testsuite}/runtest.py" ${testdir})
-        if (MSVC_IDE)
-            list (APPEND _tst_COMMAND --devenv-config $<CONFIGURATION>
-                                      --solution-path "${CMAKE_BINARY_DIR}" )
-        endif ()
-    endif ()
-    list (APPEND _tst_ENV
-              OpenImageIO_ROOT=${OpenImageIO_ROOT}
-              OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-              OSL_BUILD_DIR=${CMAKE_BINARY_DIR}
-              OSL_TESTSUITE_ROOT=${testsuite}
-              OSL_TESTSUITE_SRC=${testsrcdir}
-              OSL_TESTSUITE_CUR=${testdir}
-         )
-    file (MAKE_DIRECTORY "${testdir}")
-    add_test ( NAME ${testname} COMMAND ${_tst_COMMAND} )
-    # message ("Test -- env ${_tst_ENV} cmd ${_tst_COMMAND}")
-    set_tests_properties (${testname} PROPERTIES ENVIRONMENT "${_tst_ENV}" )
-    # Certain tests are already internally multi-threaded, so to keep them
-    # from piling up together, allocate a few cores each.
-    if (${testname} MATCHES "^render-")
-        set_tests_properties (${testname} PROPERTIES LABELS render
-                              PROCESSORS 4 COST 10)
-    endif ()
-    # Some labeling for fun
-    if (${testname} MATCHES "^texture-")
-        set_tests_properties (${testname} PROPERTIES LABELS texture
-                              PROCESSORS 2 COST 4)
-    endif ()
-    if (${testname} MATCHES "noise")
-        set_tests_properties (${testname} PROPERTIES LABELS noise
-                              PROCESSORS 2 COST 4)
-    endif ()
-    if (${testname} MATCHES "optix")
-        set_tests_properties (${testname} PROPERTIES LABELS optix)
-        if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
-            # Make sure libnvrtc-builtins.so is reachable
-            set_property (TEST ${testname} APPEND PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64)
-        endif()
-    endif ()
-endmacro ()
+osl_add_all_tests()
 
 
-macro ( TESTSUITE )
-    cmake_parse_arguments (_ats "" "LABEL;FOUNDVAR;TESTNAME" "" ${ARGN})
-    # If there was a FOUNDVAR param specified and that variable name is
-    # not defined, mark the test as broken.
-    if (_ats_FOUNDVAR AND NOT ${_ats_FOUNDVAR})
-        set (_ats_LABEL "broken")
-    endif ()
-    set (test_all_optix $ENV{TESTSUITE_OPTIX})
-    # Add the tests if all is well.
-    set (ALL_TEST_LIST "")
-    set (_testsuite "${CMAKE_SOURCE_DIR}/testsuite")
-    foreach (_testname ${_ats_UNPARSED_ARGUMENTS})
-        set (_testsrcdir "${_testsuite}/${_testname}")
-        if (_ats_TESTNAME)
-            set (_testname "${_ats_TESTNAME}")
-        endif ()
-        if (_ats_LABEL MATCHES "broken")
-            set (_testname "${_testname}-broken")
-        endif ()
-
-        set (ALL_TEST_LIST "${ALL_TEST_LIST} ${_testname}")
-
-        # Run the test unoptimized, unless it matches a few patterns that
-        # we don't test unoptimized (or has an OPTIMIZEONLY marker file).
-        if (NOT _testname MATCHES "^getattribute-shader" AND
-            NOT _testname MATCHES "optix" AND
-            NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
-            add_one_testsuite ("${_testname}" "${_testsrcdir}"
-                               ENV TESTSHADE_OPT=0 )
-        endif ()
-        # Run the same test again with aggressive -O2 runtime
-        # optimization, triggered by setting TESTSHADE_OPT env variable.
-        # Skip OptiX-only tests and those with a NOOPTIMIZE marker file.
-        if (NOT _testname MATCHES "optix"
-                AND NOT EXISTS "${_testsrcdir}/NOOPTIMIZE")
-            add_one_testsuite ("${_testname}.opt" "${_testsrcdir}"
-                               ENV TESTSHADE_OPT=2 )
-        endif ()
-        # When building for OptiX support, also run it in OptiX mode
-        # if there is an OPTIX marker file in the directory.
-        # If an environment variable $TESTSUITE_OPTIX is nonzero, then
-        # run all tests with OptiX, even if there's no OPTIX marker.
-        if (USE_OPTIX
-            AND (EXISTS "${_testsrcdir}/OPTIX" OR test_all_optix OR _testname MATCHES "optix")
-            AND NOT EXISTS "${_testsrcdir}/NOOPTIX"
-            AND NOT EXISTS "${_testsrcdir}/NOOPTIX-FIXME")
-            # Unoptimized
-            if (NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
-                add_one_testsuite ("${_testname}.optix" "${_testsrcdir}"
-                                   ENV TESTSHADE_OPT=0 TESTSHADE_OPTIX=1 )
-            endif ()
-            # and optimized
-            add_one_testsuite ("${_testname}.optix.opt" "${_testsrcdir}"
-                               ENV TESTSHADE_OPT=2 TESTSHADE_OPTIX=1 )
-        endif ()
-    endforeach ()
-    if (VERBOSE)
-        message (STATUS "Added tests: ${ALL_TEST_LIST}")
-    endif ()
-endmacro ()
-
-if (OSL_BUILD_TESTS)
-# List all the individual testsuite tests here, except those that need
-# special installed tests.
-TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
-            array array-derivs array-range array-aassign
-            blackbody blendmath breakcont
-            bug-array-heapoffsets bug-locallifetime bug-outputinit
-            bug-param-duplicate bug-peep bug-return
-            cellnoise closure closure-array color comparison
-            compile-buffer
-            component-range
-            connect-components
-            const-array-params const-array-fill
-            debugnan debug-uninit
-            derivs derivs-muldiv-clobber
-            draw_string
-            error-dupes error-serialized
-            example-deformer
-            exit exponential
-            fprintf
-            function-earlyreturn function-simple function-outputelem
-            function-overloads function-redef
-            geomath getattribute-camera getattribute-shader
-            getsymbol-nonheap gettextureinfo
-            group-outputs groupstring
-            hash hashnoise hex hyperb
-            ieee_fp if incdec initlist initops intbits isconnected isconstant
-            layers layers-Ciassign layers-entry layers-lazy layers-lazyerror
-            layers-nonlazycopy layers-repeatedoutputs
-            linearstep
-            logic loop matrix message
-            mergeinstances-duplicate-entrylayers
-            mergeinstances-nouserdata mergeinstances-vararray
-            metadata-braces miscmath missing-shader
-            named-components
-            noise noise-cell
-            noise-gabor noise-gabor2d-filter noise-gabor3d-filter
-            noise-perlin noise-simplex
-            pnoise pnoise-cell pnoise-gabor pnoise-perlin
-            operator-overloading
-            opt-warnings
-            oslc-comma oslc-D oslc-M
-            oslc-err-arrayindex oslc-err-assignmenttypes
-            oslc-err-closuremul oslc-err-field
-            oslc-err-format oslc-err-funcoverload
-            oslc-err-intoverflow oslc-err-write-nonoutput
-            oslc-err-noreturn oslc-err-notfunc
-            oslc-err-initlist-args oslc-err-initlist-return
-            oslc-err-named-components
-            oslc-err-outputparamvararray oslc-err-paramdefault
-            oslc-err-struct-array-init oslc-err-struct-ctr
-            oslc-err-struct-dup oslc-err-struct-print
-            oslc-err-unknown-ctr
-            oslc-pragma-warnerr
-            oslc-warn-commainit
-            oslc-variadic-macro
-            oslc-version
-            oslinfo-arrayparams oslinfo-colorctrfloat
-            oslinfo-metadata oslinfo-noparams
-            osl-imageio
-            paramval-floatpromotion
-            pragma-nowarn
-            printf-whole-array
-            raytype raytype-specialized reparam
-            render-background render-bumptest
-            render-cornell render-furnace-diffuse
-            render-microfacet render-oren-nayar render-veachmis render-ward
-            select shortcircuit spline splineinverse splineinverse-ident
-            spline-boundarybug spline-derivbug
-            string
-            struct struct-array struct-array-mixture
-            struct-err struct-init-copy
-            struct-isomorphic-overload struct-layers
-            struct-operator-overload struct-return struct-with-array
-            struct-nested struct-nested-assign struct-nested-deep
-            ternary
-            testshade-expr
-            texture-alpha texture-alpha-derivs
-            texture-blur texture-connected-options
-            texture-derivs texture-errormsg
-            texture-firstchannel texture-interp
-            texture-missingalpha texture-missingcolor texture-simple
-            texture-smallderivs texture-swirl texture-udim
-            texture-width texture-withderivs texture-wrap
-            trailing-commas
-            transitive-assign
-            transform transformc trig typecast
-            unknown-instruction
-            userdata userdata-passthrough
-            vararray-connect vararray-default
-            vararray-deserialize vararray-param
-            vecctr vector
-            wavelength_color Werror xml )
-
-# Add tests that require the Python bindings if we built them.
-# We also exclude these tests if this is a sanitizer build on Linux,
-# because the Python interpreter itself won't be linked with the right asan
-# libraries to run correctly.
-if (USE_PYTHON AND NOT SANITIZE_ON_LINUX)
-    TESTSUITE ( python-oslquery )
+if (NOT ${PROJECT_NAME}_IS_SUBPROJECT)
+    include (packaging)
 endif ()
-
-# Only run field3d-related tests if the local OIIO was built with f3d support.
-EXECUTE_PROCESS ( COMMAND ${OPENIMAGEIO_BIN} --help
-                  OUTPUT_VARIABLE oiiotool_help )
-if (oiiotool_help MATCHES "field3d")
-    TESTSUITE ( texture-field3d )
-endif()
-
-# Only run pointcloud tests if Partio is found
-if (PARTIO_FOUND)
-    TESTSUITE ( pointcloud pointcloud-fold )
-endif ()
-
-# Only run the OptiX tests if OptiX and CUDA are found
-if (OPTIX_FOUND AND CUDA_FOUND)
-    TESTSUITE ( testoptix testoptix-noise example-cuda)
-endif ()
-
-# FIXME: still working on MaterialX testsuite
-# add_subdirectory(testsuite/MaterialX)
-
-endif (OSL_BUILD_TESTS)
-
-
-
-#########################################################################
-# Packaging
-set (CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set (CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set (CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-# "Vendor" is only used in copyright notices, so we use the same thing that
-# the rest of the copyright notices say.
-set (CPACK_PACKAGE_VENDOR ${PROJECT_AUTHORS})
-set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenShadingLanguage is...")
-set (CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/src/doc/Description.txt")
-set (CPACK_PACKAGE_FILE_NAME ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-${platform})
-file (COPY "${PROJECT_SOURCE_DIR}/LICENSE.md" DESTINATION "${CMAKE_BINARY_DIR}")
-set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_BINARY_DIR}/LICENSE.md")
-file (COPY "${PROJECT_SOURCE_DIR}/README.md" DESTINATION "${CMAKE_BINARY_DIR}")
-set (CPACK_RESOURCE_FILE_README "${CMAKE_BINARY_DIR}/README.md")
-set (CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/src/doc/Welcome.txt")
-#set (CPACK_PACKAGE_EXECUTABLES I'm not sure what this is for)
-#set (CPACK_STRIP_FILES Do we need this?)
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set (CPACK_GENERATOR "TGZ;STGZ;RPM;DEB")
-    set (CPACK_SOURCE_GENERATOR "TGZ")
-endif ()
-if (APPLE)
-    set (CPACK_GENERATOR "TGZ;STGZ;PackageMaker")
-    set (CPACK_SOURCE_GENERATOR "TGZ")
-endif ()
-set (CPACK_SOURCE_PACKAGE_FILE_NAME ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-source)
-#set (CPACK_SOURCE_STRIP_FILES ...FIXME...)
-set (CPACK_SOURCE_IGNORE_FILES ".*~")
-include (CPack)

--- a/src/cmake/packaging.cmake
+++ b/src/cmake/packaging.cmake
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Open Shading Languge project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage/
+
+#########################################################################
+# Packaging
+set (CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set (CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set (CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+# "Vendor" is only used in copyright notices, so we use the same thing that
+# the rest of the copyright notices say.
+set (CPACK_PACKAGE_VENDOR ${PROJECT_AUTHORS})
+set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "Open Shading Language is the de facto standard for shading in modern path tracers used in film VFX and animation")
+set (CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/src/doc/Description.txt")
+set (CPACK_PACKAGE_FILE_NAME ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-${platform})
+file (COPY "${PROJECT_SOURCE_DIR}/LICENSE.md" DESTINATION "${CMAKE_BINARY_DIR}")
+set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_BINARY_DIR}/LICENSE.md")
+file (COPY "${PROJECT_SOURCE_DIR}/README.md" DESTINATION "${CMAKE_BINARY_DIR}")
+set (CPACK_RESOURCE_FILE_README "${CMAKE_BINARY_DIR}/README.md")
+set (CPACK_RESOURCE_FILE_WELCOME "${PROJECT_SOURCE_DIR}/src/doc/Welcome.txt")
+#set (CPACK_PACKAGE_EXECUTABLES I'm not sure what this is for)
+#set (CPACK_STRIP_FILES Do we need this?)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set (CPACK_GENERATOR "TGZ;STGZ;RPM;DEB")
+    set (CPACK_SOURCE_GENERATOR "TGZ")
+endif ()
+if (APPLE)
+    set (CPACK_GENERATOR "TGZ;STGZ;PackageMaker")
+    set (CPACK_SOURCE_GENERATOR "TGZ")
+endif ()
+set (CPACK_SOURCE_PACKAGE_FILE_NAME ${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-source)
+#set (CPACK_SOURCE_STRIP_FILES ...FIXME...)
+set (CPACK_SOURCE_IGNORE_FILES ".*~")
+include (CPack)

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -1,0 +1,258 @@
+# Copyright Contributors to the Open Shading Languge project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/imageworks/OpenShadingLanguage/
+
+include (CTest)
+
+# Make a build/platform/testsuite directory, and copy the master runtest.py
+# there. The rest is up to the tests themselves.
+file (MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/testsuite")
+file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/testsuite/common"
+      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/testsuite")
+add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        "${CMAKE_SOURCE_DIR}/testsuite/runtest.py"
+                        "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
+                    MAIN_DEPENDENCY "${CMAKE_SOURCE_DIR}/testsuite/runtest.py")
+add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
+
+# add_one_testsuite() - set up one testsuite entry
+#
+# Usage:
+#   add_one_testsuite ( testname
+#                  testsrcdir - Current test directory in ${CMAKE_SOURCE_DIR}
+#                  testdir    - Current test sandbox in ${CMAKE_BINARY_DIR}
+#                  [ENV env1=val1 env2=val2 ... ]  - env vars to set
+#                  [COMMAND cmd...] - optional override of launch command
+#                 )
+#
+macro (add_one_testsuite testname testsrcdir)
+    cmake_parse_arguments (_tst "" "" "ENV;COMMAND" ${ARGN})
+    set (testsuite "${CMAKE_SOURCE_DIR}/testsuite")
+    set (testdir "${CMAKE_BINARY_DIR}/testsuite/${testname}")
+    if (NOT _tst_COMMAND)
+        set (_tst_COMMAND ${Python_EXECUTABLE} "${testsuite}/runtest.py" ${testdir})
+        if (MSVC_IDE)
+            list (APPEND _tst_COMMAND --devenv-config $<CONFIGURATION>
+                                      --solution-path "${CMAKE_BINARY_DIR}" )
+        endif ()
+    endif ()
+    list (APPEND _tst_ENV
+              OpenImageIO_ROOT=${OpenImageIO_ROOT}
+              OSL_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+              OSL_BUILD_DIR=${CMAKE_BINARY_DIR}
+              OSL_TESTSUITE_ROOT=${testsuite}
+              OSL_TESTSUITE_SRC=${testsrcdir}
+              OSL_TESTSUITE_CUR=${testdir}
+         )
+    file (MAKE_DIRECTORY "${testdir}")
+    add_test ( NAME ${testname} COMMAND ${_tst_COMMAND} )
+    # message ("Test -- env ${_tst_ENV} cmd ${_tst_COMMAND}")
+    set_tests_properties (${testname} PROPERTIES ENVIRONMENT "${_tst_ENV}" )
+    # Certain tests are already internally multi-threaded, so to keep them
+    # from piling up together, allocate a few cores each.
+    if (${testname} MATCHES "^render-")
+        set_tests_properties (${testname} PROPERTIES LABELS render
+                              PROCESSORS 4 COST 10)
+    endif ()
+    # Some labeling for fun
+    if (${testname} MATCHES "^texture-")
+        set_tests_properties (${testname} PROPERTIES LABELS texture
+                              PROCESSORS 2 COST 4)
+    endif ()
+    if (${testname} MATCHES "noise")
+        set_tests_properties (${testname} PROPERTIES LABELS noise
+                              PROCESSORS 2 COST 4)
+    endif ()
+    if (${testname} MATCHES "optix")
+        set_tests_properties (${testname} PROPERTIES LABELS optix)
+        if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
+            # Make sure libnvrtc-builtins.so is reachable
+            set_property (TEST ${testname} APPEND PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+        endif()
+    endif ()
+endmacro ()
+
+
+macro ( TESTSUITE )
+    cmake_parse_arguments (_ats "" "LABEL;FOUNDVAR;TESTNAME" "" ${ARGN})
+    # If there was a FOUNDVAR param specified and that variable name is
+    # not defined, mark the test as broken.
+    if (_ats_FOUNDVAR AND NOT ${_ats_FOUNDVAR})
+        set (_ats_LABEL "broken")
+    endif ()
+    set (test_all_optix $ENV{TESTSUITE_OPTIX})
+    # Add the tests if all is well.
+    set (ALL_TEST_LIST "")
+    set (_testsuite "${CMAKE_SOURCE_DIR}/testsuite")
+    foreach (_testname ${_ats_UNPARSED_ARGUMENTS})
+        set (_testsrcdir "${_testsuite}/${_testname}")
+        if (_ats_TESTNAME)
+            set (_testname "${_ats_TESTNAME}")
+        endif ()
+        if (_ats_LABEL MATCHES "broken")
+            set (_testname "${_testname}-broken")
+        endif ()
+
+        set (ALL_TEST_LIST "${ALL_TEST_LIST} ${_testname}")
+
+        # Run the test unoptimized, unless it matches a few patterns that
+        # we don't test unoptimized (or has an OPTIMIZEONLY marker file).
+        if (NOT _testname MATCHES "^getattribute-shader" AND
+            NOT _testname MATCHES "optix" AND
+            NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
+            add_one_testsuite ("${_testname}" "${_testsrcdir}"
+                               ENV TESTSHADE_OPT=0 )
+        endif ()
+        # Run the same test again with aggressive -O2 runtime
+        # optimization, triggered by setting TESTSHADE_OPT env variable.
+        # Skip OptiX-only tests and those with a NOOPTIMIZE marker file.
+        if (NOT _testname MATCHES "optix"
+                AND NOT EXISTS "${_testsrcdir}/NOOPTIMIZE")
+            add_one_testsuite ("${_testname}.opt" "${_testsrcdir}"
+                               ENV TESTSHADE_OPT=2 )
+        endif ()
+        # When building for OptiX support, also run it in OptiX mode
+        # if there is an OPTIX marker file in the directory.
+        # If an environment variable $TESTSUITE_OPTIX is nonzero, then
+        # run all tests with OptiX, even if there's no OPTIX marker.
+        if (USE_OPTIX
+            AND (EXISTS "${_testsrcdir}/OPTIX" OR test_all_optix OR _testname MATCHES "optix")
+            AND NOT EXISTS "${_testsrcdir}/NOOPTIX"
+            AND NOT EXISTS "${_testsrcdir}/NOOPTIX-FIXME")
+            # Unoptimized
+            if (NOT EXISTS "${_testsrcdir}/OPTIMIZEONLY")
+                add_one_testsuite ("${_testname}.optix" "${_testsrcdir}"
+                                   ENV TESTSHADE_OPT=0 TESTSHADE_OPTIX=1 )
+            endif ()
+            # and optimized
+            add_one_testsuite ("${_testname}.optix.opt" "${_testsrcdir}"
+                               ENV TESTSHADE_OPT=2 TESTSHADE_OPTIX=1 )
+        endif ()
+    endforeach ()
+    if (VERBOSE)
+        message (STATUS "Added tests: ${ALL_TEST_LIST}")
+    endif ()
+endmacro ()
+
+
+macro (osl_add_all_tests)
+    # List all the individual testsuite tests here, except those that need
+    # special installed tests.
+    TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
+                array array-derivs array-range array-aassign
+                blackbody blendmath breakcont
+                bug-array-heapoffsets bug-locallifetime bug-outputinit
+                bug-param-duplicate bug-peep bug-return
+                cellnoise closure closure-array color comparison
+                compile-buffer
+                component-range
+                connect-components
+                const-array-params const-array-fill
+                debugnan debug-uninit
+                derivs derivs-muldiv-clobber
+                draw_string
+                error-dupes error-serialized
+                example-deformer
+                exit exponential
+                fprintf
+                function-earlyreturn function-simple function-outputelem
+                function-overloads function-redef
+                geomath getattribute-camera getattribute-shader
+                getsymbol-nonheap gettextureinfo
+                group-outputs groupstring
+                hash hashnoise hex hyperb
+                ieee_fp if incdec initlist initops intbits isconnected isconstant
+                layers layers-Ciassign layers-entry layers-lazy layers-lazyerror
+                layers-nonlazycopy layers-repeatedoutputs
+                linearstep
+                logic loop matrix message
+                mergeinstances-duplicate-entrylayers
+                mergeinstances-nouserdata mergeinstances-vararray
+                metadata-braces miscmath missing-shader
+                named-components
+                noise noise-cell
+                noise-gabor noise-gabor2d-filter noise-gabor3d-filter
+                noise-perlin noise-simplex
+                pnoise pnoise-cell pnoise-gabor pnoise-perlin
+                operator-overloading
+                opt-warnings
+                oslc-comma oslc-D oslc-M
+                oslc-err-arrayindex oslc-err-assignmenttypes
+                oslc-err-closuremul oslc-err-field
+                oslc-err-format oslc-err-funcoverload
+                oslc-err-intoverflow oslc-err-write-nonoutput
+                oslc-err-noreturn oslc-err-notfunc
+                oslc-err-initlist-args oslc-err-initlist-return
+                oslc-err-named-components
+                oslc-err-outputparamvararray oslc-err-paramdefault
+                oslc-err-struct-array-init oslc-err-struct-ctr
+                oslc-err-struct-dup oslc-err-struct-print
+                oslc-err-unknown-ctr
+                oslc-pragma-warnerr
+                oslc-warn-commainit
+                oslc-variadic-macro
+                oslc-version
+                oslinfo-arrayparams oslinfo-colorctrfloat
+                oslinfo-metadata oslinfo-noparams
+                osl-imageio
+                paramval-floatpromotion
+                pragma-nowarn
+                printf-whole-array
+                raytype raytype-specialized reparam
+                render-background render-bumptest
+                render-cornell render-furnace-diffuse
+                render-microfacet render-oren-nayar render-veachmis render-ward
+                select shortcircuit spline splineinverse splineinverse-ident
+                spline-boundarybug spline-derivbug
+                string
+                struct struct-array struct-array-mixture
+                struct-err struct-init-copy
+                struct-isomorphic-overload struct-layers
+                struct-operator-overload struct-return struct-with-array
+                struct-nested struct-nested-assign struct-nested-deep
+                ternary
+                testshade-expr
+                texture-alpha texture-alpha-derivs
+                texture-blur texture-connected-options
+                texture-derivs texture-errormsg
+                texture-firstchannel texture-interp
+                texture-missingalpha texture-missingcolor texture-simple
+                texture-smallderivs texture-swirl texture-udim
+                texture-width texture-withderivs texture-wrap
+                trailing-commas
+                transitive-assign
+                transform transformc trig typecast
+                unknown-instruction
+                userdata userdata-passthrough
+                vararray-connect vararray-default
+                vararray-deserialize vararray-param
+                vecctr vector
+                wavelength_color Werror xml )
+
+    # Add tests that require the Python bindings if we built them.
+    # We also exclude these tests if this is a sanitizer build on Linux,
+    # because the Python interpreter itself won't be linked with the right asan
+    # libraries to run correctly.
+    if (USE_PYTHON AND NOT SANITIZE_ON_LINUX)
+        TESTSUITE ( python-oslquery )
+    endif ()
+
+    # Only run field3d-related tests if the local OIIO was built with f3d support.
+    execute_process ( COMMAND ${OPENIMAGEIO_BIN} --help
+                      OUTPUT_VARIABLE oiiotool_help )
+    if (oiiotool_help MATCHES "field3d")
+        TESTSUITE ( texture-field3d )
+    endif()
+
+    # Only run pointcloud tests if Partio is found
+    if (PARTIO_FOUND)
+        TESTSUITE ( pointcloud pointcloud-fold )
+    endif ()
+
+    # Only run the OptiX tests if OptiX and CUDA are found
+    if (OPTIX_FOUND AND CUDA_FOUND)
+        TESTSUITE ( testoptix testoptix-noise example-cuda)
+    endif ()
+
+endmacro()


### PR DESCRIPTION
Modeled after recent similar changes in OIIO.

* Detect if OSL is being built as a subproject, and if so, set
  `OSL_IS_SUBPROJECT` (a.k.a. `${PROJECT_NAME}_IS_SUBPROJECT`).

* Move all the testing logic out of the main CMakeLists.txt (and a few
  testing-related macros from oiio_macros.cmake) and into a new
  src/cmake/testing.cmake.

* Move all of the packaging logic out of the main CMakeLists.txt and
  into a new src/cmake/packaging.cmake.

* Make all the testing and packaging inactive if this is being built
  as a subproject. Also disable the clang-format target for subprojects.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
