### PR TITLE
osltoy - Feature Request: auto-detect output variable

### DIFF
--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -9,7 +9,6 @@
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
-#include <QRadioButton>
 #include <QDir>
 #include <QDoubleSpinBox>
 #include <QErrorMessage>
@@ -24,6 +23,7 @@
 #include <QPixmap>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QScrollArea>
 #include <QSlider>
 #include <QSpinBox>
@@ -1255,10 +1255,11 @@ OSLToyMainWindow::build_shader_group()
     }
     renderer()->set_shadergroup(group);
 
-    // Doing OSLQuery here before the getattribute calls to 
+    // Doing OSLQuery here before the getattribute calls to
     // set first output param in param list as renderer output if none selected
     if (m_selectedoutput.empty()) {
-        OSLQuery oslquery = ss->oslquery(*group, 0);         // can I assume that there is only ever one group? 
+        OSLQuery oslquery = ss->oslquery(
+            *group, 0);  // can I assume that there is only ever one group?
         for (size_t p = 0; p < oslquery.nparams(); ++p) {
             auto param = oslquery.getparam(p);
             // Has to be output and vec3, so we can display as color
@@ -1270,7 +1271,8 @@ OSLToyMainWindow::build_shader_group()
     }
 
     ustring outputs[] = { m_selectedoutput };
-    ss->attribute(group.get(), "renderer_outputs", TypeDesc(TypeDesc::STRING, 1), &outputs);
+    ss->attribute(group.get(), "renderer_outputs",
+                  TypeDesc(TypeDesc::STRING, 1), &outputs);
 
     m_shader_uses_time            = false;
     int num_globals_needed        = 0;
@@ -1334,9 +1336,9 @@ OSLToyMainWindow::make_param_adjustment_row(ParamRec* param,
         typetext = OSL::fmtformat("closure {}", typetext);
     if (param->isstruct)
         typetext = OSL::fmtformat("struct {}", param->structname);
-    if (param->isoutput) 
+    if (param->isoutput)
         typetext = OSL::fmtformat("output {}", typetext);
-    
+
     if ((param->isoutput) && (param->type.is_vec3())) {
         // Create a radio button for the output parameter
         auto outputRadioButton = new QRadioButton(this);
@@ -1359,7 +1361,7 @@ OSLToyMainWindow::make_param_adjustment_row(ParamRec* param,
                 });
 
         // Check the radio button if this parameter is the currently selected output
-        if (m_selectedoutput == param->name) 
+        if (m_selectedoutput == param->name)
             outputRadioButton->setChecked(true);
 
         return;  // Skip the rest of the function for output parameters

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -87,7 +87,7 @@ public:
     CodeEditor* add_new_editor_window(const std::string& filename = "");
 
     OSLToyRenderer* renderer() const { return m_renderer.get(); }
-    
+
     ustring selected_output() const { return m_selectedoutput; }
 
     ShadingSystem* shadingsys() const;
@@ -155,7 +155,7 @@ private:
     // Set up the status bar
     void createStatusBar();
 
-    
+
 
     // Actions. To make these do things, put them in the .cpp and give them
     // bodies. Delete the ones that don't correspond to concepts in your
@@ -211,7 +211,7 @@ private:
     bool m_shader_uses_time = false;
 
     // The currently selected output
-    ustring m_selectedoutput = ustring(""); // Empty until set by user 
+    ustring m_selectedoutput = ustring("");  // Empty until set by user
 
     std::vector<std::string> m_include_search_paths;
 

--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -11,8 +11,8 @@
 #include <OSL/oslexec.h>
 #include <OSL/oslquery.h>
 
-#include "osltoyrenderer.h"
 #include "osltoyapp.h"
+#include "osltoyrenderer.h"
 
 // Create ustrings for all strings used by the free function renderer services.
 // Required to allow the reverse mapping of hash->string to work when processing messages
@@ -122,7 +122,7 @@ OSLToyRenderer::OSLToyRenderer()
 
 
 void
-OSLToyRenderer::set_output_getter(std::function<ustring()> getter) 
+OSLToyRenderer::set_output_getter(std::function<ustring()> getter)
 {
     m_get_selected_output = getter;
 }
@@ -135,13 +135,14 @@ OSLToyRenderer::render_image()
     if (!m_framebuffer.initialized())
         m_framebuffer.reset(
             OIIO::ImageSpec(m_xres, m_yres, 3, TypeDesc::FLOAT));
-    
+
     // Use the getter to get the selected output in the app
-    ustring selected_output = ustring("Cout");      // Default to "Cout"
+    ustring selected_output = ustring("Cout");  // Default to "Cout"
     if (m_get_selected_output) {
         selected_output = m_get_selected_output();
     } else {
-        std::cerr << "Warning: m_get_selected_output() is not set. Using default 'Cout'.\n";
+        std::cerr
+            << "Warning: m_get_selected_output() is not set. Using default 'Cout'.\n";
     }
 
     ustring outputs[] = { selected_output };

--- a/src/osltoy/osltoyrenderer.h
+++ b/src/osltoy/osltoyrenderer.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
-#include <functional>
 #include <unordered_map>
 
 #include <OpenImageIO/imagebuf.h>
@@ -92,7 +92,8 @@ public:
                               ShaderGlobals* sg, void* val);
 
 private:
-    std::function<ustring()> m_get_selected_output;  // Store the getter function that gets selection from app
+    std::function<ustring()>
+        m_get_selected_output;  // Store the getter function that gets selection from app
 
     OIIO::spin_mutex m_mutex;
     ShadingSystem* m_shadingsys;


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
I was contributing to Dev Days 2025 and attempting to fix this issue https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/issues/2021


<!-- how it works (if it's not going to be very clear from the code).   -->

How it works: 
- Getting all of the output color variables from OSL Query in build_shader_group() in order to set the first one as the default renderer_outputs in OSLToyRenderer. 
- Creating Radio Buttons for output color param rows in the parameter layout panel. 
- Setting up a getter function so that the user selected output can be used in OSLToyRenderer
- The selected output will be displayed when you hit recompile. 

https://github.com/user-attachments/assets/f1d11dc0-59e9-4b26-aba4-ee2a8d9a1c74


## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
I was working with a simple OSL file with two color output variables to test that the user could select the desired output with radio buttons. 
```
surface test_noise (
    float scale = 10
        [[ string help = "Scaling factor for noise frequency" ]],
    output color rgb = 0
        [[ string help = "Perlin noise in color" ]],
    output color bw = 0
        [[ string help = "Perlin noise in black and white" ]]
    

)
{
    point uvw = point(u * scale, v * scale, 0);

    float n = noise("perlin", uvw);

    bw = color(n, n, n);
    rgb = color(noise("perlin", uvw),
             noise("perlin", uvw + 10),
             noise("perlin", uvw + 20));
}
```
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [] I have updated the documentation, if applicable.
- [] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
