### PR TITLE
Symbol and Opcode changes to support batched analysis

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -1042,7 +1042,7 @@ public:
     /// Op would require masking under batched execution
     /// when its arguments are not uniform (varying)
     bool requires_masking() const { return m_requires_masking; }
-    void require_masking() { m_requires_masking = true; }
+    void requires_masking(bool v) { m_requires_masking = v; }
 
     /// Analysis might need to tag specific operations with flags that
     /// are later used in code generation.  The meaning of these flags

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -877,6 +877,7 @@ public:
         m_argwrite       = 1;   // Default - first arg only is written by the op
         m_argtakesderivs = 0;   // Default - doesn't take derivs
         m_requires_masking = 0; // Default - doesn't require masking
+        m_analysis_flag = 0;    // Default - optional analysis flag is not set
     }
 
     ustring opname() const { return m_op; }

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -749,6 +749,7 @@ public:
     // execution and must use a Wide data type to hold different values
     // for each data lane executing
     bool is_uniform() const { return m_is_uniform; }
+    bool is_varying() const { return (m_is_uniform == 0); }
     void make_varying() { m_is_uniform = false; }
 
     bool readonly() const { return m_readonly; }

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -834,10 +834,10 @@ protected:
     unsigned m_allowconnect : 1;     ///< Is the param not overridden by geom?
     unsigned m_renderer_output : 1;  ///< Is this sym a renderer output?
     unsigned m_readonly : 1;         ///< read-only symbol
-    unsigned m_is_uniform : 1;       ///< symbol is uniform under batched execution
-    char m_valuesource;              ///< Where did the value come from?
-    bool m_free_data;                ///< Free m_data upon destruction?
-    short m_fieldid;                 ///< Struct field of this var (or -1)
+    unsigned m_is_uniform : 1;    ///< symbol is uniform under batched execution
+    char m_valuesource;           ///< Where did the value come from?
+    bool m_free_data;             ///< Free m_data upon destruction?
+    short m_fieldid;              ///< Struct field of this var (or -1)
     short m_layer;                ///< Layer (within the group) this belongs to
     int m_scope;                  ///< Scope where this symbol was declared
     int m_dataoffset;             ///< Offset of the data (-1 for unknown)
@@ -876,8 +876,8 @@ public:
         m_argread        = ~1;  // Default - all args are read except the first
         m_argwrite       = 1;   // Default - first arg only is written by the op
         m_argtakesderivs = 0;   // Default - doesn't take derivs
-        m_requires_masking = 0; // Default - doesn't require masking
-        m_analysis_flag = 0;    // Default - optional analysis flag is not set
+        m_requires_masking = 0;  // Default - doesn't require masking
+        m_analysis_flag    = 0;  // Default - optional analysis flag is not set
     }
 
     ustring opname() const { return m_op; }
@@ -1067,8 +1067,11 @@ private:
     // more than 32 args, and those that do are read-only that far out.
     // Seems silly to add complexity here to deal with arbitrary param
     // counts and read/write-ability for cases that never come up.
-    unsigned m_requires_masking : 1;///< Op requires masking under batched execution when its arguments are not uniform
-    unsigned m_analysis_flag : 1;   ///< Op specific analysis flag, meaning depends on op
+
+    ///< Op requires masking under batched execution when its arguments are not uniform
+    unsigned m_requires_masking : 1;
+    ///< Op specific analysis flag, meaning depends on type of op
+    unsigned m_analysis_flag : 1;
 };
 
 


### PR DESCRIPTION
During batched analysis we will be figuring out which symbols need to be varying and which can be uniform during batched execution, we will also be figuring out the minimum number of operations which require masking as well as storing/caching some other operation specific flags used later in batched code generation.  We choose to store these analysis results inside Symbol and Opcode directly so that they are efficiently accessible and stable under optimization passes than might invalidate OpcodeVec.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

