### PR TITLE
fixed cmake setup when tests are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,11 +252,9 @@ install (EXPORT OSL_EXPORTED_TARGETS
         FILE ${OSL_TARGETS_EXPORT_NAME}
         NAMESPACE ${PROJECT_NAME}::)
 
-
-
-
-osl_add_all_tests()
-
+if (${PROJECT_NAME}_BUILD_TESTS AND NOT ${PROJECT_NAME}_IS_SUBPROJECT)
+	osl_add_all_tests()
+endif ()
 
 if (NOT ${PROJECT_NAME}_IS_SUBPROJECT)
     include (packaging)


### PR DESCRIPTION
## Description

This PR fixes cmake setup when tests are explicitly disabled ( ```-DOSL_BUILD_TESTS=0``` on cmake cmd line).
The (recently introduced) testing cmake file is only included when that option is enabled yet adding the tests themselves is not checked (and so cmake does not know ```osl_add_all_tests```).

## Tests

tested local with/without changes (with these changes it works as expected)

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

