### PR TITLE
build: small fixups for LLVM 21 support

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -2116,7 +2116,11 @@ BackendLLVM::run()
             // for NVPTX (https://www.llvm.org/docs/NVPTXUsage.html#triples).
             ll.module()->setDataLayout(
                 "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+#        if OSL_LLVM_VERSION < 210
             ll.module()->setTargetTriple("nvptx64-nvidia-cuda");
+#        else
+            ll.module()->setTargetTriple(llvm::Triple("nvptx64-nvidia-cuda"));
+#        endif
         }
 #    endif
 #else
@@ -2181,7 +2185,12 @@ BackendLLVM::run()
 
             shadeops_module->setDataLayout(
                 "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+#        if OSL_LLVM_VERSION < 210
             shadeops_module->setTargetTriple("nvptx64-nvidia-cuda");
+#        else
+            shadeops_module->setTargetTriple(
+                llvm::Triple("nvptx64-nvidia-cuda"));
+#        endif
 
             std::unique_ptr<llvm::Module> shadeops_ptr(shadeops_module);
             llvm::Linker::linkModules(*ll.module(), std::move(shadeops_ptr),
@@ -2208,7 +2217,12 @@ BackendLLVM::run()
 
                 rend_lib_module->setDataLayout(
                     "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+#        if OSL_LLVM_VERSION < 210
                 rend_lib_module->setTargetTriple("nvptx64-nvidia-cuda");
+#        else
+                rend_lib_module->setTargetTriple(
+                    llvm::Triple("nvptx64-nvidia-cuda"));
+#        endif
 
                 for (llvm::Function& fn : *rend_lib_module) {
                     fn.addFnAttr("osl-rend_lib-function", "true");


### PR DESCRIPTION
## Description

I wanted to move onto LLVM 21 so I tried the new https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/2030 merge but I think it wasn't tested with Optix and there were a few `setTargetTriple` calls that needed to be tweaked as well.

## Tests

Just a basic build with Optix 9 and LLVM 21.1.2 works with this.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
