### PR TITLE
Fix: LLVM_Util::supports_isa is not thread-safe

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1443,7 +1443,16 @@ LLVM_Util::supports_isa(TargetISA target)
             continue;
         }
         OSL_DEV_ONLY(std::cout << "Testing for cpu feature:" << f << std::endl);
-        if (sCpuFeatures[f] == false) {
+        // The required CPU feature for the specified target might not be in
+        // the sCpuFeatures. This happens, for example, when the code is probing
+        // the best target ISA when the requested one is UNKNOWN. In this case
+        // it is possible that this function is called for the TargetISA::AVX512
+        // on an ARM CPU.
+        // This function might be called from multiple threads, so it is important
+        // to keep the access to sCpuFeatures read-only.
+        const auto cpu_feature_it = sCpuFeatures.find(f);
+        if (cpu_feature_it == sCpuFeatures.end()
+            || cpu_feature_it->second == false) {
             OSL_DEV_ONLY(std::cout << "MISSING cpu feature:" << f << std::endl);
             return false;
         }


### PR DESCRIPTION
## Description

The supports_isa() function might be called from threads, and prior to this change it might have added entries to the global sCpuFeatures variable. This happened when detect_cpu_features() is called with TargetISA::UNKNOWN and the code was looking for the best ISA. This could lead to situation when the host CPU is ARM, and the probing happens for AVX512.

This change ensures that the supports_isa() accesses sCpuFeatures in the read-only manner.

This was originally noticed as unreliable OSL render tests in Blender reported at https://projects.blender.org/blender/blender/issues/147642

## Tests

The OSL's test suite has been run before and after this change on macOS. Unfortunately, even prior to this change some tests were failing (unclear why). No new tests are failing after this change.

To fully evaluate the fix "in the wild" we'd need a bit more time from Blender side. But maybe review of the logic and findings could start before we have confirmation from production scenes.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
