### PR TITLE
admin: Update security instructions to emphasize reporting via GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,14 +504,14 @@ your question quickly (more so than a GH "issue"). For quick questions, you
 could also try the [ASWF Slack](https://slack.aswf.io) `#openshadinglanguage`
 channel.
 
-Bugs, build problems, and discovered vulnerabilities that you are relatively
-certain is a legit problem in the code, and for which you can give clear
-instructions for how to reproduce, should be [reported as
+A bug or build problem that you are relatively certain is a legit problem in
+the code, and **for which you can give clear instructions for how to
+reproduce**, should be [reported as
 issues](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/issues).
 
-If you think you've found a potential vulnerability in OSL, please
-confidentially report it by emailing the project administrators at
-[security@openshadinglanguage.org](security@openshadinglanguage.org).
+To report a security vulnerability that is serious enough that it should not
+be discussed publicly until a patch is ready, please file a GitHub [security
+advisory](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/security/advisories/new).
 
 If any other issue requires confidentiality that precludes a public question
 or issue, you may contact the project administrator privately at

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,16 +15,19 @@ security vulnerabilities.
 
 ## Reporting a Vulnerability
 
-If you think you've found a potential vulnerability in OSL, please report it
-by emailing the project administrators at
-[security@openshadinglanguage.org](security@openshadinglanguage.org). Only the
-project administrators have access to these messages. Include detailed steps to
-reproduce the issue, and any other information that could aid an
-investigation. Our policy is to respond to vulnerability reports within 14
-days.
+If you think you've found a potential vulnerability in OSL, please
+report it to the maintainers. Include detailed steps to reproduce the issue,
+and any other information that could aid an investigation.
 
-Our policy is to address critical security vulnerabilities rapidly and post
-patches as quickly as possible.
+The best way to report a vulnerability is to file a GitHub [security
+advisory](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/security/advisories/new).
+If that is not possible, it is also fine to email your report to
+security@openshadinglanguage.org. Only the project administrators have access
+to these reports.
+
+Our policy is to respond to vulnerability reports within 14 days, and to
+address critical security vulnerabilities rapidly and post patches as quickly
+as possible.
 
 
 ## Other security features


### PR DESCRIPTION
The security@openshadinglanguage.org is still fine, but we prefer that true vulnerability reports come via the GitHub security advisory mechanism.  (That makes it easy for us to turn them into CVEs when needed, among other administrative niceties.)
