### PR TITLE
ci: Use bigger runner for icx job variation, needs more disk space

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -12,6 +12,9 @@ on:
   workflow_call:
     # This inputs receive values via the "with:" section in ci_workflow.yml
     inputs:
+      disable:
+        type: boolean
+        default: false
       build:
         type: string
       runner:
@@ -85,6 +88,7 @@ jobs:
 
   steps:
     name: "${{inputs.cxx_compiler}} c++${{inputs.cxx_std}} py${{inputs.python_ver}}"
+    if: ${{ !inputs.disable }}
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.container }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ name: CI
 on:
   push:
     # Skip jobs when only documentation files are changed
-    # Skip jobs when only documentation files are changed
     paths:
       - '**'
       - '!**.md'
@@ -200,6 +199,7 @@ jobs:
     uses: ./.github/workflows/build-steps.yml
     with:
       nametag: ${{ matrix.nametag || 'unnamed!' }}
+      disable: ${{ matrix.disable || false }}
       runner: ${{ matrix.runner || 'ubuntu-latest' }}
       container: ${{ matrix.container }}
       cc_compiler: ${{ matrix.cc_compiler || 'gcc' }}
@@ -367,7 +367,13 @@ jobs:
                             OPENCOLORIO_CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=g++"
           - desc: icx/C++17 llvm14 py3.10 oiio-3.0 avx2
             nametag: linux-icx
-            runner: ubuntu-latest
+            # This job variation needs a bigger runner with more "disk space",
+            # so only enable it when running on the main repo. Sorry, CI can't
+            # currently test with icx you people's individual forks until we
+            # figure out a way to require less space. Until then, they'll need
+            # to submit the PR to see how it does on icx.
+            runner: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-22.04-8c-32g-300h') || 'ubuntu-latest' }}
+            disable: ${{ github.repository_owner != 'AcademySoftwareFoundation' }}
             container: aswftesting/ci-osl:2023-clang15
             cc_compiler: icx
             cxx_compiler: icpx


### PR DESCRIPTION
A week or two ago, the icx job variation stopped working, not enough space to finish installing the packages containing icx and related material. We didn't change, the Intel package (pegged to a specific version from a couple years ago) didn't change, the ASWF docker container (also old) didn't change, so we're assuming that the GHA runner itself changed, leaving us less disk space, which is now not enough.

The easiest way out of this for now is for the icx job variation to use a paid bigger GHA runner with more "disk space". This means it can only be enabled when running on the main repo, which uses the ASWF's account that has paid runners. Sorry, CI can't currently test with icx you people's individual forks until we figure out a way to require less space. Until then, developers who don't have icx locally will need to submit the PR to see how it does on icx.

A little bit of workflow magic was needed to ensure that this job variation doesn't run at all on a developer's fork -- we don't want it to run, and look like a failed test just because they don't have an account that doesn't allow use of the big paid runners.

