### PR TITLE
fix(testrender): Default to identity for unknown testrender xforms

### DIFF
--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -516,7 +516,11 @@ SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 {
     // SimpleRaytracer doesn't understand motion blur and transformations
     // are just simple 4x4 matrices.
-    result = *reinterpret_cast<const Matrix44*>(xform);
+    if (xform)
+        result = *reinterpret_cast<const Matrix44*>(xform);
+    else
+        result = Matrix44(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+
     return true;
 }
 
@@ -543,7 +547,10 @@ SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 {
     // SimpleRaytracer doesn't understand motion blur and transformations
     // are just simple 4x4 matrices.
-    result = *reinterpret_cast<const Matrix44*>(xform);
+    if (xform)
+        result = *reinterpret_cast<const Matrix44*>(xform);
+    else
+        result = Matrix44(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     return true;
 }
 


### PR DESCRIPTION
## Description

This is a quick workaround for a testrender crash due to missing object transforms, as observed in MaterialX's OSL codegen testsuite: https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/source/MaterialXRenderOsl/OslRenderer.cpp#L490


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
