### PR TITLE
ci: Address tight disk space on GHA runners

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -21,6 +21,9 @@ on:
         type: string
       container:
         type: string
+      container_volumes:
+        type: string
+        default: '[]'
       cc_compiler:
         type: string
       cxx_compiler:
@@ -92,9 +95,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.container }}
-      options: ${{ (contains(inputs.runner, 'gpu') && '-e NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility --gpus all') || '-e A=x' }}
-      # ^^ need extra options on the GPU runners to ensure OptiX is visible
-      # in the container.
+      volumes: ${{ fromJson( inputs.container_volumes ) }}
+      options: -v /:/host/root ${{ (contains(inputs.runner, 'gpu') && '-e NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility --gpus all') || '-e A=x' }}
+      # Extra options:
+      # - Ensure the GPU runners have OptiX is visible in the container.
+      # - Mount the native filesystem under /host/root
     env:
       CXX: ${{inputs.cxx_compiler}}
       CC: ${{inputs.cc_compiler}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       volumes:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared
+      options: -v /:/host/root ${{ (contains(inputs.runner, 'gpu') && '-e NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility --gpus all') || '-e A=x' }}
     env:
       CXX: ${{matrix.cxx_compiler}}
       CC: ${{matrix.cc_compiler}}
@@ -367,13 +368,10 @@ jobs:
                             OPENCOLORIO_CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=g++"
           - desc: icx/C++17 llvm14 py3.10 oiio-3.0 avx2
             nametag: linux-icx
-            # This job variation needs a bigger runner with more "disk space",
-            # so only enable it when running on the main repo. Sorry, CI can't
-            # currently test with icx you people's individual forks until we
-            # figure out a way to require less space. Until then, they'll need
-            # to submit the PR to see how it does on icx.
-            runner: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-22.04-8c-32g-300h') || 'ubuntu-latest' }}
-            disable: ${{ github.repository_owner != 'AcademySoftwareFoundation' }}
+            runner: ubuntu-latest
+            # If we ever need the big runner:
+            #   runner: ${{ (github.repository_owner == 'AcademySoftwareFoundation' && 'ubuntu-22.04-8c-32g-300h') || 'ubuntu-latest' }}
+            #   disable: ${{ github.repository_owner != 'AcademySoftwareFoundation' }}
             container: aswftesting/ci-osl:2023-clang15
             cc_compiler: icx
             cxx_compiler: icpx

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -7,6 +7,11 @@
 
 set -ex
 
+# Make extra space on the runners
+df -h .
+time rm -rf /usr/local/lib/android /host/root/usr/local/lib/android &
+sleep 3
+
 
 #
 # Install system packages when those are acceptable for dependencies.
@@ -207,6 +212,9 @@ fi
 if [[ "$ABI_CHECK" != "" ]] ; then
     source src/build-scripts/build_abi_tools.bash
 fi
+
+df -h .
+df -h /host/root || true
 
 # Save the env for use by other stages
 src/build-scripts/save-env.bash


### PR DESCRIPTION
- Mount the host's root under /host/root so it's visible in the containers.
- Remove stuff we don't need to free lots of disk space.
- Tentatively go back to the free runner for the icx test.
