### PR TITLE
fix: crash in exception handling after OSL JIT

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -348,12 +348,22 @@ public:
         return mm->allocateDataSection(Size, Alignment, SectionID, SectionName,
                                        IsReadOnly);
     }
-    void registerEHFrames(uint8_t* Addr, uint64_t LoadAddr,
-                          size_t Size) override
+
+    // This memory manager is only used during JIT, where it is unnecessary to
+    // register EH frames in the process, as the generated code is not being
+    // executed yet. On certain platforms registering EH frames could lead to
+    // crashes due to a bug in libgcc:
+    //
+    //   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119151
+    //
+    // For example, the crash can be observed on Ubuntu 24.04 which is shipped
+    // with the affected version of libgcc. To side-step the crash, simply do
+    // not register EH frames as they are not needed during JIT.
+    void registerEHFrames(uint8_t* /*Addr*/, uint64_t /*LoadAddr*/,
+                          size_t /*Size*/) override
     {
-        mm->registerEHFrames(Addr, LoadAddr, Size);
     }
-    void deregisterEHFrames() override { mm->deregisterEHFrames(); }
+    void deregisterEHFrames() override {}
 
     uint64_t getSymbolAddress(const std::string& Name) override
     {


### PR DESCRIPTION
This change fixes crashes that could be observed on Ubuntu 24.04. The crash happens in exception handling after rendering a scene with OSL shaders.

This seems to be a bug in libgcc which was fixed in 14.3, but Ubuntu 24.04 is shipped with 14.2. There is a report in the GCC bug tracker:

  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119151

Note that this is a runtime dependency, so it doesn't really matter that a different GCC version was using during compilation as the EH frames registration happens at runtime.

The easiest solution is to simply disable EH frames registration in OSL's MemoryManager. This should not affect any runtime exception unwinding as this MemoryManager is only used during JIT, so all the EH frames are unregistered from the process when the JIT code is actually executed.

The issue was originally noticed in Blender, here is the report with some extra investigation and details:

  https://projects.blender.org/blender/blender/issues/156348
