### PR TITLE
int: minor simplification of some formatting

### DIFF
--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -252,7 +252,7 @@ RendererServices::filefmt(OSL::ShaderGlobals* sg,
                         arg_values, message);
     // By default, do not write to file for security reasons. Instead prefix the
     // the message with the filename and hand it to the current error handler.
-    auto file_message = OSL::fmtformat("{}:{}", filename_hash.c_str(), message);
+    auto file_message   = OSL::fmtformat("{}:{}", filename_hash, message);
     ShadingContext* ctx = (ShadingContext*)((ShaderGlobals*)sg)->context;
     ctx->messagefmt(file_message.c_str());
 }

--- a/src/liboslexec/wide/wide_opmessage.cpp
+++ b/src/liboslexec/wide/wide_opmessage.cpp
@@ -332,7 +332,7 @@ __OSL_MASKED_OP(getmessage)(void* bsg_, void* result, ustring_pod source_,
                     Mask(lane),
                     "type mismatch for message \"{}\" ({} as {} here: {}:{})"
                     " cannot fetch as {} from {}:{}",
-                    name.c_str(), has_data ? "created" : "queried",
+                    name, has_data ? "created" : "queried",
                     m->type == TypeDesc::PTR ? "closure color"
                                              : m->type.c_str(),
                     msg_sourcefile, msg_sourceline,


### PR DESCRIPTION
It's ok to directly pass ustring or ustringhash to fmt formatting, don't need to take c_str().

