### PR TITLE
ci: unbreak optix jobs by locking down container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,7 +665,7 @@ jobs:
             # select the right runner type and whether tests are run.
             nametag: linux-optix-vfx2025
             runner: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-20.04-gpu-t4-4c-16g-176h') || 'ubuntu-latest' }}
-            container: aswf/ci-osl:2025-clang18
+            container: aswf/ci-osl:2025-clang18.2
             cxx_std: 17
             python_ver: "3.11"
             pybind11_ver: v2.11.1


### PR DESCRIPTION
In all branches, the OptiX test job started failing several days ago, corresponding to an update of the aswf/ci-osl:2025-clang18.3 container. Reverting to aswf/ci-osl:2025-clang18.2 passes again!

Let's merge this fix so that our CI passes, and separately iterate to figure out what went wrong with the newer container.
