### PR TITLE
Add ShadingSystem attribute "searchpath:library" (similar to searchpa…

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -582,6 +582,9 @@ public:
     ustring debug_groupname() const { return m_debug_groupname; }
     ustring debug_layername() const { return m_debug_layername; }
 
+    std::string library_searchpath() const { return m_library_searchpath; }
+    const std::vector<std::string> & library_searchpath_dirs() const { return m_library_searchpath_dirs; }
+
     /// Look within the group for separate nodes that are actually
     /// duplicates of each other and combine them.  Return the number of
     /// instances that were eliminated.
@@ -790,6 +793,8 @@ private:
     ustring m_archive_filename;           ///< Name of filename for group archive
     std::string m_searchpath;             ///< Shader search path
     std::vector<std::string> m_searchpath_dirs; ///< All searchpath dirs
+    std::string m_library_searchpath;     ///< Library search path
+    std::vector<std::string> m_library_searchpath_dirs; ///< All library searchpath dirs
     ustring m_commonspace_synonym;        ///< Synonym for "common" space
     std::vector<ustring> m_raytypes;      ///< Names of ray types
     std::vector<ustring> m_renderer_outputs; ///< Names of renderer outputs

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1405,6 +1405,11 @@ ShadingSystemImpl::attribute (string_view name, TypeDesc type,
         OIIO::Filesystem::searchpath_split (m_searchpath, m_searchpath_dirs);
         return true;
     }
+    if (name == "searchpath:library" && type == TypeDesc::STRING) {
+        m_library_searchpath = std::string (*(const char **)val);
+        OIIO::Filesystem::searchpath_split (m_library_searchpath, m_library_searchpath_dirs);
+        return true;
+    }
     if (name == "colorspace" && type == TypeDesc::STRING) {
         ustring c = ustring (*(const char **)val);
         if (colorsystem().set_colorspace(c))
@@ -1473,6 +1478,7 @@ ShadingSystemImpl::getattribute (string_view name, TypeDesc type,
     lock_guard guard (m_mutex);  // Thread safety
 
     ATTR_DECODE_STRING ("searchpath:shader", m_searchpath);
+    ATTR_DECODE_STRING ("searchpath:library", m_library_searchpath);
     ATTR_DECODE ("statistics:level", int, m_statslevel);
     ATTR_DECODE ("lazylayers", int, m_lazylayers);
     ATTR_DECODE ("lazyglobals", int, m_lazyglobals);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -168,7 +168,7 @@ set_shadingsys_options ()
         {"/../lib64", "/../lib"};
 #endif
     auto executable_directory = OIIO::Filesystem::parent_path(OIIO::Sysutil::this_program_path());
-    bool dirNum = 0;
+    int dirNum = 0;
 	std::string librarypath;
     for (const char * relative_lib_dir:relative_lib_dirs) {
         if(dirNum++ > 0) librarypath	+= ":";


### PR DESCRIPTION
 (similar to searchpath:shader) it will be used to identify directories where target ISA optimized OSL shared libraries may exit.
Make testshade set "searchpath:library" to ../lib64 and ../liboslexec relative to the path testshade is executed from


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

