### PR TITLE
ci: lock bleeding edge to pybind11 latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,8 @@ jobs:
             opencolorio_ver: main
             openexr_ver: main
             openimageio_ver: main
-            pybind11_ver: master
+            pybind11_ver: v3.0.1
+            # pybind11_ver: master
             python_ver: "3.12"
             llvm_action_ver: "18.1.7"
             simd: avx2,f16c


### PR DESCRIPTION
Identical to https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/5024

There's something in pybind11 master at the moment that is crashing in its destructors. It's been causing our "bleeding edge" test to fail for over a week now. I'm tired of our test failing, so I'm locking down to the last known working version. Will check back periodically and return to testing against pybind11 master after they have fixed it.
