### PR TITLE
ci: turn unity builds off when building OIIO for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,7 @@ jobs:
                             PUGIXML_VERSION=v1.14
                             OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
                             LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
+                            OPENIMAGEIO_UNITY=0
           - desc: Windows-2025 VS2026
             runner: windows-2025-vs2026
             nametag: windows-2025-vs2026
@@ -559,6 +560,7 @@ jobs:
                             PUGIXML_VERSION=v1.14
                             OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
                             LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
+                            OPENIMAGEIO_UNITY=0
 
 
   optix-gpu:


### PR DESCRIPTION
This fixes a break where OIIO has a declaration in exrinput.cpp that is mismatched if a unity build combines it with exrinput_c.cpp.  I have a fix in progress on the OIIO side but this is the expedient workaround here -- just don't use unity build. When we are sure it's fixed on the OIIO side for any version we will build in CI, then we can go back to unity builds.
