### PR TITLE
ci: Remove deprecated windows-2025 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,19 +570,6 @@ jobs:
                             PUGIXML_VERSION=v1.14
                             OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
                             LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
-          - desc: Windows-2025 VS2022 llvm20 oiio3.1
-            runner: windows-2025
-            nametag: windows-2025-vs2022
-            generator: "Visual Studio 17 2022"
-            python_ver: "3.12"
-            opencolorio_ver: v2.3.2
-            openexr_ver: v3.3.2
-            openimageio_ver: release
-            skip_tests: 1
-            setenvs: export OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
-                            PUGIXML_VERSION=v1.14
-                            OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
-                            LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
           - desc: Windows-2025 VS2026
             runner: windows-2025-vs2026
             nametag: windows-2025-vs2026


### PR DESCRIPTION
We test on 3 Windows runner configurations currently -- Windows 2022 with VS2022, Windows 2025 with VS2022, and Windows 2025 with VS2026. GitHub says the middle one will go away imminently (actually, it won't "break", but it will redirect to Windows 2025 with VS2026, which we already test). So take it out of our lineup, it's just waste.
