### PR TITLE
Fix error when an interactive param is also connected

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -356,7 +356,7 @@ macro (osl_add_all_tests)
                 printf-reg
                 printf-whole-array
                 raytype raytype-reg raytype-specialized regex-reg
-                reparam reparam-arrays reparam-string testoptix-reparam
+                reparam reparam-arrays reparam-connected-crash reparam-string testoptix-reparam
                 render-background render-bumptest
                 render-bunny
                 render-cornell

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -232,7 +232,8 @@ BackendLLVM::getLLVMSymbolBase(const Symbol& sym)
                                 llvm_type(sym.typespec().elementtype()));
         return result;
     }
-    if (sym.symtype() == SymTypeParam && sym.interactive() && !sym.connected()) {
+    if (sym.symtype() == SymTypeParam && sym.interactive()
+        && !sym.connected()) {
         // Special case for interactively-edited parameters -- they live in
         // the interactive data block for the group.
         // Generate the pointer to this symbol by offsetting into the

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -232,7 +232,7 @@ BackendLLVM::getLLVMSymbolBase(const Symbol& sym)
                                 llvm_type(sym.typespec().elementtype()));
         return result;
     }
-    if (sym.symtype() == SymTypeParam && sym.interactive()) {
+    if (sym.symtype() == SymTypeParam && sym.interactive() && !sym.connected()) {
         // Special case for interactively-edited parameters -- they live in
         // the interactive data block for the group.
         // Generate the pointer to this symbol by offsetting into the

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -454,7 +454,8 @@ BatchedBackendLLVM::getLLVMSymbolBase(const Symbol& sym)
         return result;
     }
 
-    if (sym.symtype() == SymTypeParam && sym.interactive()) {
+    if (sym.symtype() == SymTypeParam && sym.interactive()
+        && !sym.connected()) {
         // Special case for interactively-edited parameters -- they live in
         // the interactive data block for the group.
         // Generate the pointer to this symbol by offsetting into the

--- a/testsuite/reparam-connected-crash/downstream.osl
+++ b/testsuite/reparam-connected-crash/downstream.osl
@@ -1,0 +1,11 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+// Downstream layer: 'in' will be marked interactive with an instance value
+// via testshade -param:interactive=1
+shader downstream(float in = 0, output float result = 0)
+{
+    printf("in = %g\n", in);
+    result = in;
+}

--- a/testsuite/reparam-connected-crash/ref/out.txt
+++ b/testsuite/reparam-connected-crash/ref/out.txt
@@ -1,0 +1,5 @@
+Compiled downstream.osl -> downstream.oso
+Compiled upstream.osl -> upstream.oso
+Connect upstream_layer.out to downstream_layer.in
+in = 0.5
+

--- a/testsuite/reparam-connected-crash/run.py
+++ b/testsuite/reparam-connected-crash/run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# Regression test: downstream input param is both connected (from upstream) and
+# marked interactive with an instance value.
+#
+# Bug: OSL give precedence to the interactive trait instead of connected. This
+# leads to an attempted write of the interactive buffer. However, the offset
+# is calculated incorrectly and the write occurs at interactive_buffer[-1].
+#
+# Correct output: in = 0.5 (u at the default shade point, from the connection)
+# Buggy output:   in = <garbage> (corrupted memory) or crash
+
+command += testshade(
+    "-layer upstream_layer upstream "
+    "-layer downstream_layer -param:interactive=1 in 9.0 downstream "
+    "-connect upstream_layer out downstream_layer in "
+)
+
+outputs = ["out.txt"]

--- a/testsuite/reparam-connected-crash/upstream.osl
+++ b/testsuite/reparam-connected-crash/upstream.osl
@@ -1,0 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader upstream(output float out = 0)
+{
+    out = u; // don't constant-fold
+}


### PR DESCRIPTION
When a parameter is interactive and connected, the connection should win. OSL was incorrectly treating the interactive trait as taking precedence, attempting to write into the read-only interactive buffer during shader execution.

Assisted-by: Claude Code / claude-sonnet-4-6


### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
