### PR TITLE
Fix CI after OIIO branch markers disappeared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           CMAKE_CXX_STANDARD: 11
           PYTHON_VERSION: 2.7
           USE_PYTHON: 0
-          OPENIMAGEIO_VERSION: RB-2.1
+          OPENIMAGEIO_VERSION: Release-2.1.20.0
         run: |
             # Remove pesky wrong installed OIIO version
             rm -rf /usr/local/include/OpenImageIO
@@ -305,7 +305,7 @@ jobs:
           PYTHON_VERSION: 2.7
           USE_SIMD: 0
           USE_PYTHON: 0
-          OPENIMAGEIO_VERSION: RB-2.1
+          OPENIMAGEIO_VERSION: Release-2.1.20.0
           PUGIXML_VERSION: v1.8
         run: |
             # Remove pesky wrong installed OIIO version


### PR DESCRIPTION
OIIO removed "RB-2.1" branch marker because it's not expecting any
further development in the obsolete 2.1 branch. We still test against
it, though, so replace its designation in our CI with the specific
branch tag of the last OIIO 2.1 release.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
