### PR TITLE
Added mission statement in the charter, pulled from README

### DIFF
--- a/ASWF/Technical-Charter.md
+++ b/ASWF/Technical-Charter.md
@@ -10,8 +10,9 @@ must comply with the terms of this Charter.
 ### 1. Mission and Scope of the Project
 
   * **a.** The mission of the Project is to develop an open source project
-    with the goals indicated in the "README" file within the Project's code
-    repository.
+    for programmable shading in advanced renderers and other applications,
+    ideal for describing materials, lights, displacement, and pattern 
+    generation.
 
   * **b.** The scope of the Project includes software development under an
     OSI-approved open source license supporting the mission, including


### PR DESCRIPTION
We've tended to have projects embed the mission statement in the charter lately, so pulling what was in the README to add here.

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>