### PR TITLE
batch: suppress warning for SIMD loop vectorization failure with clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,27 @@ jobs:
           - desc: latest releases gcc11/C++17 llvm17 oiio-rel exr3.2 py3.12 avx2 batch-b16avx512
             nametag: linux-latest-releases
             runner: ubuntu-24.04
-            cc_compiler: gcc-13
-            cxx_compiler: g++-13
+            cc_compiler: gcc-14
+            cxx_compiler: g++-14
+            cxx_std: 17
+            fmt_ver: 12.1.0
+            opencolorio_ver: v2.5.0
+            openexr_ver: v3.4.2
+            openimageio_ver: release
+            pybind11_ver: v3.0.1
+            python_ver: "3.12"
+            llvm_action_ver: "18.1.7"
+            simd: avx2,f16c
+            batched: b8_AVX2,b8_AVX512,b16_AVX512
+            setenvs: export LIBTIFF_VERSION=v4.7.1
+                            PTEX_VERSION=v2.4.3
+                            PUGIXML_VERSION=v1.15
+                            FREETYPE_VERSION=VER-2-14-3
+          - desc: latest releases clang18/C++17 llvm18 oiio-rel exr3.4 py3.12 avx2 batch-b16avx512
+            nametag: linux-latest-releases
+            runner: ubuntu-24.04
+            cc_compiler: clang
+            cxx_compiler: clang++
             cxx_std: 17
             fmt_ver: 11.1.4
             opencolorio_ver: v2.4.2

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -200,6 +200,21 @@
 #endif
 
 // Compiler-specific pragmas
+//
+// - OSL_PRAGMA_WARNING_PUSH/POP pushes/pops warning options (for all
+//   compilers).
+// - OSL_PRAGMA_VISIBILITY_PUSH/POP pushes/pops symbol visibility options (for
+//   all compilers that support it).
+// - OSL_GCC_PRAGMA makes a pragma for all gcc-like compilers, but does nothing
+//   for MSVS.
+// - OSL_GCC_ONLY_PRAGMA makes a pragma for real gcc only.
+// - OSL_CLANG_PRAGMA makes a pragma for all clang-based compilers (including
+//   Apple clang and Intel LLVM).
+// - OSL_NONINTEL_CLANG_PRAGMA makes a pragma for regular clang and Apple
+//   clang, but not Intel clang.
+// - OSL_INTEL_CLASSIC_PRAGMA makes a pragma for icc only.
+// - OSL_INTEL_LLVM_PRAGMA makes a pragma for icx only.
+// - OSL_MSVS_PRAGMA makes a pragma for MSVS only.
 #if defined(__GNUC__) /* gcc, clang, icc */
 #    define OSL_PRAGMA_WARNING_PUSH    OSL_PRAGMA(GCC diagnostic push)
 #    define OSL_PRAGMA_WARNING_POP     OSL_PRAGMA(GCC diagnostic pop)
@@ -223,6 +238,11 @@
 #    else
 #        define OSL_INTEL_LLVM_PRAGMA(UnQuotedPragma)
 #    endif
+#    if defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
+#        define OSL_NONINTEL_CLANG_PRAGMA(UnQuotedPragma) OSL_PRAGMA(UnQuotedPragma)
+#    else
+#        define OSL_NONINTEL_CLANG_PRAGMA(UnQuotedPragma)
+#    endif
 #    define OSL_MSVS_PRAGMA(UnQuotedPragma)
 #elif defined(_MSC_VER)
 #    define OSL_PRAGMA_WARNING_PUSH __pragma(warning(push))
@@ -232,6 +252,7 @@
 #    define OSL_GCC_PRAGMA(UnQuotedPragma)
 #    define OSL_GCC_ONLY_PRAGMA(UnQuotedPragma)
 #    define OSL_CLANG_PRAGMA(UnQuotedPragma)
+#    define OSL_NONINTEL_CLANG_PRAGMA(UnQuotedPragma)
 #    define OSL_INTEL_CLASSIC_PRAGMA(UnQuotedPragma)
 #    define OSL_INTEL_LLVM_PRAGMA(UnQuotedPragma)
 #    define OSL_MSVS_PRAGMA(UnQuotedPragma) OSL_PRAGMA(UnQuotedPragma)
@@ -243,6 +264,7 @@
 #    define OSL_GCC_PRAGMA(UnQuotedPragma)
 #    define OSL_GCC_ONLY_PRAGMA(UnQuotedPragma)
 #    define OSL_CLANG_PRAGMA(UnQuotedPragma)
+#    define OSL_NONINTEL_CLANG_PRAGMA(UnQuotedPragma)
 #    define OSL_INTEL_CLASSIC_PRAGMA(UnQuotedPragma)
 #    define OSL_INTEL_LLVM_PRAGMA(UnQuotedPragma)
 #    define OSL_MSVS_PRAGMA(UnQuotedPragma)
@@ -291,6 +313,7 @@
 #define OSL_OMP_SIMD_LOOP(...) OSL_OMP_PRAGMA(omp simd __VA_ARGS__)
 
 #if (OSL_GNUC_VERSION || OSL_INTEL_CLASSIC_COMPILER_VERSION || OSL_INTEL_LLVM_COMPILER_VERSION)
+    // GCC, icc, icx: Use a simd loop for sure
 #   define OSL_OMP_COMPLEX_SIMD_LOOP(...) OSL_OMP_SIMD_LOOP(__VA_ARGS__)
 #else
     // Ignore requests to vectorize complex/nested SIMD loops for certain

--- a/src/liboslexec/wide/wide_opalgebraic.cpp
+++ b/src/liboslexec/wide/wide_opalgebraic.cpp
@@ -128,6 +128,9 @@ calculatenormal(const Dual2<Vec3>& tmpP, bool flipHandedness)
 
 
 
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 OSL_BATCHOP void
 __OSL_OP2(length, Wf, Wv)(void* r_, void* V_)
 {
@@ -136,7 +139,7 @@ __OSL_OP2(length, Wf, Wv)(void* r_, void* V_)
         Wide<const Vec3> wV(V_);
         Wide<float> wr(r_);
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Vec3 V   = wV[lane];
             float r  = sfm::length(V);
@@ -155,7 +158,7 @@ __OSL_MASKED_OP2(length, Wf, Wv)(void* r_, void* V_, unsigned int mask_value)
         Wide<const Vec3> wV(V_);
         Masked<float> wr(r_, Mask(mask_value));
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Vec3 V = wV[lane];
             if (wr.mask()[lane]) {
@@ -165,6 +168,8 @@ __OSL_MASKED_OP2(length, Wf, Wv)(void* r_, void* V_, unsigned int mask_value)
         }
     }
 }
+
+OSL_PRAGMA_WARNING_POP
 
 
 
@@ -208,6 +213,9 @@ __OSL_MASKED_OP2(length, Wdf, Wdv)(void* r_, void* V_, unsigned int mask_value)
 
 
 
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 OSL_BATCHOP void
 __OSL_OP2(area, Wf, Wdv)(void* r_, void* DP_)
 {
@@ -217,7 +225,7 @@ __OSL_OP2(area, Wf, Wdv)(void* r_, void* DP_)
 
         Wide<float> wr(r_);
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Dual2<Vec3> DP = wDP[lane];
 
@@ -240,7 +248,7 @@ __OSL_MASKED_OP2(area, Wf, Wdv)(void* r_, void* DP_, unsigned int mask_value)
 
         Masked<float> wr(r_, Mask(mask_value));
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Dual2<Vec3> DP = wDP[lane];
             if (wr.mask()[lane]) {
@@ -252,6 +260,8 @@ __OSL_MASKED_OP2(area, Wf, Wdv)(void* r_, void* DP_, unsigned int mask_value)
         }
     }
 }
+
+OSL_PRAGMA_WARNING_POP
 
 
 
@@ -447,6 +457,9 @@ __OSL_MASKED_OP3(distance, Wdf, Wdv, Wdv)(void* r_, void* a_, void* b_,
 
 
 
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 OSL_BATCHOP void
 __OSL_OP2(normalize, Wv, Wv)(void* r_, void* V_)
 {
@@ -455,7 +468,7 @@ __OSL_OP2(normalize, Wv, Wv)(void* r_, void* V_)
         Wide<const Vec3> wV(V_);
         Wide<Vec3> wr(r_);
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Vec3 V   = wV[lane];
             Vec3 N   = sfm::normalize(V);
@@ -473,7 +486,7 @@ __OSL_MASKED_OP2(normalize, Wv, Wv)(void* r_, void* V_, unsigned int mask_value)
         Wide<const Vec3> wV(V_);
         Masked<Vec3> wr(r_, Mask(mask_value));
 
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             Vec3 V = wV[lane];
             if (wr.mask()[lane]) {
@@ -484,6 +497,7 @@ __OSL_MASKED_OP2(normalize, Wv, Wv)(void* r_, void* V_, unsigned int mask_value)
     }
 }
 
+OSL_PRAGMA_WARNING_POP
 
 
 OSL_BATCHOP void

--- a/src/liboslexec/wide/wide_opcolor.cpp
+++ b/src/liboslexec/wide/wide_opcolor.cpp
@@ -56,6 +56,9 @@ __OSL_OP(blackbody_vf)(void* bsg_, void* out, float temp)
 
 
 
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 OSL_BATCHOP void
 __OSL_MASKED_OP2(blackbody, Wv, Wf)(void* bsg_, void* wout_, void* wtemp_,
                                     unsigned int mask_value)
@@ -68,7 +71,7 @@ __OSL_MASKED_OP2(blackbody, Wv, Wf)(void* bsg_, void* wout_, void* wtemp_,
     Block<int> computeRequiredBlock;
     Wide<int> wcomputeRequired(computeRequiredBlock);
 
-    OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+    OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
     for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
         float temperature      = wL[lane];
         bool canNotLookup      = !cs.can_lookup_blackbody(temperature);
@@ -104,6 +107,8 @@ __OSL_MASKED_OP2(blackbody, Wv, Wf)(void* bsg_, void* wout_, void* wtemp_,
         }
     }
 }
+
+OSL_PRAGMA_WARNING_POP
 
 
 

--- a/src/liboslexec/wide/wide_opspline.cpp
+++ b/src/liboslexec/wide/wide_opspline.cpp
@@ -362,6 +362,9 @@ splineinverse_search(const MatrixT& M, R_T& result, X_T& xval, KArrayT knots,
 
 namespace {  // unnamed
 
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 template<bool IsBasisUConstantT, int BasisStepT, typename MatrixT,
          typename RAccessorT, typename XAccessorT, typename KAccessorT>
 OSL_FORCEINLINE void
@@ -376,7 +379,7 @@ spline_evaluate_loop_over_wide(const MatrixT& M, RAccessorT wR, XAccessorT wX,
 
     OSL_FORCEINLINE_BLOCK
     {
-        OSL_OMP_PRAGMA(omp simd simdlen(vec_width))
+        OSL_OMP_SIMD_LOOP(simdlen(vec_width))
         for (int lane = 0; lane < vec_width; ++lane) {
             X_Type x   = wX[lane];
             auto knots = wK[lane];
@@ -546,6 +549,8 @@ splineinverse_evaluate_wide(RAccessorT wR, ustring spline_basis, XAccessorT wX,
 
     impl_by_basis[basis_type](wR, wX, wK, knot_count);
 }
+
+OSL_PRAGMA_WARNING_POP
 
 }  // namespace
 

--- a/src/liboslexec/wide/wide_opstring.cpp
+++ b/src/liboslexec/wide/wide_opstring.cpp
@@ -90,6 +90,10 @@ __OSL_MASKED_OP2(strlen, Wi, Ws)(void* wr_, void* ws_, unsigned int mask_value)
 }
 
 
+
+OSL_PRAGMA_WARNING_PUSH
+OSL_NONINTEL_CLANG_PRAGMA(GCC diagnostic ignored "-Wpass-failed")
+
 OSL_BATCHOP void
 __OSL_MASKED_OP2(hash, Wi, Ws)(void* wr_, void* ws_, unsigned int mask_value)
 {
@@ -98,7 +102,7 @@ __OSL_MASKED_OP2(hash, Wi, Ws)(void* wr_, void* ws_, unsigned int mask_value)
 
     OSL_FORCEINLINE_BLOCK
     {
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_SIMD_LOOP(simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             ustring s = wS[lane];
             if (wR.mask()[lane]) {
@@ -107,6 +111,8 @@ __OSL_MASKED_OP2(hash, Wi, Ws)(void* wr_, void* ws_, unsigned int mask_value)
         }
     }
 }
+
+OSL_PRAGMA_WARNING_POP
 
 
 


### PR DESCRIPTION
Background: We knew all along that some of the omp SIMD loops that worked
fine with icc, icx, and even gcc, failed to parallelize the loop for clang,
and the warnings issued as a result would break the build in CI where we 
use compile options to turn warnings into hard errors.

So we made a `OSL_OMP_COMPLEX_SIMD_LOOP` macro that would issue the omp
simd pragma for other compilers, but not clang. These were set up by Alex
Wells, who through trial and error found the loops that clang wouldn't vectorize
and so marked them. This was a few years ago, so probably involved clang 14
or so? We hoped that in the future, new clang releases would be better at
vectorizing those loops and we could eventually reduce the number of places
we used the special "anywhere but clang" macro.

After adding a "latest dependencies with clang" test that test against clang 18
(sorry, that's not exactly state of the art, but still several releases newer
than when Alex did this work), it sure seems that FEWER such loops vectorize
properly, so it breaks the build with errors that look like this

```
/home/runner/work/OpenShadingLanguage/OpenShadingLanguage/build/src/liboslexec/wide/wide_opstring_b8_AVX2.cpp:94:1: error: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Werror,-Wpass-failed=transform-warning]
   94 | __OSL_MASKED_OP2(hash, Wi, Ws)(void* wr_, void* ws_, unsigned int mask_value)
      | ^
/home/runner/work/OpenShadingLanguage/OpenShadingLanguage/src/liboslexec/wide/define_opname_macros.h:44:5: note: expanded from macro '__OSL_MASKED_OP2'
   44 |     __OSL_CONCAT7(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, _masked)
      |     ^
/home/runner/work/OpenShadingLanguage/OpenShadingLanguage/build/include/OSL/oslversion.h:114:44: note: expanded from macro '__OSL_CONCAT7'
  114 | #define __OSL_CONCAT7(A, B, C, D, E, F, G) __OSL_CONCAT(__OSL_CONCAT6(A,B,C,D,E,F),G)
      |                                            ^
/home/runner/work/OpenShadingLanguage/OpenShadingLanguage/build/include/OSL/oslversion.h:109:28: note: expanded from macro '__OSL_CONCAT'
  109 | #define __OSL_CONCAT(A, B) __OSL_CONCAT_INDIRECT(A,B)
      |                            ^
/home/runner/work/OpenShadingLanguage/OpenShadingLanguage/build/include/OSL/oslversion.h:108:37: note: expanded from macro '__OSL_CONCAT_INDIRECT'
  108 | #define __OSL_CONCAT_INDIRECT(A, B) A ## B
      |                                     ^
<scratch space>:336:1: note: expanded from here
  336 | osl_b8_AVX2_hash_WiWs_masked
      | ^
1 error generated.
```

First, I tried using `OSL_OMP_COMPLEX_SIMD_LOOP` in more places, but eventually
decided that rather than not even try to vectorize (and somehow have to discern
exactly which clang versions could or could not do it with each loop), a
better strategy was to try to vectorize, but simply disable the warning that is
issued when we can't vectorize.
