### PR TITLE
CI Mac: the uninstall of openssl no longer needed, now causes problems

### DIFF
--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -20,7 +20,6 @@ if [[ `which brew` == "" ]] ; then
 fi
 
 
-brew uninstall openssl
 #brew update >/dev/null
 echo ""
 echo "Before my brew installs:"


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>
