### PR TITLE
Added missing implementations for LLVM_Util methods

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3328,6 +3328,15 @@ LLVM_Util::offset_ptr (llvm::Value *ptr, int offset, llvm::Type *ptrtype)
 
 
 
+void
+LLVM_Util::assume_ptr_is_aligned(llvm::Value* ptr, unsigned alignment)
+{
+    const llvm::DataLayout& data_layout = m_llvm_exec->getDataLayout();
+    builder().CreateAlignmentAssumption(data_layout, ptr, alignment);
+}
+
+
+
 llvm::Value *
 LLVM_Util::op_alloca (llvm::Type *llvmtype, int n, const std::string &name, int align)
 {
@@ -5397,6 +5406,17 @@ LLVM_Util::bitcode_string (llvm::Module *module)
         stream << func << '\n';
 
     return stream.str();
+}
+
+
+
+std::string
+LLVM_Util::module_string()
+{
+    std::string s;
+    llvm::raw_string_ostream stream(s);
+    m_llvm_module->print(stream, nullptr);
+    return s;
 }
 
 


### PR DESCRIPTION
Added missing implementations for LLVM_Util::assume_ptr_is_aligned(llvm::Value* ptr, unsigned alignment) and LLVM_Util::module_string()

These were in the llvm_util.h but not implemented, were missed in previous pull requests and are needed now.  Fixed linker error for upcoming PR's.

## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

