### PR TITLE
admin: Fix link to icon used for Slack release announcements

### DIFF
--- a/.github/workflows/release-notice.yml
+++ b/.github/workflows/release-notice.yml
@@ -22,5 +22,5 @@ jobs:
         project_name: "Open Shading Language"
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel: "#release-announcements"
-        project_logo: "https://artwork.aswf.io/projects/openshadinglanguage/Icon/Color/openshadinglanguage-Icon-Color.png"
+        project_logo: "https://artwork.aswf.io/projects/open-shading-language/icon/color/open-shading-language-icon-color.png"
       uses: jmertic/slack-release-notifier@main


### PR DESCRIPTION
I think this used to work. Did the files change their path at some point, @jmertic?
