### PR TITLE
admin: TSC roster changes

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -137,10 +137,10 @@ Current voting members of the TSC are:
 * Eric Enderton - NVIDIA
 * Stephen Friedman - Pixar
 * Nicolas Guiard - Isotropix
-* Clint Hanson - DNEG
-* Adrien Herubel - Autodesk
+* Thiago Ize - Autodesk
 * Lee Kerley - Apple
 * Mitch Prater - Laika
+* Alexey Smolenchuk - DNEG
 * Brecht Van Lommel - Blender
 * Alex Wells - Intel
 


### PR DESCRIPTION
Swap Adrien Herubel -> Thiago Ize for Autodesk (approved by TSC on 2025-12-04), and Clint Hanson -> Alexey Smolenchuk for DNEG (approved by TSC on 2026-01-15).
