### PR TITLE
ci: Remove Windows-2019 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,20 +590,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: Windows-2019 VS2019
-            runner: windows-2019
-            nametag: windows-2019
-            generator: "Visual Studio 16 2019"
-            python_ver: "3.9"
-            opencolorio_ver: v2.3.2
-            openexr_ver: v3.3.2
-            openimageio_ver: release
-            skip_tests: 1
-            setenvs: export LLVM_VERSION=18.1.8
-                            OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
-                            PUGIXML_VERSION=v1.14
-                            OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
-
           #
           # Windows 2022 / MSVS 17 case is below. It's not working yet,
           # work in progress.


### PR DESCRIPTION
Those runners are deprecated and scheduled to be removed by GitHub soon.