### PR TITLE
Fix one spot where we should have used OIIO::ofstream instead of std.

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3791,7 +3791,7 @@ ShadingSystemImpl::archive_shadergroup (ShaderGroup& group, string_view filename
 
     bool ok = true;
     std::string groupfilename = tmpdir + "/shadergroup";
-    std::ofstream groupfile;
+    OIIO::ofstream groupfile;
     OIIO::Filesystem::open(groupfile, groupfilename);
     if (groupfile.good()) {
         groupfile << group.serialize();


### PR DESCRIPTION
This is primarily for the sake of mingw, but also is the proper kind
of stream to pass to OIIO::Filesystem::open.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
