### PR TITLE
Serialize builds in testshade

### DIFF
--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -82,7 +82,9 @@ target_include_directories (testshade BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 target_link_libraries (testshade
                        PRIVATE
                            oslexec oslquery oslcomp)
-add_dependencies(testshade testshade_ptx)
+if (OSL_USE_OPTIX)
+    add_dependencies(testshade testshade_ptx)
+endif ()
 
 install (TARGETS testshade RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 


### PR DESCRIPTION
## Description

When building with:

- OptiX enabled (OSL_USE_OPTIX)
- Code Coverage disabled (NOT CODECOV)
- a parallel build

various components of the clang toolchain are likely to crash as the testshade and libtestshade builds run in parallel and can overwrite each other's intermediate results.

This chain adds explicit dependencies to serialize these builds, avoiding toolchain crashes at a minimal performance cost.

## Tests

```
cmake -DOSL_USE_OPTIX=ON ..
cmake --build  -j$(nproc) --verbose
```
and looking at the verbose log file, observe the serialization of the build steps in `testshade`:

```
grep gmake /tmp/oslbuild.txt | grep testshade
```

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
