### PR TITLE
osltoy: improved readability of cursor highlighted line

### DIFF
--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -64,7 +64,6 @@ CodeEditor::CodeEditor(QWidget* parent, const std::string& filename)
 
     updateLineNumberAreaWidth(0);
     highlightCurrentLine();
-    setTabStopDistance(4 * char_width_pixels());
 }
 
 
@@ -99,12 +98,11 @@ CodeEditor::text_string() const
 int
 CodeEditor::char_width_pixels() const
 {
-    QFontMetrics metrics(fixedFont());
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
-    return metrics.horizontalAdvance(QLatin1Char('M'));
+    return fontMetrics().horizontalAdvance(QLatin1Char('M'));
 #else
     // QFontMetric.width() deprecated from 5.11, marked as such in 5.13
-    return metrics.width(QLatin1Char('M'));
+    return fontMetrics().width(QLatin1Char('M'));
 #endif
 }
 

--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -177,8 +177,10 @@ CodeEditor::highlightCurrentLine()
         QTextEdit::ExtraSelection selection;
 
         QColor lineColor = QColor(Qt::yellow).lighter(160);
+        QColor textColor = QColor(Qt::black);
 
         selection.format.setBackground(lineColor);
+        selection.format.setForeground(textColor);
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();
         selection.cursor.clearSelection();

--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -53,6 +53,8 @@ CodeEditor::CodeEditor(QWidget* parent, const std::string& filename)
     setLineWrapMode(QPlainTextEdit::NoWrap);
     document()->setDefaultFont(fixedFont());
 
+    setTabStopDistance(4 * char_width_pixels());
+
     lineNumberArea = new LineNumberArea(this);
 
     connect(this, SIGNAL(blockCountChanged(int)), this,

--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -100,7 +100,7 @@ int
 CodeEditor::char_width_pixels() const
 {
     QFontMetrics metrics(fixedFont());
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0) 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
     return metrics.horizontalAdvance(QLatin1Char('M'));
 #else
     // QFontMetric.width() deprecated from 5.11, marked as such in 5.13

--- a/src/osltoy/codeeditor.cpp
+++ b/src/osltoy/codeeditor.cpp
@@ -53,8 +53,6 @@ CodeEditor::CodeEditor(QWidget* parent, const std::string& filename)
     setLineWrapMode(QPlainTextEdit::NoWrap);
     document()->setDefaultFont(fixedFont());
 
-    setTabStopDistance(4 * char_width_pixels());
-
     lineNumberArea = new LineNumberArea(this);
 
     connect(this, SIGNAL(blockCountChanged(int)), this,
@@ -66,6 +64,7 @@ CodeEditor::CodeEditor(QWidget* parent, const std::string& filename)
 
     updateLineNumberAreaWidth(0);
     highlightCurrentLine();
+    setTabStopDistance(4 * char_width_pixels());
 }
 
 
@@ -100,11 +99,12 @@ CodeEditor::text_string() const
 int
 CodeEditor::char_width_pixels() const
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
-    return fontMetrics().horizontalAdvance(QLatin1Char('M'));
+    QFontMetrics metrics(fixedFont());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0) 
+    return metrics.horizontalAdvance(QLatin1Char('M'));
 #else
     // QFontMetric.width() deprecated from 5.11, marked as such in 5.13
-    return fontMetrics().width(QLatin1Char('M'));
+    return metrics.width(QLatin1Char('M'));
 #endif
 }
 


### PR DESCRIPTION
## Description

- Font in the yellow highlighted line will always be black, this improves readability in dark mode 
- Tab size is now set to 4 characters wide (a request I saw in #1862 )
    - This required a small modification to char_width_pixels() to use fixedFont() for QFontMetrics. I'm not sure what font it was using previously, but it was wider than the font that showed up in the editor. This change allows me to reuse the function for the tab distance.
    - A side effect is that line number area is now slightly narrower. Let me know if it doesn't look right.

## Tests

Only using visual verification for the UI changes. 

| Before | After |
|--------|-------|
| <img width="689" height="749" alt="Screenshot 2026-01-20 at 4 53 22 PM" src="https://github.com/user-attachments/assets/9e2032ad-78d7-423b-9e06-cd23783da32f" /> | <img width="684" height="657" alt="Screenshot 2026-01-20 at 4 52 32 PM" src="https://github.com/user-attachments/assets/f8612a7a-d92f-4001-8f7f-21290da031e3" /> |
## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
