### PR TITLE
Fix "#if with no expression" errors in platform.h

### DIFF
--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -299,7 +299,7 @@
 #endif // OSL_DEBUG
 
 
-#if OSL_DEBUG
+#ifdef OSL_DEBUG
 	// Disable OPENMP_SIMD when debugging
 	#undef OSL_OPENMP_SIMD
 #endif
@@ -326,7 +326,7 @@
 // advisory. Put this attribute before the function return type, just like
 // you would use 'inline'. Note that if OSL_DEBUG is true, it just becomes
 // ordinary inline.
-#if OSL_DEBUG
+#ifdef OSL_DEBUG
 #    define OSL_FORCEINLINE inline
 #elif defined(__CUDACC__)
 #    define OSL_FORCEINLINE __inline__
@@ -363,7 +363,7 @@
 // NOTE:  only supported by Intel C++ compiler.
 // Unsupported compilers may instead use command line flags to increase their inlining
 // limits/thresholds
-#if OSL_DEBUG
+#ifdef OSL_DEBUG
 	#define OSL_FORCEINLINE_BLOCK
 #else
 	#define OSL_FORCEINLINE_BLOCK OSL_INTEL_PRAGMA(forceinline recursive)


### PR DESCRIPTION
## Description

When building in debug mode, gcc rasied multiple "#if with no expression" errors with OSL_DEBUG.

## Tests

Not applicable. Code compiles.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
